### PR TITLE
fix(toolkit-lib): message including tokens from annotations cannot output correctly

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -762,7 +762,7 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
       // Data comes from Annotations and the data can be of object type containing 'Fn::Join' or 'Ref' when tokens are included in Annotations.
       // Therefore, we use JSON.stringify to convert it to a string when the data is of object type.
       // see: https://github.com/aws/aws-cdk/issues/33527
-      const data = typeof msg.entry.data === 'object' && msg.entry.data !== null
+      const data = msg.entry.data !== null && typeof msg.entry.data === 'object'
         ? JSON.stringify(msg.entry.data)
         : msg.entry.data;
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -766,7 +766,7 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
         ? JSON.stringify(msg.entry.data)
         : msg.entry.data;
 
-      ioHost.notify({
+      await ioHost.notify({
         time: new Date(),
         level,
         code: code(level),

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
@@ -72,7 +72,7 @@ describe('message formatting', () => {
 });
 
 describe('metadata message formatting', () => {
-  test('converts object data to string for log message types', async () => {
+  test('converts object data for log message to string', async () => {
     const ioHost = new TestIoHost();
     const toolkit = new Toolkit({ ioHost });
 
@@ -104,7 +104,7 @@ describe('metadata message formatting', () => {
     }));
   });
 
-  test('keeps non-object data as-is for log message types', async () => {
+  test('keeps non-object data for log message as-is', async () => {
     const ioHost = new TestIoHost();
     const toolkit = new Toolkit({ ioHost });
 

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
@@ -88,9 +88,9 @@ describe('metadata message formatting', () => {
                 [
                   'stackId: ',
                   {
-                    'Ref': "AWS::StackId"
-                  }
-                ]
+                    Ref: 'AWS::StackId',
+                  },
+                ],
               ],
             } as any,
           }],
@@ -106,11 +106,11 @@ describe('metadata message formatting', () => {
       data: {
         entry: {
           type: 'aws:cdk:warning',
-          data: { 'Fn::Join': ['', ['stackId: ', { 'Ref': 'AWS::StackId' }]] }
+          data: { 'Fn::Join': ['', ['stackId: ', { Ref: 'AWS::StackId' }]] },
         },
         id: 'test-stack',
-        level: 'warning'
-      }
+        level: 'warning',
+      },
     }));
   });
 
@@ -124,10 +124,10 @@ describe('metadata message formatting', () => {
         metadata: {
           'test-stack': [{
             type: 'aws:cdk:info',
-            data: 'simple string message'
-          }]
-        }
-      }]
+            data: 'simple string message',
+          }],
+        },
+      }],
     });
 
     await toolkit.synth(source);
@@ -138,11 +138,11 @@ describe('metadata message formatting', () => {
       data: {
         entry: {
           type: 'aws:cdk:info',
-          data: 'simple string message'
+          data: 'simple string message',
         },
         id: 'test-stack',
-        level: 'info'
-      }
+        level: 'info',
+      },
     }));
   });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit.test.ts
@@ -82,21 +82,31 @@ describe('metadata message formatting', () => {
         metadata: {
           'test-stack': [{
             type: 'aws:cdk:warning',
-            data: { 'Fn::Join': ['','test'], 'Ref': 'someRef' } as any
-          }]
-        }
-      }]
+            data: {
+              'Fn::Join': [
+                '',
+                [
+                  'stackId: ',
+                  {
+                    'Ref': "AWS::StackId"
+                  }
+                ]
+              ],
+            } as any,
+          }],
+        },
+      }],
     });
 
     await toolkit.synth(source);
 
     expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
       level: 'warn',
