### PR TITLE
chore(cli): don't emit empty user input interfaces

### DIFF
--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -117,7 +117,7 @@ export interface UserInput {
   /**
    * Check your set-up for potential problems
    */
-  readonly doctor?: DoctorOptions;
+  readonly doctor?: {};
 }
 
 /**
@@ -1324,12 +1324,4 @@ export interface DocsOptions {
    * @default - undefined
    */
   readonly browser?: string;
-}
-
-/**
- * Check your set-up for potential problems
- *
- * @struct
- */
-export interface DoctorOptions {
 }


### PR DESCRIPTION
Fixes the generated empty interface not complying with our eslint rule to have newlines between control curly braces.

```ts
// not-allowed, but previously generated
interface DocsOptions {}
```

Instead we just avoid the problem by not generating empty interfaces.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
