### PR TITLE
refactor(toolkit): cxapp to use moden messaging infrastructure

### DIFF
--- a/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
+++ b/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
@@ -1,9 +1,10 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
 import type { SharedOptions, DeployOptions, DestroyOptions, BootstrapOptions, SynthOptions, ListOptions } from './commands';
 import { StackActivityProgress, HotswapMode } from './commands';
 import { exec as runCli } from '../../../aws-cdk/lib';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { createAssembly, prepareContext, prepareDefaultEnvironment } from '../../../aws-cdk/lib/api/cxapp/exec';
+import { debug } from '../../../aws-cdk/lib/legacy-exports';
+
+const debugFn = async (msg: string) => void debug(msg);
 
 /**
  * AWS CDK CLI operations
@@ -123,8 +124,8 @@ export class AwsCdkCli implements IAwsCdkCli {
   public static fromCloudAssemblyDirectoryProducer(producer: ICloudAssemblyDirectoryProducer) {
     return new AwsCdkCli(async (args) => changeDir(
       () => runCli(args, async (sdk, config) => {
-        const env = await prepareDefaultEnvironment(sdk);
-        const context = await prepareContext(config.settings, config.context.all, env);
+        const env = await prepareDefaultEnvironment(sdk, debugFn);
+        const context = await prepareContext(config.settings, config.context.all, env, debugFn);
 
         return withEnv(async() => createAssembly(await producer.produce(context)), env);
       }),

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
@@ -383,6 +383,14 @@ export const IO = {
     code: 'CDK_ASSEMBLY_I0000',
     description: 'Default debug messages emitted from Cloud Assembly operations',
   }),
+  DEFAULT_ASSEMBLY_INFO: make.info({
+    code: 'CDK_ASSEMBLY_I0000',
+    description: 'Default info messages emitted from Cloud Assembly operations',
+  }),
+  DEFAULT_ASSEMBLY_WARN: make.warn({
+    code: 'CDK_ASSEMBLY_W0000',
+    description: 'Default warning messages emitted from Cloud Assembly operations',
+  }),
 
   CDK_ASSEMBLY_I0010: make.debug({
     code: 'CDK_ASSEMBLY_I0010',

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -75,8 +75,8 @@ group: Documents
 | `CDK_TOOLKIT_I0101` | A notice that is marked as informational | `info` | n/a |
 | `CDK_ASSEMBLY_I0000` | Default trace messages emitted from Cloud Assembly operations | `trace` | n/a |
 | `CDK_ASSEMBLY_I0000` | Default debug messages emitted from Cloud Assembly operations | `debug` | n/a |
-| `CDK_ASSEMBLY_I0000` | Default info messages emitted from Cloud Assembly operations | `debug` | n/a |
-| `CDK_ASSEMBLY_W0000` | Default warning messages emitted from Cloud Assembly operations | `debug` | n/a |
+| `CDK_ASSEMBLY_I0000` | Default info messages emitted from Cloud Assembly operations | `info` | n/a |
+| `CDK_ASSEMBLY_W0000` | Default warning messages emitted from Cloud Assembly operations | `warn` | n/a |
 | `CDK_ASSEMBLY_I0010` | Generic environment preparation debug messages | `debug` | n/a |
 | `CDK_ASSEMBLY_W0010` | Emitted if the found framework version does not support context overflow | `warn` | n/a |
 | `CDK_ASSEMBLY_I0042` | Writing updated context | `debug` | {@link UpdatedContext} |

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -75,6 +75,8 @@ group: Documents
 | `CDK_TOOLKIT_I0101` | A notice that is marked as informational | `info` | n/a |
 | `CDK_ASSEMBLY_I0000` | Default trace messages emitted from Cloud Assembly operations | `trace` | n/a |
 | `CDK_ASSEMBLY_I0000` | Default debug messages emitted from Cloud Assembly operations | `debug` | n/a |
+| `CDK_ASSEMBLY_I0000` | Default info messages emitted from Cloud Assembly operations | `debug` | n/a |
+| `CDK_ASSEMBLY_W0000` | Default warning messages emitted from Cloud Assembly operations | `debug` | n/a |
 | `CDK_ASSEMBLY_I0010` | Generic environment preparation debug messages | `debug` | n/a |
 | `CDK_ASSEMBLY_W0010` | Emitted if the found framework version does not support context overflow | `warn` | n/a |
 | `CDK_ASSEMBLY_I0042` | Writing updated context | `debug` | {@link UpdatedContext} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -17,7 +17,7 @@ import type { AppSynthOptions, LoadAssemblyOptions } from '../source-builder';
 type Env = { [key: string]: string };
 type Context = { [key: string]: any };
 
-export class ExecutionEnviornment {
+export class ExecutionEnvironment {
   private readonly ioHelper: IoHelper;
   private readonly sdkProvider: SdkProvider;
   private readonly debugFn: (msg: string) => Promise<void>;
@@ -69,10 +69,8 @@ export class ExecutionEnviornment {
     const debugFn = (msg: string) => this.ioHelper.notify(IO.CDK_ASSEMBLY_I0010.msg(msg));
     const env = await oldPrepare(this.sdkProvider, debugFn);
 
-    if (this.outdir) {
-      env[cxapi.OUTDIR_ENV] = this.outdir;
-      await debugFn(format('outdir:', this.outdir));
-    }
+    env[cxapi.OUTDIR_ENV] = this.outdir;
+    await debugFn(format('outdir:', this.outdir));
 
     // CLI version information
     env[cxapi.CLI_ASM_VERSION_ENV] = cxschema.Manifest.version();

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -5,7 +5,8 @@ import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import * as cxapi from '@aws-cdk/cx-api';
 import * as fs from 'fs-extra';
 import { lte } from 'semver';
-import { prepareDefaultEnvironment as oldPrepare, prepareContext, spaceAvailableForContext, Settings, loadTree, some, versionNumber } from '../../../api/aws-cdk';
+import type { SdkProvider } from '../../../api/aws-cdk';
+import { prepareDefaultEnvironment as oldPrepare, prepareContext, spaceAvailableForContext, Settings, loadTree, some, versionNumber, guessExecutable } from '../../../api/aws-cdk';
 import { splitBySize } from '../../../private/util';
 import type { ToolkitServices } from '../../../toolkit/private';
 import { IO } from '../../io/private';
@@ -13,114 +14,142 @@ import type { IoHelper } from '../../shared-private';
 import { ToolkitError } from '../../shared-public';
 import type { AppSynthOptions, LoadAssemblyOptions } from '../source-builder';
 
-export { guessExecutable } from '../../../api/aws-cdk';
-
 type Env = { [key: string]: string };
 type Context = { [key: string]: any };
 
-/**
- * Turn the given optional output directory into a fixed output directory
- */
-export function determineOutputDirectory(outdir?: string) {
-  return outdir ?? fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'cdk.out'));
-}
+export class ExecutionEnviornment {
+  private readonly ioHelper: IoHelper;
+  private readonly sdkProvider: SdkProvider;
+  private readonly debugFn: (msg: string) => Promise<void>;
+  private _outdir: string | undefined;
 
-/**
- * If we don't have region/account defined in context, we fall back to the default SDK behavior
- * where region is retrieved from ~/.aws/config and account is based on default credentials provider
- * chain and then STS is queried.
- *
- * This is done opportunistically: for example, if we can't access STS for some reason or the region
- * is not configured, the context value will be 'null' and there could failures down the line. In
- * some cases, synthesis does not require region/account information at all, so that might be perfectly
- * fine in certain scenarios.
- *
- * @param context The context key/value bash.
- */
-export async function prepareDefaultEnvironment(services: ToolkitServices, props: { outdir?: string } = {}): Promise<Env> {
-  const logFn = (msg: string, ...args: any) => services.ioHelper.notify(IO.CDK_ASSEMBLY_I0010.msg(format(msg, ...args)));
-  const env = await oldPrepare(services.sdkProvider, logFn);
-
-  if (props.outdir) {
-    env[cxapi.OUTDIR_ENV] = props.outdir;
-    await logFn('outdir:', props.outdir);
+  public constructor(services: ToolkitServices, props: { outdir?: string } = {}) {
+    this.ioHelper = services.ioHelper;
+    this.sdkProvider = services.sdkProvider;
+    this.debugFn = (msg: string) => this.ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg(msg));
+    this._outdir = props.outdir;
   }
 
-  // CLI version information
-  env[cxapi.CLI_ASM_VERSION_ENV] = cxschema.Manifest.version();
-  env[cxapi.CLI_VERSION_ENV] = versionNumber();
+  /**
+   * Turn the given optional output directory into a fixed output directory
+   */
+  public get outdir(): string {
+    if (!this._outdir) {
+      const outdir = fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'cdk.out'));
+      this._outdir = outdir;
+    }
+    return this._outdir;
+  }
 
