### PR TITLE
chore: in tests, publish both upstream and candidate versions of schema

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml
@@ -100,7 +100,7 @@ jobs:
           echo 'registry=http://localhost:4873/' >> ~/.npmrc
       - name: Find an locally publish all tarballs
         run: |-
-          for pkg in packages/{@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk}/dist/js/*.tgz; do
+          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk}/dist/js/*.tgz; do
             npm publish $pkg
           done
       - name: Download and install the test artifact

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1396,16 +1396,19 @@ new CdkCliIntegTestsWorkflow(repo, {
   testRunsOn: POWERFUL_RUNNER,
 
   localPackages: [
-    // CloudAssemblySchema is not in this list because in the way we're doing
-    // Verdaccio now, its 0.0.0 version will shadow the ACTUAL published version
-    // that aws-cdk-lib depends on, and so will not be found.
-    //
-    // Not sure if that will cause problems yet.
+    cloudAssemblySchema.name,
     cloudFormationDiff.name,
     cdkAssets.name,
     cli.name,
     cliLib.name,
     cdkAliasPackage.name,
+  ],
+
+  allowUpstreamVersions: [
+    // cloud-assembly-schema gets referenced under multiple versions
+    // - Candidate version for cdk-assets
+    // - Previously released version for aws-cdk-lib
+    cloudAssemblySchema.name,
   ],
 });
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "ts5.6",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "cdklabs-projen-project-types": "^0.2.2",
+    "cdklabs-projen-project-types": "^0.2.3",
     "constructs": "^10.0.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4538,10 +4538,10 @@ cdk-from-cfn@^0.193.0:
   resolved "https://registry.yarnpkg.com/cdk-from-cfn/-/cdk-from-cfn-0.193.0.tgz#048daca73be6dfd3ab3c104f67f2828587b1c761"
   integrity sha512-LBKqAnsg12RRhyz+zyByI3H6REiDVNm1vofhdnEXSAIGIBuO0H/cw4mbCpz0Qr9huZYssF9ozGsbwa1K3RF2Tg==
 
-cdklabs-projen-project-types@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.2.tgz#337834e73e4080b959ae19c214636f0d254565a2"
-  integrity sha512-SfktcGYPwY1mbSJJtAO+u1VqQzyoe9SFMg6NzUtJcEml6JQnUrSKrnsVqR6X3hpZMa/VYs5Qtlu12GWWI9q1JQ==
+cdklabs-projen-project-types@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.3.tgz#49a9248b04c4deaa0a1cba8ca80d0f00c4881562"
+  integrity sha512-emIW3suU3JwyvIAQsE01znIpkHKFc/7RTYP+OIvyxwhTJ0gjGSE63D9iXEx892sE0JaB9iIB1Or8qpzxNGcMcw==
   dependencies:
     yaml "^2.7.0"
 


### PR DESCRIPTION
We need 2 different versions of `@aws-cdk/cloud-assembly-schema` versions available at the same time:

- The candidate version is used by `cdk-assets` (which doesn't bundle it)
- The released version is used by `aws-cdk-lib` (which is used as part of tests.

Requires updating to a new version of cdklabs-projen-project-types.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
