### PR TITLE
feat(cli): can match notices against Node version

### DIFF
--- a/packages/aws-cdk/lib/notices.ts
+++ b/packages/aws-cdk/lib/notices.ts
@@ -421,7 +421,7 @@ export interface Notice {
    * If the `components` is a single-level array, it is evaluated as an OR; it
    * matches if any of the components matches.
    */
-  components: Component[] | Component[][];
+  components: Array<Component | Component[]>;
   schemaVersion: string;
   severity?: string;
 }
@@ -429,7 +429,7 @@ export interface Notice {
 /**
  * Normalizes the given components structure into DNF form
  */
-function normalizeComponents(xs: Component[] | Component[][]): Component[][] {
+function normalizeComponents(xs: Array<Component | Component[]>): Component[][] {
   return xs.map(x => Array.isArray(x) ? x : [x]);
 }
 

--- a/packages/aws-cdk/lib/notices.ts
+++ b/packages/aws-cdk/lib/notices.ts
@@ -222,7 +222,7 @@ export abstract class NoticesFilter {
       if (x.constructInfo?.fqn && x.constructInfo?.version) {
         ret.push({
           name: x.constructInfo?.fqn,
-          version: x.constructInfo?.version
+          version: x.constructInfo?.version,
         });
       }
 

--- a/packages/aws-cdk/lib/tree.ts
+++ b/packages/aws-cdk/lib/tree.ts
@@ -29,30 +29,30 @@ export interface ConstructTreeNode {
 /**
  * Whether the provided predicate is true for at least one element in the construct (sub-)tree.
  */
-export function some(node: ConstructTreeNode, predicate: (n: ConstructTreeNode) => boolean): boolean {
+export function some(node: ConstructTreeNode | undefined, predicate: (n: ConstructTreeNode) => boolean): boolean {
   return node != null && (predicate(node) || findInChildren());
 
   function findInChildren(): boolean {
-    return Object.values(node.children ?? {}).some(child => some(child, predicate));
+    return Object.values(node?.children ?? {}).some(child => some(child, predicate));
   }
 }
 
-export function loadTree(assembly: CloudAssembly) {
+export function loadTree(assembly: CloudAssembly): ConstructTreeNode | undefined {
   try {
     const outdir = assembly.directory;
     const fileName = assembly.tree()?.file;
     return fileName ? fs.readJSONSync(path.join(outdir, fileName)).tree : {};
   } catch (e) {
     trace(`Failed to get tree.json file: ${e}. Proceeding with empty tree.`);
-    return {};
+    return undefined;
   }
 }
 
-export function loadTreeFromDir(outdir: string) {
+export function loadTreeFromDir(outdir: string): ConstructTreeNode | undefined {
   try {
     return fs.readJSONSync(path.join(outdir, 'tree.json')).tree;
   } catch (e) {
     trace(`Failed to get tree.json file: ${e}. Proceeding with empty tree.`);
-    return {};
+    return undefined;
   }
 }

--- a/packages/aws-cdk/test/notices.test.ts
+++ b/packages/aws-cdk/test/notices.test.ts
@@ -13,6 +13,7 @@ import {
   FilteredNotice,
   WebsiteNoticeDataSource,
   BootstrappedEnvironment,
+  Component,
 } from '../lib/notices';
 import * as version from '../lib/cli/version';
 import { Settings } from '../lib/api/settings';
@@ -345,8 +346,77 @@ describe(NoticesFilter, () => {
       const nodeVersion = process.version.replace(/^v/, '');
       expect(filtered.map(f => f.format()).join('\n')).toContain(`You are running ${nodeVersion}`);
     });
+
+    test.each([
+      // No components => doesnt match
+      [
+        [],
+        false,
+      ],
+      // Multiple single-level components => treated as an OR, one of them is fine
+      [
+        [['cli 1.0.0'], ['node >=999.x']],
+        true,
+      ],
+      // OR of ANDS, all must match
+      [
+        [['cli 1.0.0', 'node >=999.x']],
+        false,
+      ],
+      [
+        [['cli 1.0.0', 'node >=14.x']],
+        true,
+      ],
+      [
+        [['cli 1.0.0', 'node >=14.x'], ['cli >999.0.0']],
+        true,
+      ],
+      // Can combine matching against a construct and e.g. node version in the same query
+      [
+        [['aws-cdk-lib.App ^2', 'node >=14.x']],
+        true,
+      ],
+    ])('disjunctive normal form: %j => %p', (components: string[][], shouldMatch) => {
+      // can match node version
+      const outDir = path.join(__dirname, 'cloud-assembly-trees', 'built-with-2_12_0');
+      const cliVersion = '1.0.0';
+
+      // WHEN
+      const filtered = NoticesFilter.filter({
+        data: [
+          {
+            title: 'match',
+            overview: 'match',
+            issueNumber: 1,
+            schemaVersion: '1',
+            components: components.map(ands => ands.map(parseTestComponent)),
+          },
+        ] satisfies Notice[],
+        cliVersion,
+        outDir,
+        bootstrappedEnvironments: [],
+      });
+
+      // THEN
+      expect(filtered.map(f => f.notice.title)).toEqual(shouldMatch ? ['match'] : []);
+    });
   });
 });
+
+/**
+ * Parse a test component from a string into a Component object. Just because this is easier to read in tests.
+ */
+function parseTestComponent(x: string): Component {
+  const parts = x.split(' ');
+  if (parts.length !== 2) {
+    throw new Error(`Invalid test component: ${x} (must use exactly 1 space)`);
+  }
+  return {
+    name: parts[0],
+    version: parts[1],
+  };
+}
+
 
 describe(WebsiteNoticeDataSource, () => {
   const dataSource = new WebsiteNoticeDataSource();

--- a/packages/aws-cdk/test/tree.test.ts
+++ b/packages/aws-cdk/test/tree.test.ts
@@ -105,11 +105,11 @@ describe('some', () => {
 describe('loadTreeFromDir', () => {
   test('can find tree', () => {
     const tree = loadTreeFromDir(path.join(__dirname, 'cloud-assembly-trees', 'built-with-1_144_0'));
-    expect(tree.id).toEqual('App');
+    expect(tree?.id).toEqual('App');
   });
 
   test('cannot find tree', () => {
     const tree = loadTreeFromDir(path.join(__dirname, 'cloud-assembly-trees', 'foo'));
-    expect(tree).toEqual({});
+    expect(tree).toEqual(undefined);
   });
 });


### PR DESCRIPTION
This allows publishing notices that match against the version of Node we're executing on.

Implemented by generalizing the code that matches against CLI version and bootstrap versions: it can now match against arbitrary named components.

Also implement more complex matching rules: currently we match the pattern if one of them matches:

```ts
// Matches if one of A, B or C matches
components: [A, B, C]
```

Instead, generalize to Disjunctive Normal Form and treat the current case as a special case of DNF where every conjunction has one element: 

```ts
// The above gets interpreted as
components: [[A], [B], [C]]

// More complex rules: A and B together, or C
components: [[A, B], [C]]
```

This way we can write rules to say that "component X on Node version Y" should get a notice.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
