### PR TITLE
fix(toolkit-lib): remove deprecated options

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -1,6 +1,5 @@
 import type { BaseDeployOptions } from './private/deploy-options';
 import type { Tag } from '../../api/aws-cdk';
-import type { RequireApproval } from '../../api/shared-public';
 
 export type DeploymentMethod = DirectDeploymentMethod | ChangeSetDeploymentMethod;
 
@@ -104,14 +103,6 @@ export interface DeployOptions extends BaseDeployOptions {
   readonly notificationArns?: string[];
 
   /**
-   * Require a confirmation for security relevant changes before continuing with the deployment
-   *
-   * @default RequireApproval.NEVER
-   * @deprecated requireApproval is governed by the `IIoHost`. This property is no longer used.
-   */
-  readonly requireApproval?: RequireApproval;
-
-  /**
    * Tags to pass to CloudFormation for deployment
    */
   readonly tags?: Tag[];
@@ -145,20 +136,6 @@ export interface DeployOptions extends BaseDeployOptions {
    * @default AssetBuildTime.ALL_BEFORE_DEPLOY
    */
   readonly assetBuildTime?: AssetBuildTime;
-
-  /**
-   * Change stack watcher output to CI mode.
-   *
-   * @deprecated has no functionality, please implement in your IoHost
-   */
-  readonly ci?: boolean;
-
-  /**
-   * Display mode for stack deployment progress.
-   *
-   * @deprecated has no functionality, please implement in your IoHost
-   */
-  readonly progress?: any;
 
   /**
    * Represents configuration property overrides for hotswap deployments.

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -10,11 +10,4 @@ export interface DestroyOptions {
    * The arn of the IAM role to use
    */
   readonly roleArn?: string;
-
-  /**
-   * Change stack watcher output to CI mode.
-   *
-   * @deprecated has no effect, please implement in IoHost instead
-   */
-  readonly ci?: boolean;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -517,7 +517,6 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
         await this._destroy(assembly, 'deploy', {
           stacks: { patterns: [stack.hierarchicalId], strategy: StackSelectionStrategy.PATTERN_MUST_MATCH_SINGLE },
           roleArn: options.roleArn,
-          ci: options.ci,
         });
 
         return;
@@ -1005,7 +1004,6 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
     const hotswap = options.hotswap ?? HotswapMode.HOTSWAP_ONLY;
     const deployOptions: ExtendedDeployOptions = {
       ...options,
-      requireApproval: RequireApproval.NEVER,
       cloudWatchLogMonitor,
       hotswap,
       extraUserAgent: `cdk-watch/hotswap-${hotswap === HotswapMode.FULL_DEPLOYMENT ? 'off' : 'on'}`,


### PR DESCRIPTION
Remove deprecated options that have been replaced by IoHost functionality:
- Remove `requireApproval` from DeployOptions (deprecated)
- Remove `ci` and `progress` from DeployOptions (deprecated)
- Remove `ci` from DestroyOptions (deprecated)
- Remove related usage in toolkit.ts implementation

BREAKING CHANGE: Removes previously deprecated options from toolkit actions. From `DeployOptions`, removed the options `requireApproval`, `ci` and `progress`. From `DestroyOptions`, removed the option `ci`. All removed options were previously deprecated and had no functional effect. Instead you should implement desired functionality in your `IIoHost` implementation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
