### PR TITLE
chore: use `>=` for dependencies on `cloud-assembly-schema`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -583,7 +583,7 @@ const cdkAssets = configureProject(
     description: 'CDK Asset Publishing Tool',
     srcdir: 'lib',
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
       cxApi,
       'archiver',
       'glob',
@@ -1130,7 +1130,7 @@ const cli = configureProject(
       'xml-js',
     ],
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
       cloudFormationDiff.customizeReference({ versionType: 'exact' }),
       cxApi,
       '@aws-cdk/region-info',
@@ -1536,7 +1536,7 @@ const integRunner = configureProject(
     description: 'CDK Integration Testing Tool',
     srcdir: 'lib',
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
       cxApi,
       cdkCliWrapper.customizeReference({ versionType: 'exact' }),
       cli.customizeReference({ versionType: 'exact' }),

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -100,7 +100,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=exact @aws-cdk/cdk-cli-wrapper=exact aws-cdk=exact cdk-assets=exact @aws-cdk/cloudformation-diff=exact",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=minimal @aws-cdk/cdk-cli-wrapper=exact aws-cdk=exact cdk-assets=exact @aws-cdk/cloudformation-diff=exact",
           "receiveArgs": true
         }
       ]

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -102,7 +102,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/tmp-toolkit-helpers=exact @aws-cdk/toolkit-lib=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=exact @aws-cdk/cloudformation-diff=exact cdk-assets=major",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/tmp-toolkit-helpers=exact @aws-cdk/toolkit-lib=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=minimal @aws-cdk/cloudformation-diff=exact cdk-assets=major",
           "receiveArgs": true
         }
       ]

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -102,7 +102,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=exact",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=minimal",
           "receiveArgs": true
         }
       ]


### PR DESCRIPTION
By default we would use `^41.0.0` to depend on this package, but it is strictly backwards compatible. The major version number of this package currently tracks the revision of the cloud assembly protocol, and does not use semver major versions to indicate breaking changes (breaking changes are not allowed).

We should use `>=` to indicate that we expect a minimum version of the schema, but we don't want to imply a maximum version.

Relates to https://github.com/aws/aws-cdk-cli/issues/345.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
