### PR TITLE
fix: Symbol.asyncDispose is not defined on the current JavaScript platform

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/cached-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/cached-source.ts
@@ -1,3 +1,4 @@
+import '../../private/dispose-polyfill';
 import type * as cxapi from '@aws-cdk/cx-api';
 import { BorrowedAssembly } from './private/borrowed-assembly';
 import type { ICloudAssemblySource, IReadableCloudAssembly } from './types';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/borrowed-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/borrowed-assembly.ts
@@ -1,3 +1,4 @@
+import '../../../private/dispose-polyfill';
 import type * as cxapi from '@aws-cdk/cx-api';
 import type { IReadableCloudAssembly } from '../types';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -1,3 +1,4 @@
+import '../../../private/dispose-polyfill';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { format } from 'node:util';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
@@ -1,3 +1,4 @@
+import '../../../private/dispose-polyfill';
 import { major } from 'semver';
 import type { IoHelper } from '../../shared-private';
 import { BaseStackAssembly, StackCollection, ExtendedStackSelection as CliExtendedStackSelection } from '../../shared-private';
@@ -5,11 +6,6 @@ import { ToolkitError } from '../../shared-public';
 import type { StackSelector } from '../stack-selector';
 import { ExpandStackSelection, StackSelectionStrategy } from '../stack-selector';
 import type { IReadableCloudAssembly } from '../types';
-
-if (!Symbol.asyncDispose) {
-  // eslint-disable-next-line @cdklabs/no-throw-default-error
-  throw new Error('Symbol.asyncDispose is not defined on the current JavaScript platform!');
-}
 
 /**
  * A single Cloud Assembly wrapped to provide additional stack operations.

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1,3 +1,4 @@
+import '../private/dispose-polyfill';
 import * as path from 'node:path';
 import type { TemplateDiff } from '@aws-cdk/cloudformation-diff';
 import * as cxapi from '@aws-cdk/cx-api';


### PR DESCRIPTION
We have a polyfill file that should be imported before `Symbol.asyncDispose` is used anywhere. The polyfill file is imported in the entry point of `@aws-cdk/toolkit-lib`, but we can't guarantee that all imports go through the entry point.

Instead, import the polyfill in every file where `Symbol.asyncDispose` is used.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
