### PR TITLE
chore: change SSM timestamp name to `cli-npm`

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -143,7 +143,9 @@ jobs:
           - init-typescript-lib
           - tool-integrations
   integ:
-    needs: integ_matrix
+    needs:
+      - prepare
+      - integ_matrix
     runs-on: aws-cdk_ubuntu-latest_4-core
     permissions: {}
     if: always()
@@ -151,5 +153,5 @@ jobs:
       - name: Integ test result
         run: echo ${{ needs.integ_matrix.result }}
       - name: Set status based on matrix job
-        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result) }}
+        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.prepare.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result)) }}
         run: exit 1

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -143,9 +143,7 @@ jobs:
           - init-typescript-lib
           - tool-integrations
   integ:
-    needs:
-      - prepare
-      - integ_matrix
+    needs: integ_matrix
     runs-on: aws-cdk_ubuntu-latest_4-core
     permissions: {}
     if: always()
@@ -153,5 +151,5 @@ jobs:
       - name: Integ test result
         run: echo ${{ needs.integ_matrix.result }}
       - name: Set status based on matrix job
-        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.prepare.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result)) }}
+        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result) }}
         run: exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1044,8 +1044,8 @@ jobs:
           mask-aws-account-id: true
       - name: Publish artifacts
         run: |-
-          aws ssm put-parameter --name "/published/cdk/cli/version" --type "String" --value "${{ steps.aws-cdk-version.outputs.version }}" --overwrite
-          aws ssm put-parameter --name "/published/cdk/cli/timestamp" --type "String" --value "$(date +%s)" --overwrite
+          aws ssm put-parameter --name "/published/cdk/cli-npm/version" --type "String" --value "${{ steps.aws-cdk-version.outputs.version }}" --overwrite
+          aws ssm put-parameter --name "/published/cdk/cli-npm/timestamp" --type "String" --value "$(date +%s)" --overwrite
   aws-cdk-toolkit-lib_release_docs:
     name: "@aws-cdk/toolkit-lib: Publish docs to S3"
     needs: aws-cdk-toolkit-lib_release_npm

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -11,7 +11,7 @@ export class RecordPublishingTimestamp extends Component {
   }
 
   public preSynthesize() {
-    const ssmPrefix = '/published/cdk/cli';
+    const ssmPrefix = '/published/cdk/cli-npm';
 
     const releaseWf = this.project_.github?.tryFindWorkflow('release');
     if (!releaseWf) {


### PR DESCRIPTION
We used to publish under the key name `cli`, but the library publishing process is writing timestamps under `npm`, `pypi`, etc.

Having the keys

* `npm`
* `pypi`
* `nuget`
* ...
* `cli`

Was confusing, so we're changing it to `cli-npm` instead.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