-  await logFn('env:', env);
-  return env;
-}
+  /**
+   * Guess the executable from the command-line argument
+   *
+   * Only do this if the file is NOT marked as executable. If it is,
+   * we'll defer to the shebang inside the file itself.
+   *
+   * If we're on Windows, we ALWAYS take the handler, since it's hard to
+   * verify if registry associations have or have not been set up for this
+   * file type, so we'll assume the worst and take control.
+   */
+  public guessExecutable(app: string) {
+    return guessExecutable(app, this.debugFn);
+  }
 
-/**
- * Run code from a different working directory
- */
-export async function changeDir<T>(block: () => Promise<T>, workingDir?: string) {
-  const originalWorkingDir = process.cwd();
-  try {
-    if (workingDir) {
-      process.chdir(workingDir);
+  /**
+   * If we don't have region/account defined in context, we fall back to the default SDK behavior
+   * where region is retrieved from ~/.aws/config and account is based on default credentials provider
+   * chain and then STS is queried.
+   *
+   * This is done opportunistically: for example, if we can't access STS for some reason or the region
+   * is not configured, the context value will be 'null' and there could failures down the line. In
+   * some cases, synthesis does not require region/account information at all, so that might be perfectly
+   * fine in certain scenarios.
+   */
+  public async defaultEnvVars(): Promise<Env> {
+    const debugFn = (msg: string) => this.ioHelper.notify(IO.CDK_ASSEMBLY_I0010.msg(msg));
+    const env = await oldPrepare(this.sdkProvider, debugFn);
+
+    if (this.outdir) {
+      env[cxapi.OUTDIR_ENV] = this.outdir;
+      await debugFn(format('outdir:', this.outdir));
     }
 
-    return await block();
-  } finally {
-    if (workingDir) {
-      process.chdir(originalWorkingDir);
+    // CLI version information
+    env[cxapi.CLI_ASM_VERSION_ENV] = cxschema.Manifest.version();
+    env[cxapi.CLI_VERSION_ENV] = versionNumber();
+
+    await debugFn(format('env:', env));
+    return env;
+  }
+
+  /**
+   * Run code from a different working directory
+   */
+  public async changeDir<T>(block: () => Promise<T>, workingDir?: string) {
+    const originalWorkingDir = process.cwd();
+    try {
+      if (workingDir) {
+        process.chdir(workingDir);
+      }
+
+      return await block();
+    } finally {
+      if (workingDir) {
+        process.chdir(originalWorkingDir);
+      }
     }
   }
-}
 
-/**
- * Run code with additional environment variables
- */
-export async function withEnv<T>(env: Env = {}, block: () => Promise<T>) {
-  const originalEnv = process.env;
-  try {
-    process.env = {
-      ...originalEnv,
-      ...env,
-    };
+  /**
+   * Run code with additional environment variables
+   */
+  public async withEnv<T>(env: Env = {}, block: () => Promise<T>) {
+    const originalEnv = process.env;
+    try {
+      process.env = {
+        ...originalEnv,
+        ...env,
+      };
 
-    return await block();
-  } finally {
-    process.env = originalEnv;
-  }
-}
-
-/**
- * Run code with context setup inside the environment
- */
-export async function withContext<T>(
-  inputContext: Context,
-  env: Env,
-  synthOpts: AppSynthOptions = {},
-  block: (env: Env, context: Context) => Promise<T>,
-) {
-  const context = await prepareContext(synthOptsDefaults(synthOpts), inputContext, env);
-  let contextOverflowLocation = null;
-
-  try {
-    const envVariableSizeLimit = os.platform() === 'win32' ? 32760 : 131072;
-    const [smallContext, overflow] = splitBySize(context, spaceAvailableForContext(env, envVariableSizeLimit));
-
-    // Store the safe part in the environment variable
-    env[cxapi.CONTEXT_ENV] = JSON.stringify(smallContext);
-
-    // If there was any overflow, write it to a temporary file
-    if (Object.keys(overflow ?? {}).length > 0) {
-      const contextDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-context'));
-      contextOverflowLocation = path.join(contextDir, 'context-overflow.json');
-      fs.writeJSONSync(contextOverflowLocation, overflow);
-      env[cxapi.CONTEXT_OVERFLOW_LOCATION_ENV] = contextOverflowLocation;
+      return await block();
+    } finally {
+      process.env = originalEnv;
     }
+  }
 
-    // call the block code with new environment
-    return await block(env, context);
-  } finally {
-    if (contextOverflowLocation) {
-      fs.removeSync(path.dirname(contextOverflowLocation));
+  /**
+   * Run code with context setup inside the environment
+   */
+  public async withContext<T>(
+    inputContext: Context,
+    env: Env,
+    synthOpts: AppSynthOptions = {},
+    block: (env: Env, context: Context) => Promise<T>,
+  ) {
+    const context = await prepareContext(synthOptsDefaults(synthOpts), inputContext, env, this.debugFn);
+    let contextOverflowLocation = null;
+
+    try {
+      const envVariableSizeLimit = os.platform() === 'win32' ? 32760 : 131072;
+      const [smallContext, overflow] = splitBySize(context, spaceAvailableForContext(env, envVariableSizeLimit));
+
+      // Store the safe part in the environment variable
+      env[cxapi.CONTEXT_ENV] = JSON.stringify(smallContext);
+
+      // If there was any overflow, write it to a temporary file
+      if (Object.keys(overflow ?? {}).length > 0) {
+        const contextDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-context'));
+        contextOverflowLocation = path.join(contextDir, 'context-overflow.json');
+        fs.writeJSONSync(contextOverflowLocation, overflow);
+        env[cxapi.CONTEXT_OVERFLOW_LOCATION_ENV] = contextOverflowLocation;
+      }
+
+      // call the block code with new environment
+      return await block(env, context);
+    } finally {
+      if (contextOverflowLocation) {
+        fs.removeSync(path.dirname(contextOverflowLocation));
+      }
     }
   }
 }
@@ -130,8 +159,9 @@ export async function withContext<T>(
  *
  * @param assembly the assembly to check
  */
-export async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly, ioHelper: IoHelper): Promise<void> {
-  const tree = loadTree(assembly, (msg: string) => void ioHelper.notify(IO.DEFAULT_ASSEMBLY_TRACE.msg(msg)));
+async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly, ioHelper: IoHelper): Promise<void> {
+  const traceFn = (msg: string) => ioHelper.notify(IO.DEFAULT_ASSEMBLY_TRACE.msg(msg));
+  const tree = await loadTree(assembly, traceFn);
   const frameworkDoesNotSupportContextOverflow = some(tree, node => {
     const fqn = node.constructInfo?.fqn;
     const version = node.constructInfo?.version;
@@ -149,7 +179,7 @@ export async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly,
 /**
  * Safely create an assembly from a cloud assembly directory
  */
-export async function assemblyFromDirectory(assemblyDir: string, ioHost: IoHelper, loadOptions: LoadAssemblyOptions = {}) {
+export async function assemblyFromDirectory(assemblyDir: string, ioHelper: IoHelper, loadOptions: LoadAssemblyOptions = {}) {
   try {
     const assembly = new cxapi.CloudAssembly(assemblyDir, {
       skipVersionCheck: !(loadOptions.checkVersion ?? true),
@@ -157,14 +187,14 @@ export async function assemblyFromDirectory(assemblyDir: string, ioHost: IoHelpe
       // We sort as we deploy
       topoSort: false,
     });
-    await checkContextOverflowSupport(assembly, ioHost);
+    await checkContextOverflowSupport(assembly, ioHelper);
     return assembly;
   } catch (err: any) {
     if (err.message.includes(cxschema.VERSION_MISMATCH)) {
       // this means the CLI version is too old.
       // we instruct the user to upgrade.
       const message = 'This AWS CDK Toolkit is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.';
-      await ioHost.notify(IO.CDK_ASSEMBLY_E1111.msg(message, { error: err }));
+      await ioHelper.notify(IO.CDK_ASSEMBLY_E1111.msg(message, { error: err }));
       throw new ToolkitError(`${message}\n(${err.message}`);
     }
     throw err;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
@@ -4,7 +4,7 @@ import type { AssemblyDirectoryProps, AssemblySourceProps, ICloudAssemblySource 
 import type { ContextAwareCloudAssemblyProps } from './context-aware-source';
 import { ContextAwareCloudAssembly } from './context-aware-source';
 import { execInChildProcess } from './exec';
-import { ExecutionEnviornment, assemblyFromDirectory } from './prepare-source';
+import { ExecutionEnvironment, assemblyFromDirectory } from './prepare-source';
 import type { ToolkitServices } from '../../../toolkit/private';
 import type { ILock } from '../../aws-cdk';
 import { Context, RWLock, Settings } from '../../aws-cdk';
@@ -40,14 +40,14 @@ export abstract class CloudAssemblySourceBuilder {
     return new ContextAwareCloudAssembly(
       {
         produce: async () => {
-          const x = new ExecutionEnviornment(services, { outdir: props.outdir });
-          const env = await x.defaultEnvVars();
-          const assembly = await x.changeDir(async () =>
-            x.withContext(context.all, env, props.synthOptions ?? {}, async (envWithContext, ctx) =>
-              x.withEnv(envWithContext, () => {
+          const execution = new ExecutionEnvironment(services, { outdir: props.outdir });
+          const env = await execution.defaultEnvVars();
+          const assembly = await execution.changeDir(async () =>
+            execution.withContext(context.all, env, props.synthOptions ?? {}, async (envWithContext, ctx) =>
+              execution.withEnv(envWithContext, () => {
                 try {
                   return builder({
-                    outdir: x.outdir,
+                    outdir: execution.outdir,
                     context: ctx,
                   });
                 } catch (error: unknown) {
@@ -131,10 +131,10 @@ export abstract class CloudAssemblySourceBuilder {
 
             lock = await new RWLock(outdir).acquireWrite();
 
-            const x = new ExecutionEnviornment(services, { outdir });
-            const commandLine = await x.guessExecutable(app);
-            const env = await x.defaultEnvVars();
-            return await x.withContext(context.all, env, props.synthOptions, async (envWithContext, _ctx) => {
+            const execution = new ExecutionEnvironment(services, { outdir });
+            const commandLine = await execution.guessExecutable(app);
+            const env = await execution.defaultEnvVars();
+            return await execution.withContext(context.all, env, props.synthOptions, async (envWithContext, _ctx) => {
               await execInChildProcess(commandLine.join(' '), {
                 eventPublisher: async (type, line) => {
                   switch (type) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
@@ -4,7 +4,7 @@ import type { AssemblyDirectoryProps, AssemblySourceProps, ICloudAssemblySource 
 import type { ContextAwareCloudAssemblyProps } from './context-aware-source';
 import { ContextAwareCloudAssembly } from './context-aware-source';
 import { execInChildProcess } from './exec';
-import { assemblyFromDirectory, changeDir, determineOutputDirectory, guessExecutable, prepareDefaultEnvironment, withContext, withEnv } from './prepare-source';
+import { ExecutionEnviornment, assemblyFromDirectory } from './prepare-source';
 import type { ToolkitServices } from '../../../toolkit/private';
 import type { ILock } from '../../aws-cdk';
 import { Context, RWLock, Settings } from '../../aws-cdk';
@@ -40,14 +40,14 @@ export abstract class CloudAssemblySourceBuilder {
     return new ContextAwareCloudAssembly(
       {
         produce: async () => {
-          const outdir = determineOutputDirectory(props.outdir);
-          const env = await prepareDefaultEnvironment(services, { outdir });
-          const assembly = await changeDir(async () =>
-            withContext(context.all, env, props.synthOptions ?? {}, async (envWithContext, ctx) =>
-              withEnv(envWithContext, () => {
+          const x = new ExecutionEnviornment(services, { outdir: props.outdir });
+          const env = await x.defaultEnvVars();
+          const assembly = await x.changeDir(async () =>
+            x.withContext(context.all, env, props.synthOptions ?? {}, async (envWithContext, ctx) =>
+              x.withEnv(envWithContext, () => {
                 try {
                   return builder({
-                    outdir,
+                    outdir: x.outdir,
                     context: ctx,
                   });
                 } catch (error: unknown) {
@@ -122,9 +122,7 @@ export abstract class CloudAssemblySourceBuilder {
             //   await execInChildProcess(build, { cwd: props.workingDirectory });
             // }
 
-            const commandLine = await guessExecutable(app);
             const outdir = props.outdir ?? 'cdk.out';
-
             try {
               fs.mkdirpSync(outdir);
             } catch (e: any) {
@@ -133,8 +131,10 @@ export abstract class CloudAssemblySourceBuilder {
 
             lock = await new RWLock(outdir).acquireWrite();
 
-            const env = await prepareDefaultEnvironment(services, { outdir });
-            return await withContext(context.all, env, props.synthOptions, async (envWithContext, _ctx) => {
+            const x = new ExecutionEnviornment(services, { outdir });
+            const commandLine = await x.guessExecutable(app);
+            const env = await x.defaultEnvVars();
+            return await x.withContext(context.all, env, props.synthOptions, async (envWithContext, _ctx) => {
               await execInChildProcess(commandLine.join(' '), {
                 eventPublisher: async (type, line) => {
                   switch (type) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
@@ -19,7 +19,7 @@ export class StackAssembly extends CloudAssembly implements ICloudAssemblySource
    * @throws when the assembly does not contain any stacks, unless `selector.failOnEmpty` is `false`
    * @throws when individual selection strategies are not satisfied
    */
-  public selectStacksV2(selector: StackSelector): StackCollection {
+  public async selectStacksV2(selector: StackSelector): Promise<StackCollection> {
     const asm = this.assembly;
     const topLevelStacks = asm.stacks;
     const allStacks = major(asm.version) < 10 ? asm.stacks : asm.stacksRecursively;
@@ -48,7 +48,7 @@ export class StackAssembly extends CloudAssembly implements ICloudAssemblySource
         }
         return new StackCollection(this, topLevelStacks);
       default:
-        const matched = this.selectMatchingStacks(allStacks, patterns, extend);
+        const matched = await this.selectMatchingStacks(allStacks, patterns, extend);
         if (
           selector.strategy === StackSelectionStrategy.PATTERN_MUST_MATCH_SINGLE
           && matched.stackCount !== 1

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
@@ -18,14 +18,14 @@ export interface ToolkitServices {
  * @param cache if the assembly should be cached, default: `true`
  * @returns the CloudAssembly object
  */
-export async function assemblyFromSource(assemblySource: ICloudAssemblySource, cache: boolean = true): Promise<StackAssembly> {
+export async function assemblyFromSource(ioHelper: IoHelper, assemblySource: ICloudAssemblySource, cache: boolean = true): Promise<StackAssembly> {
   if (assemblySource instanceof StackAssembly) {
     return assemblySource;
   }
 
   if (cache) {
-    return new StackAssembly(await new CachedCloudAssemblySource(assemblySource).produce());
+    return new StackAssembly(await new CachedCloudAssemblySource(assemblySource).produce(), ioHelper);
   }
 
-  return new StackAssembly(await assemblySource.produce());
+  return new StackAssembly(await assemblySource.produce(), ioHelper);
 }

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/index.ts
@@ -1,8 +1,8 @@
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import type { AssemblyDirectoryProps, Toolkit } from '../../lib';
 import { ToolkitError } from '../../lib';
-import { determineOutputDirectory } from '../../lib/api/cloud-assembly/private';
 
 export * from '../../lib/api/shared-private';
 export * from './test-cloud-assembly-source';
@@ -18,7 +18,7 @@ export async function appFixture(toolkit: Toolkit, name: string, context?: { [ke
   }
   const app = `cat ${appPath} | node --input-type=module`;
   return toolkit.fromCdkApp(app, {
-    outdir: determineOutputDirectory(),
+    outdir: tmpOutdir(),
     context,
   });
 }
@@ -27,7 +27,7 @@ export function builderFixture(toolkit: Toolkit, name: string, context?: { [key:
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const builder = require(path.join(__dirname, '..', '_fixtures', name)).default;
   return toolkit.fromAssemblyBuilder(builder, {
-    outdir: determineOutputDirectory(),
+    outdir: tmpOutdir(),
     context,
   });
 }
@@ -38,4 +38,8 @@ export function cdkOutFixture(toolkit: Toolkit, name: string, props: AssemblyDir
     throw new ToolkitError(`Assembly Dir Fixture ${name} does not exist in ${outdir}`);
   }
   return toolkit.fromAssemblyDirectory(outdir, props);
+}
+
+function tmpOutdir(): string {
+  return fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), 'cdk.out'));
 }

--- a/packages/aws-cdk/lib/api/tree.ts
+++ b/packages/aws-cdk/lib/api/tree.ts
@@ -36,13 +36,13 @@ export function some(node: ConstructTreeNode | undefined, predicate: (n: Constru
   }
 }
 
-export function loadTree(assembly: CloudAssembly, trace: (msg: string) => void): ConstructTreeNode | undefined {
+export async function loadTree(assembly: CloudAssembly, trace: (msg: string) => Promise<void>): Promise<ConstructTreeNode | undefined > {
   try {
     const outdir = assembly.directory;
     const fileName = assembly.tree()?.file;
-    return fileName ? fs.readJSONSync(path.join(outdir, fileName)).tree : {};
+    return fileName ? fs.readJSONSync(path.join(outdir, fileName)).tree : ({} as ConstructTreeNode);
   } catch (e) {
-    trace(`Failed to get tree.json file: ${e}. Proceeding with empty tree.`);
+    await trace(`Failed to get tree.json file: ${e}. Proceeding with empty tree.`);
     return undefined;
   }
 }

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -140,10 +140,11 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         // variable here. It will be released when the CLI exits. Locks are not re-entrant
         // so release it if we have to synthesize more than once (because of context lookups).
         await outDirLock?.release();
-        const { assembly, lock } = await execProgram(aws, config);
+        const { assembly, lock } = await execProgram(aws, ioHost.asIoHelper(), config);
         outDirLock = lock;
         return assembly;
       }),
+    ioHelper: ioHost.asIoHelper(),
   });
 
   /** Function to load plug-ins, using configurations additively. */

--- a/packages/aws-cdk/lib/context-providers/index.ts
+++ b/packages/aws-cdk/lib/context-providers/index.ts
@@ -73,7 +73,7 @@ export async function provideContextValues(
   missingValues: cxschema.MissingContext[],
   context: Context,
   sdk: SdkProvider,
-  ioHelper?: IoHelper,
+  ioHelper: IoHelper,
 ) {
   for (const missingContext of missingValues) {
     const key = missingContext.key;

--- a/packages/aws-cdk/test/_helpers/assembly.ts
+++ b/packages/aws-cdk/test/_helpers/assembly.ts
@@ -6,6 +6,8 @@ import { cxapiAssemblyWithForcedVersion } from '../api/cxapp/assembly-versions';
 import { MockSdkProvider } from '../util/mock-sdk';
 import { CloudExecutable } from '../../lib/api/cxapp/cloud-executable';
 import { Configuration } from '../../lib/cli/user-configuration';
+import { asIoHelper, TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+import { IIoHost } from '../../lib/cli/io-host';
 
 export const DEFAULT_FAKE_TEMPLATE = { No: 'Resources' };
 
@@ -40,14 +42,16 @@ export class MockCloudExecutable extends CloudExecutable {
   public readonly configuration: Configuration;
   public readonly sdkProvider: MockSdkProvider;
 
-  constructor(assembly: TestAssembly, sdkProviderArg?: MockSdkProvider) {
+  constructor(assembly: TestAssembly, sdkProviderArg?: MockSdkProvider, ioHost?: IIoHost) {
     const configuration = new Configuration();
     const sdkProvider = sdkProviderArg ?? new MockSdkProvider();
-
+    const mockIoHost = ioHost ?? new TestIoHost();
+    
     super({
       configuration,
       sdkProvider,
       synthesizer: () => Promise.resolve(testAssembly(assembly)),
+      ioHelper: asIoHelper(mockIoHost, 'deploy'),
     });
 
     this.configuration = configuration;

--- a/packages/aws-cdk/test/api/cxapp/exec.test.ts
+++ b/packages/aws-cdk/test/api/cxapp/exec.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable import/order */
 jest.mock('child_process');
 import bockfs from '../../_helpers/bockfs';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
@@ -13,12 +12,16 @@ import { mockSpawn } from '../../util/mock-child_process';
 import { MockSdkProvider } from '../../util/mock-sdk';
 import { RWLock } from '../../../lib/api/util/rwlock';
 import { rewriteManifestVersion } from './assembly-versions';
-import { CliIoHost } from '../../../lib/cli/io-host';
+import { asIoHelper, TestIoHost } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 let sdkProvider: MockSdkProvider;
 let config: Configuration;
+const ioHost = new TestIoHost();
+const ioHelper = asIoHelper(ioHost, 'synth');
+
 beforeEach(() => {
-  CliIoHost.instance().logLevel = 'debug';
+  ioHost.notifySpy.mockClear();
+  ioHost.requestSpy.mockClear();
 
   sdkProvider = new MockSdkProvider();
   config = new Configuration();
@@ -37,8 +40,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  CliIoHost.instance().logLevel = 'info';
-
   sinon.restore();
   bockfs.restore();
 });
@@ -84,7 +85,7 @@ test('cli throws when manifest version > schema version', async () => {
 
   config.settings.set(['app'], 'cdk.out');
 
-  await expect(execProgram(sdkProvider, config)).rejects.toEqual(new Error(expectedError));
+  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toEqual(new Error(expectedError));
 
 }, TEN_SECOND_TIMEOUT);
 
@@ -97,7 +98,7 @@ test('cli does not throw when manifest version = schema version', async () => {
 
   config.settings.set(['app'], 'cdk.out');
 
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 
 }, TEN_SECOND_TIMEOUT);
@@ -124,7 +125,7 @@ test.skip('cli does not throw when manifest version < schema version', async () 
   // greater that the version created in the manifest, which is what we are testing for.
   const mockVersionNumber = ImportMock.mockFunction(cxschema.Manifest, 'version', semver.inc(currentSchemaVersion, 'major'));
   try {
-    const { lock } = await execProgram(sdkProvider, config);
+    const { lock } = await execProgram(sdkProvider, ioHelper, config);
     await lock.release();
   } finally {
     mockVersionNumber.restore();
@@ -134,7 +135,7 @@ test.skip('cli does not throw when manifest version < schema version', async () 
 
 test('validates --app key is present', async () => {
   // GIVEN no config key for `app`
-  await expect(execProgram(sdkProvider, config)).rejects.toThrow(
+  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toThrow(
     '--app is required either in command-line, in cdk.json or in ~/.cdk.json',
   );
 
@@ -147,7 +148,7 @@ test('bypasses synth when app points to a cloud assembly', async () => {
   rewriteManifestVersionToOurs();
 
   // WHEN
-  const { assembly: cloudAssembly, lock } = await execProgram(sdkProvider, config);
+  const { assembly: cloudAssembly, lock } = await execProgram(sdkProvider, ioHelper, config);
   expect(cloudAssembly.artifacts).toEqual([]);
   expect(cloudAssembly.directory).toEqual('cdk.out');
 
@@ -163,7 +164,7 @@ test('the application set in --app is executed', async () => {
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 });
 
@@ -176,7 +177,7 @@ test('the application set in --app is executed as-is if it contains a filename t
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 });
 
@@ -189,7 +190,7 @@ test('the application set in --app is executed with arguments', async () => {
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 });
 
@@ -203,7 +204,7 @@ test('application set in --app as `*.js` always uses handler on windows', async 
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 });
 
@@ -216,7 +217,7 @@ test('application set in --app is `*.js` and executable', async () => {
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 });
 
@@ -229,7 +230,7 @@ test('cli throws when the `build` script fails', async () => {
   });
 
   // WHEN
-  await expect(execProgram(sdkProvider, config)).rejects.toEqual(new Error('Subprocess exited with error 127'));
+  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toEqual(new Error('Subprocess exited with error 127'));
 }, TEN_SECOND_TIMEOUT);
 
 test('cli does not throw when the `build` script succeeds', async () => {
@@ -246,7 +247,7 @@ test('cli does not throw when the `build` script succeeds', async () => {
   });
 
   // WHEN
-  const { lock } = await execProgram(sdkProvider, config);
+  const { lock } = await execProgram(sdkProvider, ioHelper, config);
   await lock.release();
 }, TEN_SECOND_TIMEOUT);
 
@@ -259,7 +260,7 @@ test('cli releases the outdir lock when execProgram throws', async () => {
   });
 
   // WHEN
-  await expect(execProgram(sdkProvider, config)).rejects.toThrow();
+  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toThrow();
 
   const output = config.settings.get(['output']);
   expect(output).toBeDefined();

--- a/packages/aws-cdk/test/commands/diff.test.ts
+++ b/packages/aws-cdk/test/commands/diff.test.ts
@@ -76,7 +76,7 @@ describe('fixed template', () => {
           },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     toolkit = new CdkToolkit({
       cloudExecutable,
@@ -172,7 +172,7 @@ describe('imports', () => {
           },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     cloudFormation = instanceMockFrom(Deployments);
 
@@ -290,7 +290,7 @@ describe('non-nested stacks', () => {
           template: { resource: 'D' },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     cloudFormation = instanceMockFrom(Deployments);
 
@@ -358,7 +358,7 @@ describe('non-nested stacks', () => {
           template: { resourceC: 'C' },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     toolkit = new CdkToolkit({
       cloudExecutable,
@@ -500,7 +500,7 @@ describe('stack exists checks', () => {
           template: { resource: 'D' },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     cloudFormation = instanceMockFrom(Deployments);
 
@@ -607,7 +607,7 @@ describe('nested stacks', () => {
           template: {},
         },
       ],
-    });
+    }, undefined, ioHost);
 
     cloudFormation = instanceMockFrom(Deployments);
 
@@ -1092,7 +1092,7 @@ describe('--strict', () => {
           },
         },
       ],
-    });
+    }, undefined, ioHost);
 
     toolkit = new CdkToolkit({
       cloudExecutable,


### PR DESCRIPTION
Refactors the `cxapp` api code to use modern messaging. This had a larger amount of knock-on effects then other refactors, to the PR is a bit bigger.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
