### PR TITLE
chore: enable using the new toolkit from cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       publish-aws-cdk-cloudformation-diff: ${{ steps.check-publish-aws-cdk-cloudformation-diff.outputs.publish }}
       publish-aws-cdk-cli-plugin-contract: ${{ steps.check-publish-aws-cdk-cli-plugin-contract.outputs.publish }}
       publish-cdk-assets: ${{ steps.check-publish-cdk-assets.outputs.publish }}
+      publish-aws-cdk-toolkit-lib: ${{ steps.check-publish-aws-cdk-toolkit-lib.outputs.publish }}
       publish-aws-cdk: ${{ steps.check-publish-aws-cdk.outputs.publish }}
       publish-aws-cdk-cli-lib-alpha: ${{ steps.check-publish-aws-cdk-cli-lib-alpha.outputs.publish }}
-      publish-aws-cdk-toolkit-lib: ${{ steps.check-publish-aws-cdk-toolkit-lib.outputs.publish }}
       publish-cdk: ${{ steps.check-publish-cdk.outputs.publish }}
       publish-aws-cdk-integ-runner: ${{ steps.check-publish-aws-cdk-integ-runner.outputs.publish }}
     env:
@@ -50,15 +50,15 @@ jobs:
       - id: check-publish-cdk-assets
         run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
         working-directory: packages/cdk-assets
+      - id: check-publish-aws-cdk-toolkit-lib
+        run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
+        working-directory: packages/@aws-cdk/toolkit-lib
       - id: check-publish-aws-cdk
         run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
         working-directory: packages/aws-cdk
       - id: check-publish-aws-cdk-cli-lib-alpha
         run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
         working-directory: packages/@aws-cdk/cli-lib-alpha
-      - id: check-publish-aws-cdk-toolkit-lib
-        run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
-        working-directory: packages/@aws-cdk/toolkit-lib
       - id: check-publish-cdk
         run: (git ls-remote -q --exit-code --tags origin $(cat dist/releasetag.txt) && (echo "publish=false" >> $GITHUB_OUTPUT)) || echo "publish=true" >> $GITHUB_OUTPUT
         working-directory: packages/cdk
@@ -116,6 +116,18 @@ jobs:
           name: cdk-assets_build-artifact
           path: packages/cdk-assets/dist
           overwrite: true
+      - name: "@aws-cdk/toolkit-lib: Backup artifact permissions"
+        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
+        run: cd dist && getfacl -R . > permissions-backup.acl
+        continue-on-error: true
+        working-directory: packages/@aws-cdk/toolkit-lib
+      - name: "@aws-cdk/toolkit-lib: Upload artifact"
+        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: aws-cdk-toolkit-lib_build-artifact
+          path: packages/@aws-cdk/toolkit-lib/dist
+          overwrite: true
       - name: "aws-cdk: Backup artifact permissions"
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
         run: cd dist && getfacl -R . > permissions-backup.acl
@@ -139,18 +151,6 @@ jobs:
         with:
           name: aws-cdk-cli-lib-alpha_build-artifact
           path: packages/@aws-cdk/cli-lib-alpha/dist
-          overwrite: true
-      - name: "@aws-cdk/toolkit-lib: Backup artifact permissions"
-        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        run: cd dist && getfacl -R . > permissions-backup.acl
-        continue-on-error: true
-        working-directory: packages/@aws-cdk/toolkit-lib
-      - name: "@aws-cdk/toolkit-lib: Upload artifact"
-        if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.4.0
-        with:
-          name: aws-cdk-toolkit-lib_build-artifact
-          path: packages/@aws-cdk/toolkit-lib/dist
           overwrite: true
       - name: "cdk: Backup artifact permissions"
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
@@ -593,6 +593,60 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx -p publib@latest publib-npm
+  aws-cdk-toolkit-lib_release_github:
+    name: "@aws-cdk/toolkit-lib: Publish to GitHub Releases"
+    needs:
+      - release
+      - aws-cdk-toolkit-lib_release_npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-toolkit-lib == 'true' }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-cdk-toolkit-lib_build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_REF: ${{ github.sha }}
+        run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
+  aws-cdk-toolkit-lib_release_npm:
+    name: "@aws-cdk/toolkit-lib: Publish to npm"
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-toolkit-lib == 'true' }}
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: aws-cdk-toolkit-lib_build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Release
+        env:
+          NPM_DIST_TAG: latest
+          NPM_REGISTRY: registry.npmjs.org
+          NPM_CONFIG_PROVENANCE: "true"
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npx -p publib@latest publib-npm
   aws-cdk_release_github:
     name: "aws-cdk: Publish to GitHub Releases"
     needs:
