### PR TITLE
chore: add ADC publishing workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -840,7 +840,7 @@ jobs:
     permissions:
       contents: write
     environment: releasing
-    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-cloud-assembly-schema == 'true' }}
+    if: ${{ needs.release.outputs.latest_commit == github.sha }}
     steps:
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,13 @@ jobs:
           name: cdk_build-artifact
           path: packages/cdk/dist
           overwrite: true
+      - name: "standalone: Upload artifact"
+        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: standalone_build-artifact
+          path: dist/standalone
+          overwrite: true
   aws-cdk-cloud-assembly-schema_release_github:
     name: "@aws-cdk/cloud-assembly-schema: Publish to GitHub Releases"
     needs:
@@ -826,3 +833,34 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+  standalone_release_adc:
+    name: "standalone: publish to ADC"
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment: releasing
+    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-cloud-assembly-schema == 'true' }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: standalone_build-artifact
+          path: dist/standalone
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 14400
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
+          role-session-name: releasing@aws-cdk-cli
+          output-credentials: true
+      - name: Publish artifacts
+        env:
+          PUBLISHING_ROLE_ARN: ${{ vars.PUBLISHING_ROLE_ARN }}
+          TARGET_BUCKETS: ${{ vars.TARGET_BUCKETS }}
+        run: npx tsx projenrc/publish-to-adc.task.ts

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -8,6 +8,9 @@
         },
         {
           "exec": "yarn workspaces run build"
+        },
+        {
+          "exec": "tsx projenrc/build-standalone-zip.task.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -5,6 +5,7 @@ import { BundleCli } from './projenrc/bundle';
 import { ESLINT_RULES } from './projenrc/eslint';
 import { JsiiBuild } from './projenrc/jsii';
 import { CodeCovWorkflow } from './projenrc/codecov';
+import { AdcPublishing } from './projenrc/adc-publishing';
 
 // 5.7 sometimes gives a weird error in `ts-jest` in `@aws-cdk/cli-lib-alpha`
 // https://github.com/microsoft/TypeScript/issues/60159
@@ -214,6 +215,8 @@ const repoProject = new yarn.Monorepo({
     ],
   },
 });
