### PR TITLE
chore: pr linter allows docs/test/revert types

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -28,4 +28,7 @@ jobs:
             fix
             chore
             refactor
+            test
+            docs
+            revert
           requireScope: false

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -161,7 +161,7 @@ const repo = configureProject(
       mergeQueue: true,
       pullRequestLintOptions: {
         semanticTitleOptions: {
-          types: ['feat', 'fix', 'chore', 'refactor'],
+          types: ['feat', 'fix', 'chore', 'refactor', 'test', 'docs', 'revert'],
         },
       },
     },


### PR DESCRIPTION
god forbid we need to revert but we probably want to have that optionality in the pr linter.