@@ -888,60 +942,6 @@ jobs:
           GIT_USER_EMAIL: github-actions@github.com
           GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
         run: npx -p publib@latest publib-golang
-  aws-cdk-toolkit-lib_release_github:
-    name: "@aws-cdk/toolkit-lib: Publish to GitHub Releases"
-    needs:
-      - release
-      - aws-cdk-toolkit-lib_release_npm
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-toolkit-lib == 'true' }}
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: aws-cdk-toolkit-lib_build-artifact
-          path: dist
-      - name: Restore build artifact permissions
-        run: cd dist && setfacl --restore=permissions-backup.acl
-        continue-on-error: true
-      - name: Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_REF: ${{ github.sha }}
-        run: errout=$(mktemp); gh release create $(cat dist/releasetag.txt) -R $GITHUB_REPOSITORY -F dist/changelog.md -t $(cat dist/releasetag.txt) --target $GITHUB_REF 2> $errout && true; exitcode=$?; if [ $exitcode -ne 0 ] && ! grep -q "Release.tag_name already exists" $errout; then cat $errout; exit $exitcode; fi
-  aws-cdk-toolkit-lib_release_npm:
-    name: "@aws-cdk/toolkit-lib: Publish to npm"
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    if: ${{ needs.release.outputs.latest_commit == github.sha && needs.release.outputs.publish-aws-cdk-toolkit-lib == 'true' }}
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: aws-cdk-toolkit-lib_build-artifact
-          path: dist
-      - name: Restore build artifact permissions
-        run: cd dist && setfacl --restore=permissions-backup.acl
-        continue-on-error: true
-      - name: Release
-        env:
-          NPM_DIST_TAG: latest
-          NPM_REGISTRY: registry.npmjs.org
-          NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx -p publib@latest publib-npm
   cdk_release_github:
     name: "cdk: Publish to GitHub Releases"
     needs:

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
       "packages/@aws-cdk/cli-plugin-contract",
       "packages/cdk-assets",
       "packages/@aws-cdk/tmp-toolkit-helpers",
+      "packages/@aws-cdk/toolkit-lib",
       "packages/aws-cdk",
       "packages/@aws-cdk/cli-lib-alpha",
-      "packages/@aws-cdk/toolkit-lib",
       "packages/@aws-cdk/cdk-cli-wrapper",
       "packages/cdk",
       "packages/@aws-cdk/integ-runner"
@@ -88,9 +88,9 @@
       "<rootDir>/packages/@aws-cdk/cli-plugin-contract",
       "<rootDir>/packages/cdk-assets",
       "<rootDir>/packages/@aws-cdk/tmp-toolkit-helpers",
+      "<rootDir>/packages/@aws-cdk/toolkit-lib",
       "<rootDir>/packages/aws-cdk",
       "<rootDir>/packages/@aws-cdk/cli-lib-alpha",
-      "<rootDir>/packages/@aws-cdk/toolkit-lib",
       "<rootDir>/packages/@aws-cdk/cdk-cli-wrapper",
       "<rootDir>/packages/cdk",
       "<rootDir>/packages/@aws-cdk/integ-runner"

--- a/packages/@aws-cdk/cli-lib-alpha/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/cli-lib-alpha/THIRD_PARTY_LICENSES
@@ -23329,6 +23329,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------
 
+** split2@4.2.0 - https://www.npmjs.com/package/split2/v/4.2.0 | ISC
+Copyright (c) 2014-2018, Matteo Collina <hello@matteocollina.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
 ** sprintf-js@1.1.3 - https://www.npmjs.com/package/sprintf-js/v/1.1.3 | BSD-3-Clause
 Copyright (c) 2007-present, Alexandru Mărășteanu <hello@alexei.ro>
 All rights reserved.

