### PR TITLE
chore: switch to an explicit old version of CodeCov CLI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,3 +32,4 @@ jobs:
           fail_ci_if_error: true
           flags: suite.unit
           use_oidc: true
+          version: v10.3.0

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -53,6 +53,15 @@ export class CodeCovWorkflow extends Component {
             fail_ci_if_error: true,
             flags: 'suite.unit',
             use_oidc: true,
+
+            // Version of CodeCov CLI to download and run.
+            //
+            // 'latest' if this is omitted, but we're seeing v10.4.0 producing the following error:
+            // ```
+            // -> Token of length 0 detected
+            // error - 2025-04-08 13:34:06,401 -- Upload failed: {"message":"Token required because branch is protected"}
+            // ```
+            version: 'v10.3.0',
           },
         },
       ],


### PR DESCRIPTION
The new version seems to have a problem.

Supersedes #349.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
