### PR TITLE
refactor(cli): use IoHelper in internal APIs

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
@@ -13,7 +13,6 @@ export type ActionLessRequest<T, U> = Omit<IoRequest<T, U>, 'action'>;
  * Wraps a client provided IoHost and provides additional features & services to toolkit internal classes.
  */
 export interface IoHelper extends IIoHost {
-  action: ToolkitAction;
   notify<T>(msg: ActionLessMessage<T>): Promise<void>;
   requestResponse<T, U>(msg: ActionLessRequest<T, U>): Promise<U>;
 }
@@ -23,7 +22,6 @@ export interface IoHelper extends IIoHost {
  */
 export function asIoHelper(ioHost: IIoHost, action: ToolkitAction): IoHelper {
   return {
-    action,
     notify: async <T>(msg: Omit<IoMessage<T>, 'action'>) => {
       await ioHost.notify({
         ...msg,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
@@ -43,13 +43,13 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
   private canLookup: boolean;
   private context: Context;
   private contextFile: string;
-  private ioHost: IoHelper;
+  private ioHelper: IoHelper;
 
   constructor(private readonly source: ICloudAssemblySource, private readonly props: ContextAwareCloudAssemblyProps) {
     this.canLookup = props.lookups ?? true;
     this.context = props.context;
     this.contextFile = props.contextFile ?? PROJECT_CONTEXT; // @todo new feature not needed right now
-    this.ioHost = props.services.ioHost;
+    this.ioHelper = props.services.ioHelper;
   }
 
   /**
@@ -77,14 +77,14 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
 
         let tryLookup = true;
         if (previouslyMissingKeys && equalSets(missingKeysSet, previouslyMissingKeys)) {
-          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0240.msg('Not making progress trying to resolve environmental context. Giving up.', { missingKeys }));
+          await this.ioHelper.notify(IO.CDK_ASSEMBLY_I0240.msg('Not making progress trying to resolve environmental context. Giving up.', { missingKeys }));
           tryLookup = false;
         }
 
         previouslyMissingKeys = missingKeysSet;
 
         if (tryLookup) {
-          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0241.msg('Some context information is missing. Fetching...', { missingKeys }));
+          await this.ioHelper.notify(IO.CDK_ASSEMBLY_I0241.msg('Some context information is missing. Fetching...', { missingKeys }));
           await contextproviders.provideContextValues(
             assembly.manifest.missing,
             this.context,
@@ -92,7 +92,7 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
           );
 
           // Cache the new context to disk
-          await this.ioHost.notify(IO.CDK_ASSEMBLY_I0042.msg(`Writing updated context to ${this.contextFile}...`, {
+          await this.ioHelper.notify(IO.CDK_ASSEMBLY_I0042.msg(`Writing updated context to ${this.contextFile}...`, {
             contextFile: this.contextFile,
             context: this.context.all,
           }));

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -38,7 +38,7 @@ export function determineOutputDirectory(outdir?: string) {
  * @param context The context key/value bash.
  */
 export async function prepareDefaultEnvironment(services: ToolkitServices, props: { outdir?: string } = {}): Promise<Env> {
-  const logFn = (msg: string, ...args: any) => services.ioHost.notify(IO.CDK_ASSEMBLY_I0010.msg(format(msg, ...args)));
+  const logFn = (msg: string, ...args: any) => services.ioHelper.notify(IO.CDK_ASSEMBLY_I0010.msg(format(msg, ...args)));
   const env = await oldPrepare(services.sdkProvider, logFn);
 
   if (props.outdir) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
@@ -65,7 +65,7 @@ export abstract class CloudAssemblySourceBuilder {
             return assembly;
           }
 
-          return assemblyFromDirectory(assembly.directory, services.ioHost, props.loadAssemblyOptions);
+          return assemblyFromDirectory(assembly.directory, services.ioHelper, props.loadAssemblyOptions);
         },
       },
       contextAssemblyProps,
@@ -89,8 +89,8 @@ export abstract class CloudAssemblySourceBuilder {
       {
         produce: async () => {
           // @todo build
-          await services.ioHost.notify(IO.CDK_ASSEMBLY_I0150.msg('--app points to a cloud assembly, so we bypass synth'));
-          return assemblyFromDirectory(directory, services.ioHost, props.loadAssemblyOptions);
+          await services.ioHelper.notify(IO.CDK_ASSEMBLY_I0150.msg('--app points to a cloud assembly, so we bypass synth'));
+          return assemblyFromDirectory(directory, services.ioHelper, props.loadAssemblyOptions);
         },
       },
       contextAssemblyProps,
@@ -139,17 +139,17 @@ export abstract class CloudAssemblySourceBuilder {
                 eventPublisher: async (type, line) => {
                   switch (type) {
                     case 'data_stdout':
-                      await services.ioHost.notify(IO.CDK_ASSEMBLY_I1001.msg(line));
+                      await services.ioHelper.notify(IO.CDK_ASSEMBLY_I1001.msg(line));
                       break;
                     case 'data_stderr':
-                      await services.ioHost.notify(IO.CDK_ASSEMBLY_E1002.msg(line));
+                      await services.ioHelper.notify(IO.CDK_ASSEMBLY_E1002.msg(line));
                       break;
                   }
                 },
                 extraEnv: envWithContext,
                 cwd: props.workingDirectory,
               });
-              return assemblyFromDirectory(outdir, services.ioHost, props.loadAssemblyOptions);
+              return assemblyFromDirectory(outdir, services.ioHelper, props.loadAssemblyOptions);
             });
           } finally {
             await lock?.release();

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
@@ -9,7 +9,7 @@ import type { IoHelper } from '../../api/shared-private';
  */
 export interface ToolkitServices {
   sdkProvider: SdkProvider;
-  ioHost: IoHelper;
+  ioHelper: IoHelper;
 }
 
 /**

--- a/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
@@ -1,20 +1,19 @@
 import { inspect, format } from 'util';
 import { Logger } from '@smithy/types';
-import type { IIoHost } from '../../toolkit/cli-io-host';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { replacerBufferWithInfo } from '../../util';
 
 export class SdkToCliLogger implements Logger {
-  private readonly ioHost: IIoHost;
+  private readonly ioHelper: IoHelper;
 
-  public constructor(ioHost: IIoHost) {
-    this.ioHost = ioHost;
+  public constructor(ioHelper: IoHelper) {
+    this.ioHelper = ioHelper;
   }
 
   private notify(level: 'debug' | 'info' | 'warn' | 'error', ...content: any[]) {
-    void this.ioHost.notify({
+    void this.ioHelper.notify({
       time: new Date(),
       level: 'trace', // always log all SDK logs at trace level, no matter what level they are coming from the SDK
-      action: 'none' as any,
       code: 'CDK_SDK_I0000',
       message: format('[SDK %s] %s', level, formatSdkLoggerContent(content)),
     });

--- a/packages/aws-cdk/lib/api/bootstrap/bootstrap-environment.ts
+++ b/packages/aws-cdk/lib/api/bootstrap/bootstrap-environment.ts
@@ -4,8 +4,8 @@ import * as cxapi from '@aws-cdk/cx-api';
 import type { BootstrapEnvironmentOptions, BootstrappingParameters } from './bootstrap-props';
 import { BootstrapStack, bootstrapVersionFromTemplate } from './deploy-bootstrap';
 import { legacyBootstrapTemplate } from './legacy-template';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { warn } from '../../cli/messages';
-import { IoMessaging } from '../../toolkit/cli-io-host';
 import { ToolkitError } from '../../toolkit/error';
 import { bundledPackageRootDir, loadStructuredFile, serializeStructure } from '../../util';
 import type { SDK, SdkProvider } from '../aws-auth';
@@ -16,10 +16,13 @@ import { DEFAULT_TOOLKIT_STACK_NAME } from '../toolkit-info';
 export type BootstrapSource = { source: 'legacy' } | { source: 'default' } | { source: 'custom'; templateFile: string };
 
 export class Bootstrapper {
+  private readonly ioHelper: IoHelper;
+
   constructor(
     private readonly source: BootstrapSource = { source: 'default' },
-    private readonly msg: IoMessaging,
+    ioHelper: IoHelper,
   ) {
+    this.ioHelper = ioHelper;
   }
 
   public bootstrapEnvironment(
@@ -67,7 +70,7 @@ export class Bootstrapper {
     }
 
     const toolkitStackName = options.toolkitStackName ?? DEFAULT_TOOLKIT_STACK_NAME;
-    const current = await BootstrapStack.lookup(sdkProvider, environment, toolkitStackName, this.msg);
+    const current = await BootstrapStack.lookup(sdkProvider, environment, toolkitStackName, this.ioHelper);
     return current.update(
       await this.loadTemplate(params),
       {},
@@ -92,7 +95,7 @@ export class Bootstrapper {
     const bootstrapTemplate = await this.loadTemplate();
 
     const toolkitStackName = options.toolkitStackName ?? DEFAULT_TOOLKIT_STACK_NAME;
-    const current = await BootstrapStack.lookup(sdkProvider, environment, toolkitStackName, this.msg);
+    const current = await BootstrapStack.lookup(sdkProvider, environment, toolkitStackName, this.ioHelper);
     const partition = await current.partition();
 
     if (params.createCustomerMasterKey !== undefined && params.kmsKeyId) {
@@ -148,8 +151,7 @@ export class Bootstrapper {
       // Would leave AdministratorAccess policies with a trust relationship, without the user explicitly
       // approving the trust policy.
       const implicitPolicy = `arn:${partition}:iam::aws:policy/AdministratorAccess`;
-      await this.msg.ioHost.notify(warn(
-        this.msg.action,
+      await this.ioHelper.notify(warn(
         `Using default execution policy of '${implicitPolicy}'. Pass '--cloudformation-execution-policies' to customize.`,
       ));
     } else if (cloudFormationExecutionPolicies.length === 0) {
@@ -197,18 +199,15 @@ export class Bootstrapper {
     }
     if (currentPermissionsBoundary !== policyName) {
       if (!currentPermissionsBoundary) {
-        await this.msg.ioHost.notify(warn(
-          this.msg.action,
+        await this.ioHelper.notify(warn(
           `Adding new permissions boundary ${policyName}`,
         ));
       } else if (!policyName) {
-        await this.msg.ioHost.notify(warn(
-          this.msg.action,
+        await this.ioHelper.notify(warn(
           `Removing existing permissions boundary ${currentPermissionsBoundary}`,
         ));
       } else {
-        await this.msg.ioHost.notify(warn(
-          this.msg.action,
+        await this.ioHelper.notify(warn(
           `Changing permissions boundary from ${currentPermissionsBoundary} to ${policyName}`,
         ));
       }

--- a/packages/aws-cdk/lib/api/deployments/checks.ts
+++ b/packages/aws-cdk/lib/api/deployments/checks.ts
@@ -1,11 +1,11 @@
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { debug } from '../../cli/messages';
-import { IoMessaging } from '../../toolkit/cli-io-host';
 import { ToolkitError } from '../../toolkit/error';
 import { SDK } from '../aws-auth';
 
 export async function determineAllowCrossAccountAssetPublishing(
   sdk: SDK,
-  { ioHost, action }: IoMessaging,
+  ioHelper: IoHelper,
   customStackName?: string,
 ): Promise<boolean> {
   try {
@@ -34,8 +34,8 @@ export async function determineAllowCrossAccountAssetPublishing(
     // of creating bootstrap resources. If they do, there's nothing for us to validate,
     // but we can't use that as a reason to disallow cross-account publishing. We'll just
     // have to trust they did their due diligence. So we fail open.
-    await ioHost.notify(debug(action, `Error determining cross account asset publishing: ${e}`));
-    await ioHost.notify(debug(action, 'Defaulting to allowing cross account asset publishing'));
+    await ioHelper.notify(debug(`Error determining cross account asset publishing: ${e}`));
+    await ioHelper.notify(debug('Defaulting to allowing cross account asset publishing'));
     return true;
   }
 }

--- a/packages/aws-cdk/lib/api/deployments/deploy-stack.ts
+++ b/packages/aws-cdk/lib/api/deployments/deploy-stack.ts
@@ -28,8 +28,8 @@ import {
 import { ChangeSetDeploymentMethod, DeploymentMethod } from './deployment-method';
 import { DeployStackResult, SuccessfulDeployStackResult } from './deployment-result';
 import { tryHotswapDeployment } from './hotswap-deployments';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { debug, info, warn } from '../../cli/messages';
-import { IIoHost, IoMessaging } from '../../toolkit/cli-io-host';
 import { ToolkitError } from '../../toolkit/error';
 import { formatErrorMessage } from '../../util';
 import type { SDK, SdkProvider, ICloudFormationClient } from '../aws-auth';
@@ -201,7 +201,7 @@ export interface DeployStackOptions {
   readonly assetParallelism?: boolean;
 }
 
-export async function deployStack(options: DeployStackOptions, { ioHost, action }: IoMessaging): Promise<DeployStackResult> {
+export async function deployStack(options: DeployStackOptions, ioHelper: IoHelper): Promise<DeployStackResult> {
   const stackArtifact = options.stack;
 
   const stackEnv = options.resolvedEnvironment;
@@ -212,11 +212,11 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
   let cloudFormationStack = await CloudFormationStack.lookup(cfn, deployName);
 
   if (cloudFormationStack.stackStatus.isCreationFailure) {
-    await ioHost.notify(debug(action,
+    await ioHelper.notify(debug(
       `Found existing stack ${deployName} that had previously failed creation. Deleting it before attempting to re-create it.`,
     ));
     await cfn.deleteStack({ StackName: deployName });
-    const deletedStack = await waitForStackDelete(cfn, { ioHost, action }, deployName);
+    const deletedStack = await waitForStackDelete(cfn, ioHelper, deployName);
     if (deletedStack && deletedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new ToolkitError(
         `Failed deleting stack ${deployName} that had previously failed creation (current state: ${deletedStack.stackStatus})`,
@@ -233,7 +233,7 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
   // parameters.
   const legacyAssets = new AssetManifestBuilder();
   const assetParams = await addMetadataAssetsToManifest(
-    { ioHost, action },
+    ioHelper,
     stackArtifact,
     legacyAssets,
     options.envResources,
@@ -250,12 +250,12 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
   const hotswapMode = options.hotswap ?? HotswapMode.FULL_DEPLOYMENT;
   const hotswapPropertyOverrides = options.hotswapPropertyOverrides ?? new HotswapPropertyOverrides();
 
-  if (await canSkipDeploy(options, cloudFormationStack, stackParams.hasChanges(cloudFormationStack.parameters), { ioHost, action })) {
-    await ioHost.notify(debug(action, `${deployName}: skipping deployment (use --force to override)`));
+  if (await canSkipDeploy(options, cloudFormationStack, stackParams.hasChanges(cloudFormationStack.parameters), ioHelper)) {
+    await ioHelper.notify(debug(`${deployName}: skipping deployment (use --force to override)`));
     // if we can skip deployment and we are performing a hotswap, let the user know
     // that no hotswap deployment happened
     if (hotswapMode !== HotswapMode.FULL_DEPLOYMENT) {
-      await ioHost.notify(info(action,
+      await ioHelper.notify(info(
         format(
           `\n ${ICON} %s\n`,
           chalk.bold('hotswap deployment skipped - no changes were detected (use --force to override)'),
@@ -269,7 +269,7 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
       stackArn: cloudFormationStack.stackId,
     };
   } else {
-    await ioHost.notify(debug(action, `${deployName}: deploying...`));
+    await ioHelper.notify(debug(`${deployName}: deploying...`));
   }
 
   const bodyParameter = await makeBodyParameter(
@@ -283,19 +283,19 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
   try {
     bootstrapStackName = (await options.envResources.lookupToolkit()).stackName;
   } catch (e) {
-    await ioHost.notify(debug(action, `Could not determine the bootstrap stack name: ${e}`));
+    await ioHelper.notify(debug(`Could not determine the bootstrap stack name: ${e}`));
   }
   await publishAssets(legacyAssets.toManifest(stackArtifact.assembly.directory), options.sdkProvider, stackEnv, {
     parallel: options.assetParallelism,
-    allowCrossAccount: await determineAllowCrossAccountAssetPublishing(options.sdk, { ioHost, action }, bootstrapStackName),
-  }, { ioHost, action });
+    allowCrossAccount: await determineAllowCrossAccountAssetPublishing(options.sdk, ioHelper, bootstrapStackName),
+  }, ioHelper);
 
   if (hotswapMode !== HotswapMode.FULL_DEPLOYMENT) {
     // attempt to short-circuit the deployment if possible
     try {
       const hotswapDeploymentResult = await tryHotswapDeployment(
         options.sdkProvider,
-        { ioHost, action },
+        ioHelper,
         stackParams.values,
         cloudFormationStack,
         stackArtifact,
@@ -304,7 +304,7 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
       if (hotswapDeploymentResult) {
         return hotswapDeploymentResult;
       }
-      await ioHost.notify(info(action, format(
+      await ioHelper.notify(info(format(
         'Could not perform a hotswap deployment, as the stack %s contains non-Asset changes',
         stackArtifact.displayName,
       )));
@@ -312,14 +312,14 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
       if (!(e instanceof CfnEvaluationException)) {
         throw e;
       }
-      await ioHost.notify(info(action, format(
+      await ioHelper.notify(info(format(
         'Could not perform a hotswap deployment, because the CloudFormation template could not be resolved: %s',
         formatErrorMessage(e),
       )));
     }
 
     if (hotswapMode === HotswapMode.FALL_BACK) {
-      await ioHost.notify(info(action, 'Falling back to doing a full deployment'));
+      await ioHelper.notify(info('Falling back to doing a full deployment'));
       options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
     } else {
       return {
@@ -338,8 +338,7 @@ export async function deployStack(options: DeployStackOptions, { ioHost, action 
     stackArtifact,
     stackParams,
     bodyParameter,
-    ioHost,
-    action,
+    ioHelper,
   );
   return fullDeployment.performDeployment();
 }
@@ -367,8 +366,7 @@ class FullCloudFormationDeployment {
     private readonly stackArtifact: cxapi.CloudFormationStackArtifact,
     private readonly stackParams: ParameterValues,
     private readonly bodyParameter: TemplateBodyParameter,
-    private readonly ioHost: IIoHost,
-    private readonly action: IoMessaging['action'],
+    private readonly ioHelper: IoHelper,
   ) {
     this.cfn = options.sdk.cloudFormation();
     this.stackName = options.deployName ?? stackArtifact.stackName;
@@ -404,9 +402,9 @@ class FullCloudFormationDeployment {
     await this.updateTerminationProtection();
 
     if (changeSetHasNoChanges(changeSetDescription)) {
-      await this.ioHost.notify(debug(this.action, format('No changes are to be performed on %s.', this.stackName)));
+      await this.ioHelper.notify(debug(format('No changes are to be performed on %s.', this.stackName)));
       if (execute) {
-        await this.ioHost.notify(debug(this.action, format('Deleting empty change set %s', changeSetDescription.ChangeSetId)));
+        await this.ioHelper.notify(debug(format('Deleting empty change set %s', changeSetDescription.ChangeSetId)));
         await this.cfn.deleteChangeSet({
           StackName: this.stackName,
           ChangeSetName: changeSetName,
@@ -414,8 +412,7 @@ class FullCloudFormationDeployment {
       }
 
       if (this.options.force) {
-        await this.ioHost.notify(warn(
-          this.action,
+        await this.ioHelper.notify(warn(
           [
             'You used the --force flag, but CloudFormation reported that the deployment would not make any changes.',
             'According to CloudFormation, all resources are already up-to-date with the state in your CDK app.',
@@ -435,7 +432,7 @@ class FullCloudFormationDeployment {
     }
 
     if (!execute) {
-      await this.ioHost.notify(info(this.action, format(
+      await this.ioHelper.notify(info(format(
         'Changeset %s created and waiting in review for manual execution (--no-execute)',
         changeSetDescription.ChangeSetId,
       )));
@@ -467,8 +464,8 @@ class FullCloudFormationDeployment {
   private async createChangeSet(changeSetName: string, willExecute: boolean, importExistingResources: boolean) {
     await this.cleanupOldChangeset(changeSetName);
 
-    await this.ioHost.notify(debug(this.action, `Attempting to create ChangeSet with name ${changeSetName} to ${this.verb} stack ${this.stackName}`));
-    await this.ioHost.notify(info(this.action, format('%s: creating CloudFormation changeset...', chalk.bold(this.stackName))));
+    await this.ioHelper.notify(debug(`Attempting to create ChangeSet with name ${changeSetName} to ${this.verb} stack ${this.stackName}`));
+    await this.ioHelper.notify(info(format('%s: creating CloudFormation changeset...', chalk.bold(this.stackName))));
     const changeSet = await this.cfn.createChangeSet({
       StackName: this.stackName,
       ChangeSetName: changeSetName,
@@ -480,15 +477,15 @@ class FullCloudFormationDeployment {
       ...this.commonPrepareOptions(),
     });
 
-    await this.ioHost.notify(debug(this.action, format('Initiated creation of changeset: %s; waiting for it to finish creating...', changeSet.Id)));
+    await this.ioHelper.notify(debug(format('Initiated creation of changeset: %s; waiting for it to finish creating...', changeSet.Id)));
     // Fetching all pages if we'll execute, so we can have the correct change count when monitoring.
-    return waitForChangeSet(this.cfn, { ioHost: this.ioHost, action: this.action }, this.stackName, changeSetName, {
+    return waitForChangeSet(this.cfn, this.ioHelper, this.stackName, changeSetName, {
       fetchAll: willExecute,
     });
   }
 
   private async executeChangeSet(changeSet: DescribeChangeSetCommandOutput): Promise<SuccessfulDeployStackResult> {
-    await this.ioHost.notify(debug(this.action, format('Initiating execution of changeset %s on stack %s', changeSet.ChangeSetId, this.stackName)));
+    await this.ioHelper.notify(debug(format('Initiating execution of changeset %s on stack %s', changeSet.ChangeSetId, this.stackName)));
 
     await this.cfn.executeChangeSet({
       StackName: this.stackName,
@@ -497,8 +494,7 @@ class FullCloudFormationDeployment {
       ...this.commonExecuteOptions(),
     });
 
-    await this.ioHost.notify(debug(
-      this.action,
+    await this.ioHelper.notify(debug(
       format(
         'Execution of changeset %s on stack %s has started; waiting for the update to complete...',
         changeSet.ChangeSetId,
@@ -515,7 +511,7 @@ class FullCloudFormationDeployment {
     if (this.cloudFormationStack.exists) {
       // Delete any existing change sets generated by CDK since change set names must be unique.
       // The delete request is successful as long as the stack exists (even if the change set does not exist).
-      await this.ioHost.notify(debug(this.action, `Removing existing change set with name ${changeSetName} if it exists`));
+      await this.ioHelper.notify(debug(`Removing existing change set with name ${changeSetName} if it exists`));
       await this.cfn.deleteChangeSet({
         StackName: this.stackName,
         ChangeSetName: changeSetName,
@@ -527,8 +523,7 @@ class FullCloudFormationDeployment {
     // Update termination protection only if it has changed.
     const terminationProtection = this.stackArtifact.terminationProtection ?? false;
     if (!!this.cloudFormationStack.terminationProtection !== terminationProtection) {
-      await this.ioHost.notify(debug(
-        this.action,
+      await this.ioHelper.notify(debug(
         format (
           'Updating termination protection from %s to %s for stack %s',
           this.cloudFormationStack.terminationProtection,
@@ -540,12 +535,12 @@ class FullCloudFormationDeployment {
         StackName: this.stackName,
         EnableTerminationProtection: terminationProtection,
       });
-      await this.ioHost.notify(debug(this.action, format('Termination protection updated to %s for stack %s', terminationProtection, this.stackName)));
+      await this.ioHelper.notify(debug(format('Termination protection updated to %s for stack %s', terminationProtection, this.stackName)));
     }
   }
 
   private async directDeployment(): Promise<SuccessfulDeployStackResult> {
-    await this.ioHost.notify(info(this.action, format('%s: %s stack...', chalk.bold(this.stackName), this.update ? 'updating' : 'creating')));
+    await this.ioHelper.notify(info(format('%s: %s stack...', chalk.bold(this.stackName), this.update ? 'updating' : 'creating')));
 
     const startTime = new Date();
 
@@ -561,7 +556,7 @@ class FullCloudFormationDeployment {
         });
       } catch (err: any) {
         if (err.message === 'No updates are to be performed.') {
-          await this.ioHost.notify(debug(this.action, format('No updates are to be performed for stack %s', this.stackName)));
+          await this.ioHelper.notify(debug(format('No updates are to be performed for stack %s', this.stackName)));
           return {
             type: 'did-deploy-stack',
             noOp: true,
@@ -595,15 +590,14 @@ class FullCloudFormationDeployment {
       stack: this.stackArtifact,
       stackName: this.stackName,
       resourcesTotal: expectedChanges,
-      ioHost: this.ioHost,
-      action: this.action,
+      ioHelper: this.ioHelper,
       changeSetCreationTime: startTime,
     });
     await monitor.start();
 
     let finalState = this.cloudFormationStack;
     try {
-      const successStack = await waitForStackDeploy(this.cfn, { ioHost: this.ioHost, action: this.action }, this.stackName);
+      const successStack = await waitForStackDeploy(this.cfn, this.ioHelper, this.stackName);
 
       // This shouldn't really happen, but catch it anyway. You never know.
       if (!successStack) {
@@ -615,7 +609,7 @@ class FullCloudFormationDeployment {
     } finally {
       await monitor.stop();
     }
-    debug(this.action, format('Stack %s has completed updating', this.stackName));
+    debug(format('Stack %s has completed updating', this.stackName));
     return {
       type: 'did-deploy-stack',
       noOp: false,
@@ -666,7 +660,7 @@ export interface DestroyStackOptions {
   deployName?: string;
 }
 
-export async function destroyStack(options: DestroyStackOptions, { ioHost, action }: IoMessaging) {
+export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHelper) {
   const deployName = options.deployName || options.stack.stackName;
   const cfn = options.sdk.cloudFormation();
 
@@ -678,14 +672,13 @@ export async function destroyStack(options: DestroyStackOptions, { ioHost, actio
     cfn,
     stack: options.stack,
     stackName: deployName,
-    ioHost,
-    action,
+    ioHelper: ioHelper,
   });
   await monitor.start();
 
   try {
     await cfn.deleteStack({ StackName: deployName, RoleARN: options.roleArn });
-    const destroyedStack = await waitForStackDelete(cfn, { ioHost, action }, deployName);
+    const destroyedStack = await waitForStackDelete(cfn, ioHelper, deployName);
     if (destroyedStack && destroyedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new ToolkitError(`Failed to destroy ${deployName}: ${destroyedStack.stackStatus}`);
     }
@@ -711,14 +704,14 @@ async function canSkipDeploy(
   deployStackOptions: DeployStackOptions,
   cloudFormationStack: CloudFormationStack,
   parameterChanges: ParameterChanges,
-  { ioHost, action }: IoMessaging,
+  ioHelper: IoHelper,
 ): Promise<boolean> {
   const deployName = deployStackOptions.deployName || deployStackOptions.stack.stackName;
-  await ioHost.notify(debug(action, `${deployName}: checking if we can skip deploy`));
+  await ioHelper.notify(debug(`${deployName}: checking if we can skip deploy`));
 
   // Forced deploy
   if (deployStackOptions.force) {
-    await ioHost.notify(debug(action, `${deployName}: forced deployment`));
+    await ioHelper.notify(debug(`${deployName}: forced deployment`));
     return false;
   }
 
@@ -727,53 +720,53 @@ async function canSkipDeploy(
     deployStackOptions.deploymentMethod?.method === 'change-set' &&
     deployStackOptions.deploymentMethod.execute === false
   ) {
-    await ioHost.notify(debug(action, `${deployName}: --no-execute, always creating change set`));
+    await ioHelper.notify(debug(`${deployName}: --no-execute, always creating change set`));
     return false;
   }
 
   // No existing stack
   if (!cloudFormationStack.exists) {
-    await ioHost.notify(debug(action, `${deployName}: no existing stack`));
+    await ioHelper.notify(debug(`${deployName}: no existing stack`));
     return false;
   }
 
   // Template has changed (assets taken into account here)
   if (JSON.stringify(deployStackOptions.stack.template) !== JSON.stringify(await cloudFormationStack.template())) {
-    await ioHost.notify(debug(action, `${deployName}: template has changed`));
+    await ioHelper.notify(debug(`${deployName}: template has changed`));
     return false;
   }
 
   // Tags have changed
   if (!compareTags(cloudFormationStack.tags, deployStackOptions.tags ?? [])) {
-    await ioHost.notify(debug(action, `${deployName}: tags have changed`));
+    await ioHelper.notify(debug(`${deployName}: tags have changed`));
     return false;
   }
 
   // Notification arns have changed
   if (!arrayEquals(cloudFormationStack.notificationArns, deployStackOptions.notificationArns ?? [])) {
-    await ioHost.notify(debug(action, `${deployName}: notification arns have changed`));
+    await ioHelper.notify(debug(`${deployName}: notification arns have changed`));
     return false;
   }
 
   // Termination protection has been updated
   if (!!deployStackOptions.stack.terminationProtection !== !!cloudFormationStack.terminationProtection) {
-    await ioHost.notify(debug(action, `${deployName}: termination protection has been updated`));
+    await ioHelper.notify(debug(`${deployName}: termination protection has been updated`));
     return false;
   }
 
   // Parameters have changed
   if (parameterChanges) {
     if (parameterChanges === 'ssm') {
-      await ioHost.notify(debug(action, `${deployName}: some parameters come from SSM so we have to assume they may have changed`));
+      await ioHelper.notify(debug(`${deployName}: some parameters come from SSM so we have to assume they may have changed`));
     } else {
-      await ioHost.notify(debug(action, `${deployName}: parameters have changed`));
+      await ioHelper.notify(debug(`${deployName}: parameters have changed`));
     }
     return false;
   }
 
   // Existing stack is in a failed state
   if (cloudFormationStack.stackStatus.isFailure) {
-    await ioHost.notify(debug(action, `${deployName}: stack is in a failure state`));
+    await ioHelper.notify(debug(`${deployName}: stack is in a failure state`));
     return false;
   }
 

--- a/packages/aws-cdk/lib/api/garbage-collection/progress-printer.ts
+++ b/packages/aws-cdk/lib/api/garbage-collection/progress-printer.ts
@@ -1,13 +1,11 @@
 import * as chalk from 'chalk';
 import { GcAsset as GCAsset } from './garbage-collector';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { info } from '../../cli/messages';
-import { IoMessaging } from '../../toolkit/cli-io-host';
 import { ToolkitError } from '../../toolkit/error';
 
 export class ProgressPrinter {
-  private ioHost: IoMessaging['ioHost'];
-  private action: IoMessaging['action'];
-
+  private ioHelper: IoHelper;
   private totalAssets: number;
   private assetsScanned: number;
   private taggedAsset: number;
@@ -18,10 +16,8 @@ export class ProgressPrinter {
   private setInterval?: ReturnType<typeof setTimeout>;
   private isPaused: boolean;
 
-  constructor(msg: IoMessaging, totalAssets: number, interval?: number) {
-    this.ioHost = msg.ioHost;
-    this.action = msg.action;
-
+  constructor(ioHelper: IoHelper, totalAssets: number, interval?: number) {
+    this.ioHelper = ioHelper;
     this.totalAssets = totalAssets;
     this.assetsScanned = 0;
     this.taggedAsset = 0;
@@ -83,9 +79,9 @@ export class ProgressPrinter {
     const percentage = ((this.assetsScanned / this.totalAssets) * 100).toFixed(2);
     // print in MiB until we hit at least 1 GiB of data tagged/deleted
     if (Math.max(this.taggedAssetsSizeMb, this.deletedAssetsSizeMb) >= 1000) {
-      void this.ioHost.notify(info(this.action, chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.taggedAsset} assets (${(this.taggedAssetsSizeMb / 1000).toFixed(2)} GiB) tagged, ${this.deletedAssets} assets (${(this.deletedAssetsSizeMb / 1000).toFixed(2)} GiB) deleted.`)));
+      void this.ioHelper.notify(info(chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.taggedAsset} assets (${(this.taggedAssetsSizeMb / 1000).toFixed(2)} GiB) tagged, ${this.deletedAssets} assets (${(this.deletedAssetsSizeMb / 1000).toFixed(2)} GiB) deleted.`)));
     } else {
-      void this.ioHost.notify(info(this.action, chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.taggedAsset} assets (${this.taggedAssetsSizeMb.toFixed(2)} MiB) tagged, ${this.deletedAssets} assets (${this.deletedAssetsSizeMb.toFixed(2)} MiB) deleted.`)));
+      void this.ioHelper.notify(info(chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.taggedAsset} assets (${this.taggedAssetsSizeMb.toFixed(2)} MiB) tagged, ${this.deletedAssets} assets (${this.deletedAssetsSizeMb.toFixed(2)} MiB) deleted.`)));
     }
   }
 }

--- a/packages/aws-cdk/lib/api/logs/find-cloudwatch-logs.ts
+++ b/packages/aws-cdk/lib/api/logs/find-cloudwatch-logs.ts
@@ -1,7 +1,7 @@
 import type { CloudFormationStackArtifact, Environment } from '@aws-cdk/cx-api';
 import type { StackResourceSummary } from '@aws-sdk/client-cloudformation';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { debug } from '../../logging';
-import { IoMessaging } from '../../toolkit/cli-io-host';
 import { formatErrorMessage } from '../../util';
 import type { SDK, SdkProvider } from '../aws-auth';
 import { EnvironmentAccess } from '../environment';
@@ -38,14 +38,14 @@ export interface FoundLogGroupsResult {
 
 export async function findCloudWatchLogGroups(
   sdkProvider: SdkProvider,
-  msg: IoMessaging,
+  ioHelper: IoHelper,
   stackArtifact: CloudFormationStackArtifact,
 ): Promise<FoundLogGroupsResult> {
   let sdk: SDK;
   const resolvedEnv = await sdkProvider.resolveEnvironment(stackArtifact.environment);
   // try to assume the lookup role and fallback to the default credentials
   try {
-    sdk = (await new EnvironmentAccess(sdkProvider, DEFAULT_TOOLKIT_STACK_NAME, msg).accessStackForLookup(stackArtifact)).sdk;
+    sdk = (await new EnvironmentAccess(sdkProvider, DEFAULT_TOOLKIT_STACK_NAME, ioHelper).accessStackForLookup(stackArtifact)).sdk;
   } catch (e: any) {
     debug(`Failed to access SDK environment: ${formatErrorMessage(e)}`);
     sdk = (await sdkProvider.forEnvironment(resolvedEnv, Mode.ForReading)).sdk;

--- a/packages/aws-cdk/lib/api/work-graph/work-graph-builder.ts
+++ b/packages/aws-cdk/lib/api/work-graph/work-graph-builder.ts
@@ -2,7 +2,7 @@ import * as cxapi from '@aws-cdk/cx-api';
 import { AssetManifest, type IManifestEntry } from 'cdk-assets';
 import { WorkGraph } from './work-graph';
 import { DeploymentState, AssetBuildNode, WorkNode } from './work-graph-types';
-import { IoMessaging } from '../../toolkit/cli-io-host';
+import { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { ToolkitError } from '../../toolkit/error';
 import { contentHashAny } from '../../util';
 
@@ -22,17 +22,15 @@ export class WorkGraphBuilder {
     'stack': 5,
   };
   private readonly graph: WorkGraph;
-  private readonly ioHost: IoMessaging['ioHost'];
-  private readonly action: IoMessaging['action'];
+  private readonly ioHelper: IoHelper;
 
   constructor(
-    { ioHost, action }: IoMessaging,
+    ioHelper: IoHelper,
     private readonly prebuildAssets: boolean,
     private readonly idPrefix = '',
   ) {
-    this.graph = new WorkGraph({}, { ioHost, action });
-    this.ioHost = ioHost;
-    this.action = action;
+    this.graph = new WorkGraph({}, ioHelper);
+    this.ioHelper = ioHelper;
   }
 
   private addStack(artifact: cxapi.CloudFormationStackArtifact) {
@@ -130,7 +128,7 @@ export class WorkGraphBuilder {
       } else if (cxapi.NestedCloudAssemblyArtifact.isNestedCloudAssemblyArtifact(artifact)) {
         const assembly = new cxapi.CloudAssembly(artifact.fullPath, { topoSort: false });
         const nestedGraph = new WorkGraphBuilder(
-          { ioHost: this.ioHost, action: this.action },
+          this.ioHelper,
           this.prebuildAssets,
           `${this.idPrefix}${artifact.id}.`,
         ).build(assembly.artifacts);

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -5,6 +5,7 @@ import { parseCommandLineArguments } from './parse-command-line-arguments';
 import { checkForPlatformWarnings } from './platform-warnings';
 
 import * as version from './version';
+import { asIoHelper } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { SdkProvider } from '../api/aws-auth';
 import { SdkToCliLogger } from '../api/aws-auth/sdk-logger';
 import { setSdkTracing } from '../api/aws-auth/tracing';
@@ -107,7 +108,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
       proxyAddress: argv.proxy,
       caBundlePath: argv['ca-bundle-path'],
     },
-    logger: new SdkToCliLogger(ioHost),
+    logger: new SdkToCliLogger(asIoHelper(ioHost, ioHost.currentAction as any)),
   });
 
   let outDirLock: ILock | undefined;
@@ -185,8 +186,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     const cloudFormation = new Deployments({
       sdkProvider,
       toolkitStackName,
-      ioHost,
-      action: ioHost.currentAction,
+      ioHelper: asIoHelper(ioHost, ioHost.currentAction as any),
     });
 
     if (args.all && args.STACKS) {
@@ -265,7 +265,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         const source: BootstrapSource = determineBootstrapVersion(args);
 
         if (args.showTemplate) {
-          const bootstrapper = new Bootstrapper(source, { ioHost: ioHost, action: ioHost.currentAction });
+          const bootstrapper = new Bootstrapper(source, asIoHelper(ioHost, ioHost.currentAction));
           return bootstrapper.showTemplate(args.json);
         }
 

--- a/packages/aws-cdk/lib/cli/messages.ts
+++ b/packages/aws-cdk/lib/cli/messages.ts
@@ -2,22 +2,22 @@
 // The CLI cannot depend on the toolkit yet, because the toolkit currently depends on the CLI.
 // Once we have complete the repo split, we will create a temporary, private library package
 // for all code that is shared between CLI and toolkit. This is where this file will then live.
+import { ActionLessMessage } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import type { IoMessageCodeCategory } from '../logging';
-import type { IoMessage, IoMessageCode, IoMessageLevel, IoMessaging } from '../toolkit/cli-io-host';
+import type { IoMessageCode, IoMessageLevel } from '../toolkit/cli-io-host';
 
 type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
-type SimplifiedMessage<T> = Omit<IoMessage<T>, 'time' | 'action'> & { action: IoMessaging['action'] };
+type SimplifiedMessage<T> = Omit<ActionLessMessage<T>, 'time'>;
 
 /**
  * Internal helper that processes log inputs into a consistent format.
  * Handles string interpolation, format strings, and object parameter styles.
  * Applies optional styling and prepares the final message for logging.
  */
-export function formatMessage<T>(msg: Optional<SimplifiedMessage<T>, 'code'>, category: IoMessageCodeCategory = 'TOOLKIT'): IoMessage<T> {
+export function formatMessage<T>(msg: Optional<SimplifiedMessage<T>, 'code'>, category: IoMessageCodeCategory = 'TOOLKIT'): ActionLessMessage<T> {
   return {
     time: new Date(),
     level: msg.level,
-    action: msg.action as any,
     code: msg.code ?? defaultMessageCode(msg.level, category),
     message: msg.message,
     data: msg.data,
@@ -39,10 +39,9 @@ function defaultMessageCode(level: IoMessageLevel, category: IoMessageCodeCatego
  * Creates an error level message.
  * Errors must always have a unique code.
  */
-export const error = <T>(action: IoMessaging['action'], message: string, code: IoMessageCode, payload?: T) => {
+export const error = <T>(message: string, code: IoMessageCode, payload?: T) => {
   return formatMessage({
     level: 'error',
-    action,
     code,
     message,
     data: payload,
@@ -56,10 +55,9 @@ export const error = <T>(action: IoMessaging['action'], message: string, code: I
  * However actions that operate on Cloud Assemblies might include a result per Stack.
  * Unlike other messages, results must always have a code and a payload.
  */
-export const result = <T>(action: IoMessaging['action'], message: string, code: IoMessageCode, payload: T) => {
+export const result = <T>(message: string, code: IoMessageCode, payload: T) => {
   return formatMessage({
     level: 'result',
-    action,
     code,
     message,
     data: payload,
@@ -69,10 +67,9 @@ export const result = <T>(action: IoMessaging['action'], message: string, code: 
 /**
  * Creates a warning level message.
  */
-export const warn = <T>(action: IoMessaging['action'], message: string, code?: IoMessageCode, payload?: T) => {
+export const warn = <T>(message: string, code?: IoMessageCode, payload?: T) => {
   return formatMessage({
     level: 'warn',
-    action,
     code,
     message,
     data: payload,
@@ -82,10 +79,9 @@ export const warn = <T>(action: IoMessaging['action'], message: string, code?: I
 /**
  * Creates an info level message.
  */
-export const info = <T>(action: IoMessaging['action'], message: string, code?: IoMessageCode, payload?: T) => {
+export const info = <T>(message: string, code?: IoMessageCode, payload?: T) => {
   return formatMessage({
     level: 'info',
-    action,
     code,
     message,
     data: payload,
@@ -95,10 +91,9 @@ export const info = <T>(action: IoMessaging['action'], message: string, code?: I
 /**
  * Creates a debug level message.
  */
-export const debug = <T>(action: IoMessaging['action'], message: string, code?: IoMessageCode, payload?: T) => {
+export const debug = <T>(message: string, code?: IoMessageCode, payload?: T) => {
   return formatMessage({
     level: 'debug',
-    action,
     code,
     message,
     data: payload,
@@ -108,10 +103,9 @@ export const debug = <T>(action: IoMessaging['action'], message: string, code?: 
 /**
  * Creates a trace level message.
  */
-export const trace = <T>(action: IoMessaging['action'], message: string, code?: IoMessageCode, payload?: T) => {
+export const trace = <T>(message: string, code?: IoMessageCode, payload?: T) => {
   return formatMessage({
     level: 'trace',
-    action,
     code,
     message,
     data: payload,

--- a/packages/aws-cdk/lib/toolkit/cli-io-host.ts
+++ b/packages/aws-cdk/lib/toolkit/cli-io-host.ts
@@ -19,14 +19,6 @@ type CliAction =
 | 'version'
 | 'none';
 
-/**
- * Temporary helper to group required props for IoMessages
- */
-export interface IoMessaging {
-  ioHost: IIoHost;
-  action: CliAction;
-}
-
 export interface CliIoHostProps {
   /**
    * The initial Toolkit action the hosts starts with.

--- a/packages/aws-cdk/test/_helpers/test-io-host.ts
+++ b/packages/aws-cdk/test/_helpers/test-io-host.ts
@@ -1,0 +1,30 @@
+import { IIoHost, IoMessage, IoMessageLevel, IoRequest } from "../../../@aws-cdk/tmp-toolkit-helpers/src/api/io";
+import { isMessageRelevantForLevel } from "../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private";
+
+/**
+ * A test implementation of IIoHost that does nothing but can by spied on.
+ * Optionally set a level to filter out all irrelevant messages.
+ * Optionally set a approval level.
+ */
+export class TestIoHost implements IIoHost {
+  public readonly notifySpy: jest.Mock<any, any, any>;
+  public readonly requestSpy: jest.Mock<any, any, any>;
+
+  constructor(public level: IoMessageLevel = 'info') {
+    this.notifySpy = jest.fn();
+    this.requestSpy = jest.fn();
+  }
+
+  public async notify<T>(msg: IoMessage<T>): Promise<void> {
+    if (isMessageRelevantForLevel(msg, this.level)) {
+      this.notifySpy(msg);
+    }
+  }
+
+  public async requestResponse<T, U>(msg: IoRequest<T, U>): Promise<U> {
+    if (isMessageRelevantForLevel(msg, this.level)) {
+      this.requestSpy(msg);
+    }
+    return msg.defaultResponse;
+  }
+}

--- a/packages/aws-cdk/test/api/_helpers/hotswap-test-setup.ts
+++ b/packages/aws-cdk/test/api/_helpers/hotswap-test-setup.ts
@@ -5,7 +5,6 @@ import { ICloudFormationClient, SuccessfulDeployStackResult } from '../../../lib
 import { CloudFormationStack, Template } from '../../../lib/api/deployments';
 import * as deployments from '../../../lib/api/deployments/hotswap-deployments';
 import { HotswapMode, HotswapPropertyOverrides } from '../../../lib/api/hotswap/common';
-import { CliIoHost, IoMessaging } from '../../../lib/toolkit/cli-io-host';
 import { testStack, TestStackArtifact } from '../../util';
 import {
   mockCloudFormationClient,
@@ -15,6 +14,8 @@ import {
   setDefaultSTSMocks,
 } from '../../util/mock-sdk';
 import { FakeCloudformationStack } from './fake-cloudformation-stack';
+import { TestIoHost } from '../../_helpers/test-io-host';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const STACK_NAME = 'withouterrors';
 export const STACK_ID = 'stackId';
@@ -24,11 +25,7 @@ let currentCfnStack: FakeCloudformationStack;
 const currentCfnStackResources: StackResourceSummary[] = [];
 let stackTemplates: { [stackName: string]: any };
 let currentNestedCfnStackResources: { [stackName: string]: StackResourceSummary[] };
-
-let mockMsg: IoMessaging = {
-  ioHost: CliIoHost.instance(),
-  action: 'deploy',
-};
+let ioHost = new TestIoHost();
 
 export function setupHotswapTests(): HotswapMockSdkProvider {
   restoreSdkMocksToDefault();
@@ -149,6 +146,6 @@ export class HotswapMockSdkProvider extends MockSdkProvider {
     hotswapPropertyOverrides?: HotswapPropertyOverrides,
   ): Promise<SuccessfulDeployStackResult | undefined> {
     let hotswapProps = hotswapPropertyOverrides || new HotswapPropertyOverrides();
-    return deployments.tryHotswapDeployment(this, mockMsg, assetParams, currentCfnStack, stackArtifact, hotswapMode, hotswapProps);
+    return deployments.tryHotswapDeployment(this, asIoHelper(ioHost, 'deploy'), assetParams, currentCfnStack, stackArtifact, hotswapMode, hotswapProps);
   }
 }

--- a/packages/aws-cdk/test/api/bootstrap/bootstrap.test.ts
+++ b/packages/aws-cdk/test/api/bootstrap/bootstrap.test.ts
@@ -13,8 +13,9 @@ import { parse } from 'yaml';
 import { Bootstrapper } from '../../../lib/api/bootstrap';
 import { legacyBootstrapTemplate } from '../../../lib/api/bootstrap/legacy-template';
 import { deserializeStructure, serializeStructure, toYAML } from '../../../lib/util';
-import { CliIoHost } from '../../../lib/toolkit/cli-io-host';
 import { MockSdkProvider, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../util/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const env = {
   account: '123456789012',
@@ -31,9 +32,12 @@ jest.mock('../../../lib/api/deployments/checks', () => ({
 let sdk: MockSdkProvider;
 let changeSetTemplate: any | undefined;
 let bootstrapper: Bootstrapper;
+let ioHost = new TestIoHost();
+let ioHelper = asIoHelper(ioHost, 'bootstrap');
+
 beforeEach(() => {
   sdk = new MockSdkProvider();
-  bootstrapper = new Bootstrapper({ source: 'legacy' }, { ioHost: CliIoHost.instance(), action: 'bootstrap' });
+  bootstrapper = new Bootstrapper({ source: 'legacy' }, ioHelper);
   mockCloudFormationClient.reset();
   restoreSdkMocksToDefault();
   // First two calls, no stacks exist (first is for version checking, second is in deploy-stack.ts)

--- a/packages/aws-cdk/test/api/deployments/checks.test.ts
+++ b/packages/aws-cdk/test/api/deployments/checks.test.ts
@@ -1,12 +1,10 @@
 import { DescribeStacksCommand, StackStatus } from '@aws-sdk/client-cloudformation';
 import { determineAllowCrossAccountAssetPublishing, getBootstrapStackInfo } from '../../../lib/api/deployments/checks';
-import { CliIoHost, IoMessaging } from '../../../lib/toolkit/cli-io-host';
 import { mockCloudFormationClient, MockSdk } from '../../util/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
-let mockMsg: IoMessaging = {
-  ioHost: CliIoHost.instance(),
-  action: 'deploy',
-};
+let ioHelper = asIoHelper(new TestIoHost(), 'deploy');
 
 describe('determineAllowCrossAccountAssetPublishing', () => {
   it('should return true when hasStagingBucket is false', async () => {
@@ -20,7 +18,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
       }],
     });
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(true);
   });
 
@@ -38,7 +36,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
       }],
     });
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(true);
   });
 
@@ -57,7 +55,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
       }],
     });
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(true);
   });
 
@@ -65,7 +63,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
     const mockSDK = new MockSdk();
     mockCloudFormationClient.on(DescribeStacksCommand).rejects(new Error('Could not read bootstrap stack'));
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(true);
   });
 
@@ -73,7 +71,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
     const mockSDK = new MockSdk();
     mockCloudFormationClient.on(DescribeStacksCommand).rejects(new Error('Could not read bootstrap stack'));
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(true);
   });
 
@@ -91,7 +89,7 @@ describe('determineAllowCrossAccountAssetPublishing', () => {
       }],
     });
 
-    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, mockMsg);
+    const result = await determineAllowCrossAccountAssetPublishing(mockSDK, ioHelper);
     expect(result).toBe(false);
   });
 });

--- a/packages/aws-cdk/test/api/environment/environment-resources.test.ts
+++ b/packages/aws-cdk/test/api/environment/environment-resources.test.ts
@@ -4,14 +4,17 @@ import { Context } from '../../../lib/api/context';
 import { EnvironmentResourcesRegistry } from '../../../lib/api/environment';
 import * as version from '../../../lib/cli/version';
 import { CachedDataSource, Notices, NoticesFilter } from '../../../lib/notices';
-import { CliIoHost, IoMessaging } from '../../../lib/toolkit/cli-io-host';
 import { MockSdk, mockBootstrapStack, mockSSMClient } from '../../util/mock-sdk';
 import { MockToolkitInfo } from '../../util/mock-toolkitinfo';
+import { TestIoHost } from '../../_helpers/test-io-host';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 let mockSdk: MockSdk;
 let envRegistry: EnvironmentResourcesRegistry;
 let toolkitMock: ReturnType<typeof MockToolkitInfo.setup>;
-let mockMsg: IoMessaging = { ioHost: CliIoHost.instance(), action: 'deploy' };
+
+let ioHost = new TestIoHost();
+let ioHelper = asIoHelper(ioHost, 'deploy');
 
 beforeEach(() => {
   mockSdk = new MockSdk();
@@ -35,7 +38,7 @@ function envResources() {
       name: 'aws://11111111/us-nowhere',
     },
     mockSdk,
-    mockMsg,
+    ioHelper,
   );
 }
 

--- a/packages/aws-cdk/test/api/resource-import/import.test.ts
+++ b/packages/aws-cdk/test/api/resource-import/import.test.ts
@@ -17,9 +17,10 @@ import {
 import * as promptly from 'promptly';
 import { Deployments } from '../../../lib/api/deployments';
 import { ResourceImporter, ImportMap, ResourceImporterProps } from '../../../lib/api/resource-import';
-import { CliIoHost, IIoHost } from '../../../lib/toolkit/cli-io-host';
 import { testStack } from '../../util';
 import { MockSdkProvider, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../util/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const promptlyConfirm = promptly.confirm as jest.Mock;
 const promptlyPrompt = promptly.prompt as jest.Mock;
@@ -74,7 +75,7 @@ function stackWithKeySigningKey(props: Record<string, unknown>) {
 
 let sdkProvider: MockSdkProvider;
 let deployments: Deployments;
-let ioHost: IIoHost;
+let ioHost = new TestIoHost();
 let props: ResourceImporterProps;
 beforeEach(() => {
   restoreSdkMocksToDefault();
@@ -82,14 +83,11 @@ beforeEach(() => {
   sdkProvider = new MockSdkProvider();
   deployments = new Deployments({
     sdkProvider,
-    ioHost: CliIoHost.instance(),
-    action: 'deploy',
+    ioHelper: asIoHelper(ioHost, 'deploy'),
   });
-  ioHost = CliIoHost.instance();
   props = {
     deployments,
-    ioHost,
-    action: 'import',
+    ioHelper: asIoHelper(ioHost, 'deploy'),
   };
 });
 

--- a/packages/aws-cdk/test/api/stack-events/stack-activity-monitor.test.ts
+++ b/packages/aws-cdk/test/api/stack-events/stack-activity-monitor.test.ts
@@ -6,8 +6,9 @@ import {
 } from '@aws-sdk/client-cloudformation';
 import { MockSdk, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../util/mock-sdk';
 import { StackActivityMonitor } from '../../../lib/api/stack-events';
-import { IIoHost } from '../../../lib/toolkit/cli-io-host';
 import { testStack } from '../../util';
+import { asIoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+import { IIoHost } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io';
 
 let sdk: MockSdk;
 let monitor: StackActivityMonitor;
@@ -20,8 +21,7 @@ beforeEach(async () => {
 
   monitor = await new StackActivityMonitor({
     cfn: sdk.cloudFormation(),
-    ioHost,
-    action: 'deploy',
+    ioHelper: asIoHelper(ioHost, 'deploy'),
     stack: testStack({
       stackName: 'StackName',
     }),

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -18,8 +18,8 @@ const fakeChokidarWatcherOn = {
   },
 
   get fileEventCallback(): (
-  event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
-  path: string,
+    event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
+    path: string,
   ) => Promise<void> {
     expect(mockChokidarWatcherOn.mock.calls.length).toBeGreaterThanOrEqual(2);
     const secondCall = mockChokidarWatcherOn.mock.calls[1];
@@ -96,6 +96,7 @@ import {
   mockSSMClient,
   restoreSdkMocksToDefault,
 } from '../util/mock-sdk';
+import { asIoHelper } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 markTesting();
 
@@ -103,6 +104,8 @@ const defaultBootstrapSource: BootstrapSource = { source: 'default' };
 const bootstrapEnvironmentMock = jest.spyOn(Bootstrapper.prototype, 'bootstrapEnvironment');
 let cloudExecutable: MockCloudExecutable;
 let stderrMock: jest.SpyInstance;
+let ioHelper = asIoHelper(CliIoHost.instance(), 'deploy');
+
 beforeEach(() => {
   jest.resetAllMocks();
   restoreSdkMocksToDefault();
@@ -224,8 +227,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -265,8 +267,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -331,8 +332,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -388,8 +388,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -445,8 +444,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -499,8 +497,7 @@ describe('readCurrentTemplate', () => {
       sdkProvider: mockCloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: mockCloudExecutable.sdkProvider,
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -1038,7 +1035,7 @@ describe('watch', () => {
       });
     }).rejects.toThrow(
       "Cannot use the 'watch' command without specifying at least one directory to monitor. " +
-        'Make sure to add a "watch" key to your cdk.json',
+      'Make sure to add a "watch" key to your cdk.json',
     );
   });
 
@@ -1336,8 +1333,7 @@ describe('synth', () => {
         cloudExecutable: mockCloudExecutable,
         deployments: new Deployments({
           sdkProvider: mockSdkProvider,
-          ioHost: CliIoHost.instance(),
-          action: 'deploy',
+          ioHelper: asIoHelper(CliIoHost.instance(), 'deploy'),
         }),
         sdkProvider: mockSdkProvider,
         configuration: mockCloudExecutable.configuration,
@@ -1539,8 +1535,7 @@ describe('synth', () => {
       sdkProvider: cloudExecutable.sdkProvider,
       deployments: new Deployments({
         sdkProvider: new MockSdkProvider(),
-        ioHost: CliIoHost.instance(),
-        action: 'deploy',
+        ioHelper,
       }),
     });
 
@@ -1566,8 +1561,7 @@ describe('synth', () => {
 
     const deployments = new Deployments({
       sdkProvider: new MockSdkProvider(),
-      ioHost: CliIoHost.instance(),
-      action: 'deploy',
+      ioHelper,
     });
 
     // Rollback might be called -- just don't do anything.
@@ -1751,8 +1745,7 @@ class FakeCloudFormation extends Deployments {
   ) {
     super({
       sdkProvider: new MockSdkProvider(),
-      ioHost: CliIoHost.instance(),
-      action: 'deploy',
+      ioHelper,
     });
 
     for (const [stackName, tags] of Object.entries(expectedTags)) {


### PR DESCRIPTION
This PR is a lot. There is no good way of reviewing it, so thanks for taking the time.

The main change here is the usage of the `IoHelper` in all internal APIs. Previously we would pass an `IoHost` and an `action` around as pair, but separate value. Instead we now use the `IoHelper` which knows how to send messages with an action.

I also decided to rename all properties and params respectively. This is partly what makes the PR so large. Note that all changes are to private APIs.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
