### PR TITLE
fix: handle cross-device link error in build-standalone-zip task

### DIFF
--- a/projenrc/build-standalone-zip.task.ts
+++ b/projenrc/build-standalone-zip.task.ts
@@ -35,7 +35,11 @@ async function main() {
 
     await fs.mkdir('dist/standalone', { recursive: true });
     await fs.rm(path.join('dist/standalone/', zipFileName), { force: true });
-    await fs.rename(path.join(outdir, zipFileName), path.join('dist/standalone/', zipFileName));
+    // Use copyFile instead of rename to avoid cross-device link errors
+    const sourcePath = path.join(outdir, zipFileName);
+    const destPath = path.join('dist/standalone/', zipFileName);
+    await fs.copyFile(sourcePath, destPath);
+    await fs.unlink(sourcePath);
   } finally {
     await fs.rm(outdir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Description
When building the AWS CDK CLI, a .zip file is created in a temporary directory and moved afterward.

In certain environments, "cross-device link" fails. When the user's workspace is in a mounted volume, moving of a file fails during the build step because `fs.rename()` only works when the source and destination are in the same filesystem.

<img width="669" alt="Screenshot 2025-03-05 at 13 08 20" src="https://github.com/user-attachments/assets/6f108a34-f358-4f39-ac2e-6f6dbb147e22" />

## Solution
Copy the source file to the destination and delete the source file. This achieves the same result, but prevents us from running into limitations across filesystems.

## Testing
Ran `yarn build` successfully and all tests pass.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
