### PR TITLE
chore: jsii publishing extracting artifacts to the wrong location

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cloud-assembly-schema
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create js artifact
@@ -230,7 +230,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cloud-assembly-schema
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create java artifact
@@ -275,7 +275,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cloud-assembly-schema
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create python artifact
@@ -316,7 +316,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cloud-assembly-schema
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create dotnet artifact
@@ -356,7 +356,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cloud-assembly-schema
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create go artifact
@@ -583,7 +583,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cli-lib-alpha
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create js artifact
@@ -627,7 +627,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cli-lib-alpha
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create java artifact
@@ -671,7 +671,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cli-lib-alpha
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create python artifact
@@ -712,7 +712,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cli-lib-alpha
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create dotnet artifact
@@ -752,7 +752,7 @@ jobs:
       - name: Install Dependencies
         run: cd .repo && yarn install --check-files --frozen-lockfile
       - name: Extract build artifact
-        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo
+        run: tar --strip-components=1 -xzvf dist/js/*.tgz -C .repo/packages/@aws-cdk/cli-lib-alpha
       - name: Move build artifact out of the way
         run: mv dist dist.old
       - name: Create go artifact

--- a/projenrc/jsii.ts
+++ b/projenrc/jsii.ts
@@ -243,12 +243,12 @@ export class JsiiBuild extends pj.Component {
 
     // FIXME: Not support "runsOn" and the workflow container image for now
     const extraJobOptions: Partial<Job> = {
-    /*
-      ...this.getJobRunsOnConfig(options),
-      ...(options.workflowContainerImage
-        ? { container: { image: options.workflowContainerImage } }
-        : {}),
-    */
+      /*
+        ...this.getJobRunsOnConfig(options),
+        ...(options.workflowContainerImage
+          ? { container: { image: options.workflowContainerImage } }
+          : {}),
+      */
     };
 
     const npmjs: NpmPublishOptions = {
@@ -466,10 +466,10 @@ export class JsiiBuild extends pj.Component {
     target: JsiiPacmakTarget,
     packTask: pj.Task,
   ): {
-      publishTools: Tools;
-      bootstrapSteps: Array<Step>;
-      packagingSteps: Array<Step>;
-    } {
+    publishTools: Tools;
+    bootstrapSteps: Array<Step>;
+    packagingSteps: Array<Step>;
+  } {
     const bootstrapSteps: Array<Step> = [];
     const packagingSteps: Array<Step> = [];
 
@@ -496,7 +496,7 @@ export class JsiiBuild extends pj.Component {
       },
       {
         name: 'Extract build artifact',
-        run: `tar --strip-components=1 -xzvf ${this.tsProject.artifactsDirectory}/js/*.tgz -C ${REPO_TEMP_DIRECTORY}`,
+        run: `tar --strip-components=1 -xzvf ${this.tsProject.artifactsDirectory}/js/*.tgz -C ${REPO_TEMP_DIRECTORY}/${this.monoProject.workspaceDirectory}`,
       },
       {
         name: 'Move build artifact out of the way',


### PR DESCRIPTION
Follow up to https://github.com/aws/aws-cdk-cli/pull/71.

In contrast to single package jsii publishing, our artifacts don't contain the entire repo, but rather just the compilation result of a specific package. This means that upon extraction, it needs to be placed in the specific package directory instead of the root.

Currently release is failing with:

```console
Error: Expected to find .jsii file in /home/runner/work/aws-cdk-cli/aws-cdk-cli/.repo/packages/@aws-cdk/cli-lib-alpha, but no such file found
```

Which is expected because it operates on an uncompiled repo. Extraction of the artifact to the correct location will overlay the repo with the compiled code. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
