### PR TITLE
chore: update parameters in issue-label-assign

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -143,7 +143,9 @@ jobs:
           - init-typescript-lib
           - tool-integrations
   integ:
-    needs: integ_matrix
+    needs:
+      - prepare
+      - integ_matrix
     runs-on: aws-cdk_ubuntu-latest_4-core
     permissions: {}
     if: always()
@@ -151,5 +153,5 @@ jobs:
       - name: Integ test result
         run: echo ${{ needs.integ_matrix.result }}
       - name: Set status based on matrix job
-        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result) }}
+        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.prepare.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result)) }}
         run: exit 1

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -143,9 +143,7 @@ jobs:
           - init-typescript-lib
           - tool-integrations
   integ:
-    needs:
-      - prepare
-      - integ_matrix
+    needs: integ_matrix
     runs-on: aws-cdk_ubuntu-latest_4-core
     permissions: {}
     if: always()
@@ -153,5 +151,5 @@ jobs:
       - name: Integ test result
         run: echo ${{ needs.integ_matrix.result }}
       - name: Set status based on matrix job
-        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.prepare.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result)) }}
+        if: ${{ !contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result) }}
         run: exit 1

--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
-      AREA_PARAMS: '[{"area":"@aws-cdk/cli-lib-alpha","keywords":["cli","cli-lib","cli-lib-alpha"],"labels":["@aws-cdk/cli-lib-alpha"]},{"area":"@aws-cdk/cloud-assembly-schema","keywords":["cloud-assembly","schema"],"labels":["@aws-cdk/cloud-assembly-schema"]},{"area":"@aws-cdk/cloudformation-diff","keywords":["diff","cloudformation"],"labels":["@aws-cdk/cloudformation-diff"]},{"area":"@aws-cdk/toolkit-lib","keywords":["toolkit","programmtic toolkit","toolkit-lib"],"labels":["@aws-cdk/toolkit-lib"]},{"area":"aws-cdk","keywords":["aws-cdk","cli","cdk cli"],"labels":["aws-cdk"]},{"area":"cdk-assets","keywords":["assets","cdk-assets"],"labels":["cdk-assets"]}]'
+      AREA_PARAMS: '[{"area":"@aws-cdk/cli-lib-alpha","keywords":["cli-lib","cli-lib-alpha"],"labels":["@aws-cdk/cli-lib-alpha"]},{"area":"@aws-cdk/cloud-assembly-schema","keywords":["cloud-assembly","schema"],"labels":["@aws-cdk/cloud-assembly-schema"]},{"area":"@aws-cdk/cloudformation-diff","keywords":["diff","cloudformation"],"labels":["@aws-cdk/cloudformation-diff"]},{"area":"@aws-cdk/toolkit-lib","keywords":["toolkit","programmtic toolkit","toolkit-lib"],"labels":["@aws-cdk/toolkit-lib"]},{"area":"aws-cdk","keywords":["aws-cdk","cli","cdk cli","cdk"],"labels":["aws-cdk"]},{"area":"cdk-assets","keywords":["assets","cdk-assets"],"labels":["cdk-assets"]}]'
       AREA_AFFIXES: '{"prefixes":["@aws-cdk/"]}'
       OSDS_DEVS: '{"assignees":["ashishdhingra","khushail","hunhsieh"]}'
     steps:

--- a/projenrc/issue-labeler.ts
+++ b/projenrc/issue-labeler.ts
@@ -6,11 +6,11 @@ import { GitHubToken, stringifyList } from './util';
 const OSDS_DEVS = ['ashishdhingra', 'khushail', 'hunhsieh'];
 const AREA_AFFIXES = ['@aws-cdk/'];
 const AREA_PARAMS = [
-  { area: '@aws-cdk/cli-lib-alpha', keywords: ['cli', 'cli-lib', 'cli-lib-alpha'], labels: ['@aws-cdk/cli-lib-alpha'] },
+  { area: '@aws-cdk/cli-lib-alpha', keywords: ['cli-lib', 'cli-lib-alpha'], labels: ['@aws-cdk/cli-lib-alpha'] },
   { area: '@aws-cdk/cloud-assembly-schema', keywords: ['cloud-assembly', 'schema'], labels: ['@aws-cdk/cloud-assembly-schema'] },
   { area: '@aws-cdk/cloudformation-diff', keywords: ['diff', 'cloudformation'], labels: ['@aws-cdk/cloudformation-diff'] },
   { area: '@aws-cdk/toolkit-lib', keywords: ['toolkit', 'programmtic toolkit', 'toolkit-lib'], labels: ['@aws-cdk/toolkit-lib'] },
-  { area: 'aws-cdk', keywords: ['aws-cdk', 'cli', 'cdk cli'], labels: ['aws-cdk'] },
+  { area: 'aws-cdk', keywords: ['aws-cdk', 'cli', 'cdk cli', 'cdk'], labels: ['aws-cdk'] },
   { area: 'cdk-assets', keywords: ['assets', 'cdk-assets'], labels: ['cdk-assets'] },
 ];
 


### PR DESCRIPTION
I am trying to coerce the workflow to label `aws-cdk` more than `@aws-cdk/cli-lib-alpha` since it's far more likely that any issue that comes in is for the cdk cli.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
