### PR TITLE
fix(cli): hotswap output is different for different resources

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap.ts
@@ -1,5 +1,6 @@
 import type { PropertyDifference, Resource } from '@aws-cdk/cloudformation-diff';
 import type * as cxapi from '@aws-cdk/cx-api';
+import type { ResourceMetadata } from '../../resource-metadata/resource-metadata';
 
 /**
  * A resource affected by a change
@@ -24,6 +25,13 @@ export interface AffectedResource {
    * A physical name is not always available, e.g. new resources will not have one until after the deployment
    */
   readonly physicalName?: string;
+  /**
+   * Resource metadata attached to the logical id from the cloud assembly
+   *
+   * This is only present if the resource is present in the current Cloud Assembly,
+   * i.e. resource deletions will not have metadata.
+   */
+  readonly metadata?: ResourceMetadata;
 }
 
 /**
@@ -56,6 +64,10 @@ export interface HotswappableChange {
    * The resource change that is causing the hotswap.
    */
   readonly cause: ResourceChange;
+  /**
+   * A list of resources that are being hotswapped as part of the change
+   */
+  readonly resources: AffectedResource[];
 }
 
 /**
@@ -72,4 +84,3 @@ export interface HotswapDeployment {
    */
   readonly mode: 'hotswap-only' | 'fall-back';
 }
-

--- a/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
+++ b/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
@@ -64,10 +64,15 @@ export async function isHotswappableAppSyncChange(
     ret.push({
       change: {
         cause: change,
+        resources: [{
+          logicalId,
+          resourceType: change.newValue.Type,
+          physicalName,
+          metadata: evaluateCfnTemplate.metadataFor(logicalId),
+        }],
       },
       hotswappable: true,
       service: 'appsync',
-      resourceNames: [`${change.newValue.Type} '${physicalName}'`],
       apply: async (sdk: SDK) => {
         const sdkProperties: { [name: string]: any } = {
           ...change.oldValue.Properties,

--- a/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
+++ b/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
@@ -39,10 +39,15 @@ export async function isHotswappableCodeBuildProjectChange(
     ret.push({
       change: {
         cause: change,
+        resources: [{
+          logicalId: logicalId,
+          resourceType: change.newValue.Type,
+          physicalName: projectName,
+          metadata: evaluateCfnTemplate.metadataFor(logicalId),
+        }],
       },
       hotswappable: true,
       service: 'codebuild',
-      resourceNames: [`CodeBuild Project '${projectName}'`],
       apply: async (sdk: SDK) => {
         updateProjectInput.name = projectName;
 

--- a/packages/aws-cdk/lib/api/hotswap/common.ts
+++ b/packages/aws-cdk/lib/api/hotswap/common.ts
@@ -23,7 +23,7 @@ export interface HotswapResult {
   /**
    * The changes that were deemed hotswappable
    */
-  readonly hotswappableChanges: any[];
+  readonly hotswappableChanges: HotswappableChange[];
   /**
    * The changes that were deemed not hotswappable
    */
@@ -46,11 +46,6 @@ export interface HotswapOperation {
    * Description of the change that is applied as part of the operation
    */
   readonly change: HotswappableChange;
-
-  /**
-   * The names of the resources being hotswapped.
-   */
-  readonly resourceNames: string[];
 
   /**
    * Applies the hotswap operation
@@ -80,7 +75,7 @@ export interface NonHotswappableChange {
 export type ChangeHotswapResult = Array<HotswapOperation | NonHotswappableChange>;
 
 export interface ClassifiedResourceChanges {
-  hotswappableChanges: HotswapOperation[];
+  hotswapOperations: HotswapOperation[];
   nonHotswappableChanges: NonHotswappableChange[];
 }
 

--- a/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
+++ b/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
@@ -12,7 +12,7 @@ const REQUIRED_BY_CFN = 'required-to-be-present-by-cfn';
 const CDK_BUCKET_DEPLOYMENT_CFN_TYPE = 'Custom::CDKBucketDeployment';
 
 export async function isHotswappableS3BucketDeploymentChange(
-  _logicalId: string,
+  logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
 ): Promise<ChangeHotswapResult> {
@@ -39,10 +39,16 @@ export async function isHotswappableS3BucketDeploymentChange(
   ret.push({
     change: {
       cause: change,
+      resources: [{
+        logicalId,
+        physicalName: customResourceProperties.DestinationBucketName,
+        resourceType: CDK_BUCKET_DEPLOYMENT_CFN_TYPE,
+        description: `Contents of AWS::S3::Bucket '${customResourceProperties.DestinationBucketName}'`,
+        metadata: evaluateCfnTemplate.metadataFor(logicalId),
+      }],
     },
     hotswappable: true,
     service: 'custom-s3-deployment',
-    resourceNames: [`Contents of S3 Bucket '${customResourceProperties.DestinationBucketName}'`],
     apply: async (sdk: SDK) => {
       await sdk.lambda().invokeCommand({
         FunctionName: functionName,

--- a/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
+++ b/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
@@ -34,10 +34,15 @@ export async function isHotswappableStateMachineChange(
     ret.push({
       change: {
         cause: change,
+        resources: [{
+          logicalId,
+          resourceType: change.newValue.Type,
+          physicalName: stateMachineArn?.split(':')[6],
+          metadata: evaluateCfnTemplate.metadataFor(logicalId),
+        }],
       },
       hotswappable: true,
       service: 'stepfunctions-service',
-      resourceNames: [`${change.newValue.Type} '${stateMachineArn?.split(':')[6]}'`],
       apply: async (sdk: SDK) => {
         // not passing the optional properties leaves them unchanged
         await sdk.stepFunctions().updateStateMachine({


### PR DESCRIPTION
Aligns hotswap output to always follow the pattern: `<CfnResourceType>: '<physical name>'`
For example:

```
AWS::Lambda::Function 'my-func'
AWS::CodeBuild::Project 'my-project'
```

Previously we used "friendly" type names for some resources, but not all.
Custom descriptions are kept only for more complicated resources, e.g.:

```
Contents of AWS::S3::Bucket 'my-bucket'
AWS::Lambda::Alias 'my-alias' for AWS::Lambda::Function 'my-func'
```

Arguably this reduces output fidelity to hotswap users, however it increases consistency and maintainability.

---

Also attaches more information to each affected resources, opening up potential future changes and structured data interfaces. This completes the cleanup on the `hotswappableChanges` side. Next up is the `nonHotswappableChanges`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
