### PR TITLE
fix(toolkit-lib): remove deprecated outdir option from watch

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
@@ -28,13 +28,4 @@ export interface WatchOptions extends BaseDeployOptions {
    * @default process.cwd()
    */
   readonly watchDir?: string;
-
-  /**
-   * The output directory to write CloudFormation template to
-   *
-   * @deprecated this should be grabbed from the cloud assembly itself
-   *
-   * @default 'cdk.out'
-   */
-  readonly outdir?: string;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -769,11 +769,19 @@ export class Toolkit extends CloudAssemblySourceBuilder implements AsyncDisposab
     // 2. Any file whose name starts with a dot.
     // 3. Any directory's content whose name starts with a dot.
     // 4. Any node_modules and its content (even if it's not a JS/TS project, you might be using a local aws-cli package)
-    const outdir = options.outdir ?? 'cdk.out';
+    const outdir = assembly.directory;
     const watchExcludes = patternsArrayForWatch(options.exclude, {
       rootDir,
       returnRootDirIfEmpty: false,
-    }).concat(`${outdir}/**`, '**/.*', '**/.*/**', '**/node_modules/**');
+    });
+
+    // only exclude the outdir if it is under the rootDir
+    const relativeOutDir = path.relative(rootDir, outdir);
+    if (Boolean(relativeOutDir && !relativeOutDir.startsWith('..' + path.sep) && !path.isAbsolute(relativeOutDir))) {
+      watchExcludes.push(`${relativeOutDir}/**`);
+    }
+
+    watchExcludes.push('**/.*', '**/.*/**', '**/node_modules/**');
 
     // Print some debug information on computed settings
     await ioHelper.notify(IO.CDK_TOOLKIT_I5310.msg([


### PR DESCRIPTION
The watch functionality has been updated to:
1. Remove the deprecated outdir parameter from WatchOptions
2. Use assembly.directory instead of the hardcoded 'cdk.out' default
3. Only exclude the outdir from watching if it's under the root directory
4. Update tests to reflect these changes


BREAKING CHANGE: The `outdir` option in `WatchOptions` was deprecated and has been removed. Instead, the code now determines the assembly directory directly. To explicitly restore the previous behavior, you add the value to `WatchOptions.exclude`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
