### PR TITLE
chore(toolkit-lib): role duration and session tags don't work

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1003,9 +1003,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-duration-seconds: 14400
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
-          role-session-name: releasing@aws-cdk-cli
+          role-session-name: standalone-release@aws-cdk-cli
           output-credentials: true
           mask-aws-account-id: true
       - name: Publish artifacts
@@ -1036,10 +1035,8 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-duration-seconds: 14400
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
-          role-session-name: releasing@aws-cdk-cli
-          output-credentials: true
+          role-session-name: publish-timestamps@aws-cdk-cli
           mask-aws-account-id: true
       - name: Publish artifacts
         run: |-
@@ -1064,17 +1061,17 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-duration-seconds: 14400
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
-          role-session-name: releasing@aws-cdk-cli
+          role-session-name: s3-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
       - name: Assume the publishing role
         id: publishing-creds
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-region: us-east-1
-          role-duration-seconds: 14400
           role-to-assume: ${{ vars.PUBLISH_TOOLKIT_LIB_DOCS_ROLE_ARN }}
-          role-session-name: s3publishing@aws-cdk-cli
+          role-session-name: s3-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
           role-chaining: true
       - name: Publish docs
         env:

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -59,9 +59,8 @@ export class AdcPublishing extends Component {
           uses: 'aws-actions/configure-aws-credentials@v4',
           with: {
             'aws-region': 'us-east-1',
-            'role-duration-seconds': 14400,
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
-            'role-session-name': 'releasing@aws-cdk-cli',
+            'role-session-name': 'standalone-release@aws-cdk-cli',
             'output-credentials': true,
             'mask-aws-account-id': true,
           },

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -48,10 +48,8 @@ export class RecordPublishingTimestamp extends Component {
           uses: 'aws-actions/configure-aws-credentials@v4',
           with: {
             'aws-region': 'us-east-1',
-            'role-duration-seconds': 14400,
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
-            'role-session-name': 'releasing@aws-cdk-cli',
-            'output-credentials': true,
+            'role-session-name': 'publish-timestamps@aws-cdk-cli',
             'mask-aws-account-id': true,
           },
         },

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -71,9 +71,9 @@ export class S3DocsPublishing extends Component {
           uses: 'aws-actions/configure-aws-credentials@v4',
           with: {
             'aws-region': 'us-east-1',
-            'role-duration-seconds': 14400,
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
-            'role-session-name': 'releasing@aws-cdk-cli',
+            'role-session-name': 's3-docs-publishing@aws-cdk-cli',
+            'mask-aws-account-id': true,
           },
         },
         {
@@ -82,9 +82,9 @@ export class S3DocsPublishing extends Component {
           uses: 'aws-actions/configure-aws-credentials@v4',
           with: {
             'aws-region': 'us-east-1',
-            'role-duration-seconds': 14400,
             'role-to-assume': this.props.roleToAssume,
-            'role-session-name': 's3publishing@aws-cdk-cli',
+            'role-session-name': 's3-docs-publishing@aws-cdk-cli',
+            'mask-aws-account-id': true,
             'role-chaining': true,
           },
         },


### PR DESCRIPTION
Fixes another few issues with various publishing jobs:

- Role chaining doesn't actually work with a [session duration over one hour.](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html#:~:text=However%2C%20if%20you%20assume%20a%20role%20using%20role%20chaining%20and%20provide%20a%20DurationSeconds%20parameter%20value%20greater%20than%20one%20hour%2C%20the%20operation%20fails.)
- Also I realized none of these job actually take that long. This was a copy-and-paste fail from the integ-tests (which do take longer). So let's go back to a shorter duration for these jobs
- Use different session names for all jobs
- Consistently use `mask-aws-account-id` everywhere.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
