### PR TITLE
chore: publish `cdk-assets` as `latest`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -572,7 +572,7 @@ jobs:
         continue-on-error: true
       - name: Release
         env:
-          NPM_DIST_TAG: v3-latest
+          NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -638,7 +638,6 @@ const cdkAssets = configureProject(
         run: 'npx projen shrinkwrap',
       },
     ],
-    npmDistTag: 'v3-latest',
     majorVersion: 3,
 
     jestOptions: jestOptionsForProject({


### PR DESCRIPTION
We are currently running `cdk-assets` v3 as `latest`, and it is working fine. Make this the official disttag for this version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
