### PR TITLE
fix(toolkit): doesn't load on platforms without the Disposable API

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/index.ts
@@ -2,6 +2,9 @@
  * @module toolkit-lib
  */
 
+// Polyfills first
+import './private/dispose-polyfill';
+
 // The main show
 export * from './toolkit';
 export * from './actions';

--- a/packages/@aws-cdk/toolkit-lib/lib/private/dispose-polyfill.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/dispose-polyfill.ts
@@ -1,0 +1,17 @@
+// This file needs to be imported as one of the first files in the library.
+// It polyfills some symbols that the new JavaScript "Disposable" API introduces.
+//
+// See <https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-2.html>
+//
+// In short, the new proposal is a `using`/`await using` statement, which will automatically
+// call methods named `[Symbol.dispose]` and `[Symbol.asyncDispose]` on objects.
+//
+// TypeScript knows about those symbols, and it will downlevel the `using` syntax to
+// plain JavaScript... but it doesn't define the Symbols themselves! They must exist
+// in the environment, or code defining objects using those Symbol names will fail.
+//
+// MDN doesn't even know that Node 22 has them already; for broadest compatibility,
+// we just polyfill them here. Their value doesn't matter, they just need to exist
+// and be unique symbols.
+(Symbol as any).dispose ??= Symbol("Symbol.dispose");
+(Symbol as any).asyncDispose ??= Symbol("Symbol.asyncDispose");

--- a/packages/@aws-cdk/toolkit-lib/lib/private/dispose-polyfill.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/dispose-polyfill.ts
@@ -13,5 +13,5 @@
 // MDN doesn't even know that Node 22 has them already; for broadest compatibility,
 // we just polyfill them here. Their value doesn't matter, they just need to exist
 // and be unique symbols.
-(Symbol as any).dispose ??= Symbol("Symbol.dispose");
-(Symbol as any).asyncDispose ??= Symbol("Symbol.asyncDispose");
+(Symbol as any).dispose ??= Symbol('Symbol.dispose');
+(Symbol as any).asyncDispose ??= Symbol('Symbol.asyncDispose');


### PR DESCRIPTION
Toolkit classes reference the public static `Symbol.asyncDispose` symbol, but that is only defined on runtimes that are implementing the new Disposable API yet.

On platforms that don't know that API, that constant doesn't exist and the class definition fails.

Polyfill it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
