### PR TITLE
chore: update buffered console types to new jest environment

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -105,6 +105,11 @@
       "type": "build"
     },
     {
+      "name": "@jest/environment",
+      "version": "30.0.0-alpha.7",
+      "type": "override"
+    },
+    {
       "name": "jest-environment-node",
       "version": "30.0.0-alpha.7",
       "type": "override"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -266,7 +266,10 @@ const repoProject = new yarn.Monorepo({
 // This is necessary to make Symbol.dispose and Symbol.asyncDispose accessible
 // in Jest worker processes. It will complain about incompatibility during install
 // but work in practice all the same.
-repoProject.package.addPackageResolutions('jest-environment-node@30.0.0-alpha.7');
+repoProject.package.addPackageResolutions(
+  'jest-environment-node@30.0.0-alpha.7',
+  '@jest/environment@30.0.0-alpha.7',
+);
 
 new AdcPublishing(repoProject);
 new RecordPublishingTimestamp(repoProject);

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "typescript": "5.6"
   },
   "resolutions": {
+    "@jest/environment": "30.0.0-alpha.7",
     "jest-environment-node": "30.0.0-alpha.7"
   },
   "engines": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,7 +2295,7 @@
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@30.0.0-alpha.7":
+"@jest/environment@30.0.0-alpha.7", "@jest/environment@^29.7.0":
   version "30.0.0-alpha.7"
   resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-30.0.0-alpha.7.tgz#6de9259b2dbc1013fb55d73b7ebbdbc2345a5b8b"
   integrity sha512-sEszhsMrT7Jh0ngVjR8q36payUT2NU0kYwd5rdxUzlVha8gZg2FTq1VMjgETEnYyGXrEmnk7MmBUxTbT7dYrUw==
@@ -2304,16 +2304,6 @@
     "@jest/types" "30.0.0-alpha.7"
     "@types/node" "*"
     jest-mock "30.0.0-alpha.7"
-
-"@jest/environment@^29.7.0":
-  version "29.7.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-29.7.0.tgz#24d61f54ff1f786f3cd4073b4b94416383baf2a7"
-  integrity sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==
-  dependencies:
-    "@jest/fake-timers" "^29.7.0"
-    "@jest/types" "^29.6.3"
-    "@types/node" "*"
-    jest-mock "^29.7.0"
 
 "@jest/expect-utils@^29.7.0":
   version "29.7.0"


### PR DESCRIPTION
These problems were causing typing problems, even though they don't cause the tests to fail.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
