### PR TITLE
feat(toolkit-lib): wrap errors from assembly builder into AssemblyError

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/test/api/toolkit-error.test.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/test/api/toolkit-error.test.ts
@@ -3,35 +3,58 @@ import { AssemblyError, AuthenticationError, ContextProviderError, ToolkitError 
 describe('toolkit error', () => {
   let toolkitError = new ToolkitError('Test toolkit error');
   let authError = new AuthenticationError('Test authentication error');
-  let assemblyError = new AssemblyError('Test authentication error');
   let contextProviderError = new ContextProviderError('Test context provider error');
+  let assemblyError = AssemblyError.withStacks('Test authentication error', []);
+  let assemblyCauseError = AssemblyError.withCause('Test authentication error', new Error('other error'));
 
   test('types are correctly assigned', async () => {
     expect(toolkitError.type).toBe('toolkit');
     expect(authError.type).toBe('authentication');
     expect(assemblyError.type).toBe('assembly');
+    expect(assemblyCauseError.type).toBe('assembly');
     expect(contextProviderError.type).toBe('context-provider');
   });
 
   test('isToolkitError works', () => {
+    expect(toolkitError.source).toBe('toolkit');
+
     expect(ToolkitError.isToolkitError(toolkitError)).toBe(true);
     expect(ToolkitError.isToolkitError(authError)).toBe(true);
     expect(ToolkitError.isToolkitError(assemblyError)).toBe(true);
+    expect(ToolkitError.isToolkitError(assemblyCauseError)).toBe(true);
     expect(ToolkitError.isToolkitError(contextProviderError)).toBe(true);
   });
 
   test('isAuthenticationError works', () => {
+    expect(authError.source).toBe('user');
+
     expect(ToolkitError.isAuthenticationError(toolkitError)).toBe(false);
     expect(ToolkitError.isAuthenticationError(authError)).toBe(true);
   });
 
-  test('isAssemblyError works', () => {
-    expect(ToolkitError.isAssemblyError(assemblyError)).toBe(true);
-    expect(ToolkitError.isAssemblyError(toolkitError)).toBe(false);
-    expect(ToolkitError.isAssemblyError(authError)).toBe(false);
+  describe('isAssemblyError works', () => {
+    test('AssemblyError.fromStacks', () => {
+      expect(assemblyError.source).toBe('user');
+      expect(assemblyError.stacks).toStrictEqual([]);
+
+      expect(ToolkitError.isAssemblyError(assemblyError)).toBe(true);
+      expect(ToolkitError.isAssemblyError(toolkitError)).toBe(false);
+      expect(ToolkitError.isAssemblyError(authError)).toBe(false);
+    });
+
+    test('AssemblyError.fromCause', () => {
+      expect(assemblyCauseError.source).toBe('user');
+      expect((assemblyCauseError.cause as any)?.message).toBe('other error');
+
+      expect(ToolkitError.isAssemblyError(assemblyCauseError)).toBe(true);
+      expect(ToolkitError.isAssemblyError(toolkitError)).toBe(false);
+      expect(ToolkitError.isAssemblyError(authError)).toBe(false);
+    });
   });
 
   test('isContextProviderError works', () => {
+    expect(contextProviderError.source).toBe('user');
+
     expect(ToolkitError.isContextProviderError(contextProviderError)).toBe(true);
     expect(ToolkitError.isContextProviderError(toolkitError)).toBe(false);
     expect(ToolkitError.isContextProviderError(authError)).toBe(false);

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/source-builder.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/source-builder.test.ts
@@ -1,5 +1,9 @@
+import { ToolkitError } from '../../../lib';
 import { Toolkit } from '../../../lib/toolkit';
 import { appFixture, builderFixture, cdkOutFixture, TestIoHost } from '../../_helpers';
+
+// these tests often run a bit longer than the default
+jest.setTimeout(10_000);
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
@@ -29,6 +33,22 @@ describe('fromAssemblyBuilder', () => {
 
     // THEN
     expect(JSON.stringify(stack)).toContain('amzn-s3-demo-bucket');
+  });
+
+  test('errors are wrapped as AssemblyError', async () => {
+    // GIVEN
+    const cx = await toolkit.fromAssemblyBuilder(() => {
+      throw new Error('a wild error appeared');
+    });
+
+    // WHEN
+    try {
+      await cx.produce();
+    } catch (err: any) {
+      // THEN
+      expect(ToolkitError.isAssemblyError(err)).toBe(true);
+      expect(err.cause?.message).toContain('a wild error appeared');
+    }
   });
 });
 

--- a/packages/aws-cdk/lib/api/cxapp/cloud-assembly.ts
+++ b/packages/aws-cdk/lib/api/cxapp/cloud-assembly.ts
@@ -336,11 +336,11 @@ export class StackCollection {
     }
 
     if (errors && failAt != 'none') {
-      throw new AssemblyError('Found errors');
+      throw AssemblyError.withStacks('Found errors', this.stackArtifacts);
     }
 
     if (warnings && failAt === 'warn') {
-      throw new AssemblyError('Found warnings (--strict mode)');
+      throw AssemblyError.withStacks('Found warnings (--strict mode)', this.stackArtifacts);
     }
   }
 }


### PR DESCRIPTION
Fixes errors thrown from a CloudAssembly produced by a builder function are unstructured. Wrapping errors will allow better handling by implementors.

Also introduced the `source` property on `ToolkitError`s as per the RFC, to denote the source of an error (user or toolkit).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
