### PR TITLE
refactor(cli): context providers use dedicated, provided messaging class

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/types.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/types.ts
@@ -98,3 +98,11 @@ export interface ConfirmationRequest {
    */
   readonly concurrency?: number;
 }
+
+
+export interface ContextProviderMessageSource {
+  /**
+   * The name of the context provider sending the message
+   */
+  readonly provider: string;
+}

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/types.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/payloads/types.ts
@@ -99,7 +99,6 @@ export interface ConfirmationRequest {
   readonly concurrency?: number;
 }
 
-
 export interface ContextProviderMessageSource {
   /**
    * The name of the context provider sending the message

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
@@ -437,12 +437,12 @@ export const IO = {
   CDK_ASSEMBLY_I0300: make.info<ContextProviderMessageSource>({
     code: 'CDK_ASSEMBLY_I0300',
     description: 'An info message emitted by a Context Provider',
-    interface: 'ContextProviderMessageSource'
+    interface: 'ContextProviderMessageSource',
   }),
   CDK_ASSEMBLY_I0301: make.debug<ContextProviderMessageSource>({
     code: 'CDK_ASSEMBLY_I0301',
     description: 'A debug message emitted by a Context Provider',
-    interface: 'ContextProviderMessageSource'
+    interface: 'ContextProviderMessageSource',
   }),
 
   // Assembly Annotations

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
@@ -12,7 +12,7 @@ import type { StackRollbackProgress } from '../payloads/rollback';
 import type { SdkTrace } from '../payloads/sdk-trace';
 import type { StackActivity, StackMonitoringControlEvent } from '../payloads/stack-activity';
 import type { StackSelectionDetails } from '../payloads/synth';
-import type { AssemblyData, ConfirmationRequest, Duration, ErrorPayload, StackAndAssemblyData } from '../payloads/types';
+import type { AssemblyData, ConfirmationRequest, ContextProviderMessageSource, Duration, ErrorPayload, StackAndAssemblyData } from '../payloads/types';
 import type { FileWatchEvent, WatchSettings } from '../payloads/watch';
 
 /**
@@ -379,6 +379,10 @@ export const IO = {
     code: 'CDK_ASSEMBLY_I0000',
     description: 'Default trace messages emitted from Cloud Assembly operations',
   }),
+  DEFAULT_ASSEMBLY_DEBUG: make.debug({
+    code: 'CDK_ASSEMBLY_I0000',
+    description: 'Default debug messages emitted from Cloud Assembly operations',
+  }),
 
   CDK_ASSEMBLY_I0010: make.debug({
     code: 'CDK_ASSEMBLY_I0010',
@@ -428,6 +432,17 @@ export const IO = {
   CDK_ASSEMBLY_I0150: make.debug<never>({
     code: 'CDK_ASSEMBLY_I0150',
     description: 'Indicates the use of a pre-synthesized cloud assembly directory',
+  }),
+
+  CDK_ASSEMBLY_I0300: make.info<ContextProviderMessageSource>({
+    code: 'CDK_ASSEMBLY_I0300',
+    description: 'An info message emitted by a Context Provider',
+    interface: 'ContextProviderMessageSource'
+  }),
+  CDK_ASSEMBLY_I0301: make.debug<ContextProviderMessageSource>({
+    code: 'CDK_ASSEMBLY_I0301',
+    description: 'A debug message emitted by a Context Provider',
+    interface: 'ContextProviderMessageSource'
   }),
 
   // Assembly Annotations

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -74,6 +74,7 @@ group: Documents
 | `CDK_TOOLKIT_E0101` | A notice that is marked as an error | `error` | n/a |
 | `CDK_TOOLKIT_I0101` | A notice that is marked as informational | `info` | n/a |
 | `CDK_ASSEMBLY_I0000` | Default trace messages emitted from Cloud Assembly operations | `trace` | n/a |
+| `CDK_ASSEMBLY_I0000` | Default debug messages emitted from Cloud Assembly operations | `debug` | n/a |
 | `CDK_ASSEMBLY_I0010` | Generic environment preparation debug messages | `debug` | n/a |
 | `CDK_ASSEMBLY_W0010` | Emitted if the found framework version does not support context overflow | `warn` | n/a |
 | `CDK_ASSEMBLY_I0042` | Writing updated context | `debug` | {@link UpdatedContext} |
@@ -85,6 +86,8 @@ group: Documents
 | `CDK_ASSEMBLY_I1003` | Cloud assembly output finished | `info` | n/a |
 | `CDK_ASSEMBLY_E1111` | Incompatible CDK CLI version. Upgrade needed. | `error` | {@link ErrorPayload} |
 | `CDK_ASSEMBLY_I0150` | Indicates the use of a pre-synthesized cloud assembly directory | `debug` | n/a |
+| `CDK_ASSEMBLY_I0300` | An info message emitted by a Context Provider | `info` | {@link ContextProviderMessageSource} |
+| `CDK_ASSEMBLY_I0301` | A debug message emitted by a Context Provider | `debug` | {@link ContextProviderMessageSource} |
 | `CDK_ASSEMBLY_I9999` | Annotations emitted by the cloud assembly | `info` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_W9999` | Warnings emitted by the cloud assembly | `warn` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_E9999` | Errors emitted by the cloud assembly | `error` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
@@ -89,6 +89,7 @@ export class ContextAwareCloudAssembly implements ICloudAssemblySource {
             assembly.manifest.missing,
             this.context,
             this.props.services.sdkProvider,
+            this.ioHelper,
           );
 
           // Cache the new context to disk

--- a/packages/aws-cdk/lib/api/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/api/cxapp/cloud-executable.ts
@@ -91,7 +91,8 @@ export class CloudExecutable {
           await contextproviders.provideContextValues(
             assembly.manifest.missing,
             this.props.configuration.context,
-            this.props.sdkProvider);
+            this.props.sdkProvider,
+          );
 
           // Cache the new context to disk
           await this.props.configuration.saveContext();

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -4,6 +4,7 @@ import * as chalk from 'chalk';
 import * as promptly from 'promptly';
 import { ToolkitError } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 import type { IIoHost, IoMessage, IoMessageCode, IoMessageLevel, IoRequest, ToolkitAction } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api';
+import type { IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { asIoHelper, IO, IoDefaultMessages, isMessageRelevantForLevel } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { StackActivityProgress } from '../../commands/deploy';
 import { CurrentActivityPrinter, HistoryActivityPrinter } from '../activity-printer';
@@ -205,8 +206,11 @@ export class CliIoHost implements IIoHost {
   }
 
   public get defaults() {
-    const helper = asIoHelper(this, this.currentAction as any);
-    return new IoDefaultMessages(helper);
+    return new IoDefaultMessages(this.asIoHelper());
+  }
+
+  public asIoHelper(): IoHelper {
+    return asIoHelper(this, this.currentAction as any);
   }
 
   /**

--- a/packages/aws-cdk/lib/context-providers/availability-zones.ts
+++ b/packages/aws-cdk/lib/context-providers/availability-zones.ts
@@ -1,20 +1,20 @@
 import type { AvailabilityZonesContextQuery } from '@aws-cdk/cloud-assembly-schema';
 import type { AvailabilityZone } from '@aws-sdk/client-ec2';
+import type { IContextProviderMessages } from '.';
 import { type SdkProvider, initContextProviderSdk } from '../api/aws-auth/sdk-provider';
 import type { ContextProviderPlugin } from '../api/plugin';
-import { debug } from '../logging';
 
 /**
  * Plugin to retrieve the Availability Zones for the current account
  */
 export class AZContextProviderPlugin implements ContextProviderPlugin {
-  constructor(private readonly aws: SdkProvider) {
+  constructor(private readonly aws: SdkProvider, private readonly io: IContextProviderMessages) {
   }
 
   public async getValue(args: AvailabilityZonesContextQuery) {
     const region = args.region;
     const account = args.account;
-    debug(`Reading AZs for ${account}:${region}`);
+    await this.io.debug(`Reading AZs for ${account}:${region}`);
     const ec2 = (await initContextProviderSdk(this.aws, args)).ec2();
     const response = await ec2.describeAvailabilityZones({});
     if (!response.AvailabilityZones) {

--- a/packages/aws-cdk/lib/context-providers/keys.ts
+++ b/packages/aws-cdk/lib/context-providers/keys.ts
@@ -1,14 +1,14 @@
 import type { KeyContextQuery } from '@aws-cdk/cloud-assembly-schema';
 import type { KeyContextResponse } from '@aws-cdk/cx-api';
 import type { AliasListEntry, ListAliasesCommandOutput } from '@aws-sdk/client-kms';
+import type { IContextProviderMessages } from '.';
 import { ContextProviderError } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 import type { IKMSClient } from '../api';
 import { type SdkProvider, initContextProviderSdk } from '../api/aws-auth/sdk-provider';
 import type { ContextProviderPlugin } from '../api/plugin';
-import { debug } from '../logging';
 
 export class KeyContextProviderPlugin implements ContextProviderPlugin {
-  constructor(private readonly aws: SdkProvider) {
+  constructor(private readonly aws: SdkProvider, private readonly io: IContextProviderMessages) {
   }
 
   public async getValue(args: KeyContextQuery) {
@@ -21,7 +21,7 @@ export class KeyContextProviderPlugin implements ContextProviderPlugin {
 
   // TODO: use paginator function
   private async findKey(kms: IKMSClient, args: KeyContextQuery): Promise<AliasListEntry> {
-    debug(`Listing keys in ${args.account}:${args.region}`);
+    await this.io.debug(`Listing keys in ${args.account}:${args.region}`);
 
     let response: ListAliasesCommandOutput;
     let nextMarker: string | undefined;
@@ -54,7 +54,7 @@ export class KeyContextProviderPlugin implements ContextProviderPlugin {
       throw new ContextProviderError(`Could not find any key with alias named ${args.aliasName}`);
     }
 
-    debug(`Key found ${alias.TargetKeyId}`);
+    await this.io.debug(`Key found ${alias.TargetKeyId}`);
 
     return {
       keyId: alias.TargetKeyId,

--- a/packages/aws-cdk/lib/context-providers/ssm-parameters.ts
+++ b/packages/aws-cdk/lib/context-providers/ssm-parameters.ts
@@ -1,15 +1,15 @@
 import type { SSMParameterContextQuery } from '@aws-cdk/cloud-assembly-schema';
 import type { GetParameterCommandOutput } from '@aws-sdk/client-ssm';
+import type { IContextProviderMessages } from '.';
 import { ContextProviderError } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 import { type SdkProvider, initContextProviderSdk } from '../api/aws-auth/sdk-provider';
 import type { ContextProviderPlugin } from '../api/plugin';
-import { debug } from '../logging';
 
 /**
  * Plugin to read arbitrary SSM parameter names
  */
 export class SSMContextProviderPlugin implements ContextProviderPlugin {
-  constructor(private readonly aws: SdkProvider) {
+  constructor(private readonly aws: SdkProvider, private readonly io: IContextProviderMessages) {
   }
 
   public async getValue(args: SSMParameterContextQuery) {
@@ -20,7 +20,7 @@ export class SSMContextProviderPlugin implements ContextProviderPlugin {
       throw new ContextProviderError('parameterName must be provided in props for SSMContextProviderPlugin');
     }
     const parameterName = args.parameterName;
-    debug(`Reading SSM parameter ${account}:${region}:${parameterName}`);
+    await this.io.debug(`Reading SSM parameter ${account}:${region}:${parameterName}`);
 
     const response = await this.getSsmParameterValue(args);
     const parameterNotFound: boolean = !response.Parameter || response.Parameter.Value === undefined;

--- a/packages/aws-cdk/test/context-providers/amis.test.ts
+++ b/packages/aws-cdk/test/context-providers/amis.test.ts
@@ -10,6 +10,16 @@ const mockSDK = new (class extends MockSdkProvider {
   }
 })();
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
+beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+});
+
 test('calls DescribeImages on the request', async () => {
   // GIVEN
   mockEC2Client.on(DescribeImagesCommand).resolves({
@@ -17,7 +27,7 @@ test('calls DescribeImages on the request', async () => {
   });
 
   // WHEN
-  await new AmiContextProviderPlugin(mockSDK).getValue({
+  await new AmiContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '1234',
     region: 'asdf',
     owners: ['some-owner'],
@@ -54,7 +64,7 @@ test('returns the most recent AMI matching the criteria', async () => {
   });
 
   // WHEN
-  const result = await new AmiContextProviderPlugin(mockSDK).getValue({
+  const result = await new AmiContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '1234',
     region: 'asdf',
     filters: {},

--- a/packages/aws-cdk/test/context-providers/asymmetric-vpcs.test.ts
+++ b/packages/aws-cdk/test/context-providers/asymmetric-vpcs.test.ts
@@ -7,7 +7,15 @@ import {
 import { VpcNetworkContextProviderPlugin } from '../../lib/context-providers/vpcs';
 import { MockSdkProvider, mockEC2Client, restoreSdkMocksToDefault } from '../util/mock-sdk';
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
 beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+
   restoreSdkMocksToDefault();
   mockEC2Client
     .on(DescribeVpcsCommand)
@@ -84,7 +92,7 @@ test('looks up the requested (symmetric) VPC', async () => {
     })
     .on(DescribeVpnGatewaysCommand)
     .resolves({ VpnGateways: [{ VpnGatewayId: 'gw-abcdef' }] });
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -144,7 +152,7 @@ test('looks up the requested (symmetric) VPC', async () => {
 test('throws when no such VPC is found', async () => {
   mockEC2Client.on(DescribeVpcsCommand).resolves({});
   await expect(
-    new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+    new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
       account: '123456789012',
       region: 'us-east-1',
       filter: { foo: 'bar' },
@@ -164,7 +172,7 @@ test('throws when multiple VPCs are found', async () => {
 
   // WHEN
   await expect(
-    new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+    new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
       account: '123456789012',
       region: 'us-east-1',
       filter: { foo: 'bar' },
@@ -241,7 +249,7 @@ test('uses the VPC main route table when a subnet has no specific association', 
       VpnGateways: [{ VpnGatewayId: 'gw-abcdef' }],
     });
 
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -330,7 +338,7 @@ test('Recognize public subnet by route table', async () => {
   });
 
   // WHEN
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -396,7 +404,7 @@ test('Recognize isolated subnet by route table', async () => {
   });
 
   // WHEN
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -458,7 +466,7 @@ test('Recognize private subnet by route table', async () => {
   });
 
   // WHEN
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -551,7 +559,7 @@ test('works for asymmetric subnets (not spanning the same Availability Zones)', 
     });
 
   // WHEN
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },
@@ -667,7 +675,7 @@ test('allows specifying the subnet group name tag', async () => {
       ],
     });
 
-  const result = await new VpcNetworkContextProviderPlugin(mockSDK).getValue({
+  const result = await new VpcNetworkContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '123456789012',
     region: 'us-east-1',
     filter: { foo: 'bar' },

--- a/packages/aws-cdk/test/context-providers/availability-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/availability-zones.test.ts
@@ -9,6 +9,16 @@ const mockSDK = new (class extends MockSdkProvider {
   }
 })();
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
+beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+});
+
 test('empty array as result when response has no AZs', async () => {
   // GIVEN
   mockEC2Client.on(DescribeAvailabilityZonesCommand).resolves({
@@ -16,7 +26,7 @@ test('empty array as result when response has no AZs', async () => {
   });
 
   // WHEN
-  const azs = await new AZContextProviderPlugin(mockSDK).getValue({
+  const azs = await new AZContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '1234',
     region: 'asdf',
   });
@@ -35,7 +45,7 @@ test('returns AZs', async () => {
   });
 
   // WHEN
-  const azs = await new AZContextProviderPlugin(mockSDK).getValue({
+  const azs = await new AZContextProviderPlugin(mockSDK, mockMsg).getValue({
     account: '1234',
     region: 'asdf',
   });

--- a/packages/aws-cdk/test/context-providers/endpoint-service-availability-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/endpoint-service-availability-zones.test.ts
@@ -11,12 +11,22 @@ const mockSDK = new (class extends MockSdkProvider {
   }
 })();
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
+beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+});
+
 test('empty result when service details cannot be retrieved', async () => {
   // GIVEN
   mockEC2Client.on(DescribeVpcEndpointServicesCommand).resolves({});
 
   // WHEN
-  const result = await new EndpointServiceAZContextProviderPlugin(mockSDK).getValue({
+  const result = await new EndpointServiceAZContextProviderPlugin(mockSDK, mockMsg).getValue({
     serviceName: 'svc',
     account: 'foo',
     region: 'rgn',
@@ -34,7 +44,7 @@ test('returns availability zones', async () => {
   });
 
   // WHEN
-  const result = await new EndpointServiceAZContextProviderPlugin(mockSDK).getValue({
+  const result = await new EndpointServiceAZContextProviderPlugin(mockSDK, mockMsg).getValue({
     serviceName: 'svc',
     account: 'foo',
     region: 'rgn',

--- a/packages/aws-cdk/test/context-providers/hosted-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/hosted-zones.test.ts
@@ -9,6 +9,16 @@ const mockSDK = new (class extends MockSdkProvider {
   }
 })();
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
+beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+});
+
 test('get value without private zone', async () => {
   // GIVEN
   mockRoute53Client.on(ListHostedZonesByNameCommand).resolves({
@@ -20,7 +30,7 @@ test('get value without private zone', async () => {
   });
 
   // WHEN
-  const result = await new HostedZoneContextProviderPlugin(mockSDK).getValue({
+  const result = await new HostedZoneContextProviderPlugin(mockSDK, mockMsg).getValue({
     domainName: 'example.com',
     account: '1234',
     region: 'rgn',
@@ -46,7 +56,7 @@ test('get value with private zone', async () => {
   });
 
   // WHEN
-  const result = await new HostedZoneContextProviderPlugin(mockSDK).getValue({
+  const result = await new HostedZoneContextProviderPlugin(mockSDK, mockMsg).getValue({
     domainName: 'example.com',
     account: '1234',
     region: 'rgn',
@@ -76,7 +86,7 @@ test('get value with private zone and VPC not found', async () => {
   mockRoute53Client.on(GetHostedZoneCommand).resolves({});
 
   // WHEN
-  const result = new HostedZoneContextProviderPlugin(mockSDK).getValue({
+  const result = new HostedZoneContextProviderPlugin(mockSDK, mockMsg).getValue({
     domainName: 'example.com',
     account: '1234',
     region: 'rgn',
@@ -109,7 +119,7 @@ test('get value with private zone and VPC found', async () => {
   });
 
   // WHEN
-  const result = await new HostedZoneContextProviderPlugin(mockSDK).getValue({
+  const result = await new HostedZoneContextProviderPlugin(mockSDK, mockMsg).getValue({
     domainName: 'example.com',
     account: '1234',
     region: 'rgn',

--- a/packages/aws-cdk/test/context-providers/keys.test.ts
+++ b/packages/aws-cdk/test/context-providers/keys.test.ts
@@ -4,8 +4,16 @@ import { mockKMSClient, MockSdkProvider, restoreSdkMocksToDefault } from '../uti
 
 let provider: KeyContextProviderPlugin;
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
 beforeEach(() => {
-  provider = new KeyContextProviderPlugin(new MockSdkProvider());
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+
+  provider = new KeyContextProviderPlugin(new MockSdkProvider(), mockMsg);
   restoreSdkMocksToDefault();
 });
 

--- a/packages/aws-cdk/test/context-providers/ssm-parameters.test.ts
+++ b/packages/aws-cdk/test/context-providers/ssm-parameters.test.ts
@@ -9,10 +9,20 @@ const mockSDK = new (class extends MockSdkProvider {
   }
 })();
 
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
+
+beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+});
+
 describe('ssmParameters', () => {
   test('returns value', async () => {
     restoreSdkMocksToDefault();
-    const provider = new SSMContextProviderPlugin(mockSDK);
+    const provider = new SSMContextProviderPlugin(mockSDK, mockMsg);
 
     mockSSMClient.on(GetParameterCommand).resolves({
       Parameter: {
@@ -32,7 +42,7 @@ describe('ssmParameters', () => {
 
   test('errors when parameter is not found', async () => {
     restoreSdkMocksToDefault();
-    const provider = new SSMContextProviderPlugin(mockSDK);
+    const provider = new SSMContextProviderPlugin(mockSDK, mockMsg);
 
     const notFound = new Error('Parameter not found');
     notFound.name = 'ParameterNotFound';

--- a/packages/aws-cdk/test/context-providers/vpcs.test.ts
+++ b/packages/aws-cdk/test/context-providers/vpcs.test.ts
@@ -8,8 +8,15 @@ import { VpcNetworkContextProviderPlugin } from '../../lib/context-providers/vpc
 import { MockSdkProvider, mockEC2Client, restoreSdkMocksToDefault } from '../util/mock-sdk';
 
 const mockSDK = new MockSdkProvider();
+const mockMsg = {
+  debug: jest.fn(),
+  info: jest.fn(),
+};
 
 beforeEach(() => {
+  mockMsg.debug.mockClear();
+  mockMsg.info.mockClear();
+
   restoreSdkMocksToDefault();
   mockEC2Client
     .on(DescribeVpcsCommand)
@@ -73,7 +80,7 @@ beforeEach(() => {
 test('looks up the requested VPC', async () => {
   // GIVEN
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -117,7 +124,7 @@ test('looks up the requested VPC', async () => {
 test('throws when no such VPC is found', async () => {
   // GIVEN
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
   mockEC2Client.on(DescribeVpcsCommand).resolves({});
 
   // WHEN
@@ -136,7 +143,7 @@ test('throws when no such VPC is found', async () => {
 test('throws when subnet with subnetGroupNameTag not found', async () => {
   // GIVEN
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   await expect(
@@ -177,7 +184,7 @@ test('does not throw when subnet with subnetGroupNameTag is found', async () => 
     ],
   });
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -225,7 +232,7 @@ test('throws when multiple VPCs are found', async () => {
     Vpcs: [{ VpcId: 'vpc-1' }, { VpcId: 'vpc-2' }],
   });
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   await expect(
@@ -283,7 +290,7 @@ test('uses the VPC main route table when a subnet has no specific association', 
     ],
   });
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -364,7 +371,7 @@ test('Recognize public subnet by route table', async () => {
     .on(DescribeVpnGatewaysCommand)
     .resolves({});
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -440,7 +447,7 @@ test('Recognize private subnet by route table with NAT Gateway', async () => {
     .on(DescribeVpnGatewaysCommand)
     .resolves({});
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -516,7 +523,7 @@ test('Recognize private subnet by route table with Transit Gateway', async () =>
     .on(DescribeVpnGatewaysCommand)
     .resolves({});
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({
@@ -580,7 +587,7 @@ test('Recognize isolated subnet by route table', async () => {
     .on(DescribeVpnGatewaysCommand)
     .resolves({});
   const filter = { foo: 'bar' };
-  const provider = new VpcNetworkContextProviderPlugin(mockSDK);
+  const provider = new VpcNetworkContextProviderPlugin(mockSDK, mockMsg);
 
   // WHEN
   const result = await provider.getValue({


### PR DESCRIPTION
Introduces a dedicated messaging interface for Context Providers. This is a reduced interface to allow Context Providers send debug messages and in rare cases info messages.

Use of `ioHelper` in the `provideContextValues` function is currently still optional until the CloudExecutable supports it as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
