### PR TITLE
fix: prevent codecov upload failure from blocking CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           disable_search: true
           files: packages/aws-cdk/coverage/cobertura-coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
           flags: suite.unit
           use_oidc: true
           version: v10.3.0

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -51,7 +51,7 @@ export class CodeCovWorkflow extends Component {
           with: {
             disable_search: true,
             files: props.packages.map(p => `packages/${p}/coverage/cobertura-coverage.xml`).join(','),
-            fail_ci_if_error: true,
+            fail_ci_if_error: false, // temporary until https://github.com/codecov/codecov-action/issues/1806 is fixed
             flags: 'suite.unit',
             use_oidc: true,
 


### PR DESCRIPTION
Prevents codecov from blocking CI, until they fix the following:

https://github.com/codecov/codecov-action/issues/1806
https://github.com/codecov/codecov-action/pull/1792

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
