### PR TITLE
fix(cli): fix for code scanning alerts: Prototype-polluting assignment

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/util/objects.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/util/objects.ts
@@ -103,6 +103,9 @@ export function deepSet(x: any, path: string[], value: any) {
 
   while (path.length > 1 && isObject(x)) {
     const key = path.shift()!;
+    if (key === '__proto__' || key === 'constructor' || key === 'prototype') {
+      throw new ToolkitError(`Invalid key: ${key}`);
+    }
     if (!(key in x)) {
       x[key] = {};
     }
@@ -113,10 +116,15 @@ export function deepSet(x: any, path: string[], value: any) {
     throw new ToolkitError(`Expected an object, got '${x}'`);
   }
 
+  const finalKey = path[0];
+  if (finalKey === '__proto__' || finalKey === 'constructor' || finalKey === 'prototype') {
+    throw new ToolkitError(`Invalid key: ${finalKey}`);
+  }
+
   if (value !== undefined) {
-    x[path[0]] = value;
+    x[finalKey] = value;
   } else {
-    delete x[path[0]];
+    delete x[finalKey];
   }
 }
 


### PR DESCRIPTION
Fix for [https://github.com/aws/aws-cdk-cli/security/code-scanning/5](https://github.com/aws/aws-cdk-cli/security/code-scanning/5) [https://github.com/aws/aws-cdk-cli/security/code-scanning/6](https://github.com/aws/aws-cdk-cli/security/code-scanning/6) [https://github.com/aws/aws-cdk-cli/security/code-scanning/7](https://github.com/aws/aws-cdk-cli/security/code-scanning/7)

To fix the prototype pollution vulnerability, we need to ensure that the keys used in the `deepSet` function do not include any properties that can modify `Object.prototype`. This can be achieved by validating the keys in the `path` array and rejecting any keys that are `__proto__`, `constructor`, or `prototype`.

The best way to fix this problem without changing existing functionality is to add a validation step before using the keys in the `path` array. We will add a check to ensure that none of the keys in the `path` array are `__proto__`, `constructor`, or `prototype`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
