### PR TITLE
feat(toolkit-lib): add a return type for toolkit.diff()

### DIFF
--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/diff/diff-formatter.ts
@@ -121,11 +121,6 @@ export interface TemplateInfo {
   readonly changeSet?: any;
 
   /**
-   * The name of the stack
-   */
-  readonly stackName: string;
-
-  /**
    * Whether or not there are any imported resources
    *
    * @default false
@@ -164,7 +159,7 @@ export class DiffFormatter {
     this.ioHelper = props.ioHelper;
     this.oldTemplate = props.templateInfo.oldTemplate;
     this.newTemplate = props.templateInfo.newTemplate;
-    this.stackName = props.templateInfo.stackName;
+    this.stackName = props.templateInfo.newTemplate.stackName;
     this.changeSet = props.templateInfo.changeSet;
     this.nestedStacks = props.templateInfo.nestedStacks;
     this.isImport = props.templateInfo.isImport ?? false;

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/diff/diff-formatter.ts
@@ -122,10 +122,8 @@ export interface TemplateInfo {
 
   /**
    * The name of the stack
-   *
-   * @default undefined
    */
-  readonly stackName?: string;
+  readonly stackName: string;
 
   /**
    * Whether or not there are any imported resources
@@ -151,10 +149,16 @@ export class DiffFormatter {
   private readonly ioHelper: IoHelper;
   private readonly oldTemplate: any;
   private readonly newTemplate: cxapi.CloudFormationStackArtifact;
-  private readonly stackName?: string;
+  private readonly stackName: string;
   private readonly changeSet?: any;
   private readonly nestedStacks: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined;
   private readonly isImport: boolean;
+
+  /**
+   * Stores the TemplateDiffs that get calculated in this DiffFormatter,
+   * indexed by the stack name.
+   */
+  private _diffs: { [name: string]: TemplateDiff } = {};
 
   constructor(props: DiffFormatterProps) {
     this.ioHelper = props.ioHelper;
@@ -164,6 +168,10 @@ export class DiffFormatter {
     this.changeSet = props.templateInfo.changeSet;
     this.nestedStacks = props.templateInfo.nestedStacks;
     this.isImport = props.templateInfo.isImport ?? false;
+  }
+
+  public get diffs() {
+    return this._diffs;
   }
 
   /**
@@ -184,11 +192,12 @@ export class DiffFormatter {
 
   private formatStackDiffHelper(
     oldTemplate: any,
-    stackName: string | undefined,
+    stackName: string,
     nestedStackTemplates: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined,
     options: ReusableStackDiffOptions,
   ) {
     let diff = fullDiff(oldTemplate, this.newTemplate.template, this.changeSet, this.isImport);
+    this._diffs[stackName] = diff;
 
     // The stack diff is formatted via `Formatter`, which takes in a stream
     // and sends its output directly to that stream. To faciliate use of the
@@ -277,6 +286,7 @@ export class DiffFormatter {
     const ioDefaultHelper = new IoDefaultMessages(this.ioHelper);
 
     const diff = fullDiff(this.oldTemplate, this.newTemplate.template, this.changeSet);
+    this._diffs[this.stackName] = diff;
 
     if (diffRequiresApproval(diff, options.requireApproval)) {
       // The security diff is formatted via `Formatter`, which takes in a stream

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -49,6 +49,7 @@ async function localFileDiff(stacks: StackCollection, options: DiffOptions): Pro
   return [{
     oldTemplate: template,
     newTemplate: stacks.firstStack,
+    stackName: stacks.firstStack.stackName,
   }];
 }
 
@@ -166,4 +167,17 @@ export function determinePermissionType(
   } else {
     return PermissionChangeType.NONE;
   }
+}
+
+export function appendObject<T>(
+  obj1: { [name: string]: T },
+  obj2: { [name: string]: T },
+): { [name: string]: T } {
+  // Directly modify obj1 by adding all properties from obj2
+  for (const key in obj2) {
+    obj1[key] = obj2[key];
+  }
+
+  // Return the modified obj1
+  return obj1;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -169,6 +169,15 @@ export function determinePermissionType(
   }
 }
 
+/**
+ * Appends all properties from obj2 to obj1.
+ * obj2 values take priority in the case of collisions.
+ *
+ * @param obj1 The object to modify
+ * @param obj2 The object to consume
+ *
+ * @returns obj1 with all properties from obj2
+ */
 export function appendObject<T>(
   obj1: { [name: string]: T },
   obj2: { [name: string]: T },

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -49,7 +49,6 @@ async function localFileDiff(stacks: StackCollection, options: DiffOptions): Pro
   return [{
     oldTemplate: template,
     newTemplate: stacks.firstStack,
-    stackName: stacks.firstStack.stackName,
   }];
 }
 
@@ -92,7 +91,6 @@ async function cfnDiff(
     templateInfos.push({
       oldTemplate: currentTemplate,
       newTemplate: stack,
-      stackName: stack.stackName,
       isImport: !!resourcesToImport,
       nestedStacks,
       changeSet,

--- a/packages/@aws-cdk/toolkit-lib/test/_fixtures/two-different-stacks/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_fixtures/two-different-stacks/index.ts
@@ -1,0 +1,13 @@
+import * as core from 'aws-cdk-lib/core';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+
+export default async () => {
+  const app = new core.App({ autoSynth: false });
+  const stack1 = new core.Stack(app, 'Stack1');
+  new s3.Bucket(stack1, 'MyBucket');
+  const stack2 = new core.Stack(app, 'Stack2');
+  new sqs.Queue(stack2, 'MyQueue');
+
+  return app.synth();
+};

--- a/packages/@aws-cdk/toolkit-lib/test/_fixtures/two-different-stacks/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_fixtures/two-different-stacks/index.ts
@@ -1,6 +1,6 @@
-import * as core from 'aws-cdk-lib/core';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as core from 'aws-cdk-lib/core';
 
 export default async () => {
   const app = new core.App({ autoSynth: false });

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -61,7 +61,7 @@ describe('diff', () => {
     });
 
     // THEN
-    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+    expect(result.Stack1).toMatchObject(expect.objectContaining({
       resources: {
         diffs: expect.objectContaining({
           MyBucketF68F3FF0: expect.objectContaining({
@@ -88,7 +88,7 @@ describe('diff', () => {
     });
 
     // THEN
-    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+    expect(result.Stack1).toMatchObject(expect.objectContaining({
       resources: {
         diffs: expect.objectContaining({
           MyBucketF68F3FF0: expect.objectContaining({
@@ -105,7 +105,7 @@ describe('diff', () => {
         }),
       },
     }));
-    expect(result['Stack2']).toMatchObject(expect.objectContaining({
+    expect(result.Stack2).toMatchObject(expect.objectContaining({
       resources: {
         diffs: expect.objectContaining({
           MyQueueE6CA6235: expect.objectContaining({
@@ -150,7 +150,7 @@ describe('diff', () => {
       }),
     }));
 
-    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+    expect(result.Stack1).toMatchObject(expect.objectContaining({
       iamChanges: expect.objectContaining({
         statements: expect.objectContaining({
           additions: [expect.objectContaining({
@@ -286,7 +286,7 @@ describe('diff', () => {
       });
 
       // THEN
-      expect(result['Stack1']).toMatchObject(expect.objectContaining({
+      expect(result.Stack1).toMatchObject(expect.objectContaining({
         resources: {
           diffs: expect.objectContaining({
             MyBucketF68F3FF0: expect.objectContaining({
@@ -321,7 +321,7 @@ describe('diff', () => {
         code: 'CDK_TOOLKIT_W0000',
         message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening)'),
       }));
-      expect(result['Stack1']).toMatchObject(expect.objectContaining({
+      expect(result.Stack1).toMatchObject(expect.objectContaining({
         iamChanges: expect.objectContaining({
           statements: expect.objectContaining({
             additions: [expect.objectContaining({

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -6,7 +6,6 @@ import { RequireApproval } from '../../lib/api/shared-private';
 import { StackSelectionStrategy } from '../../lib/api/shared-public';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
-import { MockSdk } from '../_helpers/mock-sdk';
 
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
@@ -54,38 +53,49 @@ describe('diff', () => {
     }));
   });
 
-  // TODO: uncomment when diff returns a value
-  // test('returns diff', async () => {
-  //   // WHEN
-  //   const cx = await builderFixture(toolkit, 'stack-with-bucket');
-  //   const result = await toolkit.diff(cx, {
-  //     stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
-  //   });
+  test('returns diff', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-bucket');
+    const result = await toolkit.diff(cx, {
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+    });
 
-  //   // THEN
-  //   expect(result).toMatchObject(expect.objectContaining({
-  //     resources: {
-  //       diffs: expect.objectContaining({
-  //         MyBucketF68F3FF0: expect.objectContaining({
-  //           isAddition: true,
-  //           isRemoval: false,
-  //           oldValue: undefined,
-  //           newValue: {
-  //             Type: 'AWS::S3::Bucket',
-  //             UpdateReplacePolicy: 'Retain',
-  //             DeletionPolicy: 'Retain',
-  //             Metadata: { 'aws:cdk:path': 'Stack1/MyBucket/Resource' },
-  //           },
-  //         }),
-  //       }),
-  //     },
-  //   }));
-  // });
+    // THEN
+    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+      resources: {
+        diffs: expect.objectContaining({
+          MyBucketF68F3FF0: expect.objectContaining({
+            isAddition: true,
+            isRemoval: false,
+            oldValue: undefined,
+            newValue: {
+              Type: 'AWS::S3::Bucket',
+              UpdateReplacePolicy: 'Retain',
+              DeletionPolicy: 'Retain',
+              Metadata: { 'aws:cdk:path': 'Stack1/MyBucket/Resource' },
+            },
+          }),
+        }),
+      },
+    }));
+  });
+
+  test('returns multiple template diffs', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'two-empty-stacks');
+    const result = await toolkit.diff(cx, {
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+    });
+
+    // THEN
+    expect(result['Stack1']).toBeDefined();
+    expect(result['Stack2']).toBeDefined();
+  });
 
   test('only security diff', async () => {
     // WHEN
     const cx = await builderFixture(toolkit, 'stack-with-role');
-    await toolkit.diff(cx, {
+    const result = await toolkit.diff(cx, {
       stacks: { strategy: StackSelectionStrategy.PATTERN_MUST_MATCH_SINGLE, patterns: ['Stack1'] },
       securityOnly: true,
       method: DiffMethod.TemplateOnly({ compareAgainstProcessedTemplate: true }),
@@ -107,26 +117,26 @@ describe('diff', () => {
         formattedSecurityDiff: expect.stringContaining((chalk.underline(chalk.bold('IAM Statement Changes')))),
       }),
     }));
-    // TODO: uncomment when diff returns a value
-    // expect(result).toMatchObject(expect.objectContaining({
-    //   iamChanges: expect.objectContaining({
-    //     statements: expect.objectContaining({
-    //       additions: [expect.objectContaining({
-    //         actions: expect.objectContaining({
-    //           not: false,
-    //           values: ['sts:AssumeRole'],
-    //         }),
-    //         condition: undefined,
-    //         effect: 'Allow',
-    //         principals: expect.objectContaining({
-    //           not: false,
-    //           values: ['AWS:arn'],
-    //         }),
-    //       })],
-    //       removals: [],
-    //     }),
-    //   }),
-    // }));
+
+    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+      iamChanges: expect.objectContaining({
+        statements: expect.objectContaining({
+          additions: [expect.objectContaining({
+            actions: expect.objectContaining({
+              not: false,
+              values: ['sts:AssumeRole'],
+            }),
+            condition: undefined,
+            effect: 'Allow',
+            principals: expect.objectContaining({
+              not: false,
+              values: ['AWS:arn'],
+            }),
+          })],
+          removals: [],
+        }),
+      }),
+    }));
   });
 
   test('no security diff', async () => {
@@ -152,7 +162,7 @@ describe('diff', () => {
   test('TemplateOnly diff method does not try to find changeSet', async () => {
     // WHEN
     const cx = await builderFixture(toolkit, 'stack-with-bucket');
-    const result = await toolkit.diff(cx, {
+    await toolkit.diff(cx, {
       stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
       method: DiffMethod.TemplateOnly({ compareAgainstProcessedTemplate: true }),
     });
@@ -235,71 +245,70 @@ describe('diff', () => {
       })).rejects.toThrow(/There is no file at/);
     });
 
-    // TODO: uncomment when diff returns a value
-    // test('returns regular diff', async () => {
-    //   // WHEN
-    //   const cx = await builderFixture(toolkit, 'stack-with-bucket');
-    //   const result = await toolkit.diff(cx, {
-    //     stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
-    //     method: DiffMethod.LocalFile(path.join(__dirname, '..', '_fixtures', 'two-empty-stacks', 'cdk.out', 'Stack1.template.json')),
-    //   });
+    test('returns regular diff', async () => {
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-bucket');
+      const result = await toolkit.diff(cx, {
+        stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+        method: DiffMethod.LocalFile(path.join(__dirname, '..', '_fixtures', 'two-empty-stacks', 'cdk.out', 'Stack1.template.json')),
+      });
 
-    //   // THEN
-    //   expect(result).toMatchObject(expect.objectContaining({
-    //     resources: {
-    //       diffs: expect.objectContaining({
-    //         MyBucketF68F3FF0: expect.objectContaining({
-    //           isAddition: true,
-    //           isRemoval: false,
-    //           oldValue: undefined,
-    //           newValue: {
-    //             Type: 'AWS::S3::Bucket',
-    //             UpdateReplacePolicy: 'Retain',
-    //             DeletionPolicy: 'Retain',
-    //             Metadata: { 'aws:cdk:path': 'Stack1/MyBucket/Resource' },
-    //           },
-    //         }),
-    //       }),
-    //     },
-    //   }));
-    // });
+      // THEN
+      expect(result['Stack1']).toMatchObject(expect.objectContaining({
+        resources: {
+          diffs: expect.objectContaining({
+            MyBucketF68F3FF0: expect.objectContaining({
+              isAddition: true,
+              isRemoval: false,
+              oldValue: undefined,
+              newValue: {
+                Type: 'AWS::S3::Bucket',
+                UpdateReplacePolicy: 'Retain',
+                DeletionPolicy: 'Retain',
+                Metadata: { 'aws:cdk:path': 'Stack1/MyBucket/Resource' },
+              },
+            }),
+          }),
+        },
+      }));
+    });
 
-    // test('returns security diff', async () => {
-    //   // WHEN
-    //   const cx = await builderFixture(toolkit, 'stack-with-role');
-    //   const result = await toolkit.diff(cx, {
-    //     stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
-    //     securityOnly: true,
-    //     method: DiffMethod.LocalFile(path.join(__dirname, '..', '_fixtures', 'two-empty-stacks', 'cdk.out', 'Stack1.template.json')),
-    //   });
+    test('returns security diff', async () => {
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      const result = await toolkit.diff(cx, {
+        stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+        securityOnly: true,
+        method: DiffMethod.LocalFile(path.join(__dirname, '..', '_fixtures', 'two-empty-stacks', 'cdk.out', 'Stack1.template.json')),
+      });
 
-    //   // THEN
-    //   expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
-    //     action: 'diff',
-    //     level: 'warn',
-    //     code: 'CDK_TOOLKIT_W0000',
-    //     message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening)'),
-    //   }));
-    //   expect(result).toMatchObject(expect.objectContaining({
-    //     iamChanges: expect.objectContaining({
-    //       statements: expect.objectContaining({
-    //         additions: [expect.objectContaining({
-    //           actions: expect.objectContaining({
-    //             not: false,
-    //             values: ['sts:AssumeRole'],
-    //           }),
-    //           condition: undefined,
-    //           effect: 'Allow',
-    //           principals: expect.objectContaining({
-    //             not: false,
-    //             values: ['AWS:arn'],
-    //           }),
-    //         })],
-    //         removals: [],
-    //       }),
-    //     }),
-    //   }));
-    // });
+      // THEN
+      expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        action: 'diff',
+        level: 'warn',
+        code: 'CDK_TOOLKIT_W0000',
+        message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening)'),
+      }));
+      expect(result['Stack1']).toMatchObject(expect.objectContaining({
+        iamChanges: expect.objectContaining({
+          statements: expect.objectContaining({
+            additions: [expect.objectContaining({
+              actions: expect.objectContaining({
+                not: false,
+                values: ['sts:AssumeRole'],
+              }),
+              condition: undefined,
+              effect: 'Allow',
+              principals: expect.objectContaining({
+                not: false,
+                values: ['AWS:arn'],
+              }),
+            })],
+            removals: [],
+          }),
+        }),
+      }));
+    });
   });
 
   test('action disposes of assembly produced by source', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -82,14 +82,48 @@ describe('diff', () => {
 
   test('returns multiple template diffs', async () => {
     // WHEN
-    const cx = await builderFixture(toolkit, 'two-empty-stacks');
+    const cx = await builderFixture(toolkit, 'two-different-stacks');
     const result = await toolkit.diff(cx, {
       stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
     });
 
+    console.log(JSON.stringify(result));
+
     // THEN
-    expect(result['Stack1']).toBeDefined();
-    expect(result['Stack2']).toBeDefined();
+    expect(result['Stack1']).toMatchObject(expect.objectContaining({
+      resources: {
+        diffs: expect.objectContaining({
+          MyBucketF68F3FF0: expect.objectContaining({
+            isAddition: true,
+            isRemoval: false,
+            oldValue: undefined,
+            newValue: {
+              Type: 'AWS::S3::Bucket',
+              UpdateReplacePolicy: 'Retain',
+              DeletionPolicy: 'Retain',
+              Metadata: { 'aws:cdk:path': 'Stack1/MyBucket/Resource' },
+            },
+          }),
+        }),
+      },
+    }));
+    expect(result['Stack2']).toMatchObject(expect.objectContaining({
+      resources: {
+        diffs: expect.objectContaining({
+          MyQueueE6CA6235: expect.objectContaining({
+            isAddition: true,
+            isRemoval: false,
+            oldValue: undefined,
+            newValue: {
+              Type: 'AWS::SQS::Queue',
+              UpdateReplacePolicy: 'Delete',
+              DeletionPolicy: 'Delete',
+              Metadata: { 'aws:cdk:path': 'Stack2/MyQueue/Resource' },
+            },
+          }),
+        }),
+      },
+    }));
   });
 
   test('only security diff', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -87,8 +87,6 @@ describe('diff', () => {
       stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
     });
 
-    console.log(JSON.stringify(result));
-
     // THEN
     expect(result['Stack1']).toMatchObject(expect.objectContaining({
       resources: {

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -314,7 +314,6 @@ export class CdkToolkit {
           templateInfo: {
             oldTemplate: currentTemplate,
             newTemplate: stack,
-            stackName: stack.displayName,
             changeSet,
             isImport: !!resourcesToImport,
             nestedStacks,


### PR DESCRIPTION
`toolkit.diff()` now returns a `TemplateDiff` for each stack it diffs.

Closes https://github.com/aws/aws-cdk/issues/33182

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