+
+new AdcPublishing(repoProject);
 
 // Eslint for projen config
 // @ts-ignore

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -1,0 +1,76 @@
+import { Monorepo } from "cdklabs-projen-project-types/lib/yarn";
+import { Component, github } from "projen";
+import { JobPermission } from "projen/lib/github/workflows-model";
+
+export class AdcPublishing extends Component {
+  constructor(private readonly project_: Monorepo) {
+    super(project_);
+
+    this.project.tasks.tryFind('build')?.exec('tsx projenrc/build-standalone-zip.task.ts');
+  }
+
+  public preSynthesize() {
+    const releaseWf = this.project_.github?.tryFindWorkflow('release');
+    if (!releaseWf) {
+      throw new Error('Could not find release workflow');
+    }
+
+    (releaseWf.getJob('release') as github.workflows.Job).steps.push({
+      name: 'standalone: Upload artifact',
+      if: '${{ steps.git_remote.outputs.latest_commit == github.sha }}',
+      uses: 'actions/upload-artifact@v4.4.0',
+      with: {
+        name: 'standalone_build-artifact',
+        path: 'dist/standalone',
+        overwrite: true
+      },
+    });
+
+    releaseWf.addJob('standalone_release_adc', {
+      name: 'standalone: publish to ADC',
+      environment: 'releasing',  // <-- this has the configuration
+      needs: ['release'],
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        contents: JobPermission.WRITE,
+      },
+      if: `\${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-cloud-assembly-schema == 'true' }}`,
+      steps: [
+        {
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': 'lts/*',
+          },
+        },
+        {
+          name: 'Download build artifacts',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: 'standalone_build-artifact',
+            path: 'dist/standalone',
+          },
+        },
+        {
+          name: 'Authenticate Via OIDC Role',
+          id: 'creds',
+          uses: 'aws-actions/configure-aws-credentials@v4',
+          with: {
+            'aws-region': 'us-east-1',
+            'role-duration-seconds': 14400,
+            'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
+            'role-session-name': 'releasing@aws-cdk-cli',
+            'output-credentials': true,
+          },
+        },
+        {
+          name: 'Publish artifacts',
+          env: {
+            PUBLISHING_ROLE_ARN: '${{ vars.PUBLISHING_ROLE_ARN }}',
+            TARGET_BUCKETS: '${{ vars.TARGET_BUCKETS }}',
+          },
+          run: 'npx tsx projenrc/publish-to-adc.task.ts',
+        },
+      ],
+    });
+  }
+}

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -34,7 +34,7 @@ export class AdcPublishing extends Component {
       permissions: {
         contents: JobPermission.WRITE,
       },
-      if: `\${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-cloud-assembly-schema == 'true' }}`,
+      if: `\${{ needs.release.outputs.latest_commit == github.sha }}`,
       steps: [
         {
           uses: 'actions/setup-node@v4',

--- a/projenrc/build-standalone-zip.task.ts
+++ b/projenrc/build-standalone-zip.task.ts
@@ -2,14 +2,12 @@ import * as cp from 'child_process';
 import { promises as fs } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import * as util from 'util';
-import * as glob_ from 'glob';
-
-const glob = util.promisify(glob_.glob);
+import { glob } from 'glob';
 
 async function main() {
   const outdir = await fs.mkdtemp(path.join(os.tmpdir(), 'bundling'));
   try {
+
     const pkgs = ['aws-cdk'];
     // this is a build task, so we are safe either way
     // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism

--- a/projenrc/publish-to-adc.task.ts
+++ b/projenrc/publish-to-adc.task.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'fs';
 import { S3 } from '@aws-sdk/client-s3';
 import { fromTemporaryCredentials, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { Upload } from '@aws-sdk/lib-storage';
+import { glob } from 'glob';
 
 /**
  * Takes files from `dist/standalone` and moves them to specific ADC buckets
@@ -16,6 +17,11 @@ async function main() {
   if (!TARGET_BUCKETS) {
     throw new Error('Require $TARGET_BUCKETS');
   }
+  const buckets = TARGET_BUCKETS.split(/\s+|,+/).filter(x => x);
+
+  const root = 'dist/standalone';
+
+  const standaloneFiles = await glob('**/*', { cwd: root });
 
   const credentials = fromTemporaryCredentials({
     masterCredentials: fromNodeProviderChain(),
@@ -30,22 +36,24 @@ async function main() {
 
   const s3 = new S3({ region: 'us-east-1', credentials });
 
-  for (const bucket of TARGET_BUCKETS.split(' ')) {
+  for (const bucket of buckets) {
     // This value is secret-ish, mask it out
     // this is a cli
     // eslint-disable-next-line no-console
     console.log(`::add-mask::${bucket}`);
 
-    const upload = new Upload({
-      client: s3,
-      params: {
-        Bucket: bucket,
-        Key: 'aws-cdk-v2/aws-cdk-cli.zip',
-        Body: createReadStream('dist/standalone/aws-cdk-cli.zip'),
-        ChecksumAlgorithm: 'SHA256',
-      },
-    });
-    await upload.done();
+    for (const file of standaloneFiles) {
+      const upload = new Upload({
+        client: s3,
+        params: {
+          Bucket: bucket,
+          Key: `aws-cdk-v2/${file}`,
+          Body: createReadStream(`${root}/${file}`),
+          ChecksumAlgorithm: 'SHA256',
+        },
+      });
+      await upload.done();
+    }
   }
 }
 

--- a/projenrc/publish-to-adc.task.ts
+++ b/projenrc/publish-to-adc.task.ts
@@ -20,8 +20,7 @@ async function main() {
   const buckets = TARGET_BUCKETS.split(/\s+|,+/).filter(x => x);
 
   const root = 'dist/standalone';
-
-  const standaloneFiles = await glob('**/*', { cwd: root });
+  const filesToPublish = ['aws-cdk-cli.zip'];
 
   const credentials = fromTemporaryCredentials({
     masterCredentials: fromNodeProviderChain(),
@@ -42,7 +41,7 @@ async function main() {
     // eslint-disable-next-line no-console
     console.log(`::add-mask::${bucket}`);
 
-    for (const file of standaloneFiles) {
+    for (const file of filesToPublish) {
       const upload = new Upload({
         client: s3,
         params: {


### PR DESCRIPTION
The configuration lives in the 'releasing' environment, and the bucket names are masked away from the logs.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
