### PR TITLE
chore(adc): install dependencies before publishing

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -22,10 +22,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          fetch-depth: 0
       - name: Fetch tags from origin repo
         run: |-
-          git remote add upstream git@github.com:aws/aws-cdk-cli.git
+          git remote add upstream https://github.com/aws/aws-cdk-cli.git
           git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -22,9 +22,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          fetch-depth: 0
       - name: Fetch tags from origin repo
         run: |-
-          git remote add upstream https://github.com/aws/aws-cdk-cli.git
+          git remote add upstream git@github.com:aws/aws-cdk-cli.git
           git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -995,6 +995,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: lts/*
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -47,6 +47,10 @@ export class AdcPublishing extends Component {
           },
         },
         {
+          name: 'Install dependencies',
+          run: 'yarn install --check-files --frozen-lockfile',
+        },
+        {
           name: 'Download build artifacts',
           uses: 'actions/download-artifact@v4',
           with: {


### PR DESCRIPTION
Otherwise we can't find the AWS SDK dependencies that we need.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
