### PR TITLE
chore(toolkit-lib): publish toolkit-lib docs to s3 (in dryrun)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1043,3 +1043,48 @@ jobs:
         run: |-
           aws ssm put-parameter --name "/published/cdk/cli/version" --type "String" --value "${{ steps.aws-cdk-version.outputs.version }}" --overwrite
           aws ssm put-parameter --name "/published/cdk/cli/timestamp" --type "String" --value "$(date +%s)" --overwrite
+  aws-cdk-toolkit-lib_release_docs:
+    name: "@aws-cdk/toolkit-lib: Publish docs to S3"
+    needs: aws-cdk-toolkit-lib_release_npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: releasing
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: "@aws-cdk/toolkit-lib_build-artifact"
+          path: dist
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 14400
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
+          role-session-name: releasing@aws-cdk-cli
+      - name: Assume the publishing role
+        id: publishing-creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 14400
+          role-to-assume: ${{ vars.PUBLISH_TOOLKIT_LIB_DOCS_ROLE_ARN }}
+          role-session-name: s3publishing@aws-cdk-cli
+          role-chaining: true
+      - name: Publish docs
+        env:
+          BUCKET_NAME: ${{ vars.DOCS_BUCKET_NAME }}
+          DOCS_STREAM: toolkit-lib
+        run: |-
+          ::add-mask::$BUCKET_NAME
+          echo "S3_PATH=$DOCS_STREAM/aws-cdk-toolkit-lib-v$(cat dist/version.txt).zip" >> "$GITHUB_ENV"
+          echo "S3_URI=s3://$BUCKET_NAME/$S3_PATH" >> "$GITHUB_ENV"
+          echo "LATEST=latest-toolkit-lib" >> "$GITHUB_ENV"
+          echo $S3_PATH > $LATEST
+          (! aws s3 ls --human-readable $S3_URI \
+          && aws s3 cp --dryrun dist/docs.zip $S3_URI \
+          && aws s3 cp --dryrun $LATEST s3://$BUCKET_NAME/$LATEST) \
+          || (echo "Docs artifact already published, skipping upload")

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -87,7 +87,8 @@
       "name": "docs",
       "steps": [
         {
-          "exec": "typedoc lib/index.ts"
+          "exec": "typedoc lib/index.ts",
+          "receiveArgs": true
         }
       ]
     },
@@ -149,6 +150,16 @@
         },
         {
           "exec": "npm pack --pack-destination dist/js"
+        },
+        {
+          "spawn": "docs",
+          "args": [
+            "--out dist/docs/cdk/api/toolkit-lib"
+          ]
+        },
+        {
+          "exec": "zip -r ../docs.zip cdk ",
+          "cwd": "dist/docs"
         }
       ]
     },

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -1,0 +1,118 @@
+import { Monorepo, TypeScriptWorkspace } from 'cdklabs-projen-project-types/lib/yarn';
+import { Component, github } from 'projen';
+
+export interface S3DocsPublishingProps {
+  /**
+   * The docs stream to publish to.
+   */
+  readonly docsStream: string;
+
+  /**
+   * The path to the artifact in the dist folder
+   */
+  readonly artifactPath: string;
+
+  /**
+   * The role arn (or github expression) for OIDC to assume to do the actual publishing.
+   */
+  readonly roleToAssume: string;
+
+  /**
+   * The bucket name (or github expression) to publish to.
+   */
+  readonly bucketName: string;
+}
+
+export class S3DocsPublishing extends Component {
+  private readonly github: github.GitHub;
+  private readonly props: S3DocsPublishingProps;
+
+  constructor(project: TypeScriptWorkspace, props: S3DocsPublishingProps) {
+    super(project);
+
+    const gh = (project.parent! as Monorepo).github;
+    if (!gh) {
+      throw new Error('This workspace does not have a GitHub instance');
+    }
+    this.github = gh;
+
+    this.props = props;
+  }
+
+  public preSynthesize() {
+    const releaseWf = this.github.tryFindWorkflow('release');
+    if (!releaseWf) {
+      throw new Error('Could not find release workflow');
+    }
+
+    const safeName = this.project.name.replace('@', '').replace('/', '-');
+
+    releaseWf.addJob(`${safeName}_release_docs`, {
+      name: `${this.project.name}: Publish docs to S3`,
+      environment: 'releasing', // <-- this has the configuration
+      needs: [`${safeName}_release_npm`],
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        idToken: github.workflows.JobPermission.WRITE,
+        contents: github.workflows.JobPermission.READ,
+      },
+      steps: [
+        {
+          name: 'Download build artifacts',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: `${this.project.name}_build-artifact`,
+            path: 'dist',
+          },
+        },
+        {
+          name: 'Authenticate Via OIDC Role',
+          id: 'creds',
+          uses: 'aws-actions/configure-aws-credentials@v4',
+          with: {
+            'aws-region': 'us-east-1',
+            'role-duration-seconds': 14400,
+            'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
+            'role-session-name': 'releasing@aws-cdk-cli',
+          },
+        },
+        {
+          name: 'Assume the publishing role',
+          id: 'publishing-creds',
+          uses: 'aws-actions/configure-aws-credentials@v4',
+          with: {
+            'aws-region': 'us-east-1',
+            'role-duration-seconds': 14400,
+            'role-to-assume': this.props.roleToAssume,
+            'role-session-name': 's3publishing@aws-cdk-cli',
+            'role-chaining': true,
+          },
+        },
+        {
+          name: 'Publish docs',
+          env: {
+            BUCKET_NAME: this.props.bucketName,
+            DOCS_STREAM: this.props.docsStream,
+          },
+          run: [
+            '::add-mask::$BUCKET_NAME', // always hide bucket name
+
+            // setup paths
+            `echo "S3_PATH=$DOCS_STREAM/${safeName}-v$(cat dist/version.txt).zip" >> "$GITHUB_ENV"`,
+            'echo "S3_URI=s3://$BUCKET_NAME/$S3_PATH" >> "$GITHUB_ENV"',
+            `echo "LATEST=latest-${this.props.docsStream}" >> "$GITHUB_ENV"`,
+
+            // create the latest marker
+            'echo $S3_PATH > $LATEST',
+
+            // check if the target file already exists and upload
+            '(! aws s3 ls --human-readable $S3_URI \\',
+            `&& aws s3 cp --dryrun dist/${this.props.artifactPath} $S3_URI \\`,
+            '&& aws s3 cp --dryrun $LATEST s3://$BUCKET_NAME/$LATEST) \\',
+            '|| (echo "Docs artifact already published, skipping upload")',
+          ].join('\n'),
+        },
+      ],
+    });
+  }
+}


### PR DESCRIPTION
Adds a release for the toolkit-lib s3 docs to be published to s3.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
