### PR TITLE
chore: switch from 4 to 16-core runners for build workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   merge_group: {}
 jobs:
   build:
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: write
     outputs:
@@ -53,7 +53,7 @@ jobs:
           exit 1
   self-mutation:
     needs: build
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: write
     if: always() && needs.build.outputs.self_mutation_happened && !(github.event.pull_request.head.repo.full_name != github.repository)

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch: {}
 jobs:
   prepare:
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: read
     environment: integ-approval
@@ -48,7 +48,7 @@ jobs:
           overwrite: "true"
   integ_matrix:
     needs: prepare
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: read
       id-token: write
@@ -146,7 +146,7 @@ jobs:
     needs:
       - prepare
       - integ_matrix
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions: {}
     if: always()
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch: {}
 jobs:
   release:
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: write
     outputs:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -70,7 +70,7 @@ function configureProject<A extends pj.typescript.TypeScriptProject>(x: A): A {
   return x;
 }
 
-const POWERFUL_RUNNER = 'aws-cdk_ubuntu-latest_4-core';
+const POWERFUL_RUNNER = 'aws-cdk_ubuntu-latest_16-core';
 
 const workflowRunsOn = [
   POWERFUL_RUNNER,


### PR DESCRIPTION
Our build is a lot slower on CI than it is locally. Try using a bigger runner.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
