### PR TITLE
fix(toolkit-lib): remove unused extraUserAgent option from WatchOptions

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
@@ -2,13 +2,6 @@ import type { BaseDeployOptions } from '../deploy/private';
 
 export interface WatchOptions extends BaseDeployOptions {
   /**
-   * The extra string to append to the User-Agent header when performing AWS SDK calls.
-   *
-   * @default - nothing extra is appended to the User-Agent header
-   */
-  readonly extraUserAgent?: string;
-
-  /**
    * Watch the files in this list
    *
    * @default - []


### PR DESCRIPTION
BREAKING CHANGE: The `extraUserAgent`option in `WatchOptions` interface was unused and had no effect on functionality. This change removes the unused parameter.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
