### PR TITLE
chore: force minor version bumps for aws-cdk package

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1239,9 +1239,8 @@ const cli = configureProject(
     }),
 
     // Append a specific version string for testing
-
     // force a minor for the time being. This will never release a patch but that's fine for a while.
-    nextVersionCommand: 'echo minor',
+    nextVersionCommand: 'tsx ../../projenrc/next-version.ts maybeRcOrMinor',
 
     // re-enable this once we refactor the release tasks to prevent
     // major version bumps caused by breaking commits in dependencies.

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1240,7 +1240,7 @@ const cli = configureProject(
 
     // Append a specific version string for testing
 
-    // force a minor for the time being
+    // force a minor for the time being. This will never release a patch but that's fine for a while.
     nextVersionCommand: 'echo minor',
 
     // re-enable this once we refactor the release tasks to prevent

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1239,7 +1239,13 @@ const cli = configureProject(
     }),
 
     // Append a specific version string for testing
-    nextVersionCommand: 'tsx ../../projenrc/next-version.ts maybeRc',
+
+    // force a minor for the time being
+    nextVersionCommand: 'node -e "console.log(\'minor\')"',
+
+    // re-enable this once we refactor the release tasks to prevent
+    // major version bumps caused by breaking commits in dependencies.
+    // nextVersionCommand: 'tsx ../../projenrc/next-version.ts maybeRc',
 
     releasableCommits: transitiveToolkitPackages('aws-cdk'),
     majorVersion: 2,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1241,7 +1241,7 @@ const cli = configureProject(
     // Append a specific version string for testing
 
     // force a minor for the time being
-    nextVersionCommand: 'node -e "console.log(\'minor\')"',
+    nextVersionCommand: 'echo minor',
 
     // re-enable this once we refactor the release tasks to prevent
     // major version bumps caused by breaking commits in dependencies.

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "echo minor",
+        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRcOrMinor",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
         "MAJOR": "2"
       },
@@ -209,7 +209,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "echo minor",
+        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRcOrMinor",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
       },
       "steps": [

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "node -e \"console.log('minor')\"",
+        "NEXT_VERSION_COMMAND": "echo minor",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
         "MAJOR": "2"
       },
@@ -209,7 +209,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "node -e \"console.log('minor')\"",
+        "NEXT_VERSION_COMMAND": "echo minor",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
       },
       "steps": [

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
+        "NEXT_VERSION_COMMAND": "node -e \"console.log('minor')\"",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
         "MAJOR": "2"
       },
@@ -209,7 +209,7 @@
         "RELEASE_TAG_PREFIX": "aws-cdk@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
+        "NEXT_VERSION_COMMAND": "node -e \"console.log('minor')\"",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
       },
       "steps": [

--- a/projenrc/next-version.ts
+++ b/projenrc/next-version.ts
@@ -37,23 +37,13 @@ async function main() {
         break;
 
       case 'maybeRc': {
-        if (process.env.TESTING_CANDIDATE === 'true') {
-          // To make an rc version for testing, we set the last component (either
-          // patch or prerelease version) to 999.
-          //
-          // Adding `rc.0` causes problems for Amplify tests, which install
-          // `aws-cdk@^2` which won't match the prerelease version.
-          const originalPre = semver.prerelease(version);
-
-          if (originalPre) {
-            version = version.replace(new RegExp('\\.' + originalPre[1] + '$'), '.999');
-          } else {
-            const patch = semver.patch(version);
-            version = version.replace(new RegExp('\\.' + patch + '$'), '.999');
-          }
-        }
+        version = maybeRc(version) ?? version;
         break;
       }
+      case 'maybeRcOrMinor':
+        const rc = maybeRc(version);
+        version = rc ?? 'minor';
+        break;
 
       default:
         throw new Error(`Unknown command: ${cmd}`);
@@ -64,6 +54,24 @@ async function main() {
     // this is a cli
     // eslint-disable-next-line no-console
     console.log(version);
+  }
+}
+
+function maybeRc(version: string) {
+  if (process.env.TESTING_CANDIDATE === 'true') {
+    // To make an rc version for testing, we set the last component (either
+    // patch or prerelease version) to 999.
+    //
+    // Adding `rc.0` causes problems for Amplify tests, which install
+    // `aws-cdk@^2` which won't match the prerelease version.
+    const originalPre = semver.prerelease(version);
+
+    if (originalPre) {
+      return version.replace(new RegExp('\\.' + originalPre[1] + '$'), '.999');
+    } else {
+      const patch = semver.patch(version);
+      return version.replace(new RegExp('\\.' + patch + '$'), '.999');
+    }
   }
 }
 

--- a/projenrc/next-version.ts
+++ b/projenrc/next-version.ts
@@ -40,6 +40,11 @@ async function main() {
         version = maybeRc(version) ?? version;
         break;
       }
+      // this is a temporary case in order to support forcing a minor
+      // version while still preserving rc capabilities for integ testing purposes.
+      // once we refactor the release process to prevent incorporating breaking
+      // changes from dependencies, this can (and should) be removed.
+      // see https://github.com/projen/projen/pull/4156
       case 'maybeRcOrMinor':
         version = maybeRc(version) ?? 'minor';
         break;

--- a/projenrc/next-version.ts
+++ b/projenrc/next-version.ts
@@ -41,8 +41,7 @@ async function main() {
         break;
       }
       case 'maybeRcOrMinor':
-        const rc = maybeRc(version);
-        version = rc ?? 'minor';
+        version = maybeRc(version) ?? 'minor';
         break;
 
       default:


### PR DESCRIPTION
Temporary until we refactor the release process.

Tested locally. When executing `yarn workspaces run bump` on `main`:

```console
👾 Number of commits since aws-cdk@v2.1007.0: 5
✔ bumping version in /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/package.json from 2.1007.0 to 3.0.0
✔ created /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/dist/changelog.md
✔ outputting changes to /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/dist/changelog.md
Error: bump failed: this branch is configured to only publish v2 releases - bump resulted in 3.0.0
    at bump (/Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/node_modules/projen/lib/release/bump-version.js:139:19)
👾 Task "bump" failed when executing ""/opt/homebrew/Cellar/node@20/20.18.0_2/bin/node" "/Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/node_modules/projen/lib/release/bump-version.task.js"" (cwd: /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk)
```

Which fails as expected on the major version protection. When executing on this branch:

```console
👾 Number of commits since aws-cdk@v2.1007.0: 5
✔ bumping version in /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/package.json from 2.1007.0 to 2.1008.0
✔ created /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/dist/changelog.md
✔ outputting changes to /Users/epolon/dev/src/github.com/aws/aws-cdk-cli/packages/aws-cdk/dist/changelog.md
✨  Done in 6.54s.
```

Which correctly bumps from from 2.1007.0 to 2.1008.0.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
