### PR TITLE
feat(cdk-assets): release official GA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -549,7 +549,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_REF: ${{ github.sha }}
-        run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF -p 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+        run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
   cdk-assets_release_npm:
     name: "cdk-assets: Publish to npm"
     needs: release

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -627,7 +627,6 @@ const cdkAssets = configureProject(
       },
     ],
     npmDistTag: 'v3-latest',
-    prerelease: 'rc',
     majorVersion: 3,
 
     jestOptions: jestOptionsForProject({

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -34,8 +34,7 @@
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
-        "MAJOR": "3",
-        "PRERELEASE": "rc"
+        "MAJOR": "3"
       },
       "steps": [
         {


### PR DESCRIPTION
Remove the prerelease tag from `cdk-assets`. This tool is ready to be used for real.

We are still releasing under the `v3-latest` tag, so CDK Pipelines users won't automatically switch over to it just yet, but this is sending the right signal about the tool's stability and fitness for purpose.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
