### PR TITLE
chore: github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug-report.yml
+++ b/.github/ISSUE_TEMPLATES/bug-report.yml
@@ -1,0 +1,144 @@
+---
+name: "🐛 Bug Report"
+description: Report a bug
+title: "(module name): (short issue description)"
+labels: [bug, needs-triage]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+        **⚠️ Please read this before filling out the form below:**  
+        If the bug you are reporting is a security-related issue or a security vulnerability,
+        please report it via [Report a security vulnerability](https://github.com/aws/aws-cdk/security/advisories/new) instead of this template.
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: What is the problem? A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: checkboxes
+    id: regression
+    attributes:
+      label: Regression Issue
+      description:  What is a regression? If it worked in a previous version but doesn’t in the latest version, it’s considered a regression. In this case, please provide specific version number in the report.
+      options:
+        - label: Select this option if this issue appears to be a regression.
+          required: false
+  - type: input
+    id: working-version
+    attributes:
+      label: Last Known Working CDK Version
+      description: Specify the last known CDK version where this code was functioning as expected (if applicable).
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: |
+        What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: current
+    attributes:
+      label: Current Behavior
+      description: |
+        What actually happened?
+        
+        Please include full errors, uncaught exceptions, stack traces, and relevant logs.
+        If service responses are relevant, please include wire logs.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction Steps
+      description: |
+        Provide a self-contained, concise snippet of code that can be used to reproduce the issue.
+        For more complex issues provide a repo with the smallest sample that reproduces the bug.
+        
+        Avoid including business logic or unrelated code, it makes diagnosis more difficult.
+        The code sample should be an SSCCE. See http://sscce.org/ for details. In short, please provide a code sample that we can copy/paste, run and reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Possible Solution
+      description: |
+        Suggest a fix/reason for the bug
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Information/Context
+      description: |
+        Anything else that might be relevant for troubleshooting this bug. Providing context helps us come up with a solution that is most useful in the real world.
+    validations:
+      required: false
+
+  - type: input
+    id: cdk-version
+    attributes:
+      label: CDK CLI Version
+      description: Output of `cdk version`
+    validations:
+      required: true
+
+  - type: input
+    id: framework-version
+    attributes:
+      label: Framework Version
+    validations:
+      required: false
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+    validations:
+      required: true
+
+  - type: input
+    id: operating-system
+    attributes:
+      label: OS
+    validations:
+      required: true
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      multiple: true
+      options:
+        - TypeScript
+        - Python
+        - .NET
+        - Java
+        - Go
+    validations:
+      required: true
+
+  - type: input
+    id: language-version
+    attributes:
+      label: Language Version
+      description: E.g. TypeScript (3.8.3) | Java (8) | Python (3.7.3)
+    validations:
+      required: false
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Other information
+      description: |
+        e.g. detailed explanation, stacktraces, related issues, suggestions how to fix, links for us to have context, eg. associated pull-request, stackoverflow, slack, etc
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATES/feature-request.yml
+++ b/.github/ISSUE_TEMPLATES/feature-request.yml
@@ -1,0 +1,59 @@
+---
+name: 🚀 Feature Request
+description: Suggest an idea for this project
+title: "(module name): (short issue description)"
+labels: [feature-request, needs-triage]
+assignees: []
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the feature
+      description: A clear and concise description of the feature you are proposing.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: |
+        Why do you need this feature? For example: "I'm always frustrated when..."
+    validations:
+        required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Suggest how to implement the addition or change. Please include prototype/workaround/sketch/reference implementation.
+    validations:
+      required: false
+  - type: textarea
+    id: other
+    attributes:
+      label: Other Information
+      description: |
+        Any alternative solutions or features you considered, a more detailed explanation, stack traces, related issues, links for context, etc.
+    validations:
+      required: false
+  - type: checkboxes
+    id: ack
+    attributes:
+      label: Acknowledgements
+      options:
+        - label: I may be able to implement this feature request
+          required: false
+        - label: This feature might incur a breaking change
+          required: false
+  - type: input
+    id: sdk-version
+    attributes:
+      label: CDK version used
+    validations:
+      required: true
+  - type: input
+    id: environment
+    attributes:
+      label: Environment details (OS name and version, etc.)
+    validations:
+        required: true

--- a/.github/ISSUE_TEMPLATES/notice.yml
+++ b/.github/ISSUE_TEMPLATES/notice.yml
@@ -1,0 +1,58 @@
+---
+name: "❗ Notice"
+description: Post a notice for a high impact issue. Internal CDK team use only.
+title: "❗ NOTICE (module name): (short notice description)"
+labels: [needs-triage, management/tracking]
+body:
+  - type: dropdown
+    attributes:
+      label: Status
+      description: What is the current status of this issue?
+      options:
+        - Investigating (Default)
+        - In-Progress
+        - Resolved
+    validations:
+      required: true        
+  - type: textarea
+    attributes:
+      label: What is the issue?
+      description: A clear and concise description of the issue you want customers to be aware of
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Error message
+      description: If available, paste the error message users are seeing (no need to backticks)
+      render: console
+  - type: textarea
+    attributes:
+      label: What is the impact?
+      description: |
+        What can occur if this issue isn't addressed?
+    validations:
+        required: true
+  - type: textarea
+    attributes:
+      label: Workaround
+      description: |
+        Please provide a detailed workaround outlining all steps required for implementation. If none exist yet, leave blank
+  - type: textarea
+    attributes:
+      label: Who is affected?
+      description: |
+        What segment of customers are affected? Think about specific construct usage, version, feature toggles, etc...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How do I resolve this?
+      description: |
+        What actions should customers take to resolve the issue. Also elaborate on any code changes the customer may need to do. If unknown yet, say TBD
+    validations:
+      required: true        
+  - type: textarea
+    attributes:
+      label: Related issues
+      description: |
+        List all related issues here. If none related, leave blank


### PR DESCRIPTION
Grrr, no projen support: https://github.com/projen/projen/issues/3567. I'm lazy so I just copied and pasted a few from the aws-cdk repo. This is somewhat necessary because it adds the `needs-triage` label automatically, that my other PR will need: https://github.com/aws/aws-cdk-cli/pull/118

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