-      message: expect.stringContaining('{"Fn::Join":["","test"],"Ref":"someRef"}'),
+      message: expect.stringContaining('{"Fn::Join":["",["stackId: ",{"Ref":"AWS::StackId"}]]}'),
       data: {
         entry: {
           type: 'aws:cdk:warning',
-          data: { 'Fn::Join': ['','test'], 'Ref': 'someRef' }
+          data: { 'Fn::Join': ['', ['stackId: ', { 'Ref': 'AWS::StackId' }]] }
         },
         id: 'test-stack',
         level: 'warning'


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/116

# Describe the bug

If a stack with name 'some-stack' includes an info annotation

```ts
Annotations.of(this).addInfo(`stackId: ${this.stackId}`);
```

then the following output results:

```
[Info at /some-stack] [object Object]
```

That's because data comes from Annotations and the data can be of object type containing 'Fn::Join' or 'Ref' when tokens are included in Annotations.

# Approach

Change the type for the `msg.entry.data` (`MetadataEntryData` for `MetadataEntry`) to a string type with `JSON.stringify` if the type is an objective type.

https://github.com/aws/aws-cdk-cli/blob/main/packages/%40aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts#L764

Actually, the type for `data` is `any` in aws-cdk-lib (with `constructs` library).

https://github.com/aws/constructs/blob/10.x/src/metadata.ts#L13

# Alternative Approach

The issue mentioned a proposal to output the data in the form of tokens like `[Info at /CdkSampleStack] ${Token[AWS::StackId.1116]}`.

The following changes to the code would make this possible.

https://github.com/aws/aws-cdk/blob/v2.178.0/packages/aws-cdk-lib/core/lib/stack-synthesizers/_shared.ts#L103

```ts
    if (node.node.metadata.length > 0) {
      // Make the path absolute
      output[Node.PATH_SEP + node.node.path] = node.node.metadata.map(md => {
        // If Annotations include a token, the message is resolved and output as `[object Object]` after synth
        // because the message will be object type using 'Fn::Join'.
        // It would be easier for users to understand if the message from Annotations were output in token form,
        // rather than in `[object Object]` or in object type using 'Fn::Join'.
        // Therefore, we don't resolve the message if it's from Annotations.
        // see: https://github.com/aws/aws-cdk-cli/issues/116
        if ([
          cxschema.ArtifactMetadataEntryType.ERROR,
          cxschema.ArtifactMetadataEntryType.WARN,
          cxschema.ArtifactMetadataEntryType.INFO,
        ].includes(md.type as cxschema.ArtifactMetadataEntryType)) {
          return md;
        }

        const resolved = stack.resolve(md);
        return resolved as cxschema.MetadataEntry;
      });
    }
```

But that would also output a token format in `manifest.json` for cloud assembly.

```json
{
  // ...
  "CdkSampleStack": {
    // ...
      "metadata": {
        "/CdkSampleStack": [
          {
            "type": "aws:cdk:info",
            "data": "stackId: ${Token[AWS::StackId.1119]}",
```

However Cloud assembly is for CFn or CDK CLI, and the tokens are for CDK Apps and should be resolved in the synth phase. Therefore, `manifest.json` should output the resolved value.

```json
{
  // ...
  "CdkSampleStack": {
    // ...
      "metadata": {
        "/CdkSampleStack": [
          {
            "type": "aws:cdk:info",
            "data": {
              "Fn::Join": [
                "",
                [
                  "stackId: ",
                  {
                    "Ref": "AWS::StackId"
                  }
                ]
              ]
            },
```

In fact, the information in CFn format using `${AWS::AccountId}` etc. is already in `manifest.json` as shown below.

```
 "lookupRole": {
          "arn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-lookup-role-${AWS::AccountId}-${AWS::Region}",
          "requiresBootstrapStackVersion": 8,
          "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version"
        }
```

So I decided the first approach in this PR.

# Additional Information

When I reverted the code back to the original process and ran the unit test I created this time, the output was `[object Object]` as expected.

>  "message": "[warn at test-stack] [object Object]", 

```
  ● metadata message formatting › converts object data to string for log message types

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    Expected: ObjectContaining {"data": {"entry": {"data": {"Fn::Join": ["", "test"], "Ref": "someRef"}, "type": "aws:cdk:warning"}, "id": "test-stack", "level": "warning"}, "level": "warn", "message": StringContaining "{\"Fn::Join\":[\"\",\"test\"],\"Ref\":\"someRef\"}"}
    Received
           1: {"action": "synth", "code": "CDK_ASSEMBLY_W9999", "data": {"entry": {"data": {"Fn::Join": ["", "test"], "Ref": "someRef"}, "type": "aws:cdk:warning"}, "id": "test-stack", "level": "warning"}, "level": "warn", "message": "[warn at test-stack] [object Object]", "time": 2025-02-22T18:00:01.083Z}
```

When I ran the test with the code reflected, it was in the correct format, so this change is considered appropriate.

# CLI Integ Tests

Added a new cli integ test.

see: https://github.com/aws/aws-cdk-cli-testing/pull/43

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
