### PR TITLE
chore: re-add some linter rules that got lost in the migration

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -699,6 +699,17 @@ const cli = configureProject(
   }),
 );
 
+// Eslint rules
+cli.eslint?.addRules({
+  '@cdklabs/no-throw-default-error': ['error'],
+});
+cli.eslint?.addOverride({
+  files: ["./test/**"],
+  rules: {
+    "@cdklabs/no-throw-default-error": "off",
+  },
+});
+
 // Do include all .ts files inside init-templates
 cli.npmignore?.addPatterns('!lib/init-templates/**/*.ts');
 
@@ -987,6 +998,24 @@ const toolkitLib = configureProject(
     },
   }),
 );
+
+// Eslint rules
+toolkitLib.eslint?.addRules({
+  '@cdklabs/no-throw-default-error': ['error'],
+  'import/no-restricted-paths': ['error', {
+    zones: [{
+      target: './',
+      from: '../../aws-cdk',
+      message: "All `aws-cdk` code must be used via lib/api/aws-cdk.ts",
+    }]
+  }],
+});
+toolkitLib.eslint?.addOverride({
+  files: ["./test/**"],
+  rules: {
+    "@cdklabs/no-throw-default-error": "off",
+  },
+});
 
 // Prevent imports of private API surface
 toolkitLib.package.addField("exports", {

--- a/packages/@aws-cdk/toolkit/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit/.eslintrc.json
@@ -261,7 +261,31 @@
     "jest/no-focused-tests": "error",
     "prettier/prettier": [
       "off"
+    ],
+    "@cdklabs/no-throw-default-error": [
+      "error"
+    ],
+    "import/no-restricted-paths": [
+      "error",
+      {
+        "zones": [
+          {
+            "target": "./",
+            "from": "../../aws-cdk",
+            "message": "All `aws-cdk` code must be used via lib/api/aws-cdk.ts"
+          }
+        ]
+      }
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "./test/**"
+      ],
+      "rules": {
+        "@cdklabs/no-throw-default-error": "off"
+      }
+    }
+  ]
 }

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -262,7 +262,19 @@
     "jest/no-focused-tests": "error",
     "prettier/prettier": [
       "off"
+    ],
+    "@cdklabs/no-throw-default-error": [
+      "error"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "./test/**"
+      ],
+      "rules": {
+        "@cdklabs/no-throw-default-error": "off"
+      }
+    }
+  ]
 }

--- a/projenrc/eslint.ts
+++ b/projenrc/eslint.ts
@@ -1,4 +1,3 @@
-
 export const ESLINT_RULES = {
   '@cdklabs/no-core-construct': ['error'],
   '@cdklabs/invalid-cfn-imports': ['error'],


### PR DESCRIPTION
Fixes repo config not being linted

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
