### PR TITLE
fix(cli): hotswap is reporting and running changes that don't happen

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
@@ -1,0 +1,30 @@
+import type { PropertyDifference, Resource } from '@aws-cdk/cloudformation-diff';
+
+/**
+ * Represents a change in a resource
+ */
+export interface ResourceChange {
+  /**
+   * The logical ID of the resource which is being changed
+   */
+  readonly logicalId: string;
+  /**
+   * The value the resource is being updated from
+   */
+  readonly oldValue: Resource;
+  /**
+   * The value the resource is being updated to
+   */
+  readonly newValue: Resource;
+  /**
+   * The changes made to the resource properties
+   */
+  readonly propertyUpdates: Record<string, PropertyDifference<unknown>>;
+}
+
+export interface HotswappableChange {
+  /**
+   * The resource change that is causing the hotswap.
+   */
+  readonly cause: ResourceChange;
+}

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/index.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/index.ts
@@ -13,3 +13,4 @@ export * from './watch';
 export * from './stack-details';
 export * from './diff';
 export * from './logs-monitor';
+export * from './hotswap';

--- a/packages/aws-cdk/lib/api/deployments/hotswap-deployments.ts
+++ b/packages/aws-cdk/lib/api/deployments/hotswap-deployments.ts
@@ -3,6 +3,8 @@ import * as cfn_diff from '@aws-cdk/cloudformation-diff';
 import type * as cxapi from '@aws-cdk/cx-api';
 import type { WaiterResult } from '@smithy/util-waiter';
 import * as chalk from 'chalk';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads';
