### PR TITLE
chore: `@aws-cdk/toolkit-lib` is now a part of the toolkit packages

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -174,6 +174,7 @@ function transitiveToolkitPackages(thisPkg: string) {
     '@aws-cdk/tmp-toolkit-helpers',
     '@aws-cdk/cloud-assembly-schema',
     '@aws-cdk/cloudformation-diff',
+    '@aws-cdk/toolkit-lib',
   ];
 
   return transitiveFeaturesAndFixes(thisPkg, toolkitPackages.filter(name => name !== thisPkg));

--- a/packages/@aws-cdk/cli-lib-alpha/.projen/tasks.json
+++ b/packages/@aws-cdk/cli-lib-alpha/.projen/tasks.json
@@ -33,7 +33,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts copyVersion:../../../packages/aws-cdk/package.json append:-alpha.0",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib",
         "MAJOR": "2"
       },
       "steps": [
@@ -300,7 +300,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts copyVersion:../../../packages/aws-cdk/package.json append:-alpha.0",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/integ-runner@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib"
       },
       "steps": [
         {
@@ -198,7 +198,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/integ-runner@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../tmp-toolkit-helpers ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib"
       },
       "steps": [
         {

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -33,7 +33,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRcOrMinor",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff ../@aws-cdk/toolkit-lib",
         "MAJOR": "2"
       },
       "steps": [
@@ -210,7 +210,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRcOrMinor",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff ../@aws-cdk/toolkit-lib"
       },
       "steps": [
         {

--- a/packages/cdk/.projen/tasks.json
+++ b/packages/cdk/.projen/tasks.json
@@ -33,7 +33,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts copyVersion:../../packages/aws-cdk/package.json",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff ../@aws-cdk/toolkit-lib",
         "MAJOR": "2"
       },
       "steps": [
@@ -193,7 +193,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts copyVersion:../../packages/aws-cdk/package.json",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../aws-cdk ../@aws-cdk/tmp-toolkit-helpers ../@aws-cdk/cloud-assembly-schema ../@aws-cdk/cloudformation-diff ../@aws-cdk/toolkit-lib"
       },
       "steps": [
         {


### PR DESCRIPTION
Until we sort out https://github.com/aws/aws-cdk-cli/pull/364 properly, lets at least do this so that toolkit changes trigger a CLI release.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
