### PR TITLE
fix(lambda): Deprecating default behavior for issue-33688. Related to PR-33689

### DIFF
--- a/packages/aws-cdk/lib/init-templates/.recommended-feature-flags.json
+++ b/packages/aws-cdk/lib/init-templates/.recommended-feature-flags.json
@@ -65,5 +65,5 @@
   "@aws-cdk/aws-elasticloadbalancingV2:albDualstackWithoutPublicIpv4SecurityGroupRulesDefault": true,
   "@aws-cdk/aws-iam:oidcRejectUnauthorizedConnections": true,
   "@aws-cdk/core:enableAdditionalMetadataCollection": true,
-  "@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy": true
+  "@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy": false
 }


### PR DESCRIPTION
Fixes #[33688](https://github.com/aws/aws-cdk/issues/33688)
Related to #https://github.com/aws/aws-cdk/pull/33689

Defaulting to deprecate feature flag  createNewPoliciesWithAddToRolePolicy  behavior. 
`features.ts`
[Deprecated default feature] When this feature flag is enabled, Lambda will create new inline policies with AddToRolePolicy. 
      The purpose of this is to prevent lambda from creating a dependency on the Default Policy Statement.
      This solves an issue where a circular dependency could occur if adding lambda to something like a Cognito Trigger, then adding the User Pool to the lambda execution role permissions.
      However in the current implementation, we have removed a dependency of the lambda function on the policy. In addition to this, a Role will be attached to the Policy instead of an inline policy being attached to the role. 
      This will create a data race condition in the CloudFormation template because the creation of the Lambda function no longer waits for the policy to be created. Having said that, we are not deprecating the feature (we are defaulting the feature flag to false for new stacks) since this feature can still be used to get around the circular dependency issue (issue-7016) particularly in cases where the lambda resource creation doesnt need to depend on the policy resource creation. 
      We recommend to unset the feature flag if already set which will restore the original behavior.  
  
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
