### PR TITLE
chore: update to latest version of integ workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -23,6 +23,10 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
+      - name: Fetch tags from origin repo
+        run: |-
+          git remote add upstream git@github.com:aws/aws-cdk-cli.git
+          git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -39,7 +39,6 @@
     },
     {
       "name": "cdklabs-projen-project-types",
-      "version": "^0.1.220",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -164,7 +164,7 @@ const repoProject = new yarn.Monorepo({
 
   defaultReleaseBranch: 'main',
   devDeps: [
-    'cdklabs-projen-project-types@^0.1.220',
+    'cdklabs-projen-project-types',
     'glob',
     'semver',
     `@aws-sdk/client-s3@${CLI_SDK_V3_RANGE}`,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1328,11 +1328,11 @@ const APPROVAL_ENVIRONMENT = 'integ-approval';
 const TEST_ENVIRONMENT = 'run-tests';
 
 new CdkCliIntegTestsWorkflow(repo, {
+  sourceRepo: 'aws/aws-cdk-cli',
   approvalEnvironment: APPROVAL_ENVIRONMENT,
   testEnvironment: TEST_ENVIRONMENT,
   buildRunsOn: POWERFUL_RUNNER,
   testRunsOn: POWERFUL_RUNNER,
-  expectNewCliLibVersion: true,
 
   localPackages: [
     // CloudAssemblySchema is not in this list because in the way we're doing

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^22.13.5",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "cdklabs-projen-project-types": "^0.1.220",
+    "cdklabs-projen-project-types": "^0.2.0",
     "constructs": "^10.0.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4873,10 +4873,10 @@ cdk-from-cfn@^0.191.0:
   resolved "https://registry.yarnpkg.com/cdk-from-cfn/-/cdk-from-cfn-0.191.0.tgz#47af22686f5f85cee50b1628b0a2b1a4a8719909"
   integrity sha512-j+TKUSmje5iSiOQzWstH/BkrsL8L9WV57zXll+BHlGT8w5wTrou4dZvNvFQWELW9aaS+UBX0ivsJRZwuO7GiIw==
 
-cdklabs-projen-project-types@^0.1.220:
-  version "0.1.234"
-  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.1.234.tgz#2d46f793c1d0ef398b8d3006ad52c235b72e8b83"
-  integrity sha512-fx7FQ9s4C1gici/dQRIE0bKaaYqrMJn2AcwVYrCynXhsQ4pRZRtOCRLfDSFFVrqABPAvLgEcVu45sW3mSxU5yg==
+cdklabs-projen-project-types@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.0.tgz#e8ab5a8ecaf5e37288eab413d80d0112910b2d59"
+  integrity sha512-MpCGaljcyDBtkLABsMcPTPfIqk9upqv6OYWIqvPiUmtVBvyhLDJZzgGHE6ceLZY1PRjpAC7US57ANtVpS0/1Dw==
   dependencies:
     yaml "^2.7.0"
 


### PR DESCRIPTION
This one should also work from forks.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
