### PR TITLE
chore: use the same typescript version everywhere

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -25,6 +25,7 @@
     },
     {
       "name": "@types/node",
+      "version": "ts5.6",
       "type": "build"
     },
     {
@@ -99,6 +100,7 @@
     },
     {
       "name": "typescript",
+      "version": "5.6",
       "type": "build"
     }
   ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -175,6 +175,7 @@ const repoProject = new yarn.Monorepo({
   repository: 'https://github.com/aws/aws-cdk-cli',
 
   defaultReleaseBranch: 'main',
+  typescriptVersion: TYPESCRIPT_VERSION,
   devDeps: [
     'cdklabs-projen-project-types',
     'glob',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@aws-sdk/lib-storage": "^3",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@stylistic/eslint-plugin": "^3.1.0",
-    "@types/node": "^22.13.8",
+    "@types/node": "ts5.6",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
     "cdklabs-projen-project-types": "^0.2.2",
@@ -43,7 +43,7 @@
     "projen": "^0.91.13",
     "semver": "^7.7.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "5.6"
   },
   "engines": {
     "node": ">= 14.15.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,7 +3613,7 @@
   resolved "https://registry.yarnpkg.com/@types/mockery/-/mockery-1.4.33.tgz#fb511e702e38b67e95af8b1375a65350b3fb5cab"
   integrity sha512-vpuuVxCnCEM0OakYNoyFs40mjJFJFJahBHyx0Z0Piysof+YwlDJzNO4V1weRvYySAmtAvlb0UHtxVO2IfTcykw==
 
-"@types/node@*", "@types/node@^22.13.8":
+"@types/node@*":
   version "22.13.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.8.tgz#57e2450295b33a6518d6fd4f65f47236d3e41d8d"
   integrity sha512-G3EfaZS+iOGYWLLRCEAXdWK9my08oHNZ+FHluRiggIYJPOXzhOiDgpVCUHaUvyIC5/fj7C/p637jdzC666AOKQ==
@@ -3636,6 +3636,13 @@
   integrity sha512-m1ilZCTwKLkk9rruBJXFeYN0Bc5SbjirwYX/Td3MqPfioYbgun3IvK/m8dQxMCnrPGZPg1kvXjp3SIekCN/ynw==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@ts5.6":
+  version "22.13.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.9.tgz#5d9a8f7a975a5bd3ef267352deb96fb13ec02eca"
+  integrity sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==
+  dependencies:
+    undici-types "~6.20.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -10326,7 +10333,7 @@ typescript@5.6, typescript@~5.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.6.3.tgz#5f3449e31c9d94febb17de03cc081dd56d81db5b"
   integrity sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==
 
-typescript@>=5.0.2, typescript@^5.7.3, typescript@^5.8.2:
+typescript@>=5.0.2, typescript@^5.7.3:
   version "5.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.2.tgz#8170b3702f74b79db2e5a96207c15e65807999e4"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==


### PR DESCRIPTION
I was getting warnings from eslint plugins about an unsupported typescript version (5.8). Then I noticed that the monorepo root is the only package that doesn't use the "global" version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
