### PR TITLE
feat(docs): add api-extractor config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1178,3 +1178,65 @@ jobs:
             echo "::error::Failed to upload docs artifact"
             exit 1
           fi
+  aws-cdk-toolkit-lib_release_api_extractor_docs:
+    name: "@aws-cdk/toolkit-lib: Publish API Extractor docs to S3"
+    needs: aws-cdk-toolkit-lib_release_npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: releasing
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-cdk-toolkit-lib_build-artifact
+          path: dist
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
+          role-session-name: s3-api-extractor-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
+      - name: Assume the publishing role
+        id: publishing-creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ vars.PUBLISH_TOOLKIT_LIB_DOCS_ROLE_ARN }}
+          role-session-name: s3-api-extractor-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
+          role-chaining: true
+      - name: Publish API Extractor docs
+        env:
+          BUCKET_NAME: ${{ vars.DOCS_BUCKET_NAME }}
+          DOCS_STREAM: toolkit-lib
+        run: |-
+          echo "Uploading API Extractor docs to S3"
+                      echo "::add-mask::$BUCKET_NAME"
+                      S3_PATH="$DOCS_STREAM/aws-cdk-toolkit-lib-api-model-v$(cat dist/version.txt).zip"
+                      LATEST="latest-api-model-toolkit-lib"
+
+                      # Capture both stdout and stderr
+                      if OUTPUT=$(aws s3api put-object \
+                        --bucket "$BUCKET_NAME" \
+                        --key "$S3_PATH" \
+                        --body dist/api-extractor-docs.zip \
+                        --if-none-match "*" 2>&1); then
+                        
+                        # File was uploaded successfully, update the latest pointer
+                        echo "New API Extractor docs artifact uploaded successfully, updating latest pointer"
+                        echo "$S3_PATH" | aws s3 cp - "s3://$BUCKET_NAME/$LATEST"
+
+                      elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
+                        # Check specifically for PreconditionFailed in the error output
+                        echo "::warning::File already exists in S3. Skipping upload."
+                        exit 0
+
+                      else
+                        # Any other error (permissions, etc)
+                        echo "::error::Failed to upload API Extractor docs artifact"
+                        exit 1
+                      fi

