### PR TITLE
chore: add checkout step for ADC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,6 +990,8 @@ jobs:
     environment: releasing
     if: ${{ needs.release.outputs.latest_commit == github.sha }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -39,6 +39,7 @@ export class AdcPublishing extends Component {
       },
       if: '${{ needs.release.outputs.latest_commit == github.sha }}',
       steps: [
+        github.WorkflowSteps.checkout(),
         {
           uses: 'actions/setup-node@v4',
           with: {


### PR DESCRIPTION
This tries to run a script from the source repo, so it should checkout the source otherwise the script isn't going to be there 😭.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
