### PR TITLE
chore: give dependabot a deeper path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,21 +3,21 @@
 version: 2
 updates:
   - package-ecosystem: pip
-    directory: /
+    directory: /packages/aws-cdk/lib/init-templates
     schedule:
       interval: weekly
     labels:
       - auto-approve
     open-pull-requests-limit: 5
   - package-ecosystem: maven
-    directory: /
+    directory: /packages/aws-cdk/lib/init-templates
     schedule:
       interval: weekly
     labels:
       - auto-approve
     open-pull-requests-limit: 5
   - package-ecosystem: nuget
-    directory: /
+    directory: /packages/aws-cdk/lib/init-templates
     schedule:
       interval: weekly
     labels:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1244,7 +1244,7 @@ new pj.YamlFile(repo, '.github/dependabot.yml', {
     version: 2,
     updates: ['pip', 'maven', 'nuget'].map((pkgEco) => ({
       'package-ecosystem': pkgEco,
-      'directory': '/',
+      'directory': '/packages/aws-cdk/lib/init-templates',
       'schedule': { interval: 'weekly' },
       'labels': ['auto-approve'],
       'open-pull-requests-limit': 5,


### PR DESCRIPTION
Dependabot is complaining it can't find any package version files.

This is the same directory we had in the old repository, so try putting this back and see if that helps.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
