### PR TITLE
feat(toolkit-lib): make the plugin host configurable

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -756,6 +756,12 @@ const tmpToolkitHelpers = configureProject(
         target: 'es2022',
         lib: ['es2022', 'esnext.disposable', 'dom'],
         module: 'NodeNext',
+
+        // Temporarily, because it makes it impossible for us to use @internal functions
+        // from other packages. Annoyingly, VSCode won't show an error if you use @internal
+        // because it looks at the .ts, but the compilation will fail because it will use
+        // the .d.ts.
+        stripInternal: false,
       },
     },
 

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/api/aws-auth/credential-plugins.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/api/aws-auth/credential-plugins.ts
@@ -4,8 +4,8 @@ import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from '@smit
 import { credentialsAboutToExpire, makeCachingProvider } from './provider-caching';
 import { formatErrorMessage } from '../../util';
 import { IO, type IoHelper } from '../io/private';
+import type { PluginHost } from '../plugin';
 import type { Mode } from '../plugin/mode';
-import type { PluginHost } from '../plugin/plugin';
 import { AuthenticationError } from '../toolkit-error';
 
 /**
@@ -22,12 +22,8 @@ import { AuthenticationError } from '../toolkit-error';
  */
 export class CredentialPlugins {
   private readonly cache: { [key: string]: PluginCredentialsFetchResult | undefined } = {};
-  private readonly host: PluginHost;
-  private readonly ioHelper: IoHelper;
 
-  constructor(host: PluginHost, ioHelper: IoHelper) {
-    this.host = host;
-    this.ioHelper = ioHelper;
+  constructor(private readonly host: PluginHost, private readonly ioHelper: IoHelper) {
   }
 
   public async fetchCredentialsFor(awsAccountId: string, mode: Mode): Promise<PluginCredentialsFetchResult | undefined> {

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/context-providers/index.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/context-providers/index.ts
@@ -16,8 +16,7 @@ import { TRANSIENT_CONTEXT_KEY } from '../api/context';
 import { replaceEnvPlaceholders } from '../api/environment';
 import { IO } from '../api/io/private';
 import type { IoHelper } from '../api/io/private';
-import { PluginHost } from '../api/plugin';
-import type { ContextProviderPlugin } from '../api/plugin';
+import type { PluginHost, ContextProviderPlugin } from '../api/plugin';
 import { ContextProviderError } from '../api/toolkit-error';
 import { formatErrorMessage } from '../util';
 
@@ -72,6 +71,7 @@ export async function provideContextValues(
   missingValues: cxschema.MissingContext[],
   context: Context,
   sdk: SdkProvider,
+  pluginHost: PluginHost,
   ioHelper: IoHelper,
 ) {
   for (const missingContext of missingValues) {
@@ -83,7 +83,7 @@ export async function provideContextValues(
 
     let factory;
     if (providerName.startsWith(`${PLUGIN_PROVIDER_PREFIX}:`)) {
-      const plugin = PluginHost.instance.contextProviderPlugins[providerName.substring(PLUGIN_PROVIDER_PREFIX.length + 1)];
+      const plugin = pluginHost.contextProviderPlugins[providerName.substring(PLUGIN_PROVIDER_PREFIX.length + 1)];
       if (!plugin) {
         // eslint-disable-next-line max-len
         throw new ContextProviderError(`Unrecognized plugin context provider name: ${missingContext.provider}.`);

--- a/packages/@aws-cdk/tmp-toolkit-helpers/src/context-providers/security-groups.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/src/context-providers/security-groups.ts
@@ -60,8 +60,7 @@ export class SecurityGroupContextProviderPlugin implements ContextProviderPlugin
 }
 
 /**
- * TODO: We intend this to be @*internal but a test in aws-cdk depends on it.
- * Put the tag back later.
+ * @internal
  */
 export function hasAllTrafficEgress(securityGroup: SecurityGroup) {
   let hasAllTrafficCidrV4 = false;

--- a/packages/@aws-cdk/tmp-toolkit-helpers/tsconfig.dev.json
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/tsconfig.dev.json
@@ -24,7 +24,7 @@
     "strict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,

--- a/packages/@aws-cdk/tmp-toolkit-helpers/tsconfig.json
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/tsconfig.json
@@ -26,7 +26,7 @@
     "strict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
-    "stripInternal": true,
+    "stripInternal": false,
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/context-aware-source.ts
@@ -103,6 +103,7 @@ export class ContextAwareCloudAssemblySource implements ICloudAssemblySource {
             assembly.manifest.missing,
             this.context,
             this.props.services.sdkProvider,
+            this.props.services.pluginHost,
             this.ioHelper,
           );
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/shared-public.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/shared-public.ts
@@ -20,5 +20,6 @@ export type {
 } from '../../../tmp-toolkit-helpers/src/api/io/io-message';
 export type { IIoHost } from '../../../tmp-toolkit-helpers/src/api/io/io-host';
 export type { ToolkitAction } from '../../../tmp-toolkit-helpers/src/api/io/toolkit-action';
+export { PluginHost } from '../../../tmp-toolkit-helpers/src/api/plugin/plugin';
 
 export * from '../../../tmp-toolkit-helpers/src/payloads';

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
@@ -1,7 +1,7 @@
 
 import type { ICloudAssemblySource } from '../../api/cloud-assembly';
 import { StackAssembly } from '../../api/cloud-assembly/private';
-import type { SdkProvider, IoHelper } from '../../api/shared-private';
+import type { SdkProvider, IoHelper, PluginHost } from '../../api/shared-private';
 
 /**
  * Helper struct to pass internal services around.
@@ -9,6 +9,7 @@ import type { SdkProvider, IoHelper } from '../../api/shared-private';
 export interface ToolkitServices {
   sdkProvider: SdkProvider;
   ioHelper: IoHelper;
+  pluginHost: PluginHost;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/_fixtures/stack-with-defined-env/app.js
+++ b/packages/@aws-cdk/toolkit-lib/test/_fixtures/stack-with-defined-env/app.js
@@ -1,0 +1,12 @@
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as core from 'aws-cdk-lib/core';
+
+const app = new core.App({ autoSynth: false });
+const stack = new core.Stack(app, 'Stack1', {
+  env: {
+    account: '11111111111',
+    region: 'us-east-1',
+  },
+});
+new s3.Bucket(stack, 'MyBucket');
+app.synth();

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
@@ -24,7 +24,7 @@ import type { AwsCredentialIdentity } from '@smithy/types';
 import { mockClient } from 'aws-sdk-client-mock';
 import { type Account } from 'cdk-assets';
 import { TestIoHost } from './test-io-host';
-import { SDK, SdkProvider, CloudFormationStack } from '../../lib/api/shared-private';
+import { SDK, SdkProvider, CloudFormationStack, PluginHost } from '../../lib/api/shared-private';
 
 export const FAKE_CREDENTIALS: AwsCredentialIdentity = {
   accessKeyId: 'ACCESS',
@@ -144,7 +144,7 @@ export const setDefaultSTSMocks = () => {
  */
 export class MockSdkProvider extends SdkProvider {
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new TestIoHost().asHelper('sdk'));
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new PluginHost(), new TestIoHost().asHelper('sdk'));
   }
 
   public defaultAccount(): Promise<Account | undefined> {

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/plugins.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/plugins.test.ts
@@ -1,0 +1,60 @@
+import type { PluginProviderResult } from '@aws-cdk/cli-plugin-contract';
+import { StackSelectionStrategy } from '../../lib';
+import { SdkProvider } from '../../lib/api/shared-private';
+import { Toolkit } from '../../lib/toolkit/toolkit';
+import { appFixture, TestIoHost } from '../_helpers';
+import { MockSdk } from '../_helpers/mock-sdk';
+
+test('two toolkit instances have independent plugin hosts by default', () => {
+  // GIVEN
+  const toolkit1 = new Toolkit();
+  const toolkit2 = new Toolkit();
+
+  // WHEN
+  toolkit1.pluginHost.registerCredentialProviderSource({
+    name: 'test',
+    isAvailable: () => Promise.resolve(false),
+    canProvideCredentials: () => Promise.resolve(false),
+    getProvider: () => Promise.reject('should not be called'),
+  });
+
+  // THEN
+  expect(toolkit1.pluginHost.credentialProviderSources.length).toEqual(1);
+  expect(toolkit2.pluginHost.credentialProviderSources.length).toEqual(0);
+});
+
+test('credential plugins registered into toolkit are queried', async () => {
+  // GIVEN
+  const toolkit = new Toolkit({
+    ioHost: new TestIoHost(),
+  });
+
+  const canProvideCredentials = jest.fn().mockResolvedValue(true);
+  const getProvider = jest.fn().mockResolvedValue({
+    accessKeyId: 'a',
+    secretAccessKey: 's',
+  } satisfies PluginProviderResult);
+
+  toolkit.pluginHost.registerCredentialProviderSource({
+    name: 'test plugin',
+    isAvailable: () => Promise.resolve(true),
+    canProvideCredentials,
+    getProvider,
+  });
+
+  const mockSdk = jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+
+  // WHEN - simplest API that uses some credentials
+  const cx = await appFixture(toolkit, 'stack-with-defined-env');
+  // We expect this to fail because we didn't really put in the effort to make the mocks return
+  // something sensible.
+  await expect(toolkit.rollback(cx, {
+    stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+  })).rejects.toThrow();
+
+  // THEN
+  expect(canProvideCredentials).toHaveBeenCalled();
+  expect(getProvider).toHaveBeenCalledWith('11111111111', 0, expect.anything());
+
+  mockSdk.mockRestore();
+});

--- a/packages/aws-cdk/lib/cli/singleton-plugin-host.ts
+++ b/packages/aws-cdk/lib/cli/singleton-plugin-host.ts
@@ -1,0 +1,9 @@
+/**
+ * The singleton plugin host
+ *
+ * This is only a concept in the CLI, not in the toolkit library.
+ */
+
+import { PluginHost } from '../../../@aws-cdk/tmp-toolkit-helpers';
+
+export const GLOBAL_PLUGIN_HOST = new PluginHost();

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -5,6 +5,7 @@ import { BorrowedAssembly } from '../../../@aws-cdk/toolkit-lib/lib/api/cloud-as
 import { ToolkitError } from '../api';
 import type { SdkProvider } from '../api/aws-auth';
 import { IO, type IoHelper } from '../api-private';
+import { GLOBAL_PLUGIN_HOST } from '../cli/singleton-plugin-host';
 import type { Configuration } from '../cli/user-configuration';
 import * as contextproviders from '../context-providers';
 
@@ -109,6 +110,7 @@ export class CloudExecutable implements ICloudAssemblySource {
             assembly.manifest.missing,
             this.props.configuration.context,
             this.props.sdkProvider,
+            GLOBAL_PLUGIN_HOST,
             this.props.ioHelper,
           );
 

--- a/packages/aws-cdk/lib/legacy-aws-auth.ts
+++ b/packages/aws-cdk/lib/legacy-aws-auth.ts
@@ -9,6 +9,7 @@
 import type { AwsCredentialIdentityProvider, Logger, NodeHttpHandlerOptions } from '@smithy/types';
 import { SdkProvider as SdkProviderCurrentVersion } from './api/aws-auth';
 import { CliIoHost } from './cli/io-host';
+import { GLOBAL_PLUGIN_HOST } from './cli/singleton-plugin-host';
 
 /**
  * @deprecated
@@ -96,6 +97,7 @@ export class SdkProvider {
     return SdkProviderCurrentVersion.withAwsCliCompatibleDefaults({
       ...options,
       ioHelper: CliIoHost.instance().asIoHelper(),
+      pluginHost: GLOBAL_PLUGIN_HOST,
     });
   }
 
@@ -105,6 +107,13 @@ export class SdkProvider {
     requestHandler: NodeHttpHandlerOptions = {},
     logger?: Logger,
   ) {
-    return new SdkProviderCurrentVersion(defaultCredentialProvider, defaultRegion, requestHandler, CliIoHost.instance().asIoHelper(), logger);
+    return new SdkProviderCurrentVersion(
+      defaultCredentialProvider,
+      defaultRegion,
+      requestHandler,
+      GLOBAL_PLUGIN_HOST,
+      CliIoHost.instance().asIoHelper(),
+      logger,
+    );
   }
 }

--- a/packages/aws-cdk/test/_helpers/mock-sdk.ts
+++ b/packages/aws-cdk/test/_helpers/mock-sdk.ts
@@ -25,6 +25,7 @@ import { type Account } from 'cdk-assets';
 import { SDK, SdkProvider } from '../../lib/api/aws-auth';
 import { CloudFormationStack } from '../../lib/api/cloudformation';
 import { TestIoHost } from './io-host';
+import { PluginHost } from '../../lib/api/plugin';
 
 export const FAKE_CREDENTIALS: AwsCredentialIdentity = {
   accessKeyId: 'ACCESS',
@@ -146,7 +147,7 @@ export class MockSdkProvider extends SdkProvider {
   private defaultAccounts: string[] = [];
 
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new TestIoHost().asHelper('sdk'));
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new PluginHost(), new TestIoHost().asHelper('sdk'));
   }
 
   public returnsDefaultAccounts(...accounts: string[]) {

--- a/packages/aws-cdk/test/api/aws-auth/credential-plugins.test.ts
+++ b/packages/aws-cdk/test/api/aws-auth/credential-plugins.test.ts
@@ -1,8 +1,8 @@
 import type { PluginProviderResult, SDKv2CompatibleCredentials } from '@aws-cdk/cli-plugin-contract';
 import { CredentialPlugins } from '../../../lib/api/aws-auth';
-import { PluginHost } from '../../../lib/api/plugin';
 import { Mode } from '../../../lib/api/plugin';
 import { TestIoHost } from '../../_helpers/io-host';
+import { GLOBAL_PLUGIN_HOST } from '../../../lib/cli/singleton-plugin-host';
 
 const ioHost = new TestIoHost();
 const ioHelper = ioHost.asHelper('deploy');
@@ -14,7 +14,7 @@ test('returns credential from plugin', async () => {
     secretAccessKey: 'bbb',
     getPromise: () => Promise.resolve(),
   } satisfies SDKv2CompatibleCredentials;
-  const host = PluginHost.instance;
+  const host = GLOBAL_PLUGIN_HOST;
 
   host.registerCredentialProviderSource({
     name: 'Fake',

--- a/packages/aws-cdk/test/api/plugin/credential-plugin.test.ts
+++ b/packages/aws-cdk/test/api/plugin/credential-plugin.test.ts
@@ -170,7 +170,7 @@ function mockCredentialPlugin(p: CredentialProviderSource) {
     };
   }, { virtual: true });
 
-  host.load(THE_PLUGIN);
+  host._doLoad(THE_PLUGIN);
 }
 
 async function fetchNow() {

--- a/packages/aws-cdk/test/api/plugin/plugin-host.test.ts
+++ b/packages/aws-cdk/test/api/plugin/plugin-host.test.ts
@@ -20,7 +20,7 @@ test('load a plugin using the PluginHost', () => {
     };
   }, { virtual: true });
 
-  host.load(THE_PLUGIN);
+  host._doLoad(THE_PLUGIN);
 });
 
 test('fail to load a plugin using the PluginHost', () => {
@@ -31,7 +31,7 @@ test('fail to load a plugin using the PluginHost', () => {
     return {};
   }, { virtual: true });
 
-  expect(() => host.load(THE_PLUGIN)).toThrow(/Unable to load plug-in/);
+  expect(() => host._doLoad(THE_PLUGIN)).toThrow(/Unable to load plug-in/);
 });
 
 test('plugin that registers a Credential Provider', () => {
@@ -52,7 +52,7 @@ test('plugin that registers a Credential Provider', () => {
     };
   }, { virtual: true });
 
-  host.load(THE_PLUGIN);
+  host._doLoad(THE_PLUGIN);
 
   expect(host.credentialProviderSources).toHaveLength(1);
 });
@@ -73,7 +73,7 @@ test('plugin that registers a Context Provider', () => {
     };
   }, { virtual: true });
 
-  host.load(THE_PLUGIN);
+  host._doLoad(THE_PLUGIN);
 
   expect(Object.keys(host.contextProviderPlugins)).toHaveLength(1);
 });
@@ -91,7 +91,7 @@ test('plugin that registers an invalid Context Provider throws', () => {
   }, { virtual: true });
 
   try {
-    host.load(THE_PLUGIN);
+    host._doLoad(THE_PLUGIN);
     expect(true).toBe(false); // should not happen
   } catch(e: any) {
     expect(e).toHaveProperty('cause');

--- a/packages/aws-cdk/test/context-providers/generic.test.ts
+++ b/packages/aws-cdk/test/context-providers/generic.test.ts
@@ -26,7 +26,7 @@ test('errors are reported into the context value', async () => {
   // WHEN
   await contextproviders.provideContextValues([
     { key: 'asdf', props: { account: '1234', region: 'us-east-1' }, provider: TEST_PROVIDER },
-  ], context, mockSDK, ioHelper);
+  ], context, mockSDK, new PluginHost(), ioHelper);
 
   // THEN - error is now in context
 
@@ -63,7 +63,7 @@ test('lookup role ARN is resolved', async () => {
       },
       provider: TEST_PROVIDER,
     },
-  ], context, mockSDK, ioHelper);
+  ], context, mockSDK, new PluginHost(), ioHelper);
 
   // THEN - Value gets resolved
   expect(context.get('asdf')).toEqual('some resolved value');
@@ -81,7 +81,7 @@ test('errors are marked transient', async () => {
   // WHEN
   await contextproviders.provideContextValues([
     { key: 'asdf', props: { account: '1234', region: 'us-east-1' }, provider: TEST_PROVIDER },
-  ], context, mockSDK, ioHelper);
+  ], context, mockSDK, new PluginHost(), ioHelper);
 
   // THEN - error is marked transient
   expect(context.get('asdf')[TRANSIENT_CONTEXT_KEY]).toBeTruthy();
@@ -91,7 +91,8 @@ test('context provider can be registered using PluginHost', async () => {
   let called = false;
 
   // GIVEN
-  PluginHost.instance.registerContextProviderAlpha('prov', {
+  const ph = new PluginHost();
+  ph.registerContextProviderAlpha('prov', {
     async getValue(_: {[key: string]: any}): Promise<any> {
       called = true;
       return '';
@@ -102,7 +103,7 @@ test('context provider can be registered using PluginHost', async () => {
   // WHEN
   await contextproviders.provideContextValues([
     { key: 'asdf', props: { account: '1234', region: 'us-east-1', pluginName: 'prov' }, provider: PLUGIN_PROVIDER },
-  ], context, mockSDK, ioHelper);
+  ], context, mockSDK, ph, ioHelper);
 
   // THEN - error is marked transient
   expect(called).toEqual(true);
@@ -110,7 +111,8 @@ test('context provider can be registered using PluginHost', async () => {
 
 test('plugin context provider can be called without account/region', async () => {
   // GIVEN
-  PluginHost.instance.registerContextProviderAlpha('prov', {
+  const ph = new PluginHost();
+  ph.registerContextProviderAlpha('prov', {
     async getValue(_: {[key: string]: any}): Promise<any> {
       return 'yay';
     },
@@ -120,7 +122,7 @@ test('plugin context provider can be called without account/region', async () =>
   // WHEN
   await contextproviders.provideContextValues([
     { key: 'asdf', props: { banana: 'yellow', pluginName: 'prov' } as any, provider: PLUGIN_PROVIDER },
-  ], context, mockSDK, ioHelper);
+  ], context, mockSDK, ph, ioHelper);
 
   // THEN - error is marked transient
   expect(context.get('asdf')).toEqual('yay');


### PR DESCRIPTION
This makes the plugin host configurable for toolkit users:

## Design decisions

- Every `Toolkit` instance gets a fresh `PluginHost` by default (not a global singleton `PluginHost`)
- ...in fact, the concept of a global singleton `PluginHost` gets fully moved to the CLI. That concept disappears from the toolkit and the helpers, and all functions that used to implicitly assume a global plugin host now get an explicit parameter, that defaults to a fresh plugin host if not supplied.

These choices lead to a lot of downstream test changes.

- Plugin module resolution, module deduplication and logging was moved from the CLI into the plugin host.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
