### PR TITLE
docs(toolkit-lib): await `cdk.fromAssemblyBuilder` in readme

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/README.md
+++ b/packages/@aws-cdk/toolkit-lib/README.md
@@ -61,7 +61,7 @@ import * as core from 'aws-cdk-lib/core';
 
 declare const cdk: Toolkit;
 
-const cx = cdk.fromAssemblyBuilder(async () => {
+const cx = await cdk.fromAssemblyBuilder(async () => {
   const app = new core.App();
 
   // Define your stacks here
@@ -321,7 +321,7 @@ Alternatively a inline `AssemblyBuilder` function can be used to build a CDK app
 ```ts
 declare const cdk: Toolkit;
 
-const cx = cdk.fromAssemblyBuilder(async () => {
+const cx = await cdk.fromAssemblyBuilder(async () => {
   const app = new core.App();
 
   // Define your stacks here


### PR DESCRIPTION
In subsequent examples we type `cx` as `ICloudAssemblySource`, so it makes more sense for our examples to show `cx` as an `ICloudAssemblySource` and not `Promise<ICloudAssemblySource>`. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
