### PR TITLE
refactor(cli): remove generic argument from `notify<T>()`

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/io-host.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/io-host.ts
@@ -5,7 +5,7 @@ export interface IIoHost {
    * Notifies the host of a message.
    * The caller waits until the notification completes.
    */
-  notify<T>(msg: IoMessage<T>): Promise<void>;
+  notify(msg: IoMessage<unknown>): Promise<void>;
 
   /**
    * Notifies the host of a message that requires a response.

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
@@ -13,7 +13,7 @@ export type ActionLessRequest<T, U> = Omit<IoRequest<T, U>, 'action'>;
  * Wraps a client provided IoHost and provides additional features & services to toolkit internal classes.
  */
 export interface IoHelper extends IIoHost {
-  notify(msg: ActionLessMessage<any>): Promise<void>;
+  notify(msg: ActionLessMessage<unkown>): Promise<void>;
   requestResponse<T, U>(msg: ActionLessRequest<T, U>): Promise<U>;
 }
 

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
@@ -13,7 +13,7 @@ export type ActionLessRequest<T, U> = Omit<IoRequest<T, U>, 'action'>;
  * Wraps a client provided IoHost and provides additional features & services to toolkit internal classes.
  */
 export interface IoHelper extends IIoHost {
-  notify<T>(msg: ActionLessMessage<T>): Promise<void>;
+  notify(msg: ActionLessMessage<any>): Promise<void>;
   requestResponse<T, U>(msg: ActionLessRequest<T, U>): Promise<U>;
 }
 

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/io-helper.ts
@@ -13,7 +13,7 @@ export type ActionLessRequest<T, U> = Omit<IoRequest<T, U>, 'action'>;
  * Wraps a client provided IoHost and provides additional features & services to toolkit internal classes.
  */
 export interface IoHelper extends IIoHost {
-  notify(msg: ActionLessMessage<unkown>): Promise<void>;
+  notify(msg: ActionLessMessage<unknown>): Promise<void>;
   requestResponse<T, U>(msg: ActionLessRequest<T, U>): Promise<U>;
 }
 

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/test-io-host.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/test-io-host.ts
@@ -18,7 +18,7 @@ export class TestIoHost implements IIoHost {
     this.requestSpy = jest.fn();
   }
 
-  public async notify<T>(msg: IoMessage<T>): Promise<void> {
+  public async notify(msg: IoMessage<unknown>): Promise<void> {
     if (isMessageRelevantForLevel(msg, this.level)) {
       this.notifySpy(msg);
     }

--- a/packages/aws-cdk/lib/cli/activity-printer/base.ts
+++ b/packages/aws-cdk/lib/cli/activity-printer/base.ts
@@ -5,7 +5,7 @@ import { IoMessage } from '../../toolkit/cli-io-host';
 import { maxResourceTypeLength, stackEventHasErrorMessage } from '../../util';
 
 export interface IActivityPrinter {
-  notify<T>(msg: IoMessage<T>): void;
+  notify(msg: IoMessage<unknown>): void;
 }
 
 export interface ActivityPrinterProps {
@@ -51,10 +51,10 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
   /**
    * Receive a stack activity message
    */
-  public notify(msg: IoMessage<any>): void {
+  public notify(msg: IoMessage<unknown>): void {
     switch (msg.code) {
       case 'CDK_TOOLKIT_I5501':
-        this.start(msg.data);
+        this.start(msg.data as { stack: CloudFormationStackArtifact });
         break;
       case 'CDK_TOOLKIT_I5502':
         this.activity(msg.data as StackActivity);

--- a/packages/aws-cdk/lib/toolkit/cli-io-host.ts
+++ b/packages/aws-cdk/lib/toolkit/cli-io-host.ts
@@ -127,7 +127,7 @@ export class CliIoHost implements IIoHost {
 
   // Corked Logging
   private corkedCounter = 0;
-  private readonly corkedLoggingBuffer: IoMessage<any>[] = [];
+  private readonly corkedLoggingBuffer: IoMessage<unknown>[] = [];
 
   private constructor(props: CliIoHostProps = {}) {
     this.currentAction = props.currentAction ?? 'none';
@@ -220,7 +220,7 @@ export class CliIoHost implements IIoHost {
    * Notifies the host of a message.
    * The caller waits until the notification completes.
    */
-  public async notify<T>(msg: IoMessage<T>): Promise<void> {
+  public async notify(msg: IoMessage<unknown>): Promise<void> {
     if (this._internalIoHost) {
       return this._internalIoHost.notify(msg);
     }
@@ -250,7 +250,7 @@ export class CliIoHost implements IIoHost {
   /**
    * Detect stack activity messages so they can be send to the printer.
    */
-  private isStackActivity(msg: IoMessage<any>) {
+  private isStackActivity(msg: IoMessage<unknown>) {
     return [
       'CDK_TOOLKIT_I5501',
       'CDK_TOOLKIT_I5502',
@@ -376,7 +376,7 @@ export class CliIoHost implements IIoHost {
   /**
    * Formats a message for console output with optional color support
    */
-  private formatMessage(msg: IoMessage<any>): string {
+  private formatMessage(msg: IoMessage<unknown>): string {
     // apply provided style or a default style if we're in TTY mode
     let message_text = this.isTTY
       ? styleMap[msg.level](msg.message)

--- a/packages/aws-cdk/test/_helpers/test-io-host.ts
+++ b/packages/aws-cdk/test/_helpers/test-io-host.ts
@@ -15,7 +15,7 @@ export class TestIoHost implements IIoHost {
     this.requestSpy = jest.fn();
   }
 
-  public async notify<T>(msg: IoMessage<T>): Promise<void> {
+  public async notify(msg: IoMessage<unknown>): Promise<void> {
     if (isMessageRelevantForLevel(msg, this.level)) {
       this.notifySpy(msg);
     }


### PR DESCRIPTION
The `IIoHost` interface has the following method:

```ts
interface IIoHost {
  notify<T>(msg: IoMessage<T>): Promise<void>;
}
```

The generic parameter `T` is only used once, without bounds, for a singleton argument in input position. This means it is equivalent to the following:

```ts
interface IIoHost {
  notify(msg: IoMessage<unknown>): Promise<void>;
}
```

(Preferring `unknown` over `any` so that implementors are forced to test for the type of the `data` field, just like they would need to do with an argument of type `T`)

In the words of the [Java generics tutorial](https://docs.oracle.com/javase/tutorial/extra/generics/methods.html):

> Generic methods allow type parameters to be used to express
> dependencies among the types of one or more arguments to a method and/or
> its return type. If there isn't such a dependency, a generic method
> should not be used.

Or [similar advice for TypeScript](https://effectivetypescript.com/2020/08/12/generics-golden-rule/):

> Type Parameters Should Appear Twice
>
> Type parameters are for relating the types of multiple values. If a
> type parameter is only used once in the function signature, it's not
> relating anything.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
