### PR TITLE
chore: move minimum Node version back to 14

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -25,6 +25,7 @@ const TYPESCRIPT_VERSION = '5.6';
  * and 30 is not stable yet.
  */
 function configureProject<A extends pj.typescript.TypeScriptProject>(x: A): A {
+  x.package.addEngine('node', '>= 14.15.0');
   x.addDevDeps(
     '@typescript-eslint/eslint-plugin@^8',
     '@typescript-eslint/parser@^8',

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.7.3"
   },
+  "engines": {
+    "node": ">= 14.15.0"
+  },
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/@aws-cdk/cdk-build-tools/package.json
+++ b/packages/@aws-cdk/cdk-build-tools/package.json
@@ -73,7 +73,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cdk-cli-wrapper/package.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/package.json
@@ -60,7 +60,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cli-lib-alpha/package.json
+++ b/packages/@aws-cdk/cli-lib-alpha/package.json
@@ -74,7 +74,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/main.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cli-plugin-contract/package.json
+++ b/packages/@aws-cdk/cli-plugin-contract/package.json
@@ -59,7 +59,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cloud-assembly-schema/package.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/package.json
@@ -82,7 +82,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cloudformation-diff/package.json
+++ b/packages/@aws-cdk/cloudformation-diff/package.json
@@ -70,7 +70,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/node-bundle/package.json
+++ b/packages/@aws-cdk/node-bundle/package.json
@@ -71,7 +71,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -126,7 +126,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/user-input-gen/package.json
+++ b/packages/@aws-cdk/user-input-gen/package.json
@@ -65,7 +65,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 17.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/yarn-cling/package.json
+++ b/packages/@aws-cdk/yarn-cling/package.json
@@ -65,7 +65,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -148,7 +148,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/cdk-assets/package.json
+++ b/packages/cdk-assets/package.json
@@ -93,7 +93,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -65,7 +65,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 16.0.0"
+    "node": ">= 14.15.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
We are currently producing errors when trying to install on Node 14.

Even though we don't know if it works, we didn't officially stop supporting it yet, so we shouldn't error on old versions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
