### PR TITLE
fix(cdk-assets): `--profile` is ignored while publishing assets

### DIFF
--- a/packages/cdk-assets/lib/aws.ts
+++ b/packages/cdk-assets/lib/aws.ts
@@ -228,6 +228,8 @@ export class DefaultAwsClient implements IAws {
       config.region = options.region;
       if (options.assumeRoleArn) {
         config.credentials = fromTemporaryCredentials({
+          // dont forget the credentials chain.
+          masterCredentials: config.credentials,
           params: {
             RoleArn: options.assumeRoleArn,
             ExternalId: options.assumeRoleExternalId,


### PR DESCRIPTION
We neglected to configure the main credentials when assuming the file publishing role. The main credentials are where the profile is already configured. 

- Integration Test: https://github.com/aws/aws-cdk-cli-testing/pull/59

Fixes https://github.com/aws/aws-cdk-cli/issues/212

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
