### PR TITLE
chore(toolkit-lib): rename StackSelector option to `expand`

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
@@ -27,7 +27,7 @@ export class StackAssembly extends CloudAssembly implements ICloudAssemblySource
       throw new ToolkitError('This app contains no stacks');
     }
 
-    const extend = convertExtend(selector.extend);
+    const extend = expandToExtendEnum(selector.expand);
     const patterns = sanitizePatterns(selector.patterns ?? []);
 
     switch (selector.strategy) {
@@ -94,7 +94,7 @@ export class StackAssembly extends CloudAssembly implements ICloudAssemblySource
   }
 }
 
-function convertExtend(extend?: ExpandStackSelection): CliExtendedStackSelection | undefined {
+function expandToExtendEnum(extend?: ExpandStackSelection): CliExtendedStackSelection | undefined {
   switch (extend) {
     case ExpandStackSelection.DOWNSTREAM:
       return CliExtendedStackSelection.Downstream;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-selector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-selector.ts
@@ -82,10 +82,10 @@ export interface StackSelector {
   patterns?: string[];
 
   /**
-   * Extend the selection to upstream/downstream stacks.
-   * @default ExtendedStackSelection.None only select the specified/matched stacks
+   * Expand the selection to upstream/downstream stacks.
+   * @default ExpandStackSelection.None only select the specified/matched stacks
    */
-  extend?: ExpandStackSelection;
+  expand?: ExpandStackSelection;
 
   /**
    * By default, we throw an exception if the assembly contains no stacks.


### PR DESCRIPTION
In #105 I renamed the interface from `Extend` to `Expand`, but forgot the options itself and some docs.

This is marked as a chore so it doesn't show up in the changelog for the first release. That's what we want, because it is not relevant to users just yet.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
