### PR TITLE
refactor(cli): aws-auth uses modern messaging infrastructure everywhere

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/messages.ts
@@ -45,6 +45,12 @@ export const IO = {
     description: 'Default trace messages emitted from the Toolkit',
   }),
 
+  // warnings & errors
+  CDK_TOOLKIT_W0100: make.warn({
+    code: 'CDK_TOOLKIT_W0100',
+    description: 'Credential plugin warnings',
+  }),
+
   // 1: Synth (1xxx)
   CDK_TOOLKIT_I1000: make.info<Duration>({
     code: 'CDK_TOOLKIT_I1000',
@@ -268,7 +274,6 @@ export const IO = {
     description: 'Hotswap disclosure message',
   }),
 
-  // errors
   CDK_TOOLKIT_E5001: make.error({
     code: 'CDK_TOOLKIT_E5001',
     description: 'No stacks found',
@@ -482,9 +487,17 @@ export const IO = {
   }),
 
   // SDK codes
-  CDK_SDK_I0000: make.trace({
+  DEFAULT_SDK_TRACE: make.trace({
     code: 'CDK_SDK_I0000',
-    description: 'An SDK message.',
+    description: 'An SDK trace message.',
+  }),
+  DEFAULT_SDK_DEBUG: make.debug({
+    code: 'CDK_SDK_I0000',
+    description: 'An SDK debug message.',
+  }),
+  DEFAULT_SDK_WARN: make.warn({
+    code: 'CDK_SDK_W0000',
+    description: 'An SDK warning message.',
   }),
   CDK_SDK_I0100: make.trace<SdkTrace>({
     code: 'CDK_SDK_I0100',

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/testing/test-io-host.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/io/private/testing/test-io-host.ts
@@ -1,6 +1,8 @@
 import { RequireApproval } from '../../../require-approval';
 import type { IIoHost } from '../../io-host';
 import type { IoMessage, IoMessageLevel, IoRequest } from '../../io-message';
+import type { IoHelper } from '../io-helper';
+import { asIoHelper } from '../io-helper';
 import { isMessageRelevantForLevel } from '../level-priority';
 
 /**
@@ -24,6 +26,10 @@ export class TestIoHost implements IIoHost {
   constructor(public level: IoMessageLevel = 'info') {
     this.notifySpy = jest.fn();
     this.requestSpy = jest.fn();
+  }
+
+  public asHelper(action = 'synth'): IoHelper {
+    return asIoHelper(this, action as any);
   }
 
   public async notify(msg: IoMessage<unknown>): Promise<void> {

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -11,6 +11,7 @@ group: Documents
 | `CDK_TOOLKIT_W0000` | Default warning messages emitted from the Toolkit | `warn` | n/a |
 | `CDK_TOOLKIT_E0000` | Default error messages emitted from the Toolkit | `error` | n/a |
 | `CDK_TOOLKIT_I0000` | Default trace messages emitted from the Toolkit | `trace` | n/a |
+| `CDK_TOOLKIT_W0100` | Credential plugin warnings | `warn` | n/a |
 | `CDK_TOOLKIT_I1000` | Provides synthesis times. | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I1001` | Cloud Assembly synthesis is starting | `trace` | {@link StackSelectionDetails} |
 | `CDK_TOOLKIT_I1901` | Provides stack data | `result` | {@link StackAndAssemblyData} |
@@ -95,5 +96,7 @@ group: Documents
 | `CDK_ASSEMBLY_I9999` | Annotations emitted by the cloud assembly | `info` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_W9999` | Warnings emitted by the cloud assembly | `warn` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_E9999` | Errors emitted by the cloud assembly | `error` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
-| `CDK_SDK_I0000` | An SDK message. | `trace` | n/a |
+| `CDK_SDK_I0000` | An SDK trace message. | `trace` | n/a |
+| `CDK_SDK_I0000` | An SDK debug message. | `debug` | n/a |
+| `CDK_SDK_W0000` | An SDK warning message. | `warn` | n/a |
 | `CDK_SDK_I0100` | An SDK trace. SDK traces are emitted as traces to the IoHost, but contain the original SDK logging level. | `trace` | {@link SdkTrace} |

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -128,9 +128,11 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
   private async sdkProvider(action: ToolkitAction): Promise<SdkProvider> {
     // @todo this needs to be different instance per action
     if (!this._sdkProvider) {
+      const ioHelper = asIoHelper(this.ioHost, action);
       this._sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
         ...this.props.sdkConfig,
-        logger: asSdkLogger(asIoHelper(this.ioHost, action)),
+        ioHelper,
+        logger: asSdkLogger(ioHelper),
       });
     }
 

--- a/packages/aws-cdk/lib/api/aws-auth/account-cache.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/account-cache.ts
@@ -1,7 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import type { Account } from './sdk-provider';
-import { debug } from '../../logging';
 import { cdkCacheDir } from '../../util';
 
 /**
@@ -16,13 +15,24 @@ export class AccountAccessKeyCache {
    */
   public static readonly MAX_ENTRIES = 1000;
 
+  /**
+   * The default path used for the accounts access key cache
+   */
+  public static get DEFAULT_PATH(): string {
+    // needs to be a getter because cdkCacheDir can be set via env variable and might change
+    return path.join(cdkCacheDir(), 'accounts_partitions.json');
+  }
+
   private readonly cacheFile: string;
+
+  private readonly debug: (msg: string) => Promise<void>;
 
   /**
    * @param filePath Path to the cache file
    */
-  constructor(filePath?: string) {
-    this.cacheFile = filePath || path.join(cdkCacheDir(), 'accounts_partitions.json');
+  constructor(filePath: string = AccountAccessKeyCache.DEFAULT_PATH, debugFn: (msg: string) => Promise<void>) {
+    this.cacheFile = filePath;
+    this.debug = debugFn;
   }
 
   /**
@@ -40,7 +50,7 @@ export class AccountAccessKeyCache {
     // try to get account ID based on this access key ID from disk.
     const cached = await this.get(accessKeyId);
     if (cached) {
-      debug(`Retrieved account ID ${cached.accountId} from disk cache`);
+      await this.debug(`Retrieved account ID ${cached.accountId} from disk cache`);
       return cached;
     }
 

--- a/packages/aws-cdk/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/awscli-compatible.ts
@@ -1,15 +1,15 @@
+import { format } from 'node:util';
 import { createCredentialChain, fromEnv, fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
 import type { NodeHttpHandlerOptions } from '@smithy/node-http-handler';
 import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
 import type { AwsCredentialIdentityProvider, Logger } from '@smithy/types';
 import * as promptly from 'promptly';
-import { ProxyAgent } from 'proxy-agent';
 import { makeCachingProvider } from './provider-caching';
+import { ProxyAgentProvider } from './proxy-agent';
 import type { SdkHttpOptions } from './sdk-provider';
-import { readIfPossible } from './util';
 import { AuthenticationError } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api';
-import { debug } from '../../logging';
+import { IO, type IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const DEFAULT_CONNECTION_TIMEOUT = 10000;
 const DEFAULT_TIMEOUT = 300000;
@@ -23,16 +23,22 @@ const DEFAULT_TIMEOUT = 300000;
  * https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
  */
 export class AwsCliCompatible {
+  private readonly ioHelper: IoHelper;
+
+  public constructor(ioHelper: IoHelper) {
+    this.ioHelper = ioHelper;
+  }
+
   /**
    * Build an AWS CLI-compatible credential chain provider
    *
    * The credential chain returned by this function is always caching.
    */
-  public static async credentialChainBuilder(
+  public async credentialChainBuilder(
     options: CredentialChainOptions = {},
   ): Promise<AwsCredentialIdentityProvider> {
     const clientConfig = {
-      requestHandler: AwsCliCompatible.requestHandlerBuilder(options.httpOptions),
+      requestHandler: await this.requestHandlerBuilder(options.httpOptions),
       customUserAgent: 'aws-cdk',
       logger: options.logger,
     };
@@ -63,7 +69,7 @@ export class AwsCliCompatible {
       return makeCachingProvider(fromIni({
         profile: options.profile,
         ignoreCache: true,
-        mfaCodeProvider: tokenCodeFn,
+        mfaCodeProvider: makeTokenCodeFn(this.ioHelper),
         clientConfig,
         parentClientConfig,
         logger: options.logger,
@@ -100,7 +106,7 @@ export class AwsCliCompatible {
       clientConfig,
       parentClientConfig,
       logger: options.logger,
-      mfaCodeProvider: tokenCodeFn,
+      mfaCodeProvider: makeTokenCodeFn(this.ioHelper),
       ignoreCache: true,
     });
 
@@ -109,8 +115,8 @@ export class AwsCliCompatible {
       : nodeProviderChain;
   }
 
-  public static requestHandlerBuilder(options: SdkHttpOptions = {}): NodeHttpHandlerOptions {
-    const agent = this.proxyAgent(options);
+  public async requestHandlerBuilder(options: SdkHttpOptions = {}): Promise<NodeHttpHandlerOptions> {
+    const agent = await new ProxyAgentProvider(this.ioHelper).create(options);
 
     return {
       connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
@@ -118,19 +124,6 @@ export class AwsCliCompatible {
       httpsAgent: agent,
       httpAgent: agent,
     };
-  }
-
-  public static proxyAgent(options: SdkHttpOptions) {
-    // Force it to use the proxy provided through the command line.
-    // Otherwise, let the ProxyAgent auto-detect the proxy using environment variables.
-    const getProxyForUrl = options.proxyAddress != null
-      ? () => Promise.resolve(options.proxyAddress!)
-      : undefined;
-
-    return new ProxyAgent({
-      ca: tryGetCACert(options.caBundlePath),
-      getProxyForUrl,
-    });
   }
 
   /**
@@ -147,7 +140,7 @@ export class AwsCliCompatible {
    * 3. IMDS instance identity region from the Metadata Service.
    * 4. us-east-1
    */
-  public static async region(maybeProfile?: string): Promise<string> {
+  public async region(maybeProfile?: string): Promise<string> {
     const defaultRegion = 'us-east-1';
     const profile = maybeProfile || process.env.AWS_PROFILE || process.env.AWS_DEFAULT_PROFILE || 'default';
 
@@ -156,69 +149,71 @@ export class AwsCliCompatible {
       process.env.AMAZON_REGION ||
       process.env.AWS_DEFAULT_REGION ||
       process.env.AMAZON_DEFAULT_REGION ||
-      (await getRegionFromIni(profile)) ||
-      (await regionFromMetadataService());
+      (await this.getRegionFromIni(profile)) ||
+      (await this.regionFromMetadataService());
 
     if (!region) {
       const usedProfile = !profile ? '' : ` (profile: "${profile}")`;
-      debug(
+      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(
         `Unable to determine AWS region from environment or AWS configuration${usedProfile}, defaulting to '${defaultRegion}'`,
-      );
+      ));
       return defaultRegion;
     }
 
     return region;
   }
-}
 
-/**
- * Looks up the region of the provided profile. If no region is present,
- * it will attempt to lookup the default region.
- * @param profile The profile to use to lookup the region
- * @returns The region for the profile or default profile, if present. Otherwise returns undefined.
- */
-async function getRegionFromIni(profile: string): Promise<string | undefined> {
-  const sharedFiles = await loadSharedConfigFiles({ ignoreCache: true });
+  /**
+   * The MetadataService class will attempt to fetch the instance identity document from
+   * IMDSv2 first, and then will attempt v1 as a fallback.
+   *
+   * If this fails, we will use us-east-1 as the region so no error should be thrown.
+   * @returns The region for the instance identity
+   */
+  private async regionFromMetadataService() {
+    await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg('Looking up AWS region in the EC2 Instance Metadata Service (IMDS).'));
+    try {
+      const metadataService = new MetadataService({
+        httpOptions: {
+          timeout: 1000,
+        },
+      });
 
-  // Priority:
-  //
-  // credentials come before config because aws-cli v1 behaves like that.
-  //
-  // 1. profile-region-in-credentials
-  // 2. profile-region-in-config
-  // 3. default-region-in-credentials
-  // 4. default-region-in-config
-
-  return getRegionFromIniFile(profile, sharedFiles.credentialsFile)
-    ?? getRegionFromIniFile(profile, sharedFiles.configFile)
-    ?? getRegionFromIniFile('default', sharedFiles.credentialsFile)
-    ?? getRegionFromIniFile('default', sharedFiles.configFile);
-}
-
-function getRegionFromIniFile(profile: string, data?: any) {
-  return data?.[profile]?.region;
-}
-
-function tryGetCACert(bundlePath?: string) {
-  const path = bundlePath || caBundlePathFromEnvironment();
-  if (path) {
-    debug('Using CA bundle path: %s', path);
-    return readIfPossible(path);
+      await metadataService.fetchMetadataToken();
+      const document = await metadataService.request('/latest/dynamic/instance-identity/document', {});
+      return JSON.parse(document).region;
+    } catch (e) {
+      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Unable to retrieve AWS region from IMDS: ${e}`));
+    }
   }
-  return undefined;
-}
 
-/**
- * Find and return a CA certificate bundle path to be passed into the SDK.
- */
-function caBundlePathFromEnvironment(): string | undefined {
-  if (process.env.aws_ca_bundle) {
-    return process.env.aws_ca_bundle;
+  /**
+   * Looks up the region of the provided profile. If no region is present,
+   * it will attempt to lookup the default region.
+   * @param profile The profile to use to lookup the region
+   * @returns The region for the profile or default profile, if present. Otherwise returns undefined.
+   */
+  private async getRegionFromIni(profile: string): Promise<string | undefined> {
+    const sharedFiles = await loadSharedConfigFiles({ ignoreCache: true });
+
+    // Priority:
+    //
+    // credentials come before config because aws-cli v1 behaves like that.
+    //
+    // 1. profile-region-in-credentials
+    // 2. profile-region-in-config
+    // 3. default-region-in-credentials
+    // 4. default-region-in-config
+
+    return this.getRegionFromIniFile(profile, sharedFiles.credentialsFile)
+    ?? this.getRegionFromIniFile(profile, sharedFiles.configFile)
+    ?? this.getRegionFromIniFile('default', sharedFiles.credentialsFile)
+    ?? this.getRegionFromIniFile('default', sharedFiles.configFile);
   }
-  if (process.env.AWS_CA_BUNDLE) {
-    return process.env.AWS_CA_BUNDLE;
+
+  private getRegionFromIniFile(profile: string, data?: any) {
+    return data?.[profile]?.region;
   }
-  return undefined;
 }
 
 /**
@@ -245,30 +240,6 @@ function shouldPrioritizeEnv() {
   return false;
 }
 
-/**
- * The MetadataService class will attempt to fetch the instance identity document from
- * IMDSv2 first, and then will attempt v1 as a fallback.
- *
- * If this fails, we will use us-east-1 as the region so no error should be thrown.
- * @returns The region for the instance identity
- */
-async function regionFromMetadataService() {
-  debug('Looking up AWS region in the EC2 Instance Metadata Service (IMDS).');
-  try {
-    const metadataService = new MetadataService({
-      httpOptions: {
-        timeout: 1000,
-      },
-    });
-
-    await metadataService.fetchMetadataToken();
-    const document = await metadataService.request('/latest/dynamic/instance-identity/document', {});
-    return JSON.parse(document).region;
-  } catch (e) {
-    debug(`Unable to retrieve AWS region from IMDS: ${e}`);
-  }
-}
-
 export interface CredentialChainOptions {
   readonly profile?: string;
   readonly httpOptions?: SdkHttpOptions;
@@ -280,19 +251,22 @@ export interface CredentialChainOptions {
  *
  * Result is send to callback function for SDK to authorize the request
  */
-async function tokenCodeFn(serialArn: string): Promise<string> {
-  debug('Require MFA token for serial ARN', serialArn);
-  try {
-    const token: string = await promptly.prompt(`MFA token for ${serialArn}: `, {
-      trim: true,
-      default: '',
-    });
-    debug('Successfully got MFA token from user');
-    return token;
-  } catch (err: any) {
-    debug('Failed to get MFA token', err);
-    const e = new AuthenticationError(`Error fetching MFA token: ${err.message ?? err}`);
-    e.name = 'SharedIniFileCredentialsProviderFailure';
-    throw e;
-  }
+function makeTokenCodeFn(ioHelper: IoHelper) {
+  const debugFn = (msg: string, ...args: any[]) => ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(format(msg, ...args)));
+  return async (serialArn: string): Promise<string> => {
+    await debugFn('Require MFA token for serial ARN', serialArn);
+    try {
+      const token: string = await promptly.prompt(`MFA token for ${serialArn}: `, {
+        trim: true,
+        default: '',
+      });
+      await debugFn('Successfully got MFA token from user');
+      return token;
+    } catch (err: any) {
+      await debugFn('Failed to get MFA token', err);
+      const e = new AuthenticationError(`Error fetching MFA token: ${err.message ?? err}`);
+      e.name = 'SharedIniFileCredentialsProviderFailure';
+      throw e;
+    }
+  };
 }

--- a/packages/aws-cdk/lib/api/aws-auth/index.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/index.ts
@@ -1,3 +1,4 @@
 export * from './sdk';
 export * from './sdk-provider';
 export * from './sdk-logger';
+export * from './proxy-agent';

--- a/packages/aws-cdk/lib/api/aws-auth/proxy-agent.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/proxy-agent.ts
@@ -1,0 +1,48 @@
+import { ProxyAgent } from 'proxy-agent';
+import type { SdkHttpOptions } from './sdk-provider';
+import { readIfPossible } from './util';
+import { IO, type IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+
+export class ProxyAgentProvider {
+  private readonly ioHelper: IoHelper;
+
+  public constructor(ioHelper: IoHelper) {
+    this.ioHelper = ioHelper;
+  }
+
+  public async create(options: SdkHttpOptions) {
+    // Force it to use the proxy provided through the command line.
+    // Otherwise, let the ProxyAgent auto-detect the proxy using environment variables.
+    const getProxyForUrl = options.proxyAddress != null
+      ? () => Promise.resolve(options.proxyAddress!)
+      : undefined;
+
+    return new ProxyAgent({
+      ca: await this.tryGetCACert(options.caBundlePath),
+      getProxyForUrl,
+    });
+  }
+
+  private async tryGetCACert(bundlePath?: string) {
+    const path = bundlePath || this.caBundlePathFromEnvironment();
+    if (path) {
+      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Using CA bundle path: ${path}`));
+      return readIfPossible(path);
+    }
+    return undefined;
+  }
+
+  /**
+   * Find and return a CA certificate bundle path to be passed into the SDK.
+   */
+  private caBundlePathFromEnvironment(): string | undefined {
+    if (process.env.aws_ca_bundle) {
+      return process.env.aws_ca_bundle;
+    }
+    if (process.env.AWS_CA_BUNDLE) {
+      return process.env.AWS_CA_BUNDLE;
+    }
+    return undefined;
+  }
+}
+

--- a/packages/aws-cdk/lib/api/aws-auth/proxy-agent.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/proxy-agent.ts
@@ -1,6 +1,6 @@
+import * as fs from 'fs-extra';
 import { ProxyAgent } from 'proxy-agent';
 import type { SdkHttpOptions } from './sdk-provider';
-import { readIfPossible } from './util';
 import { IO, type IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 export class ProxyAgentProvider {
@@ -27,7 +27,15 @@ export class ProxyAgentProvider {
     const path = bundlePath || this.caBundlePathFromEnvironment();
     if (path) {
       await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Using CA bundle path: ${path}`));
-      return readIfPossible(path);
+      try {
+        if (!fs.pathExistsSync(path)) {
+          return undefined;
+        }
+        return fs.readFileSync(path, { encoding: 'utf-8' });
+      } catch (e: any) {
+        await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(String(e)));
+        return undefined;
+      }
     }
     return undefined;
   }

--- a/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
@@ -12,7 +12,7 @@ export class SdkToCliLogger implements Logger {
   }
 
   private notify(level: 'debug' | 'info' | 'warn' | 'error', ...content: any[]) {
-    void this.ioHelper.notify(IO.CDK_SDK_I0000.msg(format('[SDK %s] %s', level, formatSdkLoggerContent(content))));
+    void this.ioHelper.notify(IO.DEFAULT_SDK_TRACE.msg(format('[SDK %s] %s', level, formatSdkLoggerContent(content))));
   }
 
   public trace(..._content: any[]) {

--- a/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/sdk-logger.ts
@@ -11,8 +11,11 @@ export class SdkToCliLogger implements Logger {
     this.ioHelper = ioHelper;
   }
 
-  private notify(level: 'debug' | 'info' | 'warn' | 'error', ...content: any[]) {
-    void this.ioHelper.notify(IO.DEFAULT_SDK_TRACE.msg(format('[SDK %s] %s', level, formatSdkLoggerContent(content))));
+  private notify(level: 'info' | 'warn' | 'error', ...content: any[]) {
+    void this.ioHelper.notify(IO.CDK_SDK_I0100.msg(format('[SDK %s] %s', level, formatSdkLoggerContent(content)), {
+      sdkLevel: level,
+      content,
+    }));
   }
 
   public trace(..._content: any[]) {

--- a/packages/aws-cdk/lib/api/aws-auth/sdk.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/sdk.ts
@@ -347,7 +347,7 @@ import type { Account } from './sdk-provider';
 import { traceMemberMethods } from './tracing';
 import { defaultCliUserAgent } from './user-agent';
 import { AuthenticationError } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api';
-import { debug } from '../../logging';
+import { IO, type IoHelper } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { formatErrorMessage } from '../../util';
 
 export interface S3ClientOptions {
@@ -555,13 +555,13 @@ export interface IStepFunctionsClient {
  */
 @traceMemberMethods
 export class SDK {
-  private static readonly accountCache = new AccountAccessKeyCache();
-
   public readonly currentRegion: string;
 
   public readonly config: ConfigurationOptions;
 
   protected readonly logger?: Logger;
+
+  private readonly accountCache;
 
   /**
    * STS is used to check credential validity, don't do too many retries.
@@ -577,12 +577,21 @@ export class SDK {
    */
   private _credentialsValidated = false;
 
+  /**
+   * A function to create debug messages
+   */
+  private readonly debug: (msg: string) => Promise<void>;
+
   constructor(
     private readonly credProvider: AwsCredentialIdentityProvider,
     region: string,
     requestHandler: NodeHttpHandlerOptions,
+    ioHelper: IoHelper,
     logger?: Logger,
   ) {
+    const debugFn = async (msg: string) => ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(msg));
+    this.accountCache = new AccountAccessKeyCache(AccountAccessKeyCache.DEFAULT_PATH, debugFn);
+    this.debug = debugFn;
     this.config = {
       region,
       credentials: credProvider,
@@ -992,9 +1001,9 @@ export class SDK {
   public async currentAccount(): Promise<Account> {
     return cachedAsync(this, CURRENT_ACCOUNT_KEY, async () => {
       const creds = await this.credProvider();
-      return SDK.accountCache.fetch(creds.accessKeyId, async () => {
+      return this.accountCache.fetch(creds.accessKeyId, async () => {
         // if we don't have one, resolve from STS and store in cache.
-        debug('Looking up default account ID from STS');
+        await this.debug('Looking up default account ID from STS');
         const client = new STSClient({
           ...this.config,
           retryStrategy: this.stsRetryStrategy,
@@ -1006,7 +1015,7 @@ export class SDK {
         if (!accountId) {
           throw new AuthenticationError("STS didn't return an account ID");
         }
-        debug('Default account ID:', accountId);
+        await this.debug(`Default account ID ${accountId}`);
 
         // Save another STS call later if this one already succeeded
         this._credentialsValidated = true;

--- a/packages/aws-cdk/lib/api/aws-auth/sdk.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/sdk.ts
@@ -1015,7 +1015,7 @@ export class SDK {
         if (!accountId) {
           throw new AuthenticationError("STS didn't return an account ID");
         }
-        await this.debug(`Default account ID ${accountId}`);
+        await this.debug(`Default account ID: ${accountId}`);
 
         // Save another STS call later if this one already succeeded
         this._credentialsValidated = true;

--- a/packages/aws-cdk/lib/api/aws-auth/util.ts
+++ b/packages/aws-cdk/lib/api/aws-auth/util.ts
@@ -1,5 +1,4 @@
 import * as fs from 'fs-extra';
-import { debug } from '../../logging';
 
 /**
  * Read a file if it exists, or return undefined
@@ -13,7 +12,6 @@ export function readIfPossible(filename: string): string | undefined {
     }
     return fs.readFileSync(filename, { encoding: 'utf-8' });
   } catch (e: any) {
-    debug(e);
     return undefined;
   }
 }

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -120,7 +120,9 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   });
   await notices.refresh();
 
+  const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
   const sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
+    ioHelper,
     profile: configuration.settings.get(['profile']),
     httpOptions: {
       proxyAddress: argv.proxy,

--- a/packages/aws-cdk/lib/legacy-aws-auth.ts
+++ b/packages/aws-cdk/lib/legacy-aws-auth.ts
@@ -1,0 +1,69 @@
+// This is a legacy wrapper for code from the aws-auth that we want to keep the signatures intact
+// We generally use two different patterns here:
+// - make a copy of the old code as is
+// - wrap the old code and add a deprecation warning
+// This way we can keep the old code running until the new code is fully ready
+// and can be used by the users that are ready to migrate
+// The old code will be removed in a future version of aws-cdk
+import type { AwsCredentialIdentityProvider, Logger, NodeHttpHandlerOptions } from '@smithy/types';
+import { SdkProvider as SdkProviderCurrentVersion } from './api/aws-auth/sdk-provider';
+import { CliIoHost } from './cli/io-host';
+
+/**
+ * Options for individual SDKs
+ */
+interface SdkHttpOptions {
+  /**
+   * Proxy address to use
+   *
+   * @default No proxy
+   */
+  readonly proxyAddress?: string;
+
+  /**
+   * A path to a certificate bundle that contains a cert to be trusted.
+   *
+   * @default No certificate bundle
+   */
+  readonly caBundlePath?: string;
+}
+
+/**
+ * Options for the default SDK provider
+ */
+interface SdkProviderOptions {
+  /**
+   * Profile to read from ~/.aws
+   *
+   * @default - No profile
+   */
+  readonly profile?: string;
+
+  /**
+   * HTTP options for SDK
+   */
+  readonly httpOptions?: SdkHttpOptions;
+
+  /**
+   * The logger for sdk calls.
+   */
+  readonly logger?: Logger;
+}
+
+export class SdkProvider {
+  public static async withAwsCliCompatibleDefaults(options: SdkProviderOptions = {}) {
+    return SdkProviderCurrentVersion.withAwsCliCompatibleDefaults({
+      ...options,
+      ioHelper: CliIoHost.instance().asIoHelper(),
+    });
+  }
+
+  public constructor(
+    defaultCredentialProvider: AwsCredentialIdentityProvider,
+    defaultRegion: string,
+    requestHandler: NodeHttpHandlerOptions = {},
+    logger?: Logger,
+  ) {
+    return new SdkProviderCurrentVersion(defaultCredentialProvider, defaultRegion, requestHandler, CliIoHost.instance().asIoHelper(), logger);
+  }
+}

--- a/packages/aws-cdk/lib/legacy-exports-source.ts
+++ b/packages/aws-cdk/lib/legacy-exports-source.ts
@@ -5,25 +5,31 @@
 
 // Note: All type exports are in `legacy-exports.ts`
 export * from './legacy-logging-source';
-export { deepClone, flatten, ifDefined, isArray, isEmpty, numberFromBool, partition, padLeft as leftPad, contentHash, deepMerge, lowerCaseFirstCharacter } from './util';
-export { deployStack } from './api/deployments/deploy-stack';
-export { cli, exec } from './cli/cli';
-export { SdkProvider } from './api/aws-auth';
-export { PluginHost } from './api/plugin';
-export { Command, Configuration, PROJECT_CONTEXT } from './cli/user-configuration';
-export { Settings } from './api/settings';
-export { Bootstrapper } from './api/bootstrap';
+
+// API
+export { SdkProvider } from './legacy-aws-auth';
+export { setSdkTracing as enableTracing } from './api/aws-auth/tracing';
+export { cached } from './api/aws-auth/cached';
+export { CfnEvaluationException } from './api/cloudformation';
 export { CloudExecutable } from './api/cxapp/cloud-executable';
 export { execProgram } from './api/cxapp/exec';
-export { RequireApproval } from './commands/diff';
-export { formatAsBanner } from './cli/util/console-formatters';
-export { setSdkTracing as enableTracing } from './api/aws-auth/tracing';
-export { aliases, command, describe } from './commands/docs';
 export { Deployments } from './api/deployments';
+export { deployStack } from './api/deployments/deploy-stack';
+export { PluginHost } from './api/plugin';
+export { Settings } from './api/settings';
+export { Bootstrapper } from './api/bootstrap';
+
+// CLI
+export { cli, exec } from './cli/cli';
 export { cliRootDir as rootDir } from './cli/root-dir';
+export { Command, Configuration, PROJECT_CONTEXT } from './cli/user-configuration';
+export { formatAsBanner } from './cli/util/console-formatters';
 export { latestVersionIfHigher, versionNumber } from './cli/version';
+
+// Commands
+export { RequireApproval } from './commands/diff';
 export { availableInitTemplates } from './commands/init';
-export { cached } from './api/aws-auth/cached';
-export { CfnEvaluationException } from './api/cloudformation/evaluate-cloudformation-template';
-export { CredentialPlugins } from './api/aws-auth/credential-plugins';
-export { AwsCliCompatible } from './api/aws-auth/awscli-compatible';
+export { aliases, command, describe } from './commands/docs';
+
+// util
+export { deepClone, flatten, ifDefined, isArray, isEmpty, numberFromBool, partition, padLeft as leftPad, contentHash, deepMerge, lowerCaseFirstCharacter } from './util';

--- a/packages/aws-cdk/lib/legacy-exports.ts
+++ b/packages/aws-cdk/lib/legacy-exports.ts
@@ -70,8 +70,6 @@ export const {
   availableInitTemplates,
   cached,
   CfnEvaluationException,
-  CredentialPlugins,
-  AwsCliCompatible,
   withCorkedLogging,
   LogLevel,
   logLevel,

--- a/packages/aws-cdk/test/api/_helpers/hotswap-test-setup.ts
+++ b/packages/aws-cdk/test/api/_helpers/hotswap-test-setup.ts
@@ -145,6 +145,6 @@ export class HotswapMockSdkProvider extends MockSdkProvider {
     hotswapPropertyOverrides?: HotswapPropertyOverrides,
   ): Promise<SuccessfulDeployStackResult | undefined> {
     let hotswapProps = hotswapPropertyOverrides || new HotswapPropertyOverrides();
-    return deployments.tryHotswapDeployment(this, asIoHelper(ioHost, 'deploy'), assetParams, currentCfnStack, stackArtifact, hotswapMode, hotswapProps);
+    return deployments.tryHotswapDeployment(this, asIoHelper(ioHost, 'deploy'), assetParams, currentCfnStack, stackArtifact, hotswapMode as any, hotswapProps);
   }
 }

--- a/packages/aws-cdk/test/api/aws-auth/awscli-compatible.test.ts
+++ b/packages/aws-cdk/test/api/aws-auth/awscli-compatible.test.ts
@@ -2,6 +2,10 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import { AwsCliCompatible } from '../../../lib/api/aws-auth/awscli-compatible';
+import { TestIoHost } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('sdk');
 
 describe('AwsCliCompatible.region', () => {
 
@@ -235,7 +239,7 @@ async function region(opts: {
       process.env.AWS_SHARED_CREDENTIALS_FILE = credentialsPath;
     }
 
-    return await AwsCliCompatible.region(opts.profile);
+    return await new AwsCliCompatible(ioHelper).region(opts.profile);
 
   } finally {
     fs.removeSync(workdir);
@@ -253,7 +257,7 @@ describe('Session token', () => {
     delete process.env.AWS_SESSION_TOKEN;
     delete process.env.AMAZON_SESSION_TOKEN;
 
-    await AwsCliCompatible.credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toBeUndefined();
   });
@@ -262,7 +266,7 @@ describe('Session token', () => {
     process.env.AWS_SESSION_TOKEN = 'aaa';
     delete process.env.AMAZON_SESSION_TOKEN;
 
-    await AwsCliCompatible.credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });
@@ -271,7 +275,7 @@ describe('Session token', () => {
     delete process.env.AWS_SESSION_TOKEN;
     process.env.AMAZON_SESSION_TOKEN = 'aaa';
 
-    await AwsCliCompatible.credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });
@@ -280,7 +284,7 @@ describe('Session token', () => {
     process.env.AWS_SESSION_TOKEN = 'aaa';
     process.env.AMAZON_SESSION_TOKEN = 'bbb';
 
-    await AwsCliCompatible.credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });

--- a/packages/aws-cdk/test/api/aws-auth/credential-plugins.test.ts
+++ b/packages/aws-cdk/test/api/aws-auth/credential-plugins.test.ts
@@ -2,6 +2,10 @@ import type { PluginProviderResult, SDKv2CompatibleCredentials } from '@aws-cdk/
 import { CredentialPlugins } from '../../../lib/api/aws-auth/credential-plugins';
 import { PluginHost } from '../../../lib/api/plugin';
 import { Mode } from '../../../lib/api/plugin/mode';
+import { TestIoHost } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
 
 test('returns credential from plugin', async () => {
   // GIVEN
@@ -28,7 +32,7 @@ test('returns credential from plugin', async () => {
     },
   });
 
-  const plugins = new CredentialPlugins();
+  const plugins = new CredentialPlugins(host, ioHelper);
 
   // WHEN
   const pluginCredentials = await plugins.fetchCredentialsFor('aaa', Mode.ForReading);

--- a/packages/aws-cdk/test/api/plugin/credential-plugin.test.ts
+++ b/packages/aws-cdk/test/api/plugin/credential-plugin.test.ts
@@ -3,15 +3,19 @@ import { CredentialPlugins } from '../../../lib/api/aws-auth/credential-plugins'
 import { credentialsAboutToExpire } from '../../../lib/api/aws-auth/provider-caching';
 import { Mode } from '../../../lib/api/plugin/mode';
 import { PluginHost, markTesting } from '../../../lib/api/plugin/plugin';
+import { TestIoHost } from '../../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private/testing';
 
 markTesting();
 
 let host: PluginHost;
 let credentialPlugins: CredentialPlugins;
 
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
+
 beforeEach(() => {
   host = new PluginHost();
-  credentialPlugins = new CredentialPlugins(host);
+  credentialPlugins = new CredentialPlugins(host, ioHelper);
   jest.resetModules();
   jest.useFakeTimers();
 });

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -73,7 +73,6 @@ import { Bootstrapper, type BootstrapSource } from '../../lib/api/bootstrap';
 import {
   DeployStackResult,
   SuccessfulDeployStackResult,
-  Template,
   Deployments,
   DeployStackOptions,
   DestroyStackOptions,
@@ -99,6 +98,7 @@ import {
 } from '../util/mock-sdk';
 import { asIoHelper } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 import { StackActivityProgress } from '../../lib/commands/deploy';
+import { Template } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 
 markTesting();
 

--- a/packages/aws-cdk/test/context-providers/amis.test.ts
+++ b/packages/aws-cdk/test/context-providers/amis.test.ts
@@ -3,10 +3,11 @@ import { DescribeImagesCommand } from '@aws-sdk/client-ec2';
 import { SDK, SdkForEnvironment } from '../../lib/api';
 import { AmiContextProviderPlugin } from '../../lib/context-providers/ami';
 import { FAKE_CREDENTIAL_CHAIN, MockSdkProvider, mockEC2Client } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/availability-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/availability-zones.test.ts
@@ -2,10 +2,11 @@ import { DescribeAvailabilityZonesCommand } from '@aws-sdk/client-ec2';
 import { SDK, SdkForEnvironment } from '../../lib/api';
 import { AZContextProviderPlugin } from '../../lib/context-providers/availability-zones';
 import { FAKE_CREDENTIAL_CHAIN, mockEC2Client, MockSdkProvider } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/endpoint-service-availability-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/endpoint-service-availability-zones.test.ts
@@ -4,10 +4,11 @@ import {
   EndpointServiceAZContextProviderPlugin,
 } from '../../lib/context-providers/endpoint-service-availability-zones';
 import { FAKE_CREDENTIAL_CHAIN, mockEC2Client, MockSdkProvider } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/hosted-zones.test.ts
+++ b/packages/aws-cdk/test/context-providers/hosted-zones.test.ts
@@ -2,10 +2,11 @@ import { GetHostedZoneCommand, ListHostedZonesByNameCommand } from '@aws-sdk/cli
 import { SDK, SdkForEnvironment } from '../../lib/api';
 import { HostedZoneContextProviderPlugin } from '../../lib/context-providers/hosted-zones';
 import { FAKE_CREDENTIAL_CHAIN, mockRoute53Client, MockSdkProvider } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/load-balancers.test.ts
+++ b/packages/aws-cdk/test/context-providers/load-balancers.test.ts
@@ -15,10 +15,11 @@ import {
   mockElasticLoadBalancingV2Client,
   restoreSdkMocksToDefault,
 } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/security-groups.test.ts
+++ b/packages/aws-cdk/test/context-providers/security-groups.test.ts
@@ -2,10 +2,11 @@ import { DescribeSecurityGroupsCommand } from '@aws-sdk/client-ec2';
 import { SDK, type SdkForEnvironment } from '../../lib/api';
 import { hasAllTrafficEgress, SecurityGroupContextProviderPlugin } from '../../lib/context-providers/security-groups';
 import { FAKE_CREDENTIAL_CHAIN, MockSdkProvider, mockEC2Client, restoreSdkMocksToDefault } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/context-providers/ssm-parameters.test.ts
+++ b/packages/aws-cdk/test/context-providers/ssm-parameters.test.ts
@@ -2,10 +2,11 @@ import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import { SDK, SdkForEnvironment } from '../../lib/api';
 import { SSMContextProviderPlugin } from '../../lib/context-providers/ssm-parameters';
 import { FAKE_CREDENTIAL_CHAIN, MockSdkProvider, mockSSMClient, restoreSdkMocksToDefault } from '../util/mock-sdk';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 const mockSDK = new (class extends MockSdkProvider {
   public forEnvironment(): Promise<SdkForEnvironment> {
-    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}), didAssumeRole: false });
+    return Promise.resolve({ sdk: new SDK(FAKE_CREDENTIAL_CHAIN, mockSDK.defaultRegion, {}, new TestIoHost().asHelper("deploy")), didAssumeRole: false });
   }
 })();
 

--- a/packages/aws-cdk/test/notices.test.ts
+++ b/packages/aws-cdk/test/notices.test.ts
@@ -167,7 +167,8 @@ const NOTICE_FOR_APIGATEWAYV2_CFN_STAGE = {
 };
 
 const ioHost = new FakeIoHost();
-const ioHostEmitter = new IoDefaultMessages(asIoHelper(ioHost, 'notices' as any));
+const ioHelper = asIoHelper(ioHost, 'notices' as any)
+const ioHostEmitter = new IoDefaultMessages(ioHelper);
 const noticesFilter = new NoticesFilter(ioHostEmitter);
 
 beforeEach(() => {
@@ -448,7 +449,7 @@ function parseTestComponent(x: string): Component {
 
 
 describe(WebsiteNoticeDataSource, () => {
-  const dataSource = new WebsiteNoticeDataSource(ioHostEmitter);
+  const dataSource = new WebsiteNoticeDataSource(ioHelper);
 
   test('returns data when download succeeds', async () => {
     const result = await mockCall(200, {

--- a/packages/aws-cdk/test/util/mock-sdk.ts
+++ b/packages/aws-cdk/test/util/mock-sdk.ts
@@ -24,6 +24,7 @@ import { mockClient } from 'aws-sdk-client-mock';
 import { type Account } from 'cdk-assets';
 import { SDK, SdkProvider } from '../../lib/api/aws-auth';
 import { CloudFormationStack } from '../../lib/api/cloudformation';
+import { TestIoHost } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
 
 export const FAKE_CREDENTIALS: AwsCredentialIdentity = {
   accessKeyId: 'ACCESS',
@@ -143,7 +144,7 @@ export const setDefaultSTSMocks = () => {
  */
 export class MockSdkProvider extends SdkProvider {
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337');
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new TestIoHost().asHelper('sdk'));
   }
 
   public defaultAccount(): Promise<Account | undefined> {
@@ -159,7 +160,7 @@ export class MockSdkProvider extends SdkProvider {
  */
 export class MockSdk extends SDK {
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {});
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new TestIoHost().asHelper('sdk'));
   }
 }
 


### PR DESCRIPTION
Updates `aws-auth` module to use modern messaging infrastructure.

## Testing

- Existing unit and integration tests are passing
- Successfully run the auth test suite, with the exception of `tests/test-non-commercial-region.sh` which was skipped. 
- Manually confirmed that the `AccountAccessKeyCache` is still written
- Manually executed common CLI operations and I did not spot  any additional output (as expected)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
