### PR TITLE
docs(toolkit-lib): include `VERSION` file

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1204,18 +1204,19 @@ for (const tsconfig of [toolkitLib.tsconfigDev]) {
   }
 }
 
+// Ad a command for the docs
 const toolkitLibDocs = toolkitLib.addTask('docs', {
   exec: 'typedoc lib/index.ts',
   receiveArgs: true,
 });
-toolkitLib.packageTask.spawn(toolkitLibDocs, {
-  // the nested directory is important
-  // the zip file needs to have this structure when created
-  args: ['--out dist/docs/cdk/api/toolkit-lib'],
-});
-toolkitLib.packageTask.exec('zip -r ../docs.zip cdk ', {
-  cwd: 'dist/docs',
-});
+
+// When packaging, output the docs into a specific nested directory
+// This is required because the zip file needs to have this structure when created
+toolkitLib.packageTask.spawn(toolkitLibDocs, { args: ['--out dist/docs/cdk/api/toolkit-lib'] });
+// The docs build needs the version in a specific file at the nested root
+toolkitLib.packageTask.exec('(cat dist/version.txt || echo "latest") > dist/docs/cdk/api/toolkit-lib/VERSION');
+// Zip the whole thing up, again paths are important here to get the desired folder structure
+toolkitLib.packageTask.exec('zip -r ../docs.zip cdk', { cwd: 'dist/docs' });
 
 toolkitLib.addTask('publish-local', {
   exec: './build-tools/package.sh',

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -158,7 +158,10 @@
           ]
         },
         {
-          "exec": "zip -r ../docs.zip cdk ",
+          "exec": "(cat dist/version.txt || echo \"latest\") > dist/docs/cdk/api/toolkit-lib/VERSION"
+        },
+        {
+          "exec": "zip -r ../docs.zip cdk",
           "cwd": "dist/docs"
         }
       ]


### PR DESCRIPTION
The docs build requires this file to contain the current version number.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
