### PR TITLE
chore(toolkit-lib): diff test fails if AWS credentials set

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -6,6 +6,7 @@ import { RequireApproval } from '../../lib/api/shared-private';
 import { StackSelectionStrategy } from '../../lib/api/shared-public';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
+import { MockSdkProvider } from '../_helpers/mock-sdk';
 
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
@@ -18,6 +19,8 @@ beforeEach(() => {
   toolkit = new Toolkit({ ioHost });
 
   // Some default implementations
+  jest.spyOn(apis.SdkProvider, 'withAwsCliCompatibleDefaults').mockResolvedValue(new MockSdkProvider());
+
   jest.spyOn(apis.Deployments.prototype, 'readCurrentTemplateWithNestedStacks').mockResolvedValue({
     deployedRootTemplate: {
       Parameters: {},


### PR DESCRIPTION
The `diff.test` times out trying to get the current account from actual AWS credentials, if they happen to be in the environment where unit tests are run.

Make sure a fake SDK provider is used that doesn't do any of that stuff.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