+import type { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import type { SDK, SdkProvider } from '../aws-auth';
 import type { CloudFormationStack } from './cloudformation';
 import type { NestedStackTemplates } from './nested-stack-helpers';
@@ -17,8 +19,8 @@ import type {
   ChangeHotswapResult,
   HotswapOperation,
   NonHotswappableChange,
-  ResourceChange,
-  HotswapPropertyOverrides, ClassifiedResourceChanges,
+  HotswapPropertyOverrides,
+  ClassifiedResourceChanges,
 } from '../hotswap/common';
 import {
   ICON,
@@ -35,7 +37,6 @@ import {
 import { isHotswappableStateMachineChange } from '../hotswap/stepfunctions-state-machines';
 import { Mode } from '../plugin';
 import type { SuccessfulDeployStackResult } from './deployment-result';
-import type { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 // Must use a require() otherwise esbuild complains about calling a namespace
 // eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/consistent-type-imports
@@ -324,7 +325,8 @@ async function findNestedHotswappableChanges(
     evaluateNestedCfnTemplate,
     sdk,
     nestedStackTemplates[logicalId].nestedStackTemplates,
-    hotswapPropertyOverrides);
+    hotswapPropertyOverrides,
+  );
 }
 
 /** Returns 'true' if a pair of changes is for the same resource. */

--- a/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
+++ b/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
@@ -55,6 +55,12 @@ export async function isHotswappableAppSyncChange(
     } else {
       physicalName = arn;
     }
+
+    // nothing do here
+    if (!physicalName) {
+      return ret;
+    }
+
     ret.push({
       change: {
         cause: change,
@@ -63,10 +69,6 @@ export async function isHotswappableAppSyncChange(
       service: 'appsync',
       resourceNames: [`${change.newValue.Type} '${physicalName}'`],
       apply: async (sdk: SDK) => {
-        if (!physicalName) {
-          return;
-        }
-
         const sdkProperties: { [name: string]: any } = {
           ...change.oldValue.Properties,
           Definition: change.newValue.Properties?.Definition,

--- a/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
+++ b/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
@@ -5,10 +5,10 @@ import type {
 import {
   type ChangeHotswapResult,
   classifyChanges,
-  type HotswappableChangeCandidate,
   lowerCaseFirstCharacter,
   transformObjectKeys,
 } from './common';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import { ToolkitError } from '../../toolkit/error';
 import type { SDK } from '../aws-auth';
 
@@ -16,7 +16,7 @@ import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-
 
 export async function isHotswappableAppSyncChange(
   logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
   const isResolver = change.newValue.Type === 'AWS::AppSync::Resolver';
@@ -56,9 +56,10 @@ export async function isHotswappableAppSyncChange(
       physicalName = arn;
     }
     ret.push({
+      change: {
+        cause: change,
+      },
       hotswappable: true,
-      resourceType: change.newValue.Type,
-      propsChanged: namesOfHotswappableChanges,
       service: 'appsync',
       resourceNames: [`${change.newValue.Type} '${physicalName}'`],
       apply: async (sdk: SDK) => {

--- a/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
+++ b/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
@@ -2,16 +2,16 @@ import type { UpdateProjectCommandInput } from '@aws-sdk/client-codebuild';
 import {
   type ChangeHotswapResult,
   classifyChanges,
-  type HotswappableChangeCandidate,
   lowerCaseFirstCharacter,
   transformObjectKeys,
 } from './common';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
 export async function isHotswappableCodeBuildProjectChange(
   logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
   if (change.newValue.Type !== 'AWS::CodeBuild::Project') {
@@ -31,9 +31,10 @@ export async function isHotswappableCodeBuildProjectChange(
       change.newValue.Properties?.Name,
     );
     ret.push({
+      change: {
+        cause: change,
+      },
       hotswappable: true,
-      resourceType: change.newValue.Type,
-      propsChanged: classifiedChanges.namesOfHotswappableProps,
       service: 'codebuild',
       resourceNames: [`CodeBuild Project '${projectName}'`],
       apply: async (sdk: SDK) => {

--- a/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
+++ b/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
@@ -30,6 +30,12 @@ export async function isHotswappableCodeBuildProjectChange(
       logicalId,
       change.newValue.Properties?.Name,
     );
+
+    // nothing to do jere
+    if (!projectName) {
+      return ret;
+    }
+
     ret.push({
       change: {
         cause: change,
@@ -38,9 +44,6 @@ export async function isHotswappableCodeBuildProjectChange(
       service: 'codebuild',
       resourceNames: [`CodeBuild Project '${projectName}'`],
       apply: async (sdk: SDK) => {
-        if (!projectName) {
-          return;
-        }
         updateProjectInput.name = projectName;
 
         for (const updatedPropName in change.propertyUpdates) {

--- a/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
+++ b/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
@@ -1,19 +1,19 @@
 import type {
   HotswapPropertyOverrides,
   ChangeHotswapResult,
-  HotswappableChangeCandidate,
 } from './common';
 import {
   classifyChanges, lowerCaseFirstCharacter,
   reportNonHotswappableChange,
   transformObjectKeys,
 } from './common';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
 export async function isHotswappableEcsServiceChange(
   logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
   hotswapPropertyOverrides: HotswapPropertyOverrides,
 ): Promise<ChangeHotswapResult> {
@@ -65,9 +65,10 @@ export async function isHotswappableEcsServiceChange(
   if (namesOfHotswappableChanges.length > 0) {
     const taskDefinitionResource = await prepareTaskDefinitionChange(evaluateCfnTemplate, logicalId, change);
     ret.push({
+      change: {
+        cause: change,
+      },
       hotswappable: true,
-      resourceType: change.newValue.Type,
-      propsChanged: namesOfHotswappableChanges,
       service: 'ecs-service',
       resourceNames: [
         `ECS Task Definition '${await taskDefinitionResource.Family}'`,
@@ -144,7 +145,7 @@ interface EcsService {
 async function prepareTaskDefinitionChange(
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
   logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
 ) {
   const taskDefinitionResource: { [name: string]: any } = {
     ...change.oldValue.Properties,

--- a/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
+++ b/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
@@ -11,7 +11,7 @@ import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/sr
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
-const EcsServiceResourceType = 'AWS::ECS::Service';
+const ECS_SERVICE_RESOURCE_TYPE = 'AWS::ECS::Service';
 
 export async function isHotswappableEcsServiceChange(
   logicalId: string,
@@ -35,7 +35,7 @@ export async function isHotswappableEcsServiceChange(
   // find all ECS Services that reference the TaskDefinition that changed
   const resourcesReferencingTaskDef = evaluateCfnTemplate.findReferencesTo(logicalId);
   const ecsServiceResourcesReferencingTaskDef = resourcesReferencingTaskDef.filter(
-    (r) => r.Type === EcsServiceResourceType,
+    (r) => r.Type === ECS_SERVICE_RESOURCE_TYPE,
   );
   const ecsServicesReferencingTaskDef = new Array<EcsService>();
   for (const ecsServiceResource of ecsServiceResourcesReferencingTaskDef) {
@@ -52,7 +52,7 @@ export async function isHotswappableEcsServiceChange(
   if (resourcesReferencingTaskDef.length > ecsServicesReferencingTaskDef.length) {
     // if something besides an ECS Service is referencing the TaskDefinition,
     // hotswap is not possible in FALL_BACK mode
-    const nonEcsServiceTaskDefRefs = resourcesReferencingTaskDef.filter((r) => r.Type !== EcsServiceResourceType);
+    const nonEcsServiceTaskDefRefs = resourcesReferencingTaskDef.filter((r) => r.Type !== ECS_SERVICE_RESOURCE_TYPE);
     for (const taskRef of nonEcsServiceTaskDefRefs) {
       reportNonHotswappableChange(
         ret,

--- a/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
+++ b/packages/aws-cdk/lib/api/hotswap/ecs-services.ts
@@ -11,6 +11,8 @@ import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/sr
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
+const EcsServiceResourceType = 'AWS::ECS::Service';
+
 export async function isHotswappableEcsServiceChange(
   logicalId: string,
   change: ResourceChange,
@@ -33,7 +35,7 @@ export async function isHotswappableEcsServiceChange(
   // find all ECS Services that reference the TaskDefinition that changed
   const resourcesReferencingTaskDef = evaluateCfnTemplate.findReferencesTo(logicalId);
   const ecsServiceResourcesReferencingTaskDef = resourcesReferencingTaskDef.filter(
-    (r) => r.Type === 'AWS::ECS::Service',
+    (r) => r.Type === EcsServiceResourceType,
   );
   const ecsServicesReferencingTaskDef = new Array<EcsService>();
   for (const ecsServiceResource of ecsServiceResourcesReferencingTaskDef) {
@@ -50,7 +52,7 @@ export async function isHotswappableEcsServiceChange(
   if (resourcesReferencingTaskDef.length > ecsServicesReferencingTaskDef.length) {
     // if something besides an ECS Service is referencing the TaskDefinition,
     // hotswap is not possible in FALL_BACK mode
-    const nonEcsServiceTaskDefRefs = resourcesReferencingTaskDef.filter((r) => r.Type !== 'AWS::ECS::Service');
+    const nonEcsServiceTaskDefRefs = resourcesReferencingTaskDef.filter((r) => r.Type !== EcsServiceResourceType);
     for (const taskRef of nonEcsServiceTaskDefRefs) {
       reportNonHotswappableChange(
         ret,

--- a/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
+++ b/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
@@ -18,26 +18,15 @@ export async function isHotswappableLambdaFunctionChange(
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
-  // if the change is for a Lambda Version,
-  // ignore it by returning an empty hotswap operation -
-  // we will publish a new version when we get to hotswapping the actual Function this Version points to, below
+  // if the change is for a Lambda Version, we just ignore it
+  // we will publish a new version when we get to hotswapping the actual Function this Version points to
   // (Versions can't be changed in CloudFormation anyway, they're immutable)
   if (change.newValue.Type === 'AWS::Lambda::Version') {
-    return [
-      {
-        change: {
-          cause: change,
-        },
-        hotswappable: true,
-        resourceNames: [],
-        service: 'lambda',
-        apply: async (_sdk: SDK) => {
-        },
-      },
-    ];
+    return [];
   }
 
   // we handle Aliases specially too
+  // the actual alias update will happen if we change the function
   if (change.newValue.Type === 'AWS::Lambda::Alias') {
     return classifyAliasChanges(change);
   }
@@ -55,7 +44,20 @@ export async function isHotswappableLambdaFunctionChange(
     change.newValue.Properties?.FunctionName,
   );
   const namesOfHotswappableChanges = Object.keys(classifiedChanges.hotswappableProps);
-  if (namesOfHotswappableChanges.length > 0) {
+  if (functionName && namesOfHotswappableChanges.length > 0) {
+    const lambdaCodeChange = await evaluateLambdaFunctionProps(
+      classifiedChanges.hotswappableProps,
+      change.newValue.Properties?.Runtime,
+      evaluateCfnTemplate,
+    );
+
+    // nothing to do here
+    if (lambdaCodeChange === undefined) {
+      return ret;
+    }
+
+    const dependencies = await dependantResources(logicalId, functionName, evaluateCfnTemplate);
+
     ret.push({
       change: {
         cause: change,
@@ -64,30 +66,9 @@ export async function isHotswappableLambdaFunctionChange(
       service: 'lambda',
       resourceNames: [
         `Lambda Function '${functionName}'`,
-        // add Version here if we're publishing a new one
-        ...(await renderVersions(logicalId, evaluateCfnTemplate, [`Lambda Version for Function '${functionName}'`])),
-        // add any Aliases that we are hotswapping here
-        ...(await renderAliases(
-          logicalId,
-          evaluateCfnTemplate,
-          async (alias) => `Lambda Alias '${alias}' for Function '${functionName}'`,
-        )),
+        ...dependencies.map(d => d.description),
       ],
       apply: async (sdk: SDK) => {
-        const lambdaCodeChange = await evaluateLambdaFunctionProps(
-          classifiedChanges.hotswappableProps,
-          change.newValue.Properties?.Runtime,
-          evaluateCfnTemplate,
-        );
-        if (lambdaCodeChange === undefined) {
-          return;
-        }
-
-        if (!functionName) {
-          return;
-        }
-
-        const { versionsReferencingFunction, aliasesNames } = await versionsAndAliases(logicalId, evaluateCfnTemplate);
         const lambda = sdk.lambda();
         const operations: Promise<any>[] = [];
 
@@ -120,19 +101,21 @@ export async function isHotswappableLambdaFunctionChange(
           }
 
           // only if the code changed is there any point in publishing a new Version
-          if (versionsReferencingFunction.length > 0) {
+          const versions = dependencies.filter((d) => d.resourceType === 'AWS::Lambda::Version');
+          if (versions.length) {
             const publishVersionPromise = lambda.publishVersion({
               FunctionName: functionName,
             });
 
-            if (aliasesNames.length > 0) {
+            const aliases = dependencies.filter((d) => d.resourceType === 'AWS::Lambda::Alias');
+            if (aliases.length) {
               // we need to wait for the Version to finish publishing
               const versionUpdate = await publishVersionPromise;
-              for (const alias of aliasesNames) {
+              for (const alias of aliases) {
                 operations.push(
                   lambda.updateAlias({
                     FunctionName: functionName,
-                    Name: alias,
+                    Name: alias.physicalName,
                     FunctionVersion: versionUpdate.Version,
                   }),
                 );
@@ -162,19 +145,8 @@ function classifyAliasChanges(change: ResourceChange): ChangeHotswapResult {
   const classifiedChanges = classifyChanges(change, ['FunctionVersion']);
   classifiedChanges.reportNonHotswappablePropertyChanges(ret);
 
-  const namesOfHotswappableChanges = Object.keys(classifiedChanges.hotswappableProps);
-  if (namesOfHotswappableChanges.length > 0) {
-    ret.push({
-      change: {
-        cause: change,
-      },
-      hotswappable: true,
-      service: 'lambda',
-      resourceNames: [],
-      apply: async (_sdk: SDK) => {
-      },
-    });
-  }
+  // we only want to report not hotswappable changes to aliases
+  // the actual alias update will happen if we change the function
 
   return ret;
 }
@@ -374,38 +346,44 @@ async function versionsAndAliases(logicalId: string, evaluateCfnTemplate: Evalua
   // find all Lambda Aliases that reference the above Versions
   const aliasesReferencingVersions = flatMap(versionsReferencingFunction, v =>
     evaluateCfnTemplate.findReferencesTo(v.LogicalId));
-  // Limited set of updates per function
-  // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
-  const aliasesNames = await Promise.all(aliasesReferencingVersions.map(a =>
-    evaluateCfnTemplate.evaluateCfnExpression(a.Properties?.Name)));
 
-  return { versionsReferencingFunction, aliasesNames };
+  return { versionsReferencingFunction, aliasesReferencingVersions };
 }
 
-/**
- * Renders the string used in displaying Alias resource names that reference the specified Lambda Function
- */
-async function renderAliases(
+async function dependantResources(
   logicalId: string,
+  functionName: string,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-  callbackfn: (value: any, index: number, array: any[]) => Promise<string>,
-): Promise<string[]> {
-  const aliasesNames = (await versionsAndAliases(logicalId, evaluateCfnTemplate)).aliasesNames;
+): Promise<Array<{
+    logicalId: string;
+    resourceType: string;
+    physicalName?: string;
+    description: string;
+  }>> {
+  const candidates = await versionsAndAliases(logicalId, evaluateCfnTemplate);
 
   // Limited set of updates per function
   // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
-  return Promise.all(aliasesNames.map(callbackfn));
-}
+  const aliases = await Promise.all(candidates.aliasesReferencingVersions.map(async (a) => {
+    const name = await evaluateCfnTemplate.evaluateCfnExpression(a.Properties?.Name);
+    return {
+      logicalId: a.LogicalId,
+      physicalName: name,
+      resourceType: 'AWS::Lambda::Alias',
+      description: `Lambda Alias '${name}' for Function '${functionName}'`,
+    };
+  }));
 
-/**
- * Renders the string used in displaying Version resource names that reference the specified Lambda Function
- */
-async function renderVersions(
-  logicalId: string,
-  evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-  versionString: string[],
-): Promise<string[]> {
-  const versions = (await versionsAndAliases(logicalId, evaluateCfnTemplate)).versionsReferencingFunction;
+  const versions = candidates.versionsReferencingFunction.map((v) => (
+    {
+      logicalId: v.LogicalId,
+      resourceType: v.Type,
+      description: `Lambda Version for Function '${functionName}'`,
+    }
+  ));
 
-  return versions.length > 0 ? versionString : [];
+  return [
+    ...versions,
+    ...aliases,
+  ];
 }

--- a/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
+++ b/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
@@ -1,4 +1,5 @@
-import type { ChangeHotswapResult, HotswappableChangeCandidate } from './common';
+import type { ChangeHotswapResult } from './common';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
@@ -10,7 +11,7 @@ export const REQUIRED_BY_CFN = 'required-to-be-present-by-cfn';
 
 export async function isHotswappableS3BucketDeploymentChange(
   _logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
   // In old-style synthesis, the policy used by the lambda to copy assets Ref's the assets directly,
@@ -28,9 +29,10 @@ export async function isHotswappableS3BucketDeploymentChange(
   });
 
   ret.push({
+    change: {
+      cause: change,
+    },
     hotswappable: true,
-    resourceType: change.newValue.Type,
-    propsChanged: ['*'],
     service: 'custom-s3-deployment',
     resourceNames: [`Contents of S3 Bucket '${customResourceProperties.DestinationBucketName}'`],
     apply: async (sdk: SDK) => {
@@ -61,7 +63,7 @@ export async function isHotswappableS3BucketDeploymentChange(
 
 export async function skipChangeForS3DeployCustomResourcePolicy(
   iamPolicyLogicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<boolean> {
   if (change.newValue.Type !== 'AWS::IAM::Policy') {

--- a/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
+++ b/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
@@ -1,10 +1,11 @@
-import { type ChangeHotswapResult, classifyChanges, type HotswappableChangeCandidate } from './common';
+import { type ChangeHotswapResult, classifyChanges } from './common';
+import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
 export async function isHotswappableStateMachineChange(
   logicalId: string,
-  change: HotswappableChangeCandidate,
+  change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
   if (change.newValue.Type !== 'AWS::StepFunctions::StateMachine') {
@@ -25,9 +26,10 @@ export async function isHotswappableStateMachineChange(
       })
       : await evaluateCfnTemplate.findPhysicalNameFor(logicalId);
     ret.push({
+      change: {
+        cause: change,
+      },
       hotswappable: true,
-      resourceType: change.newValue.Type,
-      propsChanged: namesOfHotswappableChanges,
       service: 'stepfunctions-service',
       resourceNames: [`${change.newValue.Type} '${stateMachineArn?.split(':')[6]}'`],
       apply: async (sdk: SDK) => {

--- a/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
+++ b/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
@@ -25,6 +25,12 @@ export async function isHotswappableStateMachineChange(
             stateMachineNameInCfnTemplate,
       })
       : await evaluateCfnTemplate.findPhysicalNameFor(logicalId);
+
+    // nothing to do
+    if (!stateMachineArn) {
+      return ret;
+    }
+
     ret.push({
       change: {
         cause: change,
@@ -33,10 +39,6 @@ export async function isHotswappableStateMachineChange(
       service: 'stepfunctions-service',
       resourceNames: [`${change.newValue.Type} '${stateMachineArn?.split(':')[6]}'`],
       apply: async (sdk: SDK) => {
-        if (!stateMachineArn) {
-          return;
-        }
-
         // not passing the optional properties leaves them unchanged
         await sdk.stepFunctions().updateStateMachine({
           stateMachineArn,

--- a/packages/aws-cdk/test/api/hotswap/s3-bucket-hotswap-deployments.test.ts
+++ b/packages/aws-cdk/test/api/hotswap/s3-bucket-hotswap-deployments.test.ts
@@ -1,12 +1,12 @@
 import { InvokeCommand } from '@aws-sdk/client-lambda';
 import * as setup from '../_helpers/hotswap-test-setup';
 import { HotswapMode } from '../../../lib/api/hotswap/common';
-import { REQUIRED_BY_CFN } from '../../../lib/api/hotswap/s3-bucket-deployments';
 import { mockLambdaClient } from '../../util/mock-sdk';
 import { silentTest } from '../../util/silent';
 
 let hotswapMockSdkProvider: setup.HotswapMockSdkProvider;
 
+const REQUIRED_BY_CFN = 'required-to-be-present-by-cfn';
 const payloadWithoutCustomResProps = {
   RequestType: 'Update',
   ResponseURL: REQUIRED_BY_CFN,


### PR DESCRIPTION
This change is three fold:

- We clean up the private `HotswapOperation` interface (née `HotswappableChange`) by removing two unused fields and adding in a new filed in preparation for structured data alongside hotswap messages
- In the hotswap providers, pull gates outside of the apply function. This prevents hotswaps being reported when nothing would actually be done. These are local checks and now just run a little bit earlier.
- In `lambda-functions.ts` don't report hotswappable changes for versions and aliases. These used to be reported with an empty array for `resourceNames` and a noop `apply` function. This means that literally nothing happens with these entries, since `apply` doesn't do anything and the CLI uses `resourceNames` to print anything. Just removing these as they are reported as part of a change to the function.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
