### PR TITLE
chore: update cdklabs-projen-project-types to 0.2.14 and set maxWorkers to 150

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -128,7 +128,7 @@ jobs:
           CDK_MAJOR_VERSION: "2"
           RELEASE_TAG: latest
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bin/run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+        run: bin/run-suite --maxWorkers=150 --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
     strategy:
       fail-fast: false
       matrix:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1522,6 +1522,7 @@ new CdkCliIntegTestsWorkflow(repo, {
   testEnvironment: TEST_ENVIRONMENT,
   buildRunsOn: POWERFUL_RUNNER,
   testRunsOn: POWERFUL_RUNNER,
+  maxWorkers: '150',
 
   localPackages: [
     cloudAssemblySchema.name,

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "ts5.6",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "cdklabs-projen-project-types": "^0.2.13",
+    "cdklabs-projen-project-types": "^0.2.14",
     "constructs": "^10.0.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4652,10 +4652,10 @@ cdk-from-cfn@^0.205.0:
   resolved "https://registry.yarnpkg.com/cdk-from-cfn/-/cdk-from-cfn-0.205.0.tgz#6479a1a753a54bfe2fbe45236624e046e8521370"
   integrity sha512-2bX+ASFFUdfn211++ElQXqf+V9zL8xe3UOm+m0aUkF3zp45aqdT8VjxFfI45dAYiPLYihgoqfo6W7MU0JkR4uQ==
 
-cdklabs-projen-project-types@^0.2.13:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.13.tgz#fcd19b1c006f74a4802f927492e6a0b4872806d9"
-  integrity sha512-tRY+ewbmPYhQEo9d32rQ2inUNG6vkjaFb4wAaKsjvycwBCkHhlb6KXuHH1olri8D8dx/QwC90WUo5cp7pxbzKg==
+cdklabs-projen-project-types@^0.2.14:
+  version "0.2.14"
+  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.14.tgz#8bc451b660687a1b20c0a7d3b4043fa56424b331"
+  integrity sha512-7iG53dZAgiXQ2xacrTuYjXqPjIFjmsYx90dYFAf2Qu2yIwDleSUQsUvc/uVHEv/C/pArhm4s8pKdskNi59t/HA==
   dependencies:
     yaml "^2.7.1"
 


### PR DESCRIPTION
This PR updates the cdklabs-projen-project-types package to version 0.2.14 and sets the maxWorkers option on CdkCliIntegTestsWorkflow to 150 as described in https://github.com/cdklabs/cdklabs-projen-project-types/pull/841.

This change sets an appropriate maxWorkers value (150) that's optimized for the GitHub workflow runner environment. This ensures we're making efficient use of the available resources during integration tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license