### PR TITLE
chore(toolkit-lib): fixes "ambiguous redirect" error during docs publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1086,7 +1086,7 @@ jobs:
           echo "S3_PATH=$DOCS_STREAM/aws-cdk-toolkit-lib-v$(cat dist/version.txt).zip" >> "$GITHUB_ENV"
           echo "S3_URI=s3://$BUCKET_NAME/$S3_PATH" >> "$GITHUB_ENV"
           echo "LATEST=latest-toolkit-lib" >> "$GITHUB_ENV"
-          echo $S3_PATH > $LATEST
+          echo "$S3_PATH" > "$LATEST"
           (! aws s3 ls --human-readable $S3_URI \
           && aws s3 cp --dryrun dist/docs.zip $S3_URI \
           && aws s3 cp --dryrun $LATEST s3://$BUCKET_NAME/$LATEST) \

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -103,7 +103,7 @@ export class S3DocsPublishing extends Component {
             `echo "LATEST=latest-${this.props.docsStream}" >> "$GITHUB_ENV"`,
 
             // create the latest marker
-            'echo $S3_PATH > $LATEST',
+            'echo "$S3_PATH" > "$LATEST"',
 
             // check if the target file already exists and upload
             '(! aws s3 ls --human-readable $S3_URI \\',


### PR DESCRIPTION
It makes the job fail.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
