### PR TITLE
chore: enable `unbound-method` eslint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -316,6 +316,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cdk-build-tools/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-build-tools/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cdk-cli-wrapper/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cli-lib-alpha/.eslintrc.json
+++ b/packages/@aws-cdk/cli-lib-alpha/.eslintrc.json
@@ -303,6 +303,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cloud-assembly-schema/lib/manifest.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/manifest.ts
@@ -259,7 +259,7 @@ export class Manifest {
    * Ideally, we would start writing the `camelCased` and translate to how CloudFormation expects it when needed. But this requires nasty
    * backwards-compatibility code and it just doesn't seem to be worth the effort.
    */
-  private static patchStackTagsOnRead(manifest: assembly.AssemblyManifest) {
+  private static patchStackTagsOnRead(this: void, manifest: assembly.AssemblyManifest) {
     return Manifest.replaceStackTags(manifest, (tags) =>
       tags.map((diskTag: any) => ({
         key: diskTag.Key,
@@ -273,6 +273,7 @@ export class Manifest {
    * should have dedicated properties preceding this (e.g `assumeRoleArn` and `assumeRoleExternalId`).
    */
   private static validateAssumeRoleAdditionalOptions(
+    this: void,
     instance: any,
     key: string,
     _schema: jsonschema.Schema,
@@ -301,7 +302,7 @@ export class Manifest {
    *
    * Translate stack tags metadata if it has the "right" casing.
    */
-  private static patchStackTagsOnWrite(manifest: assembly.AssemblyManifest) {
+  private static patchStackTagsOnWrite(this: void, manifest: assembly.AssemblyManifest) {
     return Manifest.replaceStackTags(manifest, (tags) =>
       tags.map(
         (memTag) =>

--- a/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
+++ b/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/node-bundle/.eslintrc.json
+++ b/packages/@aws-cdk/node-bundle/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -303,6 +303,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -501,7 +501,7 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
 
     const stacksAndTheirAssetManifests = stacks.flatMap((stack) => [
       stack,
-      ...stack.dependencies.filter(cxapi.AssetManifestArtifact.isAssetManifestArtifact),
+      ...stack.dependencies.filter(x => cxapi.AssetManifestArtifact.isAssetManifestArtifact(x)),
     ]);
     const workGraph = new WorkGraphBuilder({ ioHost, action }, prebuildAssets).build(stacksAndTheirAssetManifests);
 

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-bufferedconsole.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-bufferedconsole.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies,@typescript-eslint/unbound-method */
 /**
  * A Jest environment that buffers outputs to `console.log()` and only shows it for failing tests.
  */

--- a/packages/@aws-cdk/user-input-gen/.eslintrc.json
+++ b/packages/@aws-cdk/user-input-gen/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/yarn-cling/.eslintrc.json
+++ b/packages/@aws-cdk/yarn-cling/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -304,6 +304,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/aws-cdk/lib/api/work-graph/work-graph-builder.ts
+++ b/packages/aws-cdk/lib/api/work-graph/work-graph-builder.ts
@@ -177,8 +177,8 @@ export class WorkGraphBuilder {
 
 function stacksFromAssets(artifacts: cxapi.CloudArtifact[]) {
   const ret = new Map<cxapi.AssetManifestArtifact, cxapi.CloudFormationStackArtifact>();
-  for (const stack of artifacts.filter(cxapi.CloudFormationStackArtifact.isCloudFormationStackArtifact)) {
-    const assetArtifacts = stack.dependencies.filter(cxapi.AssetManifestArtifact.isAssetManifestArtifact);
+  for (const stack of artifacts.filter(x => cxapi.CloudFormationStackArtifact.isCloudFormationStackArtifact(x))) {
+    const assetArtifacts = stack.dependencies.filter((x) => cxapi.AssetManifestArtifact.isAssetManifestArtifact(x));
     for (const art of assetArtifacts) {
       ret.set(art, stack);
     }
@@ -188,5 +188,5 @@ function stacksFromAssets(artifacts: cxapi.CloudArtifact[]) {
 }
 
 function onlyStacks(artifacts: cxapi.CloudArtifact[]) {
-  return artifacts.filter(cxapi.CloudFormationStackArtifact.isCloudFormationStackArtifact);
+  return artifacts.filter(x => cxapi.CloudFormationStackArtifact.isCloudFormationStackArtifact(x));
 }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -581,7 +581,7 @@ export class CdkToolkit {
 
     const stacksAndTheirAssetManifests = stacks.flatMap((stack) => [
       stack,
-      ...stack.dependencies.filter(cxapi.AssetManifestArtifact.isAssetManifestArtifact),
+      ...stack.dependencies.filter(x => cxapi.AssetManifestArtifact.isAssetManifestArtifact(x)),
     ]);
     const workGraph = new WorkGraphBuilder({
       ioHost: this.ioHost,

--- a/packages/aws-cdk/test/jest-bufferedconsole.ts
+++ b/packages/aws-cdk/test/jest-bufferedconsole.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable import/no-extraneous-dependencies,@typescript-eslint/unbound-method */
 /**
  * A Jest environment that buffers outputs to `console.log()` and only shows it for failing tests.
  */

--- a/packages/cdk-assets/.eslintrc.json
+++ b/packages/cdk-assets/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/cdk/.eslintrc.json
+++ b/packages/cdk/.eslintrc.json
@@ -306,6 +306,7 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       }
     ],
+    "@typescript-eslint/unbound-method": "error",
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/projenrc/eslint.ts
+++ b/projenrc/eslint.ts
@@ -165,6 +165,9 @@ export const ESLINT_RULES = {
     ],
   }],
 
+  // Unbound methods are a JavaScript footgun
+  'unbound-method': 'error',
+
   // Overrides for plugin:jest/recommended
   'jest/expect-expect': 'off',
   'jest/no-conditional-expect': 'off',

--- a/projenrc/eslint.ts
+++ b/projenrc/eslint.ts
@@ -166,7 +166,7 @@ export const ESLINT_RULES = {
   }],
 
   // Unbound methods are a JavaScript footgun
-  'unbound-method': 'error',
+  '@typescript-eslint/unbound-method': 'error',
 
   // Overrides for plugin:jest/recommended
   'jest/expect-expect': 'off',


### PR DESCRIPTION
Unbound method calls using `this` are likely to have unintended effects.

Here is an example with static methods, but the same thing applies to object methods:

```ts
class Class {
  public static staticMethod() {
    this.otherStaticMethod()
  }

  public static otherStaticMethod() { }
}

// ✅ valid
Class.staticMethod();

// ❌ boom
const x = Class.staticMethod;
x();
```

When assigning a method to a variable, you need to take extra care and this linter rule is going to remind you.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
