### PR TITLE
sanity check to run integ tests | DO NOT MERGE

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk---exclusively-selects-only-selected-stack.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk---exclusively-selects-only-selected-stack.integtest.ts
@@ -13,7 +13,7 @@ integTest(
     const outputsFile = path.join(fixture.integTestDir, 'outputs', 'outputs.json');
     await fs.mkdir(path.dirname(outputsFile), { recursive: true });
 
-    await fixture.cdkDeploy('depends-on-failed', {
+    await fixture.cdkDeploy('depends-on-failed-delete-me', {
       options: ['--exclusively', '--outputs-file', outputsFile],
     });
 


### PR DESCRIPTION
Just sanity testing integ still works after the move. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
