### PR TITLE
fix(cli): cannot set `progress` via app or user configuration

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -294,6 +294,11 @@ export class CdkToolkit {
       return this.watch(options);
     }
 
+    // set progress from options, this includes user and app config
+    if (options.progress) {
+      this.ioHost.stackProgress = options.progress;
+    }
+
     const startSynthTime = new Date().getTime();
     const stackCollection = await this.selectStacksForDeploy(
       options.selector,
@@ -759,6 +764,11 @@ export class CdkToolkit {
 
   public async import(options: ImportOptions) {
     const stacks = await this.selectStacksForDeploy(options.selector, true, true, false);
+
+    // set progress from options, this includes user and app config
+    if (options.progress) {
+      this.ioHost.stackProgress = options.progress;
+    }
 
     if (stacks.stackCount > 1) {
       throw new ToolkitError(


### PR DESCRIPTION
In [v2.172.0](https://github.com/aws/aws-cdk/releases/tag/v2.172.0) (via https://github.com/aws/aws-cdk/commit/069b72ca5613b0ec731067fdad7b8ded831044e1) we accidentally broke the "bar" stack activity progress output mode (*). Turns out no-one noticed.

In [v2.1002.0](https://github.com/aws/aws-cdk-cli/releases/tag/aws-cdk%40v2.1002.0) (via https://github.com/aws/aws-cdk-cli/commit/0d9912f9c90dd435cc991a903aff6767016f46b1) this got unintentionally fixed and the `--progress` was honored again. However the accidental fix didn't consider options set by app or user configuration. Again this went unnoticed for a while, until this week a user alerted my to the issue on the cdk.dev Slack.

This PR fixes `progress` set via app or user configuration.

(*) This line is the culprit:
https://github.com/aws/aws-cdk/commit/069b72ca5613b0ec731067fdad7b8ded831044e1#diff-d03bd87f399ba5824d5442aa691df8b6f08f4f8a3848cfc8492c3d52fab5e48bR105 
Previously "default" verbosity was a `0`, which meant `verbose = 0` and later on `!verbose` would turn into `true`.
The change caused `verbose` to be a value different than `0` and thus turning `!verbose` to be `false` and the code would always assume we are in verbose logging mode and must use the "events" progress.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
