### PR TITLE
feat(toolkit): add a return type for toolkit.rollback()

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/actions/rollback.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/rollback.test.ts
@@ -22,6 +22,7 @@ beforeEach(() => {
   mockRollbackStack.mockResolvedValue({
     notInRollbackableState: false,
     success: true,
+    stackArn: 'arn:stack',
   });
 });
 
@@ -29,10 +30,33 @@ describe('rollback', () => {
   test('successful rollback', async () => {
     // WHEN
     const cx = await builderFixture(toolkit, 'two-empty-stacks');
-    await toolkit.rollback(cx, { stacks: { strategy: StackSelectionStrategy.ALL_STACKS } });
+    const result = await toolkit.rollback(cx, { stacks: { strategy: StackSelectionStrategy.ALL_STACKS } });
 
     // THEN
     successfulRollback();
+
+    expect(result).toEqual({
+      stacks: [
+        {
+          environment: {
+            account: 'unknown-account',
+            region: 'unknown-region',
+          },
+          result: 'rolled-back',
+          stackArn: 'arn:stack',
+          stackName: 'Stack1',
+        },
+        {
+          environment: {
+            account: 'unknown-account',
+            region: 'unknown-region',
+          },
+          result: 'rolled-back',
+          stackArn: 'arn:stack',
+          stackName: 'Stack2',
+        },
+      ],
+    });
   });
 
   test('rollback not in rollbackable state', async () => {

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -21566,26 +21566,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
-** fs-extra@10.1.0 - https://www.npmjs.com/package/fs-extra/v/10.1.0 | MIT
-(The MIT License)
-
-Copyright (c) 2011-2017 JP Richardson
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files
-(the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify,
- merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
- furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
-WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
-OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-----------------
-
 ** fs-extra@9.1.0 - https://www.npmjs.com/package/fs-extra/v/9.1.0 | MIT
 (The MIT License)
 

--- a/packages/aws-cdk/lib/api/deployments/deployments.ts
+++ b/packages/aws-cdk/lib/api/deployments/deployments.ts
@@ -229,10 +229,10 @@ export interface RollbackStackOptions {
   readonly validateBootstrapStackVersion?: boolean;
 }
 
-export interface RollbackStackResult {
-  readonly notInRollbackableState?: boolean;
-  readonly success?: boolean;
-}
+export type RollbackStackResult = { readonly stackArn: string } & (
+  | { readonly notInRollbackableState: true }
+  | { readonly success: true; notInRollbackableState?: undefined }
+);
 
 interface AssetOptions {
   /**
@@ -467,14 +467,15 @@ export class Deployments {
     // We loop in case of `--force` and the stack ends up in `CONTINUE_UPDATE_ROLLBACK`.
     let maxLoops = 10;
     while (maxLoops--) {
-      let cloudFormationStack = await CloudFormationStack.lookup(cfn, deployName);
+      const cloudFormationStack = await CloudFormationStack.lookup(cfn, deployName);
+      const stackArn = cloudFormationStack.stackId;
 
       const executionRoleArn = await env.replacePlaceholders(options.roleArn ?? options.stack.cloudFormationExecutionRoleArn);
 
       switch (cloudFormationStack.stackStatus.rollbackChoice) {
         case RollbackChoice.NONE:
           await this.ioHelper.notify(IO.DEFAULT_TOOLKIT_WARN.msg(`Stack ${deployName} does not need a rollback: ${cloudFormationStack.stackStatus}`));
-          return { notInRollbackableState: true };
+          return { stackArn: cloudFormationStack.stackId, notInRollbackableState: true };
 
         case RollbackChoice.START_ROLLBACK:
           await this.ioHelper.notify(IO.DEFAULT_TOOLKIT_DEBUG.msg(`Initiating rollback of stack ${deployName}`));
@@ -516,7 +517,7 @@ export class Deployments {
           await this.ioHelper.notify(IO.DEFAULT_TOOLKIT_WARN.msg(
             `Stack ${deployName} failed creation and rollback. This state cannot be rolled back. You can recreate this stack by running 'cdk deploy'.`,
           ));
-          return { notInRollbackableState: true };
+          return { stackArn, notInRollbackableState: true };
 
         default:
           throw new ToolkitError(`Unexpected rollback choice: ${cloudFormationStack.stackStatus.rollbackChoice}`);
@@ -552,7 +553,7 @@ export class Deployments {
       }
 
       if (finalStackState.stackStatus.isRollbackSuccess || !stackErrorMessage) {
-        return { success: true };
+        return { stackArn, success: true };
       }
 
       // Either we need to ignore some resources to continue the rollback, or something went wrong


### PR DESCRIPTION
`toolkit.rollback()` now returns information about the stacks it rolled back.

Includes some refactoring that deduplicates return information between deploy/destroy and rollback.

Closes https://github.com/aws/aws-cdk/issues/33188

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
