### PR TITLE
refactor(cli): various code re-organization in hotswap code

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/util/objects.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/util/objects.ts
@@ -215,3 +215,35 @@ export function splitBySize(data: any, maxSizeBytes: number): [any, any] {
     ];
   }
 }
+
+type Exclude = { [key: string]: Exclude | true };
+
+/**
+ * This function transforms all keys (recursively) in the provided `val` object.
+ *
+ * @param val The object whose keys need to be transformed.
+ * @param transform The function that will be applied to each key.
+ * @param exclude The keys that will not be transformed and copied to output directly
+ * @returns A new object with the same values as `val`, but with all keys transformed according to `transform`.
+ */
+export function transformObjectKeys(val: any, transform: (str: string) => string, exclude: Exclude = {}): any {
+  if (val == null || typeof val !== 'object') {
+    return val;
+  }
+  if (Array.isArray(val)) {
+    // For arrays we just pass parent's exclude object directly
+    // since it makes no sense to specify different exclude options for each array element
+    return val.map((input: any) => transformObjectKeys(input, transform, exclude));
+  }
+  const ret: { [k: string]: any } = {};
+  for (const [k, v] of Object.entries(val)) {
+    const childExclude = exclude[k];
+    if (childExclude === true) {
+      // we don't transform this object if the key is specified in exclude
+      ret[transform(k)] = v;
+    } else {
+      ret[transform(k)] = transformObjectKeys(v, transform, childExclude);
+    }
+  }
+  return ret;
+}

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/util/string-manipulation.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/util/string-manipulation.ts
@@ -35,3 +35,10 @@ function roundPercentage(num: number): number {
 function millisecondsToSeconds(num: number): number {
   return num / 1000;
 }
+
+/**
+ * This function lower cases the first character of the string provided.
+ */
+export function lowerCaseFirstCharacter(str: string): string {
+  return str.length > 0 ? `${str[0].toLowerCase()}${str.slice(1)}` : str;
+}

--- a/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
+++ b/packages/aws-cdk/lib/api/hotswap/appsync-mapping-templates.ts
@@ -3,13 +3,12 @@ import type {
   GetSchemaCreationStatusCommandInput,
 } from '@aws-sdk/client-appsync';
 import {
-  type ChangeHotswapResult,
+  type HotswapChange,
   classifyChanges,
-  lowerCaseFirstCharacter,
-  transformObjectKeys,
 } from './common';
 import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import { ToolkitError } from '../../toolkit/error';
+import { lowerCaseFirstCharacter, transformObjectKeys } from '../../util';
 import type { SDK } from '../aws-auth';
 
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
@@ -18,7 +17,7 @@ export async function isHotswappableAppSyncChange(
   logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<ChangeHotswapResult> {
+): Promise<HotswapChange[]> {
   const isResolver = change.newValue.Type === 'AWS::AppSync::Resolver';
   const isFunction = change.newValue.Type === 'AWS::AppSync::FunctionConfiguration';
   const isGraphQLSchema = change.newValue.Type === 'AWS::AppSync::GraphQLSchema';
@@ -27,7 +26,7 @@ export async function isHotswappableAppSyncChange(
     return [];
   }
 
-  const ret: ChangeHotswapResult = [];
+  const ret: HotswapChange[] = [];
 
   const classifiedChanges = classifyChanges(change, [
     'RequestMappingTemplate',

--- a/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
+++ b/packages/aws-cdk/lib/api/hotswap/code-build-projects.ts
@@ -1,11 +1,10 @@
 import type { UpdateProjectCommandInput } from '@aws-sdk/client-codebuild';
 import {
-  type ChangeHotswapResult,
+  type HotswapChange,
   classifyChanges,
-  lowerCaseFirstCharacter,
-  transformObjectKeys,
 } from './common';
 import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
+import { lowerCaseFirstCharacter, transformObjectKeys } from '../../util';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
 
@@ -13,12 +12,12 @@ export async function isHotswappableCodeBuildProjectChange(
   logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<ChangeHotswapResult> {
+): Promise<HotswapChange[]> {
   if (change.newValue.Type !== 'AWS::CodeBuild::Project') {
     return [];
   }
 
-  const ret: ChangeHotswapResult = [];
+  const ret: HotswapChange[] = [];
 
   const classifiedChanges = classifyChanges(change, ['Source', 'Environment', 'SourceVersion']);
   classifiedChanges.reportNonHotswappablePropertyChanges(ret);

--- a/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
+++ b/packages/aws-cdk/lib/api/hotswap/lambda-functions.ts
@@ -1,7 +1,7 @@
 import { Writable } from 'stream';
 import type { PropertyDifference } from '@aws-cdk/cloudformation-diff';
 import type { FunctionConfiguration, UpdateFunctionConfigurationCommandInput } from '@aws-sdk/client-lambda';
-import type { ChangeHotswapResult } from './common';
+import type { HotswapChange } from './common';
 import { classifyChanges } from './common';
 import type { AffectedResource, ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import { ToolkitError } from '../../toolkit/error';
@@ -17,7 +17,7 @@ export async function isHotswappableLambdaFunctionChange(
   logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<ChangeHotswapResult> {
+): Promise<HotswapChange[]> {
   // if the change is for a Lambda Version, we just ignore it
   // we will publish a new version when we get to hotswapping the actual Function this Version points to
   // (Versions can't be changed in CloudFormation anyway, they're immutable)
@@ -35,7 +35,7 @@ export async function isHotswappableLambdaFunctionChange(
     return [];
   }
 
-  const ret: ChangeHotswapResult = [];
+  const ret: HotswapChange[] = [];
   const classifiedChanges = classifyChanges(change, ['Code', 'Environment', 'Description']);
   classifiedChanges.reportNonHotswappablePropertyChanges(ret);
 
@@ -145,8 +145,8 @@ export async function isHotswappableLambdaFunctionChange(
 /**
  * Determines which changes to this Alias are hotswappable or not
  */
-function classifyAliasChanges(change: ResourceChange): ChangeHotswapResult {
-  const ret: ChangeHotswapResult = [];
+function classifyAliasChanges(change: ResourceChange): HotswapChange[] {
+  const ret: HotswapChange[] = [];
   const classifiedChanges = classifyChanges(change, ['FunctionVersion']);
   classifiedChanges.reportNonHotswappablePropertyChanges(ret);
 

--- a/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
+++ b/packages/aws-cdk/lib/api/hotswap/s3-bucket-deployments.ts
@@ -1,4 +1,4 @@
-import type { ChangeHotswapResult } from './common';
+import type { HotswapChange } from './common';
 import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
@@ -15,10 +15,10 @@ export async function isHotswappableS3BucketDeploymentChange(
   logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<ChangeHotswapResult> {
+): Promise<HotswapChange[]> {
   // In old-style synthesis, the policy used by the lambda to copy assets Ref's the assets directly,
   // meaning that the changes made to the Policy are artifacts that can be safely ignored
-  const ret: ChangeHotswapResult = [];
+  const ret: HotswapChange[] = [];
 
   if (change.newValue.Type !== CDK_BUCKET_DEPLOYMENT_CFN_TYPE) {
     return [];

--- a/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
+++ b/packages/aws-cdk/lib/api/hotswap/stepfunctions-state-machines.ts
@@ -1,4 +1,4 @@
-import { type ChangeHotswapResult, classifyChanges } from './common';
+import { type HotswapChange, classifyChanges } from './common';
 import type { ResourceChange } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/hotswap';
 import type { SDK } from '../aws-auth';
 import type { EvaluateCloudFormationTemplate } from '../evaluate-cloudformation-template';
@@ -7,11 +7,11 @@ export async function isHotswappableStateMachineChange(
   logicalId: string,
   change: ResourceChange,
   evaluateCfnTemplate: EvaluateCloudFormationTemplate,
-): Promise<ChangeHotswapResult> {
+): Promise<HotswapChange[]> {
   if (change.newValue.Type !== 'AWS::StepFunctions::StateMachine') {
     return [];
   }
-  const ret: ChangeHotswapResult = [];
+  const ret: HotswapChange[] = [];
   const classifiedChanges = classifyChanges(change, ['DefinitionString']);
   classifiedChanges.reportNonHotswappablePropertyChanges(ret);
 

--- a/packages/aws-cdk/lib/legacy-exports-source.ts
+++ b/packages/aws-cdk/lib/legacy-exports-source.ts
@@ -5,7 +5,7 @@
 
 // Note: All type exports are in `legacy-exports.ts`
 export * from './legacy-logging-source';
-export { deepClone, flatten, ifDefined, isArray, isEmpty, numberFromBool, partition, padLeft as leftPad, contentHash, deepMerge } from './util';
+export { deepClone, flatten, ifDefined, isArray, isEmpty, numberFromBool, partition, padLeft as leftPad, contentHash, deepMerge, lowerCaseFirstCharacter } from './util';
 export { deployStack } from './api/deployments/deploy-stack';
 export { cli, exec } from './cli/cli';
 export { SdkProvider } from './api/aws-auth';
@@ -19,7 +19,6 @@ export { RequireApproval } from './diff';
 export { formatAsBanner } from './cli/util/console-formatters';
 export { setSdkTracing as enableTracing } from './api/aws-auth/tracing';
 export { aliases, command, describe } from './commands/docs';
-export { lowerCaseFirstCharacter } from './api/hotswap/common';
 export { Deployments } from './api/deployments';
 export { cliRootDir as rootDir } from './cli/root-dir';
 export { latestVersionIfHigher, versionNumber } from './cli/version';


### PR DESCRIPTION
Various straight-forward code re-organization changes and renames:

- moved helper functions into `util`
- `ChangeHotswapResult` -> `HotswapChange[]`
- shared `ClassifiedResourceChanges` -> localized `ClassifiedChanges`
- `NonHotswappableChange` -> `RejectedChange`
- `rejectedChanges` -> `rejectedProperties` cause that's what they are
- simplified and aligned `reportNonHotswappableChange` and `reportNonHotswappableResource` to be non-mutating and only take actually used args

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