--- a/packages/@aws-cdk/toolkit-lib/.projen/deps.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/deps.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "@aws-cdk/aws-service-spec",
+      "type": "build"
+    },
+    {
       "name": "@aws-cdk/tmp-toolkit-helpers",
       "type": "build"
     },

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -51,7 +51,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@smithy/types,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,projen,ts-jest,typedoc,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-stream,@smithy/util-waiter,archiver,cdk-from-cfn,glob,json-diff,minimatch,promptly,proxy-agent,semver,split2,uuid"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@smithy/types,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,projen,ts-jest,typedoc,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-stream,@smithy/util-waiter,archiver,cdk-from-cfn,glob,json-diff,minimatch,promptly,proxy-agent,semver,split2,uuid"
         }
       ]
     },
@@ -172,6 +172,9 @@
       "steps": [
         {
           "spawn": "registry"
+        },
+        {
+          "exec": "build-tools/build-info.sh"
         },
         {
           "exec": "node build-tools/bundle.mjs"

--- a/packages/@aws-cdk/toolkit-lib/build-tools/build-info.sh
+++ b/packages/@aws-cdk/toolkit-lib/build-tools/build-info.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+commit=${CODEBUILD_RESOLVED_SOURCE_VERSION:-}
+# CODEBUILD_RESOLVED_SOURCE_VERSION is not defined (i.e. local build or CodePipeline build),
+# use the HEAD commit hash
+if [ -z "${commit}" ]; then
+  commit="$(git rev-parse --verify HEAD)"
+fi
+
+cat > build-info.json <<HERE
+{
+  "comment": "Generated at $(date -u +"%Y-%m-%dT%H:%M:%SZ") by build-info.sh",
+  "commit": "${commit:0:7}"
+}
+HERE

--- a/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
+++ b/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
@@ -7,8 +7,16 @@ import { generateDtsBundle } from 'dts-bundle-generator';
 // copy files
 const require = createRequire(import.meta.url);
 const cliPackage = path.dirname(require.resolve('aws-cdk/package.json'));
+const cdkFromCfnPkg = path.dirname(require.resolve('cdk-from-cfn/package.json'));
+const serviceSpecPkg = path.dirname(require.resolve('@aws-cdk/aws-service-spec/package.json'));
 const copyFromCli = (from, to = undefined) => {
   return fs.copy(path.join(cliPackage, ...from), path.join(process.cwd(), ...(to ?? from)));
+};
+const copyFromCdkFromCfn = (from, to = undefined) => {
+  return fs.copy(path.join(cdkFromCfnPkg, ...from), path.join(process.cwd(), ...(to ?? from)));
+};
+const copyFromServiceSpec = (from, to = undefined) => {
+  return fs.copy(path.join(serviceSpecPkg, ...from), path.join(process.cwd(), ...(to ?? from)));
 };
 
 // declaration bundling
@@ -38,13 +46,9 @@ const declarations = bundleDeclarations(['lib/api/shared-public.ts']);
 // This is a build script, we are fine
 // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
 const resources = Promise.all([
-  copyFromCli(['build-info.json']),
-  copyFromCli(['/db.json.gz']),
-  copyFromCli(['lib', 'index_bg.wasm']),
+  copyFromServiceSpec(['db.json.gz']),
+  copyFromCdkFromCfn(['index_bg.wasm'], ['lib', 'index_bg.wasm']),
   copyFromCli(['lib', 'api', 'bootstrap', 'bootstrap-template.yaml']),
-
-  // cdk init is not yet available in the toolkit-lib
-  // copyFromCli(['lib', 'init-templates']),
 ]);
 
 // bundle entrypoints from the library packages

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -1,5 +1,6 @@
 import * as child_process from 'node:child_process';
-import * as split2 from 'split2';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+import split = require('split2');
 import { ToolkitError } from '../../shared-public';
 
 type EventPublisher = (event: 'open' | 'data_stdout' | 'data_stderr' | 'close', line: string) => void;
@@ -47,8 +48,8 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
           return;
       }
     });
