### PR TITLE
chore(adc-publishing): build standalone release in 'release' workflow

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -132,6 +132,9 @@
         },
         {
           "exec": "git diff --ignore-space-at-eol --exit-code"
+        },
+        {
+          "exec": "tsx projenrc/build-standalone-zip.task.ts"
         }
       ]
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -10,10 +10,10 @@
           "exec": "yarn workspaces run build"
         },
         {
-          "exec": "tsx projenrc/build-standalone-zip.task.ts"
+          "spawn": "eslint"
         },
         {
-          "spawn": "eslint"
+          "exec": "tsx projenrc/build-standalone-zip.task.ts"
         },
         {
           "exec": "tsx projenrc/build-standalone-zip.task.ts"
@@ -135,6 +135,9 @@
         },
         {
           "exec": "git diff --ignore-space-at-eol --exit-code"
+        },
+        {
+          "exec": "tsx projenrc/build-standalone-zip.task.ts"
         },
         {
           "exec": "tsx projenrc/build-standalone-zip.task.ts"

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -5,11 +5,13 @@ import { JobPermission } from 'projen/lib/github/workflows-model';
 export class AdcPublishing extends Component {
   constructor(private readonly project_: Monorepo) {
     super(project_);
-
-    this.project.tasks.tryFind('build')?.exec('tsx projenrc/build-standalone-zip.task.ts');
   }
 
   public preSynthesize() {
+    for (const taskName of ['build', 'release']) {
+      this.project.tasks.tryFind(taskName)?.exec('tsx projenrc/build-standalone-zip.task.ts');
+    }
+
     const releaseWf = this.project_.github?.tryFindWorkflow('release');
     if (!releaseWf) {
       throw new Error('Could not find release workflow');


### PR DESCRIPTION
`release` doesn't call `build`, but has its own implementation of building instead.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
