### PR TITLE
chore: use older version of codecov-action

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build and test CLI
         run: yarn nx run aws-cdk:build
       - name: Upload results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.1.2
         with:
           files: packages/aws-cdk/coverage/cobertura-coverage.xml
           fail_ci_if_error: true

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -47,7 +47,7 @@ export class CodeCovWorkflow extends Component {
         },
         {
           name: 'Upload results to Codecov',
-          uses: 'codecov/codecov-action@v5',
+          uses: 'codecov/codecov-action@v5.1.2',
           with: {
             files: props.packages.map(p => `packages/${p}/coverage/cobertura-coverage.xml`).join(','),
             fail_ci_if_error: true,


### PR DESCRIPTION
To work around the "Token required because branch is protected" error message.

See https://github.com/codecov/codecov-action/issues/1791

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
