### PR TITLE
fix(toolkit-lib): `ToolkitError` is not exported

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1174,6 +1174,7 @@ const toolkitLib = configureProject(
       tmpToolkitHelpers,
       'aws-cdk-lib',
       'aws-sdk-client-mock',
+      'dts-bundle-generator',
       'esbuild',
       'typedoc',
     ],

--- a/packages/@aws-cdk/toolkit-lib/.projen/deps.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/deps.json
@@ -70,6 +70,10 @@
       "type": "build"
     },
     {
+      "name": "dts-bundle-generator",
+      "type": "build"
+    },
+    {
       "name": "esbuild",
       "type": "build"
     },

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -51,7 +51,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@smithy/types,@stylistic/eslint-plugin,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,projen,ts-jest,typedoc,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-stream,@smithy/util-waiter,archiver,cdk-from-cfn,glob,json-diff,minimatch,promptly,proxy-agent,semver,split2,uuid"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@smithy/types,@stylistic/eslint-plugin,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,dts-bundle-generator,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,projen,ts-jest,typedoc,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-stream,@smithy/util-waiter,archiver,cdk-from-cfn,glob,json-diff,minimatch,promptly,proxy-agent,semver,split2,uuid"
         }
       ]
     },

--- a/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
+++ b/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
@@ -2,13 +2,34 @@ import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import * as esbuild from 'esbuild';
 import * as fs from 'fs-extra';
+import { generateDtsBundle } from 'dts-bundle-generator';
 
+// copy files
 const require = createRequire(import.meta.url);
-
 const cliPackage = path.dirname(require.resolve('aws-cdk/package.json'));
-let copyFromCli = (from, to = undefined) => {
+const copyFromCli = (from, to = undefined) => {
   return fs.copy(path.join(cliPackage, ...from), path.join(process.cwd(), ...(to ?? from)));
 };
+
+// declaration bundling
+const bundleDeclarations = async (entryPoints) => {
+  const results = generateDtsBundle(entryPoints.map(filePath => ({
+    filePath,
+    output: {
+      noBanner: true,
+      exportReferencedTypes: false,
+    },
+  })), { preferredConfigPath: 'tsconfig.dev.json' });
+
+  const files = [];
+  for (const [idx, declaration] of results.entries()) {
+    const outputPath = path.format({ ...path.parse(entryPoints[idx]), base: '', ext: '.d.ts' });
+    files.push(fs.promises.writeFile(outputPath, declaration));
+  }
+
+  return Promise.all(files);
+}
+
 
 // This is a build script, we are fine
 // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
@@ -17,16 +38,17 @@ await Promise.all([
   copyFromCli(['/db.json.gz']),
   copyFromCli(['lib', 'index_bg.wasm']),
   copyFromCli(['lib', 'api', 'bootstrap', 'bootstrap-template.yaml']),
+
+  // cdk init is not yet available in the toolkit-lib
+  // copyFromCli(['lib', 'init-templates']),
 ]);
 
-// # Copy all resources that aws_cdk/generate.sh produced, and some othersCall the generator for the
-// cp -R $aws_cdk/lib/init-templates ./lib/
-
+// bundle entrypoints from the library packages
 await esbuild.build({
   outdir: 'lib',
   entryPoints: [
     'lib/api/aws-cdk.ts',
-    'lib/api/shared-public.ts', 
+    'lib/api/shared-public.ts',
     'lib/private/util.ts',
   ],
   target: 'node18',
@@ -35,3 +57,6 @@ await esbuild.build({
   sourcemap: true,
   bundle: true,
 });
+
+// for the shared public API we also need to bundle the types
+await bundleDeclarations(['lib/api/shared-public.ts']);

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -49,6 +49,7 @@
     "aws-sdk-client-mock": "^4.1.0",
     "commit-and-tag-version": "^12",
     "constructs": "^10.0.0",
+    "dts-bundle-generator": "^9.5.1",
     "esbuild": "^0.25.0",
     "eslint": "^9",
     "eslint-config-prettier": "^10.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5537,6 +5537,14 @@ dreamopt@~0.8.0:
   dependencies:
     wordwrap ">=0.0.2"
 
+dts-bundle-generator@^9.5.1:
+  version "9.5.1"
+  resolved "https://registry.yarnpkg.com/dts-bundle-generator/-/dts-bundle-generator-9.5.1.tgz#7eac7f47a2d5b51bdaf581843e7f969b88bfc225"
+  integrity sha512-DxpJOb2FNnEyOzMkG11sxO2dmxPjthoVWxfKqWYJ/bI/rT1rvTMktF5EKjAYrRZu6Z6t3NhOUZ0sZ5ZXevOfbA==
+  dependencies:
+    typescript ">=5.0.2"
+    yargs "^17.6.0"
+
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
@@ -10318,7 +10326,7 @@ typescript@5.6, typescript@~5.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-typescript@^5.7.3, typescript@^5.8.2:
+typescript@>=5.0.2, typescript@^5.7.3, typescript@^5.8.2:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
@@ -10739,7 +10747,7 @@ yargs@^16.0.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17.1.1, yargs@^17.3.1, yargs@^17.6.2, yargs@^17.7.2:
+yargs@^17.1.1, yargs@^17.3.1, yargs@^17.6.0, yargs@^17.6.2, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
Fixes `'@aws-cdk/toolkit-lib' has no exported member named 'ToolkitError'`

Because we are now moving parts of the public API into a shared package, we also need to export the respective types.
During the regular build, type declarations are not bundled. So we need to take care of it afterwards.
This is not ideal, but required. Thankfully the temporary package is a, well, temporary construct and we are actively working to get rid of it (first by adding new stuff, then by moving everything to `toolkit-lib`).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