-    proc.stdout.pipe(split2()).on('data', (line) => eventPublisher('data_stdout', line));
-    proc.stderr.pipe(split2()).on('data', (line) => eventPublisher('data_stderr', line));
+    proc.stdout.pipe(split()).on('data', (line) => eventPublisher('data_stdout', line));
+    proc.stderr.pipe(split()).on('data', (line) => eventPublisher('data_stderr', line));
 
     proc.on('error', fail);
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/source-builder.ts
@@ -15,6 +15,7 @@ import type { AssemblyBuilder } from '../source-builder';
 export abstract class CloudAssemblySourceBuilder {
   /**
    * Helper to provide the CloudAssemblySourceBuilder with required toolkit services
+   * @internal
    * @deprecated this should move to the toolkit really.
    */
   protected abstract sourceBuilderServices(): Promise<ToolkitServices>;

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -93,7 +93,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   /**
    * Cache of the internal SDK Provider instance
    */
-  private _sdkProvider?: SdkProvider;
+  private sdkProviderCache?: SdkProvider;
 
   public constructor(private readonly props: ToolkitOptions = {}) {
     super();
@@ -113,23 +113,25 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
   /**
    * Access to the AWS SDK
+   * @internal
    */
-  private async sdkProvider(action: ToolkitAction): Promise<SdkProvider> {
+  protected async sdkProvider(action: ToolkitAction): Promise<SdkProvider> {
     // @todo this needs to be different instance per action
-    if (!this._sdkProvider) {
+    if (!this.sdkProviderCache) {
       const ioHelper = asIoHelper(this.ioHost, action);
-      this._sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
+      this.sdkProviderCache = await SdkProvider.withAwsCliCompatibleDefaults({
         ...this.props.sdkConfig,
         ioHelper,
         logger: asSdkLogger(ioHelper),
       });
     }
 
-    return this._sdkProvider;
+    return this.sdkProviderCache;
   }
 
   /**
    * Helper to provide the CloudAssemblySourceBuilder with required toolkit services
+   * @internal
    */
   protected override async sourceBuilderServices(): Promise<ToolkitServices> {
     return {

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -34,6 +34,7 @@
     "organization": true
   },
   "devDependencies": {
+    "@aws-cdk/aws-service-spec": "^0.1.67",
     "@aws-cdk/tmp-toolkit-helpers": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@smithy/types": "^4.2.0",

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
@@ -37,8 +37,7 @@
     "test/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "lib/init-templates/*/typescript/*/*.template.ts"
+    "node_modules"
   ],
   "references": [
     {

--- a/packages/aws-cdk/.projen/deps.json
+++ b/packages/aws-cdk/.projen/deps.json
@@ -13,6 +13,10 @@
       "type": "build"
     },
     {
+      "name": "@aws-cdk/toolkit-lib",
+      "type": "build"
+    },
+    {
       "name": "@aws-cdk/user-input-gen",
       "type": "build"
     },

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -101,7 +101,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/tmp-toolkit-helpers=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=exact @aws-cdk/cloudformation-diff=exact cdk-assets=major",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/tmp-toolkit-helpers=exact @aws-cdk/toolkit-lib=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=exact @aws-cdk/cloudformation-diff=exact cdk-assets=major",
           "receiveArgs": true
         }
       ]

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -23122,6 +23122,24 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------
 
+** split2@4.2.0 - https://www.npmjs.com/package/split2/v/4.2.0 | ISC
+Copyright (c) 2014-2018, Matteo Collina <hello@matteocollina.com>
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
 ** sprintf-js@1.1.3 - https://www.npmjs.com/package/sprintf-js/v/1.1.3 | BSD-3-Clause
 Copyright (c) 2007-present, Alexandru Mărășteanu <hello@alexei.ro>
 All rights reserved.

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -153,7 +153,7 @@ class InternalToolkit extends Toolkit {
    * Access to the AWS SDK
    * @internal
    */
-  protected override async sdkProvider(_action: ToolkitAction): Promise<SdkProvider> {
+  protected async sdkProvider(_action: ToolkitAction): Promise<SdkProvider> {
     return this._sdkProvider;
   }
 }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -9,8 +9,11 @@ import * as uuid from 'uuid';
 import { CliIoHost } from './io-host';
 import type { Configuration } from './user-configuration';
 import { PROJECT_CONFIG } from './user-configuration';
+import type { ToolkitAction } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 import { ToolkitError } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api';
 import { asIoHelper } from '../../../@aws-cdk/tmp-toolkit-helpers/src/api/io/private';
+import type { ToolkitOptions } from '../../../@aws-cdk/toolkit-lib/lib/toolkit';
+import { Toolkit } from '../../../@aws-cdk/toolkit-lib/lib/toolkit';
 import { DEFAULT_TOOLKIT_STACK_NAME } from '../api';
 import type { SdkProvider } from '../api/aws-auth';
 import type { BootstrapEnvironmentOptions } from '../api/bootstrap';
@@ -139,6 +142,22 @@ export enum AssetBuildTime {
   JUST_IN_TIME = 'just-in-time',
 }
 
+class InternalToolkit extends Toolkit {
+  private readonly _sdkProvider: SdkProvider;
+  public constructor(sdkProvider: SdkProvider, options: ToolkitOptions) {
+    super(options);
+    this._sdkProvider = sdkProvider;
+  }
+
+  /**
+   * Access to the AWS SDK
+   * @internal
+   */
+  protected override async sdkProvider(_action: ToolkitAction): Promise<SdkProvider> {
+    return this._sdkProvider;
+  }
+}
+
 /**
  * Toolkit logic
  *
@@ -148,10 +167,21 @@ export enum AssetBuildTime {
 export class CdkToolkit {
   private ioHost: CliIoHost;
   private toolkitStackName: string;
+  private toolkit: InternalToolkit;
 
   constructor(private readonly props: CdkToolkitProps) {
     this.ioHost = props.ioHost ?? CliIoHost.instance();
     this.toolkitStackName = props.toolkitStackName ?? DEFAULT_TOOLKIT_STACK_NAME;
+
+    this.toolkit = new InternalToolkit(props.sdkProvider, {
+      assemblyFailureAt: this.validateMetadataFailAt(),
+      color: true,
+      emojis: true,
+      ioHost: this.ioHost,
+      sdkConfig: {},
+      toolkitStackName: this.toolkitStackName,
+    });
+    this.toolkit; // aritifical use of this.toolkit to satisfy TS, we want to prepare usage of the new toolkit without using it just yet
   }
 
   public async metadata(stackName: string, json: boolean) {
@@ -1250,6 +1280,11 @@ export class CdkToolkit {
    * Validate the stacks for errors and warnings according to the CLI's current settings
    */
   private async validateStacks(stacks: StackCollection) {
+    const failAt = this.validateMetadataFailAt();
+    await stacks.validateMetadata(failAt, stackMetadataLogger(this.props.verbose));
+  }
+
+  private validateMetadataFailAt(): 'warn' | 'error' | 'none' {
     let failAt: 'warn' | 'error' | 'none' = 'error';
     if (this.props.ignoreErrors) {
       failAt = 'none';
@@ -1258,7 +1293,7 @@ export class CdkToolkit {
       failAt = 'warn';
     }
 
-    await stacks.validateMetadata(failAt, stackMetadataLogger(this.props.verbose));
+    return failAt;
   }
 
   /**

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -1,5 +1,6 @@
 import type * as cxapi from '@aws-cdk/cx-api';
 import { CloudAssembly } from './cloud-assembly';
+import type { ICloudAssemblySource } from '../../../@aws-cdk/toolkit-lib/lib/api/cloud-assembly';
 import { ToolkitError } from '../api';
 import type { SdkProvider } from '../api/aws-auth';
 import { IO, type IoHelper } from '../api-private';
@@ -36,10 +37,14 @@ export interface CloudExecutableProps {
 /**
  * Represent the Cloud Executable and the synthesis we can do on it
  */
-export class CloudExecutable {
+export class CloudExecutable implements ICloudAssemblySource {
   private _cloudAssembly?: CloudAssembly;
 
   constructor(private readonly props: CloudExecutableProps) {
+  }
+
+  public async produce(): Promise<cxapi.CloudAssembly> {
+    return (await this.synthesize(true)).assembly;
   }
 
   /**

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -37,6 +37,7 @@
     "@aws-cdk/cli-plugin-contract": "^0.0.0",
     "@aws-cdk/node-bundle": "^0.0.0",
     "@aws-cdk/tmp-toolkit-helpers": "^0.0.0",
+    "@aws-cdk/toolkit-lib": "^0.0.0",
     "@aws-cdk/user-input-gen": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@octokit/rest": "^21.1.1",

--- a/packages/aws-cdk/tsconfig.dev.json
+++ b/packages/aws-cdk/tsconfig.dev.json
@@ -61,6 +61,9 @@
     },
     {
       "path": "../@aws-cdk/tmp-toolkit-helpers"
+    },
+    {
+      "path": "../@aws-cdk/toolkit-lib"
     }
   ]
 }

--- a/packages/aws-cdk/tsconfig.json
+++ b/packages/aws-cdk/tsconfig.json
@@ -60,6 +60,9 @@
     },
     {
       "path": "../@aws-cdk/tmp-toolkit-helpers"
+    },
+    {
+      "path": "../@aws-cdk/toolkit-lib"
     }
   ]
 }

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -55,13 +55,13 @@
       "path": "packages/@aws-cdk/tmp-toolkit-helpers"
     },
     {
+      "path": "packages/@aws-cdk/toolkit-lib"
+    },
+    {
       "path": "packages/aws-cdk"
     },
     {
       "path": "packages/@aws-cdk/cli-lib-alpha"
-    },
-    {
-      "path": "packages/@aws-cdk/toolkit-lib"
     },
     {
       "path": "packages/@aws-cdk/cdk-cli-wrapper"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,13 +52,13 @@
       "path": "packages/@aws-cdk/tmp-toolkit-helpers"
     },
     {
+      "path": "packages/@aws-cdk/toolkit-lib"
+    },
+    {
       "path": "packages/aws-cdk"
     },
     {
       "path": "packages/@aws-cdk/cli-lib-alpha"
-    },
-    {
-      "path": "packages/@aws-cdk/toolkit-lib"
     },
     {
       "path": "packages/@aws-cdk/cdk-cli-wrapper"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,14 @@
     "@aws-cdk/service-spec-types" "^0.0.132"
     "@cdklabs/tskb" "^0.0.3"
 
+"@aws-cdk/aws-service-spec@^0.1.67":
+  version "0.1.67"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/aws-service-spec/-/aws-service-spec-0.1.67.tgz#61c265fe9a1363de473d06b22a72cde8767da00b"
+  integrity sha512-X02ntivyBSPM/V3yfxmWi4DiXKVQ7sAmSkvl5o5mRr4lt4GCIfIsuLyElNSlrRhYm6wAX4HdWDtnbZEaly1e0g==
+  dependencies:
+    "@aws-cdk/service-spec-types" "^0.0.133"
+    "@cdklabs/tskb" "^0.0.3"
+
 "@aws-cdk/cloud-assembly-schema@^41.0.0":
   version "41.2.0"
   resolved "https://registry.yarnpkg.com/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-41.2.0.tgz#c1ef513e1cc0528dbc05948ae39d5631306af423"
@@ -68,6 +76,13 @@
   version "0.0.132"
   resolved "https://registry.yarnpkg.com/@aws-cdk/service-spec-types/-/service-spec-types-0.0.132.tgz#de30ad27c951f182299365fb680e9a7ae6d74000"
   integrity sha512-DuBsNUgiAlXUpo1MLKvD44iIjKxdfqKd181blPdzvVQ0AYGOoP0OIBxAElLsqyVhUhsRDLli0nA2RoRmAjnaUQ==
+  dependencies:
+    "@cdklabs/tskb" "^0.0.3"
+
+"@aws-cdk/service-spec-types@^0.0.133":
+  version "0.0.133"
+  resolved "https://registry.yarnpkg.com/@aws-cdk/service-spec-types/-/service-spec-types-0.0.133.tgz#a2e5a14e9dcd359a67800e9db1c982627f7e189c"
+  integrity sha512-pFcKB8DL02/QCZfSv0KxvIdx9J5606VG9i/wCRtSRBwkFMj152MZEx4GSo3iH3rlcxYd9R+O84Yvv85KtqmwWA==
   dependencies:
     "@cdklabs/tskb" "^0.0.3"
 


### PR DESCRIPTION
Enable using the new Toolkit class from `toolki-lib`, inside the "old" `CdkToolkit` used by the CLI.

This will allow us to have new features be only implemented once with a thing pass through layer.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
