### PR TITLE
chore: mask bucket name in s3 docs publishing step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1080,7 +1080,7 @@ jobs:
           BUCKET_NAME: ${{ vars.DOCS_BUCKET_NAME }}
           DOCS_STREAM: toolkit-lib
         run: |-
-          ::add-mask::$BUCKET_NAME
+          echo ::add-mask::$BUCKET_NAME
           echo "S3_PATH=$DOCS_STREAM/aws-cdk-toolkit-lib-v$(cat dist/version.txt).zip" >> "$GITHUB_ENV"
           echo "S3_URI=s3://$BUCKET_NAME/$S3_PATH" >> "$GITHUB_ENV"
           echo "LATEST=latest-toolkit-lib" >> "$GITHUB_ENV"

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -95,7 +95,7 @@ export class S3DocsPublishing extends Component {
             DOCS_STREAM: this.props.docsStream,
           },
           run: [
-            '::add-mask::$BUCKET_NAME', // always hide bucket name
+            'echo ::add-mask::$BUCKET_NAME', // always hide bucket name
 
             // setup paths
             `echo "S3_PATH=$DOCS_STREAM/${safeName}-v$(cat dist/version.txt).zip" >> "$GITHUB_ENV"`,


### PR DESCRIPTION
Actually mask the bucket name in s3 docs publishing logs. This isn't a secret, so it's not bad. The logs for the one run that did accidentally print the name have already been deleted.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
