### PR TITLE
chore(cli): remove unused destroy options

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -14,7 +14,7 @@ export interface DestroyOptions {
   /**
    * Change stack watcher output to CI mode.
    *
-   * @deprecated Implement in IoHost instead
+   * @deprecated has no effect, please implement in IoHost instead
    */
   readonly ci?: boolean;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -738,7 +738,6 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
             stack,
             deployName: stack.stackName,
             roleArn: options.roleArn,
-            ci: options.ci,
           });
           await ioHost.notify(success(`\n ✅  ${chalk.blue(stack.displayName)}: ${action}ed`));
         } catch (e) {

--- a/packages/aws-cdk/lib/api/deployments/deploy-stack.ts
+++ b/packages/aws-cdk/lib/api/deployments/deploy-stack.ts
@@ -664,8 +664,6 @@ export interface DestroyStackOptions {
   sdk: SDK;
   roleArn?: string;
   deployName?: string;
-  quiet?: boolean;
-  ci?: boolean;
 }
 
 export async function destroyStack(options: DestroyStackOptions, { ioHost, action }: IoMessaging) {

--- a/packages/aws-cdk/lib/api/deployments/deployments.ts
+++ b/packages/aws-cdk/lib/api/deployments/deployments.ts
@@ -278,9 +278,6 @@ export interface DestroyStackOptions {
   stack: cxapi.CloudFormationStackArtifact;
   deployName?: string;
   roleArn?: string;
-  quiet?: boolean;
-  force?: boolean;
-  ci?: boolean;
 }
 
 export interface StackExistsOptions {
@@ -590,8 +587,6 @@ export class Deployments {
       roleArn: executionRoleArn,
       stack: options.stack,
       deployName: options.deployName,
-      quiet: options.quiet,
-      ci: options.ci,
     }, { ioHost: this.ioHost, action: this.action });
   }
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -382,7 +382,6 @@ export class CdkToolkit {
             force: true,
             roleArn: options.roleArn,
             fromDeploy: true,
-            ci: options.ci,
           });
         }
         return;
@@ -857,7 +856,6 @@ export class CdkToolkit {
           stack,
           deployName: stack.stackName,
           roleArn: options.roleArn,
-          ci: options.ci,
         });
         success(`\n ✅  %s: ${action}ed`, chalk.blue(stack.displayName));
       } catch (e) {
@@ -1699,13 +1697,6 @@ export interface DestroyOptions {
    * Whether the destroy request came from a deploy.
    */
   fromDeploy?: boolean;
-
-  /**
-   * Whether we are on a CI system
-   *
-   * @default false
-   */
-  readonly ci?: boolean;
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -428,7 +428,6 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           exclusively: args.exclusively,
           force: args.force,
           roleArn: args.roleArn,
-          ci: args.ci,
         });
 
       case 'gc':


### PR DESCRIPTION
These are not used downstream, so let's remove them for clarity.

Note that low-level force destroy is a thing in CFN and we _might_ reintroduce this later. It's basically about abandoning failed resources. But we currently don't support it, so let's not bother. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
