### PR TITLE
feat(toolkit-lib): make base credentials configurable

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/types.ts
@@ -1,12 +1,23 @@
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+import type { SdkProviderServices } from '../shared-private';
+import { AwsCliCompatible } from '../shared-private';
 
 /**
  * Options for the default SDK provider
  */
 export interface SdkConfig {
   /**
-   * Profile to read from ~/.aws
+   * The base credentials and region used to seed the Toolkit with
+   *
+   * @default BaseCredentials.awsCliCompatible()
+   */
+  readonly baseCredentials?: BaseCredentials;
+
+  /**
+   * Profile to read from ~/.aws for base credentials
    *
    * @default - No profile
+   * @deprecated Use `baseCredentials` instead
    */
   readonly profile?: string;
 
@@ -33,4 +44,124 @@ export interface SdkHttpOptions {
    * @default No certificate bundle
    */
   readonly caBundlePath?: string;
+}
+
+export abstract class BaseCredentials {
+  /**
+   * Use no base credentials
+   *
+   * There will be no current account and no current region during synthesis. To
+   * successfully deploy with this set of base credentials:
+   *
+   * - The CDK app must provide concrete accounts and regions during synthesis
+   * - Credential plugins must be installed to provide credentials for those
+   *   accounts.
+   */
+  public static none(): BaseCredentials {
+    return new class extends BaseCredentials {
+      public async makeSdkConfig(): Promise<SdkBaseConfig> {
+        return {
+          credentialProvider: () => {
+            // eslint-disable-next-line @cdklabs/no-throw-default-error
+            throw new Error('No credentials available due to BaseCredentials.none()');
+          },
+        };
+      }
+
+      public toString() {
+        return 'BaseCredentials.none()';
+      }
+    };
+  }
+
+  /**
+   * Obtain base credentials and base region the same way the AWS CLI would
+   *
+   * Credentials and region will be read from the environment first, falling back
+   * to INI files or other sources if available.
+   *
+   * The profile name is configurable.
+   */
+  public static awsCliCompatible(options: AwsCliCompatibleOptions = {}): BaseCredentials {
+    return new class extends BaseCredentials {
+      public makeSdkConfig(services: SdkProviderServices): Promise<SdkBaseConfig> {
+        const awsCli = new AwsCliCompatible(services.ioHelper, services.requestHandler ?? {}, services.logger);
+        return awsCli.baseConfig(options.profile);
+      }
+
+      public toString() {
+        return `BaseCredentials.awsCliCompatible(${JSON.stringify(options)})`;
+      }
+    };
+  }
+
+  /**
+   * Use a custom SDK identity provider for the base credentials
+   *
+   * If your provider uses STS calls to obtain base credentials, you must make
+   * sure to also configure the necessary HTTP options (like proxy and user
+   * agent) and the region on the STS client directly; the toolkit code cannot
+   * do this for you.
+   */
+  public static custom(options: CustomBaseCredentialsOption): BaseCredentials {
+    return new class extends BaseCredentials {
+      public makeSdkConfig(): Promise<SdkBaseConfig> {
+        return Promise.resolve({
+          credentialProvider: options.provider,
+          defaultRegion: options.region,
+        });
+      }
+
+      public toString() {
+        return `BaseCredentials.custom(${JSON.stringify({
+          ...options,
+          provider: '...',
+        })})`;
+      }
+    };
+  }
+
+  /**
+   * Make SDK config from the BaseCredentials settings
+   */
+  public abstract makeSdkConfig(services: SdkProviderServices): Promise<SdkBaseConfig>;
+}
+
+export interface AwsCliCompatibleOptions {
+  /**
+   * The profile to read from `~/.aws/credentials`.
+   *
+   * If not supplied the environment variable AWS_PROFILE will be used.
+   *
+   * @default - Use environment variable if set.
+   */
+  readonly profile?: string;
+}
+
+export interface CustomBaseCredentialsOption {
+  /**
+   * The credentials provider to use to obtain base credentials
+   *
+   * If your provider uses STS calls to obtain base credentials, you must make
+   * sure to also configure the necessary HTTP options (like proxy and user
+   * agent) on the STS client directly; the toolkit code cannot do this for you.
+   */
+  readonly provider: AwsCredentialIdentityProvider;
+
+  /**
+   * The default region to synthesize for
+   *
+   * CDK applications can override this region. NOTE: this region will *not*
+   * affect any STS calls made by the given provider, if any. You need to configure
+   * your credential provider separately.
+   *
+   * @default 'us-east-1'
+   */
+  readonly region?: string;
+}
+
+export interface SdkBaseConfig {
+  readonly credentialProvider: AwsCredentialIdentityProvider;
+
+  readonly defaultRegion?: string;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/shared-private.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/shared-private.ts
@@ -4,6 +4,7 @@ export * from '../../../tmp-toolkit-helpers/src/api/io/private';
 export * from '../../../tmp-toolkit-helpers/src/private';
 export * from '../../../tmp-toolkit-helpers/src/api';
 export * as cfnApi from '../../../tmp-toolkit-helpers/src/api/deployments/cfn-api';
+export { makeRequestHandler } from '../../../tmp-toolkit-helpers/src/api/aws-auth/awscli-compatible';
 
 // Context Providers
 export * as contextproviders from '../../../tmp-toolkit-helpers/src/context-providers';

--- a/packages/@aws-cdk/toolkit-lib/test/_fixtures/stack-with-env-from-env/app.js
+++ b/packages/@aws-cdk/toolkit-lib/test/_fixtures/stack-with-env-from-env/app.js
@@ -1,0 +1,12 @@
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as core from 'aws-cdk-lib/core';
+
+const app = new core.App({ autoSynth: false });
+const stack = new core.Stack(app, 'Stack1', {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});
+new s3.Bucket(stack, 'MyBucket');
+app.synth();

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
@@ -24,7 +24,7 @@ import type { AwsCredentialIdentity } from '@smithy/types';
 import { mockClient } from 'aws-sdk-client-mock';
 import { type Account } from 'cdk-assets';
 import { TestIoHost } from './test-io-host';
-import { SDK, SdkProvider, CloudFormationStack, PluginHost } from '../../lib/api/shared-private';
+import { SDK, SdkProvider, CloudFormationStack } from '../../lib/api/shared-private';
 
 export const FAKE_CREDENTIALS: AwsCredentialIdentity = {
   accessKeyId: 'ACCESS',
@@ -144,7 +144,9 @@ export const setDefaultSTSMocks = () => {
  */
 export class MockSdkProvider extends SdkProvider {
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new PluginHost(), new TestIoHost().asHelper('sdk'));
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {
+      ioHelper: new TestIoHost().asHelper('sdk'),
+    });
   }
 
   public defaultAccount(): Promise<Account | undefined> {
@@ -161,6 +163,13 @@ export class MockSdkProvider extends SdkProvider {
 export class MockSdk extends SDK {
   constructor() {
     super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new TestIoHost().asHelper('sdk'));
+  }
+
+  public async currentAccount(): Promise<Account> {
+    return {
+      accountId: '123456789012',
+      partition: 'aws',
+    };
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
@@ -16,7 +16,6 @@ import { SdkProvider } from '../../lib/api/shared-private';
 import { Toolkit } from '../../lib/toolkit';
 import { TestIoHost, builderFixture, disposableCloudAssemblySource } from '../_helpers';
 import {
-  MockSdkProvider,
   MockSdk,
   mockCloudFormationClient,
   restoreSdkMocksToDefault,
@@ -25,18 +24,16 @@ import {
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
-const mockSdkProvider = new MockSdkProvider();
-
-// we don't need to use AWS CLI compatible defaults here, since everything is mocked anyway
-jest.spyOn(SdkProvider, 'withAwsCliCompatibleDefaults').mockResolvedValue(mockSdkProvider);
 
 beforeEach(() => {
   restoreSdkMocksToDefault();
   setDefaultSTSMocks();
   ioHost.notifySpy.mockClear();
 
-  mockSdkProvider.forEnvironment = jest.fn().mockImplementation(() => {
-    return { sdk: new MockSdk() };
+  jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+  jest.spyOn(SdkProvider.prototype, 'forEnvironment').mockResolvedValue({
+    sdk: new MockSdk(),
+    didAssumeRole: false,
   });
 });
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -6,7 +6,7 @@ import { RequireApproval } from '../../lib/api/shared-private';
 import { StackSelectionStrategy } from '../../lib/api/shared-public';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
-import { MockSdkProvider } from '../_helpers/mock-sdk';
+import { MockSdk } from '../_helpers/mock-sdk';
 
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
@@ -19,7 +19,7 @@ beforeEach(() => {
   toolkit = new Toolkit({ ioHost });
 
   // Some default implementations
-  jest.spyOn(apis.SdkProvider, 'withAwsCliCompatibleDefaults').mockResolvedValue(new MockSdkProvider());
+  jest.spyOn(apis.SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
 
   jest.spyOn(apis.Deployments.prototype, 'readCurrentTemplateWithNestedStacks').mockResolvedValue({
     deployedRootTemplate: {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -2,17 +2,15 @@ import { GetTemplateCommand, ListStacksCommand } from '@aws-sdk/client-cloudform
 import { StackSelectionStrategy, Toolkit } from '../../lib';
 import { SdkProvider } from '../../lib/api/shared-private';
 import { builderFixture, TestIoHost } from '../_helpers';
-import { mockCloudFormationClient, MockSdkProvider } from '../_helpers/mock-sdk';
+import { mockCloudFormationClient, MockSdk } from '../_helpers/mock-sdk';
 
 // these tests often run a bit longer than the default
 jest.setTimeout(10_000);
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
-const mockSdkProvider = new MockSdkProvider();
 
-// we don't need to use AWS CLI compatible defaults here, since everything is mocked anyway
-jest.spyOn(SdkProvider, 'withAwsCliCompatibleDefaults').mockResolvedValue(mockSdkProvider);
+jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
 
 beforeEach(() => {
   ioHost.notifySpy.mockClear();

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/base-credentials.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/base-credentials.test.ts
@@ -1,0 +1,74 @@
+import { BaseCredentials } from '../../lib/api/aws-auth/types';
+import { SdkProvider } from '../../lib/api/shared-private';
+import { Toolkit } from '../../lib/toolkit/toolkit';
+import { appFixture, TestIoHost } from '../_helpers';
+import { MockSdk } from '../_helpers/mock-sdk';
+
+let ioHost: TestIoHost;
+let makeSdk: jest.SpiedFunction<SdkProvider['_makeSdk']>;
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  ioHost = new TestIoHost();
+  makeSdk = jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+});
+
+test('custom credentials can be used for synth', async () => {
+  const customProvider = async () => ({ accessKeyId: 'a', secretAccessKey: 's' });
+  const toolkit = new Toolkit({
+    ioHost,
+    sdkConfig: {
+      baseCredentials: BaseCredentials.custom({
+        provider: customProvider,
+        region: 'south-pole-1',
+      }),
+    },
+  });
+
+  const cx = await appFixture(toolkit, 'stack-with-env-from-env');
+  await using asm = await toolkit.synth(cx);
+
+  expect(asm.cloudAssembly.getStackByName('Stack1').environment).toMatchObject({
+    account: '123456789012', // Returned from the MockSdk
+    region: 'south-pole-1', // Configured by the BaseCredentials
+  });
+  expect(makeSdk).toHaveBeenCalledWith(customProvider, expect.anything());
+});
+
+test('none credentials can be used for a self-defining stack', async () => {
+  const toolkit = new Toolkit({
+    ioHost,
+    sdkConfig: {
+      baseCredentials: BaseCredentials.none(),
+    },
+  });
+
+  const cx = await appFixture(toolkit, 'stack-with-defined-env');
+  await using asm = await toolkit.synth(cx);
+
+  expect(asm.cloudAssembly.getStackByName('Stack1').environment).toMatchObject({
+    account: '11111111111',
+    region: 'us-east-1',
+  });
+});
+
+test.each([
+  [BaseCredentials.awsCliCompatible({ profile: 'this-profile-doesnt-exist' }), true],
+  [BaseCredentials.custom({ provider: () => Promise.resolve({ accessKeyId: 'a', secretAccessKey: 's' }) }), false],
+  [BaseCredentials.none(), false],
+])('credentials %s respects environment variables: %p', async (baseCredentials, respectsEnv) => {
+  const toolkit = new Toolkit({
+    ioHost,
+    sdkConfig: { baseCredentials },
+  });
+
+  // We create the SdkProvider currently *inside* `appFixture`, so this needs to be set beforehand
+  process.env.AWS_REGION = 'south-pole-1';
+
+  const cx = await appFixture(toolkit, 'stack-with-env-from-env');
+  await using _ = await toolkit.synth(cx);
+
+  expect(makeSdk).toHaveBeenCalledWith(expect.anything(), respectsEnv ? 'south-pole-1' : 'us-east-1');
+
+  delete process.env.AWS_REGION;
+});

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -30,6 +30,7 @@ import { getMigrateScanType } from '../commands/migrate';
 import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
 import { GLOBAL_PLUGIN_HOST } from './singleton-plugin-host';
+import { makeRequestHandler } from '../../../@aws-cdk/toolkit-lib/lib/api/shared-private';
 /* eslint-disable max-len */
 /* eslint-disable @typescript-eslint/no-shadow */ // yargs
 
@@ -121,10 +122,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   const sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
     ioHelper,
     profile: configuration.settings.get(['profile']),
-    httpOptions: {
+    requestHandler: await makeRequestHandler(ioHelper, {
       proxyAddress: argv.proxy,
       caBundlePath: argv['ca-bundle-path'],
-    },
+    }),
     logger: new SdkToCliLogger(asIoHelper(ioHost, ioHost.currentAction as any)),
     pluginHost: GLOBAL_PLUGIN_HOST,
   });

--- a/packages/aws-cdk/lib/legacy-aws-auth.ts
+++ b/packages/aws-cdk/lib/legacy-aws-auth.ts
@@ -107,13 +107,11 @@ export class SdkProvider {
     requestHandler: NodeHttpHandlerOptions = {},
     logger?: Logger,
   ) {
-    return new SdkProviderCurrentVersion(
-      defaultCredentialProvider,
-      defaultRegion,
+    return new SdkProviderCurrentVersion(defaultCredentialProvider, defaultRegion, {
+      pluginHost: GLOBAL_PLUGIN_HOST,
+      ioHelper: CliIoHost.instance().asIoHelper(),
       requestHandler,
-      GLOBAL_PLUGIN_HOST,
-      CliIoHost.instance().asIoHelper(),
       logger,
-    );
+    });
   }
 }

--- a/packages/aws-cdk/test/_helpers/mock-sdk.ts
+++ b/packages/aws-cdk/test/_helpers/mock-sdk.ts
@@ -25,7 +25,6 @@ import { type Account } from 'cdk-assets';
 import { SDK, SdkProvider } from '../../lib/api/aws-auth';
 import { CloudFormationStack } from '../../lib/api/cloudformation';
 import { TestIoHost } from './io-host';
-import { PluginHost } from '../../lib/api/plugin';
 
 export const FAKE_CREDENTIALS: AwsCredentialIdentity = {
   accessKeyId: 'ACCESS',
@@ -147,7 +146,9 @@ export class MockSdkProvider extends SdkProvider {
   private defaultAccounts: string[] = [];
 
   constructor() {
-    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {}, new PluginHost(), new TestIoHost().asHelper('sdk'));
+    super(FAKE_CREDENTIAL_CHAIN, 'bermuda-triangle-1337', {
+      ioHelper: new TestIoHost().asHelper('sdk'),
+    });
   }
 
   public returnsDefaultAccounts(...accounts: string[]) {

--- a/packages/aws-cdk/test/api/aws-auth/awscli-compatible.test.ts
+++ b/packages/aws-cdk/test/api/aws-auth/awscli-compatible.test.ts
@@ -226,7 +226,7 @@ async function region(opts: {
       process.env.AWS_SHARED_CREDENTIALS_FILE = credentialsPath;
     }
 
-    return await new AwsCliCompatible(ioHelper).region(opts.profile);
+    return await new AwsCliCompatible(ioHelper, {}).region(opts.profile);
   } finally {
     fs.removeSync(workdir);
   }
@@ -243,7 +243,7 @@ describe('Session token', () => {
     delete process.env.AWS_SESSION_TOKEN;
     delete process.env.AMAZON_SESSION_TOKEN;
 
-    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper, {}).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toBeUndefined();
   });
@@ -252,7 +252,7 @@ describe('Session token', () => {
     process.env.AWS_SESSION_TOKEN = 'aaa';
     delete process.env.AMAZON_SESSION_TOKEN;
 
-    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper, {}).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });
@@ -261,7 +261,7 @@ describe('Session token', () => {
     delete process.env.AWS_SESSION_TOKEN;
     process.env.AMAZON_SESSION_TOKEN = 'aaa';
 
-    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper, {}).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });
@@ -270,7 +270,7 @@ describe('Session token', () => {
     process.env.AWS_SESSION_TOKEN = 'aaa';
     process.env.AMAZON_SESSION_TOKEN = 'bbb';
 
-    await new AwsCliCompatible(ioHelper).credentialChainBuilder();
+    await new AwsCliCompatible(ioHelper, {}).credentialChainBuilder();
 
     expect(process.env.AWS_SESSION_TOKEN).toEqual('aaa');
   });

--- a/packages/aws-cdk/test/api/aws-auth/sdk-provider.test.ts
+++ b/packages/aws-cdk/test/api/aws-auth/sdk-provider.test.ts
@@ -163,7 +163,7 @@ describe('with intercepted network calls', () => {
       const error = new Error('Expired Token');
       error.name = 'ExpiredToken';
       const identityProvider = () => Promise.reject(error);
-      const provider = new SdkProvider(identityProvider, 'rgn', {}, GLOBAL_PLUGIN_HOST, ioHelper);
+      const provider = new SdkProvider(identityProvider, 'rgn', { ioHelper, pluginHost: GLOBAL_PLUGIN_HOST });
       const creds = await provider.baseCredentialsPartition({ ...env(account), region: 'rgn' }, Mode.ForReading);
 
       expect(creds).toBeUndefined();


### PR DESCRIPTION
Previously, the Toolkit would always use AWS CLI-compatible base credentials. This is now configurable:

```ts
const toolkit = new Toolkit({
  sdkConfig: {
    baseCredentials: BaseCredentials.custom(...),
  },
});
```

## Design

The `BaseCredentials` (abstract) class is responsible for producing the following 2 bits of information:

- A credential provider
- A default region

These will be used to initialize an `SdkProvider`, which will then proceed to use that information:

- To inform the CDK app about the desired target environment
- After synthesis and during lookup:
  - use those credentials directly; or
  - use those credentials to assume roles; or
  - use available plugins to obtain credentials

`requestHandler` (the proxy agent plus some SDK settings) used to be produced by the `SdkProvider` itself, but it is now produced by the `Toolkit` and part of the "services" that get passed in. That way, it is both available to the `AwsCliCompatible` base credentials to initialize the STS client, as well as to the `SdkProvider` class that now also gets instantiated by the `Toolkit`.

![image](https://github.com/user-attachments/assets/4ee1656b-d54f-4d1d-8ac7-77cd75c145b2)


## Supporting changes

- Many of the supporting positional arguments to `SdkProvider` have been grouped into `SdkProviderServices`.
- Change how we mock the SDK in a number of tests (instead of mocking the SDK Provider, mock the SDK)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
