### PR TITLE
fix(cli): `[object Object]` in error message when CcApiContextProviderPlugin `listResources` throws

### DIFF
--- a/packages/aws-cdk/lib/context-providers/cc-api-provider.ts
+++ b/packages/aws-cdk/lib/context-providers/cc-api-provider.ts
@@ -120,7 +120,7 @@ export class CcApiContextProviderPlugin implements ContextProviderPlugin {
         }
       });
     } catch (err) {
-      throw new ContextProviderError(`Could not get resources ${propertyMatch}. Error: ${err}`);
+      throw new ContextProviderError(`Could not get resources ${JSON.stringify(propertyMatch)}. Error: ${err}`);
     }
     return resultObjs;
   }

--- a/packages/aws-cdk/test/context-providers/cc-api-provider.test.ts
+++ b/packages/aws-cdk/test/context-providers/cc-api-provider.test.ts
@@ -188,6 +188,22 @@ test('looks up RDS instance using CC API listResources - nested prop', async () 
   expect(results.length).toEqual(1);
 });
 
+test('looks up RDS instance using CC API listResources - error in CC API', async () => {
+  // GIVEN
+  mockCloudControlClient.on(ListResourcesCommand).rejects('No data found');
+
+  await expect(
+    // WHEN
+    provider.getValue({
+      account: '123456789012',
+      region: 'us-east-1',
+      typeName: 'AWS::RDS::DBInstance',
+      propertyMatch: { 'Endpoint.Port': '5432' },
+      propertiesToReturn: ['DBInstanceArn', 'StorageEncrypted'],
+    }),
+  ).rejects.toThrow('Could not get resources {"Endpoint.Port":"5432"}.'); // THEN
+});
+
 test('error by specifying both exactIdentifier and propertyMatch', async () => {
   // GIVEN
   mockCloudControlClient.on(GetResourceCommand).resolves({


### PR DESCRIPTION
Interporating `propertyMatch` directly in error message causes `[object Object]` representation because it's an object.
This PR wraps it in `JSON.stringify()` to fix the message correctly.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
