### PR TITLE
docs(toolkit-lib): add CODE_REGISTRY directly to doc site

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1295,7 +1295,7 @@ for (const tsconfig of [toolkitLib.tsconfigDev]) {
   }
 }
 
-// Ad a command for the docs
+// Add a command for the docs
 const toolkitLibDocs = toolkitLib.addTask('docs', {
   exec: 'typedoc lib/index.ts',
   receiveArgs: true,

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -71,7 +71,7 @@ export interface ToolkitOptions {
 
 /**
  * The AWS CDK Programmatic Toolkit
- * 
+ *
  * @document ../../CODE_REGISTRY.md
  */
 export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposable {

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -71,6 +71,8 @@ export interface ToolkitOptions {
 
 /**
  * The AWS CDK Programmatic Toolkit
+ * 
+ * @document ../../CODE_REGISTRY.md
  */
 export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposable {
   /**


### PR DESCRIPTION
Looks like this on the doc site:

<img width="1418" alt="Screenshot 2025-03-05 at 5 03 51 PM" src="https://github.com/user-attachments/assets/dd938d26-d66f-45fd-9474-5609c62f9c08" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
