### PR TITLE
chore(toolkit-lib): rename CODES to IO

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
@@ -2,7 +2,7 @@ import type { MissingContext } from '@aws-cdk/cloud-assembly-schema';
 import type * as cxapi from '@aws-cdk/cx-api';
 import type { ToolkitServices } from '../../../toolkit/private';
 import { type Context, contextproviders, PROJECT_CONTEXT } from '../../aws-cdk';
-import { CODES } from '../../io/private';
+import { IO } from '../../io/private';
 import type { ActionAwareIoHost } from '../../shared-private';
 import { ToolkitError } from '../../shared-public';
 import type { ICloudAssemblySource } from '../types';
@@ -77,14 +77,14 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
 
         let tryLookup = true;
         if (previouslyMissingKeys && equalSets(missingKeysSet, previouslyMissingKeys)) {
-          await this.ioHost.notify(CODES.CDK_ASSEMBLY_I0240.msg('Not making progress trying to resolve environmental context. Giving up.', { missingKeys }));
+          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0240.msg('Not making progress trying to resolve environmental context. Giving up.', { missingKeys }));
           tryLookup = false;
         }
 
         previouslyMissingKeys = missingKeysSet;
 
         if (tryLookup) {
-          await this.ioHost.notify(CODES.CDK_ASSEMBLY_I0241.msg('Some context information is missing. Fetching...', { missingKeys }));
+          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0241.msg('Some context information is missing. Fetching...', { missingKeys }));
           await contextproviders.provideContextValues(
             assembly.manifest.missing,
             this.context,
@@ -92,7 +92,7 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
           );
 
           // Cache the new context to disk
