### PR TITLE
chore: upgrade dependencies weekly

### DIFF
--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -4,7 +4,7 @@ name: upgrade
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -154,6 +154,12 @@ const repoProject = new yarn.Monorepo({
     releaseTrigger: pj.release.ReleaseTrigger.workflowDispatch(),
   },
 
+  depsUpgradeOptions: {
+    workflowOptions: {
+      schedule: pj.javascript.UpgradeDependenciesSchedule.WEEKLY,
+    },
+  },
+
   githubOptions: {
     mergify: false,
     mergeQueue: true,


### PR DESCRIPTION
Given that we need to manually give permissions to run workflows for every update, better reduce the frequency to not sit with a giant inventory of PRs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
