### PR TITLE
chore: require approval before actually releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   aws-cdk-cloud-assembly-schema_release_npm:
     name: "@aws-cdk/cloud-assembly-schema: Publish to npm"
     needs: release
@@ -180,6 +181,7 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval
   aws-cdk-cloudformation-diff_release_github:
     name: "@aws-cdk/cloudformation-diff: Publish to GitHub Releases"
     needs:
@@ -207,6 +209,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   aws-cdk-cloudformation-diff_release_npm:
     name: "@aws-cdk/cloudformation-diff: Publish to npm"
     needs: release
@@ -232,6 +235,7 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval
   cdk-assets_release_github:
     name: "cdk-assets: Publish to GitHub Releases"
     needs:
@@ -259,6 +263,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   cdk-assets_release_npm:
     name: "cdk-assets: Publish to npm"
     needs: release
@@ -284,6 +289,7 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval
   aws-cdk_release_github:
     name: "aws-cdk: Publish to GitHub Releases"
     needs:
@@ -311,6 +317,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   aws-cdk_release_npm:
     name: "aws-cdk: Publish to npm"
     needs: release
@@ -336,6 +343,7 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval
   aws-cdk-cli-lib-alpha_release_github:
     name: "@aws-cdk/cli-lib-alpha: Publish to GitHub Releases"
     needs:
@@ -363,6 +371,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   aws-cdk-cli-lib-alpha_release_npm:
     name: "@aws-cdk/cli-lib-alpha: Publish to npm"
     needs: release
@@ -388,6 +397,7 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval
   cdk_release_github:
     name: "cdk: Publish to GitHub Releases"
     needs:
@@ -415,6 +425,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
         run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+    environment: integ-approval
   cdk_release_npm:
     name: "cdk: Publish to npm"
     needs: release
@@ -440,3 +451,4 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+    environment: integ-approval

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1113,4 +1113,30 @@ new CdkCliIntegTestsWorkflow(repo, {
   ],
 });
 
+const originalPreSynth = repo.monorepoRelease?.preSynthesize;
+
+(repo.monorepoRelease ?? {} as any).preSynthesize = function() {
+  originalPreSynth?.call(this);
+
+  const wf = this.workflow;
+  if (!wf) {
+    throw new Error('wut');
+  }
+  if (!wf.file) {
+    throw new Error('No whey');
+  }
+
+  wf?.file?.patch(...[
+    'aws-cdk-cloud-assembly-schema',
+    'aws-cdk-cloudformation-diff',
+    'cdk-assets',
+    'aws-cdk',
+    'aws-cdk-cli-lib-alpha',
+    'cdk',
+  ].flatMap(name => [
+    pj.JsonPatch.add(`/jobs/${name}_release_github/environment`, 'integ-approval'),
+    pj.JsonPatch.add(`/jobs/${name}_release_npm/environment`, 'integ-approval'),
+  ]));
+}
+
 repo.synth();


### PR DESCRIPTION
This is temporary so we can double-check the version numbers before we have side effects we can't take back.