-          await this.ioHost.notify(CODES.CDK_ASSEMBLY_I0042.msg(`Writing updated context to ${this.contextFile}...`, {
+          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0042.msg(`Writing updated context to ${this.contextFile}...`, {
             contextFile: this.contextFile,
             context: this.context.all,
           }));

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -8,7 +8,7 @@ import { lte } from 'semver';
 import { prepareDefaultEnvironment as oldPrepare, prepareContext, spaceAvailableForContext, Settings, loadTree, some, versionNumber } from '../../../api/aws-cdk';
 import { splitBySize } from '../../../private/util';
 import type { ToolkitServices } from '../../../toolkit/private';
-import { CODES } from '../../io/private';
+import { IO } from '../../io/private';
 import type { ActionAwareIoHost } from '../../shared-private';
 import { ToolkitError } from '../../shared-public';
 import type { AppSynthOptions, LoadAssemblyOptions } from '../source-builder';
@@ -38,7 +38,7 @@ export function determineOutputDirectory(outdir?: string) {
  * @param context The context key/value bash.
  */
 export async function prepareDefaultEnvironment(services: ToolkitServices, props: { outdir?: string } = {}): Promise<Env> {
-  const logFn = (msg: string, ...args: any) => services.ioHost.notify(CODES.CDK_ASSEMBLY_I0010.msg(format(msg, ...args)));
+  const logFn = (msg: string, ...args: any) => services.ioHost.notify(IO.CDK_ASSEMBLY_I0010.msg(format(msg, ...args)));
   const env = await oldPrepare(services.sdkProvider, logFn);
 
   if (props.outdir) {
@@ -142,7 +142,7 @@ export async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly,
   // We're dealing with an old version of the framework here. It is unaware of the temporary
   // file, which means that it will ignore the context overflow.
   if (frameworkDoesNotSupportContextOverflow) {
-    await ioHost.notify(CODES.CDK_ASSEMBLY_W0010.msg('Part of the context could not be sent to the application. Please update the AWS CDK library to the latest version.'));
+    await ioHost.notify(IO.CDK_ASSEMBLY_W0010.msg('Part of the context could not be sent to the application. Please update the AWS CDK library to the latest version.'));
   }
 }
 
@@ -164,7 +164,7 @@ export async function assemblyFromDirectory(assemblyDir: string, ioHost: ActionA
       // this means the CLI version is too old.
       // we instruct the user to upgrade.
       const message = 'This AWS CDK Toolkit is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.';
-      await ioHost.notify(CODES.CDK_ASSEMBLY_E1111.msg(message, { error: err }));
+      await ioHost.notify(IO.CDK_ASSEMBLY_E1111.msg(message, { error: err }));
       throw new ToolkitError(`${message}\n(${err.message}`);
     }
     throw err;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
@@ -8,7 +8,7 @@ import { assemblyFromDirectory, changeDir, determineOutputDirectory, guessExecut
 import type { ToolkitServices } from '../../../toolkit/private';
 import type { ILock } from '../../aws-cdk';
 import { Context, RWLock, Settings } from '../../aws-cdk';
-import { CODES } from '../../io/private';
+import { IO } from '../../io/private';
 import { ToolkitError, AssemblyError } from '../../shared-public';
 import type { AssemblyBuilder } from '../source-builder';
 
@@ -89,7 +89,7 @@ export abstract class CloudAssemblySourceBuilder {
       {
         produce: async () => {
           // @todo build
-          await services.ioHost.notify(CODES.CDK_ASSEMBLY_I0150.msg('--app points to a cloud assembly, so we bypass synth'));
+          await services.ioHost.notify(IO.CDK_ASSEMBLY_I0150.msg('--app points to a cloud assembly, so we bypass synth'));
           return assemblyFromDirectory(directory, services.ioHost, props.loadAssemblyOptions);
         },
       },
@@ -139,10 +139,10 @@ export abstract class CloudAssemblySourceBuilder {
                 eventPublisher: async (type, line) => {
                   switch (type) {
                     case 'data_stdout':
-                      await services.ioHost.notify(CODES.CDK_ASSEMBLY_I1001.msg(line));
+                      await services.ioHost.notify(IO.CDK_ASSEMBLY_I1001.msg(line));
                       break;
                     case 'data_stderr':
-                      await services.ioHost.notify(CODES.CDK_ASSEMBLY_E1002.msg(line));
+                      await services.ioHost.notify(IO.CDK_ASSEMBLY_E1002.msg(line));
                       break;
                   }
                 },

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/index.ts
@@ -1,4 +1,4 @@
-export * from './codes';
+export * from './messages';
 export * from './io-host-wrappers';
 export * from './level-priority';
 export * from './timer';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -17,7 +17,7 @@ import * as make from '../../shared-private';
  * - X000-X009 are reserved for timings
  * - X900-X999 are reserved for results
  */
-export const CODES = {
+export const IO = {
   // Defaults
   DEFAULT_TOOLKIT_INFO: make.info({
     code: 'CDK_TOOLKIT_I0000',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/sdk-logger.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/sdk-logger.ts
@@ -1,7 +1,7 @@
 
 import { inspect } from 'util';
 import type { Logger } from '@smithy/types';
-import { CODES } from './codes';
+import { IO } from './messages';
 import { replacerBufferWithInfo } from '../../../private/util';
 import type { ActionAwareIoHost } from '../../shared-private';
 
@@ -63,14 +63,14 @@ export function asSdkLogger(ioHost: ActionAwareIoHost): Logger {
      * ```
      */
     public info(...content: any[]) {
-      void ioHost.notify(CODES.CDK_SDK_I0100.msg(`[sdk info] ${formatSdkLoggerContent(content)}`, {
+      void ioHost.notify(IO.CDK_SDK_I0100.msg(`[sdk info] ${formatSdkLoggerContent(content)}`, {
         sdkLevel: 'info',
         content,
       }));
     }
 
     public warn(...content: any[]) {
-      void ioHost.notify(CODES.CDK_SDK_I0100.msg(`[sdk warn] ${formatSdkLoggerContent(content)}`, {
+      void ioHost.notify(IO.CDK_SDK_I0100.msg(`[sdk warn] ${formatSdkLoggerContent(content)}`, {
         sdkLevel: 'warn',
         content,
       }));
@@ -98,7 +98,7 @@ export function asSdkLogger(ioHost: ActionAwareIoHost): Logger {
      * ```
      */
     public error(...content: any[]) {
-      void ioHost.notify(CODES.CDK_SDK_I0100.msg(`[sdk error] ${formatSdkLoggerContent(content)}`, {
+      void ioHost.notify(IO.CDK_SDK_I0100.msg(`[sdk error] ${formatSdkLoggerContent(content)}`, {
         sdkLevel: 'error',
         content,
       }));

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/timer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/timer.ts
@@ -1,5 +1,5 @@
 import { format } from 'util';
-import { CODES } from './codes';
+import { IO } from './messages';
 import { formatTime } from '../../../private/util';
 import type { ActionAwareIoHost } from '../../shared-private';
 
@@ -52,10 +52,10 @@ function timerMessage(type: 'synth' | 'deploy' | 'rollback'| 'destroy' | 'bootst
   const payload = { duration: duration.asMs };
 
   switch (type) {
-    case 'synth': return CODES.CDK_TOOLKIT_I1000.msg(format(message, 'Synthesis'), payload);
-    case 'deploy': return CODES.CDK_TOOLKIT_I5000.msg(format(message, 'Deployment'), payload);
-    case 'rollback': return CODES.CDK_TOOLKIT_I6000.msg(format(message, 'Rollback'), payload);
-    case 'destroy': return CODES.CDK_TOOLKIT_I7000.msg(format(message, 'Destroy'), payload);
-    case 'bootstrap': return CODES.CDK_TOOLKIT_I9000.msg(format(message, 'Bootstrap'), payload);
+    case 'synth': return IO.CDK_TOOLKIT_I1000.msg(format(message, 'Synthesis'), payload);
+    case 'deploy': return IO.CDK_TOOLKIT_I5000.msg(format(message, 'Deployment'), payload);
+    case 'rollback': return IO.CDK_TOOLKIT_I6000.msg(format(message, 'Rollback'), payload);
+    case 'destroy': return IO.CDK_TOOLKIT_I7000.msg(format(message, 'Destroy'), payload);
+    case 'bootstrap': return IO.CDK_TOOLKIT_I9000.msg(format(message, 'Bootstrap'), payload);
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/scripts/gen-code-registry.ts
+++ b/packages/@aws-cdk/toolkit-lib/scripts/gen-code-registry.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs';
-import { CODES } from '../lib/api/io/private/codes';
+import { IO } from '../lib/api/io/private/messages';
 
 function codesToMarkdownTable(codes: Record<string, {
   code: string;
@@ -30,6 +30,6 @@ function linkInterface(interfaceName: string) {
 }
 
 fs.writeFileSync('CODE_REGISTRY.md', codesToMarkdownTable(
-  CODES,
+  IO,
   '## Toolkit Code Registry',
 ));


### PR DESCRIPTION
I don't want to type `CODES` all the time and the new name is more inline with the new purpose of a message builder registry anyway.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