--- a/packages/@aws-cdk/cloud-assembly-schema/README.md
+++ b/packages/@aws-cdk/cloud-assembly-schema/README.md
@@ -5,8 +5,8 @@ This module is part of the [AWS Cloud Development Kit](https://github.com/aws/aw
 ## Cloud Assembly
 
 The _Cloud Assembly_ is the output of the synthesis operation. It is produced as part of the
-[`cdk synth`](https://github.com/aws/aws-cdk/tree/main/packages/aws-cdk#cdk-synthesize)
-command, or the [`app.synth()`](https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk/core/lib/app.ts#L135) method invocation.
+[`cdk synth`](https://github.com/aws/aws-cdk-cli/tree/main/packages/aws-cdk#cdk-synthesize)
+command, or the [`app.synth()`](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/core/lib/stage.ts#L219) method invocation.
 
 Its essentially a set of files and directories, one of which is the `manifest.json` file. It defines the set of instructions that are
 needed in order to deploy the assembly directory.
@@ -51,4 +51,3 @@ cannot be guaranteed because some instructions will be ignored.
 ## Contributing
 
 See [Contribution Guide](./CONTRIBUTING.md)
-

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json
@@ -1024,19 +1024,19 @@
             ]
         },
         "CcApiContextQuery": {
-            "description": "Query input for lookup up Cloudformation resources using CC API",
+            "description": "Query input for lookup up CloudFormation resources using CC API",
             "type": "object",
             "properties": {
                 "typeName": {
-                    "description": "The Cloudformation resource type.\nSee https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html",
+                    "description": "The CloudFormation resource type.\nSee https://docs.aws.amazon.com/cloudcontrolapi/latest/userguide/supported-resources.html",
                     "type": "string"
                 },
                 "exactIdentifier": {
-                    "description": "Identifier of the resource to look up using `GetResource`.\n\nSpecifying exactIdentifier will return exactly one result, or throw an error. (Default - Either exactIdentifier or propertyMatch should be specified.)",
+                    "description": "Identifier of the resource to look up using `GetResource`.\n\nSpecifying exactIdentifier will return exactly one result, or throw an error\nunless `ignoreErrorOnMissingContext` is set. (Default - Either exactIdentifier or propertyMatch should be specified.)",
                     "type": "string"
                 },
                 "propertyMatch": {
-                    "description": "Returns any resources matching these properties, using `ListResources`.\n\nSpecifying propertyMatch will return 0 or more results.\n\n## Notes on property completeness\n\nCloudControl API's `ListResources` may return fewer properties than\n`GetResource` would, depending on the resource implementation.\n\nThe resources that `propertyMatch` matches against will *only ever* be the\nproperties returned by the `ListResources` call. (Default - Either exactIdentifier or propertyMatch should be specified.)",
+                    "description": "Returns any resources matching these properties, using `ListResources`.\n\nBy default, specifying propertyMatch will successfully return 0 or more\nresults. To throw an error if the number of results is unexpected (and\nprevent the query results from being committed to context), specify\n`expectedMatchCount`.\n\n## Notes on property completeness\n\nCloudControl API's `ListResources` may return fewer properties than\n`GetResource` would, depending on the resource implementation.\n\nThe resources that `propertyMatch` matches against will *only ever* be the\nproperties returned by the `ListResources` call. (Default - Either exactIdentifier or propertyMatch should be specified.)",
                     "$ref": "#/definitions/Record<string,unknown>"
                 },
                 "propertiesToReturn": {
@@ -1046,11 +1046,21 @@
                         "type": "string"
                     }
                 },
+                "expectedMatchCount": {
+                    "description": "Expected count of results if `propertyMatch` is specified.\n\nIf the expected result count does not match the actual count,\nby default an error is produced and the result is not committed to cached\ncontext, and the user can correct the situation and try again without\nhaving to manually clear out the context key using `cdk context --remove`\n\nIf the value of * `ignoreErrorOnMissingContext` is `true`, the value of\n`expectedMatchCount` is `at-least-one | exactly-one` and the number\nof found resources is 0, `dummyValue` is returned and committed to context\ninstead. (Default 'any')",
+                    "enum": [
+                        "any",
+                        "at-least-one",
+                        "at-most-one",
+                        "exactly-one"
+                    ],
+                    "type": "string"
+                },
                 "dummyValue": {
                     "description": "The value to return if the resource was not found and `ignoreErrorOnMissingContext` is true.\n\nIf supplied, `dummyValue` should be an array of objects.\n\n`dummyValue` does not have to have elements, and it may have objects with\ndifferent properties than the properties in `propertiesToReturn`, but it\nwill be easiest for downstream code if the `dummyValue` conforms to\nthe expected response shape. (Default - No dummy value available)"
                 },
                 "ignoreErrorOnMissingContext": {
-                    "description": "Ignore an error and return the `dummyValue` instead if the resource was not found.\n\n- In case of an `exactIdentifier` lookup, return the `dummyValue` if the resource with\n  that identifier was not found.\n- In case of a `propertyMatch` lookup, this setting currently does not have any effect,\n  as `propertyMatch` queries can legally return 0 resources.\n\nif `ignoreErrorOnMissingContext` is set, `dummyValue` should be set and be an array.",
+                    "description": "Ignore an error and return the `dummyValue` instead if the resource was not found.\n\n- In case of an `exactIdentifier` lookup, return the `dummyValue` if the resource with\n  that identifier was not found.\n- In case of a `propertyMatch` lookup, return the `dummyValue` if `expectedMatchCount`\n  is `at-least-one | exactly-one` and the number of resources found was 0.\n\nif `ignoreErrorOnMissingContext` is set, `dummyValue` should be set and be an array.",
                     "default": false,
                     "type": "boolean"
                 },

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,4 +1,4 @@
 {
-  "schemaHash": "5683db246fac20b864d94d7bceef24ebda1a38c8c1f8ef0d5978534097dc9504",
-  "revision": 42
+  "schemaHash": "78936b0f9299bbe47497dd77f8065d71e65d8d739a0413ad7698ad03b22ef83e",
+  "revision": 43
 }

--- a/packages/@aws-cdk/node-bundle/README.md
+++ b/packages/@aws-cdk/node-bundle/README.md
@@ -151,4 +151,4 @@ Note that this will balloon up the package size significantly.
 If you are bundling a CLI application that also has top level exports, we suggest to extract
 the CLI functionality into a function, and add this function as an export to `index.js`.
 
-> See [aws-cdk](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk/bin/cdk.ts) as an example.
+> See [aws-cdk](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/bin/cdk) as an example.

--- a/packages/@aws-cdk/toolkit-lib/.gitattributes
+++ b/packages/@aws-cdk/toolkit-lib/.gitattributes
@@ -12,6 +12,7 @@
 /.projen/deps.json linguist-generated
 /.projen/files.json linguist-generated
 /.projen/tasks.json linguist-generated
+/api-extractor.json linguist-generated
 /jest.config.json linguist-generated
 /LICENSE linguist-generated
 /package.json linguist-generated

--- a/packages/@aws-cdk/toolkit-lib/.gitignore
+++ b/packages/@aws-cdk/toolkit-lib/.gitignore
@@ -58,3 +58,4 @@ lib/**/*.js.map
 lib/init-templates/**
 !test/_fixtures/**/app.js
 !test/_fixtures/**/cdk.out
+!/api-extractor.json

--- a/packages/@aws-cdk/toolkit-lib/.projen/files.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/files.json
@@ -10,6 +10,7 @@
     ".projen/deps.json",
     ".projen/files.json",
     ".projen/tasks.json",
+    "api-extractor.json",
     "jest.config.json",
     "LICENSE",
     "tsconfig.dev.json",

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -1,5 +1,13 @@
 {
   "tasks": {
+    "api-extractor-docs": {
+      "name": "api-extractor-docs",
+      "steps": [
+        {
+          "exec": "api-extractor run --local || true && mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib && cp dist/*.api.json dist/api-extractor-docs/cdk/api/toolkit-lib/ && (cat dist/version.txt || echo \"latest\") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION && find . -type f -name \"*.md\" -not -path \"*/node_modules/*\" -not -path \"*/dist/*\" | while read file; do mkdir -p \"dist/api-extractor-docs/cdk/api/toolkit-lib/$(dirname \"$file\")\" && cp \"$file\" \"dist/api-extractor-docs/cdk/api/toolkit-lib/$file\"; done && cd dist/api-extractor-docs && zip -r ../api-extractor-docs.zip cdk"
+        }
+      ]
+    },
     "build": {
       "name": "build",
       "description": "Full release build",
@@ -150,6 +158,9 @@
         },
         {
           "exec": "npm pack --pack-destination dist/js"
+        },
+        {
+          "spawn": "api-extractor-docs"
         },
         {
           "spawn": "docs",

--- a/packages/@aws-cdk/toolkit-lib/api-extractor.json
+++ b/packages/@aws-cdk/toolkit-lib/api-extractor.json
@@ -1,0 +1,37 @@
+{
+  "projectFolder": ".",
+  "mainEntryPointFilePath": "<projectFolder>/lib/index.d.ts",
+  "bundledPackages": [],
+  "apiReport": {
+    "enabled": false
+  },
+  "docModel": {
+    "enabled": true,
+    "apiJsonFilePath": "./temp/<unscopedPackageName>.api.json",
+    "projectFolderUrl": "https://github.com/aws/aws-cdk-cli"
+  },
+  "dtsRollup": {
+    "enabled": false
+  },
+  "tsdocMetadata": {
+    "enabled": false
+  },
+  "messages": {
+    "compilerMessageReporting": {
+      "default": {
+        "logLevel": "error"
+      }
+    },
+    "extractorMessageReporting": {
+      "default": {
+        "logLevel": "error"
+      }
+    },
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "error"
+      }
+    }
+  }
+}
+

--- a/packages/@aws-cdk/toolkit-lib/api-extractor.json
+++ b/packages/@aws-cdk/toolkit-lib/api-extractor.json
@@ -7,7 +7,7 @@
   },
   "docModel": {
     "enabled": true,
-    "apiJsonFilePath": "./temp/<unscopedPackageName>.api.json",
+    "apiJsonFilePath": "./dist/<unscopedPackageName>.api.json",
     "projectFolderUrl": "https://github.com/aws/aws-cdk-cli"
   },
   "dtsRollup": {
@@ -19,19 +19,18 @@
   "messages": {
     "compilerMessageReporting": {
       "default": {
-        "logLevel": "error"
+        "logLevel": "warning"
       }
     },
     "extractorMessageReporting": {
       "default": {
-        "logLevel": "error"
+        "logLevel": "warning"
       }
     },
     "tsdocMessageReporting": {
       "default": {
-        "logLevel": "error"
+        "logLevel": "warning"
       }
     }
   }
 }
-

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -7,6 +7,7 @@
     "directory": "packages/@aws-cdk/toolkit-lib"
   },
   "scripts": {
+    "api-extractor-docs": "npx projen api-extractor-docs",
     "build": "npx projen build",
     "bump": "npx projen bump",
     "check-for-updates": "npx projen check-for-updates",

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -536,7 +536,7 @@ and might have breaking changes in the future.
 - `Fn::Split`
 - `Fn::Sub`
 
-> *: `Fn::GetAtt` is only partially supported. Refer to [this implementation](https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk/lib/api/evaluate-cloudformation-template.ts#L477-L492) for supported resources and attributes.
+> *: `Fn::GetAtt` is only partially supported. Refer to [this implementation](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/api/cloudformation/evaluate-cloudformation-template.ts#L256-L266) for supported resources and attributes.
 
 ### `cdk rollback`
 

--- a/projenrc/api-extractor-docs-publishing.ts
+++ b/projenrc/api-extractor-docs-publishing.ts
@@ -1,0 +1,147 @@
+import type { Monorepo, TypeScriptWorkspace } from 'cdklabs-projen-project-types/lib/yarn';
+import { Component, github } from 'projen';
+
+export interface ApiExtractorDocsPublishingProps {
+  /**
+   * The docs stream to publish to.
+   */
+  readonly docsStream: string;
+
+  /**
+   * The role arn (or github expression) for OIDC to assume to do the actual publishing.
+   */
+  readonly roleToAssume: string;
+
+  /**
+   * The bucket name (or github expression) to publish to.
+   */
+  readonly bucketName: string;
+}
+
+export class ApiExtractorDocsPublishing extends Component {
+  private readonly github: github.GitHub;
+  private readonly props: ApiExtractorDocsPublishingProps;
+
+  constructor(project: TypeScriptWorkspace, props: ApiExtractorDocsPublishingProps) {
+    super(project);
+
+    const gh = (project.parent! as Monorepo).github;
+    if (!gh) {
+      throw new Error('This workspace does not have a GitHub instance');
+    }
+    this.github = gh;
+
+    this.props = props;
+
+    // Add a task to run api-extractor and zip the output
+    const apiExtractorDocsTask = project.addTask('api-extractor-docs', {
+      exec: [
+        // Run api-extractor to generate the API model
+        // Use || true to ensure the task continues even if api-extractor reports failures
+        'api-extractor run --local || true',
+        // Create a directory for the API model
+        'mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib',
+        // Copy the API model to the directory
+        'cp dist/*.api.json dist/api-extractor-docs/cdk/api/toolkit-lib/',
+        // Add version file
+        '(cat dist/version.txt || echo "latest") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION',
+        // Find and copy all markdown files (excluding node_modules)
+        'find . -type f -name "*.md" -not -path "*/node_modules/*" -not -path "*/dist/*" | while read file; do ' +
+        'mkdir -p "dist/api-extractor-docs/cdk/api/toolkit-lib/$(dirname "$file")" && ' +
+        'cp "$file" "dist/api-extractor-docs/cdk/api/toolkit-lib/$file"; ' +
+        'done',
+        // Zip the API model and markdown files
+        'cd dist/api-extractor-docs && zip -r ../api-extractor-docs.zip cdk',
+      ].join(' && '),
+    });
+
+    // Add the api-extractor-docs task to the package task
+    project.packageTask.spawn(apiExtractorDocsTask);
+  }
+
+  public preSynthesize() {
+    const releaseWf = this.github.tryFindWorkflow('release');
+    if (!releaseWf) {
+      throw new Error('Could not find release workflow');
+    }
+
+    const safeName = this.project.name.replace('@', '').replace('/', '-');
+
+    releaseWf.addJob(`${safeName}_release_api_extractor_docs`, {
+      name: `${this.project.name}: Publish API Extractor docs to S3`,
+      environment: 'releasing', // <-- this has the configuration
+      needs: [`${safeName}_release_npm`],
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        idToken: github.workflows.JobPermission.WRITE,
+        contents: github.workflows.JobPermission.READ,
+      },
+      steps: [
+        {
+          name: 'Download build artifacts',
+          uses: 'actions/download-artifact@v4',
+          with: {
+            name: `${safeName}_build-artifact`,
+            path: 'dist',
+          },
+        },
+        {
+          name: 'Authenticate Via OIDC Role',
+          id: 'creds',
+          uses: 'aws-actions/configure-aws-credentials@v4',
+          with: {
+            'aws-region': 'us-east-1',
+            'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
+            'role-session-name': 's3-api-extractor-docs-publishing@aws-cdk-cli',
+            'mask-aws-account-id': true,
+          },
+        },
+        {
+          name: 'Assume the publishing role',
+          id: 'publishing-creds',
+          uses: 'aws-actions/configure-aws-credentials@v4',
+          with: {
+            'aws-region': 'us-east-1',
+            'role-to-assume': this.props.roleToAssume,
+            'role-session-name': 's3-api-extractor-docs-publishing@aws-cdk-cli',
+            'mask-aws-account-id': true,
+            'role-chaining': true,
+          },
+        },
+        {
+          name: 'Publish API Extractor docs',
+          env: {
+            BUCKET_NAME: this.props.bucketName,
+            DOCS_STREAM: this.props.docsStream,
+          },
+          run: `echo "Uploading API Extractor docs to S3"
+            echo "::add-mask::$BUCKET_NAME"
+            S3_PATH="$DOCS_STREAM/${safeName}-api-model-v$(cat dist/version.txt).zip"
+            LATEST="latest-api-model-${this.props.docsStream}"
+
+            # Capture both stdout and stderr
+            if OUTPUT=$(aws s3api put-object \\
+              --bucket "$BUCKET_NAME" \\
+              --key "$S3_PATH" \\
+              --body dist/api-extractor-docs.zip \\
+              --if-none-match "*" 2>&1); then
+              
+              # File was uploaded successfully, update the latest pointer
+              echo "New API Extractor docs artifact uploaded successfully, updating latest pointer"
+              echo "$S3_PATH" | aws s3 cp - "s3://$BUCKET_NAME/$LATEST"
+
+            elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
+              # Check specifically for PreconditionFailed in the error output
+              echo "::warning::File already exists in S3. Skipping upload."
+              exit 0
+
+            else
+              # Any other error (permissions, etc)
+              echo "::error::Failed to upload API Extractor docs artifact"
+              exit 1
+            fi`,
+        },
+      ],
+    });
+  }
+}


### PR DESCRIPTION
Allows us to invoke `api-extractor` to get an outputted JSON file produced from source code and TSDocs.

Ref: https://api-extractor.com/pages/setup/invoking/#4-running-the-tool

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
