### PR TITLE
chore: reduce maxWorkers from 150 to 80 in test workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -128,7 +128,7 @@ jobs:
           CDK_MAJOR_VERSION: "2"
           RELEASE_TAG: latest
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: bin/run-suite --maxWorkers=150 --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+        run: bin/run-suite --maxWorkers=80 --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
     strategy:
       fail-fast: false
       matrix:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1522,7 +1522,7 @@ new CdkCliIntegTestsWorkflow(repo, {
   testEnvironment: TEST_ENVIRONMENT,
   buildRunsOn: POWERFUL_RUNNER,
   testRunsOn: POWERFUL_RUNNER,
-  maxWorkers: '150',
+  maxWorkers: '80',
 
   localPackages: [
     cloudAssemblySchema.name,


### PR DESCRIPTION
Reduce workers to not overload the system.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
