### PR TITLE
fix(toolkit-lib): remove `AsyncDisposable` from `Toolkit`

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -81,7 +81,7 @@ export interface ToolkitOptions {
 /**
  * The AWS CDK Programmatic Toolkit
  */
-export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposable {
+export class Toolkit extends CloudAssemblySourceBuilder {
   /**
    * The toolkit stack name used for bootstrapping resources.
    */
@@ -112,14 +112,6 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
     // After removing emojis and color, we might end up with floating whitespace at either end of the message
     // This also removes newlines that we currently emit for CLI backwards compatibility.
     this.ioHost = withTrimmedWhitespace(ioHost);
-  }
-
-  public async dispose(): Promise<void> {
-    // nothing to do yet
-  }
-
-  public async [Symbol.asyncDispose](): Promise<void> {
-    await this.dispose();
   }
 
   /**


### PR DESCRIPTION
BREAKING CHANGE: Remove the `AsyncDisposable` interface and `dispose()` method from the `Toolkit` class. These were previously unused and had no effect.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
