### PR TITLE
feat(toolkit-lib): report hotswap messages into a message span

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
@@ -1,4 +1,30 @@
 import type { PropertyDifference, Resource } from '@aws-cdk/cloudformation-diff';
+import type * as cxapi from '@aws-cdk/cx-api';
+
+/**
+ * A resource affected by a change
+ */
+export interface AffectedResource {
+  /**
+   * The logical ID of the affected resource in the template
+   */
+  readonly logicalId: string;
+  /**
+   * The CloudFormation type of the resource
+   * This could be a custom type.
+   */
+  readonly resourceType: string;
+  /**
+   * The friendly description of the affected resource
+   */
+  readonly description?: string;
+  /**
+   * The physical name of the resource when deployed.
+   *
+   * A physical name is not always available, e.g. new resources will not have one until after the deployment
+   */
+  readonly physicalName?: string;
+}
 
 /**
  * Represents a change in a resource
@@ -22,9 +48,28 @@ export interface ResourceChange {
   readonly propertyUpdates: Record<string, PropertyDifference<unknown>>;
 }
 
+/**
+ * A change that can be hotswapped
+ */
 export interface HotswappableChange {
   /**
    * The resource change that is causing the hotswap.
    */
   readonly cause: ResourceChange;
 }
+
+/**
+ * Information about a hotswap deployment
+ */
+export interface HotswapDeployment {
+  /**
+   * The stack that's currently being deployed
+   */
+  readonly stack: cxapi.CloudFormationStackArtifact;
+
+  /**
+   * The mode the hotswap deployment was initiated with.
+   */
+  readonly mode: 'hotswap-only' | 'fall-back';
+}
+

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
@@ -5,6 +5,7 @@ import type { BootstrapEnvironmentProgress } from '../payloads/bootstrap-environ
 import type { MissingContext, UpdatedContext } from '../payloads/context';
 import type { BuildAsset, DeployConfirmationRequest, PublishAsset, StackDeployProgress, SuccessfulDeployStackResult } from '../payloads/deploy';
 import type { StackDestroy, StackDestroyProgress } from '../payloads/destroy';
+import type { HotswapDeployment } from '../payloads/hotswap';
 import type { StackDetailsPayload } from '../payloads/list';
 import type { CloudWatchLogEvent, CloudWatchLogMonitorControlEvent } from '../payloads/logs-monitor';
 import type { StackRollbackProgress } from '../payloads/rollback';
@@ -188,6 +189,16 @@ export const IO = {
   }),
 
   // Hotswap (54xx)
+  CDK_TOOLKIT_I5400: make.trace<HotswapDeployment>({
+    code: 'CDK_TOOLKIT_I5400',
+    description: 'Starting a hotswap deployment',
+    interface: 'HotswapDeployment',
+  }),
+  CDK_TOOLKIT_I5410: make.info<Duration>({
+    code: 'CDK_TOOLKIT_I5410',
+    description: 'Hotswap deployment has ended, a full deployment might still follow if needed',
+    interface: 'Duration',
+  }),
 
   // Stack Monitor (55xx)
   CDK_TOOLKIT_I5501: make.info<StackMonitoringControlEvent>({
@@ -442,5 +453,10 @@ export const SPAN = {
     name: 'Publish Asset',
     start: IO.CDK_TOOLKIT_I5220,
     end: IO.CDK_TOOLKIT_I5221,
+  },
+  HOTSWAP: {
+    name: 'hotswap-deployment',
+    start: IO.CDK_TOOLKIT_I5400,
+    end: IO.CDK_TOOLKIT_I5410,
   },
 } satisfies Record<string, SpanDefinition<any, any>>;

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -38,6 +38,8 @@ group: Documents
 | `CDK_TOOLKIT_I5313` | File event detected during active deployment, changes are queued | `info` | {@link FileWatchEvent} |
 | `CDK_TOOLKIT_I5314` | Initial watch deployment started | `info` | n/a |
 | `CDK_TOOLKIT_I5315` | Queued watch deployment started | `info` | n/a |
+| `CDK_TOOLKIT_I5400` | Starting a hotswap deployment | `trace` | {@link HotswapDeployment} |
+| `CDK_TOOLKIT_I5410` | Hotswap deployment has ended, a full deployment might still follow if needed | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I5501` | Stack Monitoring: Start monitoring of a single stack | `info` | {@link StackMonitoringControlEvent} |
 | `CDK_TOOLKIT_I5502` | Stack Monitoring: Activity event for a single stack | `info` | {@link StackActivity} |
 | `CDK_TOOLKIT_I5503` | Stack Monitoring: Finished monitoring of a single stack | `info` | {@link StackMonitoringControlEvent} |

--- a/packages/aws-cdk/lib/api/hotswap/common.ts
+++ b/packages/aws-cdk/lib/api/hotswap/common.ts
@@ -1,9 +1,34 @@
 import type { PropertyDifference } from '@aws-cdk/cloudformation-diff';
+import type { CloudFormationStackArtifact } from '@aws-cdk/cx-api';
 import type { HotswappableChange, ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import { ToolkitError } from '../../toolkit/error';
 import type { SDK } from '../aws-auth';
 
 export const ICON = '✨';
+
+/**
+ * The result of an attempted hotswap deployment
+ */
+export interface HotswapResult {
+  /**
+   * The stack that was hotswapped
+   */
+  readonly stack: CloudFormationStackArtifact;
+  /**
+   * Whether hotswapping happened or not.
+   *
+   * `false` indicates that the deployment could not be hotswapped and full deployment may be attempted as fallback.
+   */
+  readonly hotswapped: boolean;
+  /**
+   * The changes that were deemed hotswappable
+   */
+  readonly hotswappableChanges: any[];
+  /**
+   * The changes that were deemed not hotswappable
+   */
+  readonly nonHotswappableChanges: any[];
+}
 
 export interface HotswapOperation {
   /**

--- a/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
+++ b/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
@@ -3,7 +3,7 @@ import type { PropertyDifference } from '@aws-cdk/cloudformation-diff';
 import type { FunctionConfiguration, UpdateFunctionConfigurationCommandInput } from '@aws-sdk/client-lambda';
 import type { ChangeHotswapResult } from './common';
 import { classifyChanges } from './common';
-import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
+import type { AffectedResource, ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import { ToolkitError } from '../../toolkit/error';
 import { flatMap } from '../../util';
 import type { ILambdaClient, SDK } from '../aws-auth';
@@ -66,7 +66,7 @@ export async function isHotswappableLambdaFunctionChange(
       service: 'lambda',
       resourceNames: [
         `Lambda Function '${functionName}'`,
-        ...dependencies.map(d => d.description),
+        ...dependencies.map(d => d.description ?? `${d.resourceType} '${d.physicalName}'`),
       ],
       apply: async (sdk: SDK) => {
         const lambda = sdk.lambda();
@@ -354,12 +354,7 @@ async function dependantResources(
   logicalId: string,
   functionName: string,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<Array<{
-    logicalId: string;
-    resourceType: string;
-    physicalName?: string;
-    description: string;
-  }>> {
+): Promise<Array<AffectedResource>> {
   const candidates = await versionsAndAliases(logicalId, evaluateCfnTemplate);
 
   // Limited set of updates per function


### PR DESCRIPTION
Requested by early `toolkit-lib` users, all hotswap messages are now reported into span. Structured data reported for start and end is intentionally limited and will be extended further in future.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
