### PR TITLE
chore(integ-runner): fix test failing in integ workflow

### DIFF
--- a/packages/@aws-cdk/integ-runner/test/runner/private/cloud-assembly.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/private/cloud-assembly.test.ts
@@ -146,7 +146,7 @@ describe('cloud assembly manifest reader', () => {
 
     // THEN
     const newManifest = Manifest.loadAssetManifest(manifestFile);
-    expect(newManifest).toEqual({
+    expect(newManifest).toMatchObject({
       version: expect.any(String),
       artifacts: expect.objectContaining({
         'Tree': {
@@ -193,7 +193,7 @@ describe('cloud assembly manifest reader', () => {
 
     // THEN
     const newManifest = Manifest.loadAssetManifest(manifestFile);
-    expect(newManifest).toEqual({
+    expect(newManifest).toMatchObject({
       version: expect.any(String),
       artifacts: expect.objectContaining({
         'Tree': {
@@ -241,7 +241,7 @@ describe('cloud assembly manifest reader', () => {
 
     // THEN
     const newManifest = Manifest.loadAssetManifest(manifestFile);
-    expect(newManifest).toEqual({
+    expect(newManifest).toMatchObject({
       version: expect.any(String),
       artifacts: expect.objectContaining({
         'Tree': {


### PR DESCRIPTION
Fixes an integ-runner test case that is only failing during the integ test workflow.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
