### PR TITLE
chore: enforce major version for cdk, aws-cdk, and cli-lib-alpha

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1239,6 +1239,7 @@ const cli = configureProject(
     nextVersionCommand: 'tsx ../../projenrc/next-version.ts maybeRc',
 
     releasableCommits: transitiveToolkitPackages('aws-cdk'),
+    majorVersion: 2,
   }),
 );
 
@@ -1375,6 +1376,7 @@ const cliLib = configureProject(
     disableTsconfig: true,
     nextVersionCommand: `tsx ../../../projenrc/next-version.ts copyVersion:../../../${cliPackageJson} append:-alpha.0`,
     releasableCommits: transitiveToolkitPackages('@aws-cdk/cli-lib-alpha'),
+    majorVersion: 2,
     eslintOptions: {
       dirs: ['lib'],
       ignorePatterns: [
@@ -1511,6 +1513,7 @@ const cdkAliasPackage = configureProject(
     deps: [cli.customizeReference({ versionType: 'exact' })],
     nextVersionCommand: `tsx ../../projenrc/next-version.ts copyVersion:../../${cliPackageJson}`,
     releasableCommits: transitiveToolkitPackages('cdk'),
+    majorVersion: 2,
     tsconfig: {
       compilerOptions: {
         ...defaultTsOptions,

--- a/packages/@aws-cdk/cli-lib-alpha/.projen/tasks.json
+++ b/packages/@aws-cdk/cli-lib-alpha/.projen/tasks.json
@@ -33,7 +33,8 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts copyVersion:../../../packages/aws-cdk/package.json append:-alpha.0",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff",
+        "MAJOR": "2"
       },
       "steps": [
         {

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -33,7 +33,8 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
+        "MAJOR": "2"
       },
       "steps": [
         {

--- a/packages/cdk/.projen/tasks.json
+++ b/packages/cdk/.projen/tasks.json
@@ -33,7 +33,8 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts copyVersion:../../packages/aws-cdk/package.json",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
+        "MAJOR": "2"
       },
       "steps": [
         {


### PR DESCRIPTION
When a major version is defined, bumps will fail if the new version crosses the major version boundary.

This makes sure that cdk, aws-cdk, and cli-lib-alpha bumps will always be major version 2, or fail

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
