### PR TITLE
feat(refactor): support for stack filtering

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -405,6 +405,13 @@ export class TestFixture extends ShellHelper {
     ], options);
   }
 
+  public async cdkRefactor(options: CdkCliOptions = {}) {
+    return this.cdk([
+      'refactor',
+      ...(options.options ?? []),
+    ], options);
+  }
+
   public async cdkDestroy(stackNames: string | string[], options: CdkDestroyCliOptions = {}) {
     stackNames = typeof stackNames === 'string' ? [stackNames] : stackNames;
 

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "node refactoring.js",
+  "versionReporting": false,
+  "context": {
+    "aws-cdk:enableDiffNoFail": "true"
+  }
+}

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring/refactoring.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring/refactoring.js
@@ -1,0 +1,18 @@
+const cdk = require('aws-cdk-lib');
+const sqs = require('aws-cdk-lib/aws-sqs');
+
+class BasicStack extends cdk.Stack {
+  constructor(parent, id, props) {
+    super(parent, id, props);
+    new sqs.Queue(this, props.queueName);
+  }
+}
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+const app = new cdk.App();
+
+new BasicStack(app, `${stackPrefix}-basic`, {
+    queueName: process.env.BASIC_QUEUE_LOGICAL_ID ?? 'BasicQueue',
+});
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-lib-security-related-changes-without-a-cli-are-expected-to-fail-when-approval-is-required.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-lib-security-related-changes-without-a-cli-are-expected-to-fail-when-approval-is-required.integtest.ts
@@ -14,9 +14,6 @@ integTest(
     });
 
     expect(stdErr).toContain(
-      'This deployment will make potentially sensitive changes according to your current security approval level',
-    );
-    expect(stdErr).toContain(
       '"--require-approval" is enabled and stack includes security-sensitive updates',
     );
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-refactor-dry-run.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-refactor-dry-run.integtest.ts
@@ -1,0 +1,53 @@
+import { integTest, withSpecificFixture } from '../../lib';
+
+integTest(
+  'detects refactoring changes and prints the result',
+  withSpecificFixture('refactoring', async (fixture) => {
+    // First, deploy a stack
+    await fixture.cdkDeploy('basic', {
+      modEnv: {
+        BASIC_QUEUE_LOGICAL_ID: 'OldName',
+      },
+    });
+
+    // Then see if the refactoring tool detects the change
+    const stdErr = await fixture.cdkRefactor({
+      options: ['--dry-run', '--unstable=refactor'],
+      allowErrExit: true,
+      // Making sure the synthesized stack has the new name
+      // so that a refactor is detected
+      modEnv: {
+        BASIC_QUEUE_LOGICAL_ID: 'NewName',
+      },
+    });
+
+    expect(stdErr).toContain('The following resources were moved or renamed:');
+    expect(removeColor(stdErr)).toMatch(/│ AWS::SQS::Queue │ .*\/OldName\/Resource │ .*\/NewName\/Resource │/);
+  }),
+);
+
+integTest(
+  'no refactoring changes detected',
+  withSpecificFixture('refactoring', async (fixture) => {
+    const modEnv = {
+      BASIC_QUEUE_LOGICAL_ID: 'OldName',
+    };
+
+    // First, deploy a stack
+    await fixture.cdkDeploy('basic', { modEnv });
+
+    // Then see if the refactoring tool detects the change
+    const stdErr = await fixture.cdkRefactor({
+      options: ['--dry-run', '--unstable=refactor'],
+      allowErrExit: true,
+      modEnv,
+    });
+
+    expect(stdErr).toContain('Nothing to refactor');
+  }),
+);
+
+function removeColor(str: string): string {
+  return str.replace(/\x1B[[(?);]{0,2}(;?\d)*./g, '');
+}
+

--- a/packages/@aws-cdk/tmp-toolkit-helpers/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/tmp-toolkit-helpers/test/api/diff/diff.test.ts
@@ -2,7 +2,6 @@ import type * as cxapi from '@aws-cdk/cx-api';
 import * as chalk from 'chalk';
 import { DiffFormatter } from '../../../src/api/diff/diff-formatter';
 import { IoHelper, IoDefaultMessages } from '../../../src/api/io/private';
-import { RequireApproval } from '../../../src/api/require-approval';
 
 jest.mock('../../../src/api/io/private/messages', () => ({
   IoDefaultMessages: jest.fn(),
@@ -214,7 +213,7 @@ describe('formatSecurityDiff', () => {
     } as any;
   });
 
-  test('returns empty object when no security changes exist', () => {
+  test('returns information on security changes for the IoHost to interpret', () => {
     // WHEN
     const formatter = new DiffFormatter({
       ioHelper: mockIoHelper,
@@ -223,16 +222,14 @@ describe('formatSecurityDiff', () => {
         newTemplate: mockNewTemplate,
       },
     });
-    const result = formatter.formatSecurityDiff({
-      requireApproval: RequireApproval.BROADENING,
-    });
+    const result = formatter.formatSecurityDiff();
 
     // THEN
-    expect(result.formattedDiff).toBeUndefined();
+    expect(result.permissionChangeType).toEqual('none');
     expect(mockIoDefaultMessages.warning).not.toHaveBeenCalled();
   });
 
-  test('formats diff when permissions are broadened and approval level is BROADENING', () => {
+  test('returns formatted diff for broadening security changes', () => {
     // WHEN
     const formatter = new DiffFormatter({
       ioHelper: mockIoHelper,
@@ -241,12 +238,10 @@ describe('formatSecurityDiff', () => {
         newTemplate: mockNewTemplate,
       },
     });
-    const result = formatter.formatSecurityDiff({
-      requireApproval: RequireApproval.BROADENING,
-    });
+    const result = formatter.formatSecurityDiff();
 
     // THEN
-    expect(result.formattedDiff).toBeDefined();
+    expect(result.permissionChangeType).toEqual('broadening');
     const sanitizedDiff = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '').trim();
     expect(sanitizedDiff).toBe(
       'Stack test-stack\n' +
@@ -264,60 +259,5 @@ describe('formatSecurityDiff', () => {
       '└───┴──────────┴──────────────────────────────────────────────────────────────────┘\n' +
       '(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)',
     );
-  });
-
-  test('formats diff for any security change when approval level is ANY_CHANGE', () => {
-    // WHEN
-    const formatter = new DiffFormatter({
-      ioHelper: mockIoHelper,
-      templateInfo: {
-        oldTemplate: {},
-        newTemplate: mockNewTemplate,
-      },
-    });
-    const result = formatter.formatSecurityDiff({
-      requireApproval: RequireApproval.ANY_CHANGE,
-    });
-
-    // THEN
-    expect(result.formattedDiff).toBeDefined();
-    expect(mockIoDefaultMessages.warning).toHaveBeenCalledWith(
-      expect.stringContaining('potentially sensitive changes'),
-    );
-    const sanitizedDiff = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '').trim();
-    expect(sanitizedDiff).toBe(
-      'Stack test-stack\n' +
-      'IAM Statement Changes\n' +
-      '┌───┬─────────────┬────────┬────────────────┬──────────────────────────────┬───────────┐\n' +
-      '│   │ Resource    │ Effect │ Action         │ Principal                    │ Condition │\n' +
-      '├───┼─────────────┼────────┼────────────────┼──────────────────────────────┼───────────┤\n' +
-      '│ + │ ${Role.Arn} │ Allow  │ sts:AssumeRole │ Service:lambda.amazonaws.com │           │\n' +
-      '└───┴─────────────┴────────┴────────────────┴──────────────────────────────┴───────────┘\n' +
-      'IAM Policy Changes\n' +
-      '┌───┬──────────┬──────────────────────────────────────────────────────────────────┐\n' +
-      '│   │ Resource │ Managed Policy ARN                                               │\n' +
-      '├───┼──────────┼──────────────────────────────────────────────────────────────────┤\n' +
-      '│ + │ ${Role}  │ arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole │\n' +
-      '└───┴──────────┴──────────────────────────────────────────────────────────────────┘\n' +
-      '(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)',
-    );
-  });
-
-  test('returns empty object when approval level is NEVER', () => {
-    // WHEN
-    const formatter = new DiffFormatter({
-      ioHelper: mockIoHelper,
-      templateInfo: {
-        oldTemplate: {},
-        newTemplate: mockNewTemplate,
-      },
-    });
-    const result = formatter.formatSecurityDiff({
-      requireApproval: RequireApproval.NEVER,
-    });
-
-    // THEN
-    expect(result.formattedDiff).toBeUndefined();
-    expect(mockIoDefaultMessages.warning).not.toHaveBeenCalled();
   });
 });

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -1,5 +1,3 @@
-import type { DescribeChangeSetOutput } from '@aws-cdk/cloudformation-diff';
-import { fullDiff } from '@aws-cdk/cloudformation-diff';
 import type * as cxapi from '@aws-cdk/cx-api';
 import * as fs from 'fs-extra';
 import * as uuid from 'uuid';
@@ -7,10 +5,10 @@ import type { ChangeSetDiffOptions, DiffOptions, LocalFileDiffOptions } from '..
 import { DiffMethod } from '..';
 import type { Deployments, ResourcesToImport, IoHelper, SdkProvider, StackCollection, TemplateInfo } from '../../../api/shared-private';
 import { ResourceMigrator, IO, removeNonImportResources, cfnApi } from '../../../api/shared-private';
-import { PermissionChangeType, ToolkitError } from '../../../api/shared-public';
+import { ToolkitError } from '../../../api/shared-public';
 import { deserializeStructure, formatErrorMessage } from '../../../private/util';
 
-export function makeTemplateInfos(
+export function prepareDiff(
   ioHelper: IoHelper,
   stacks: StackCollection,
   deployments: Deployments,
@@ -144,26 +142,6 @@ async function changeSetDiff(
 
     await ioHelper.notify(IO.DEFAULT_TOOLKIT_DEBUG.msg(`the stack '${stack.stackName}' has not been deployed to CloudFormation, skipping changeset creation.`));
     return;
-  }
-}
-
-/**
- * Return whether the diff has security-impacting changes that need confirmation.
- */
-export function determinePermissionType(
-  oldTemplate: any,
-  newTemplate: cxapi.CloudFormationStackArtifact,
-  changeSet?: DescribeChangeSetOutput,
-): PermissionChangeType {
-  // @todo return a printable version of the full diff.
-  const diff = fullDiff(oldTemplate, newTemplate.template, changeSet);
-
-  if (diff.permissionsBroadened) {
-    return PermissionChangeType.BROADENING;
-  } else if (diff.permissionsAnyChanges) {
-    return PermissionChangeType.NON_BROADENING;
-  } else {
-    return PermissionChangeType.NONE;
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -979,19 +979,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       throw new ToolkitError('Refactor is not available yet. Too see the proposed changes, use the --dry-run flag.');
     }
 
-    const strategy = options.stacks?.strategy ?? StackSelectionStrategy.ALL_STACKS;
-    if (strategy !== StackSelectionStrategy.ALL_STACKS) {
-      await ioHelper.notify(IO.CDK_TOOLKIT_W8010.msg(
-        'Refactor does not yet support stack selection. Proceeding with the default behavior (considering all stacks).',
-      ));
-    }
     const stacks = await assembly.selectStacksV2(ALL_STACKS);
-
     const sdkProvider = await this.sdkProvider('refactor');
     const movements = await findResourceMovements(stacks.stackArtifacts, sdkProvider);
     const ambiguous = ambiguousMovements(movements);
     if (ambiguous.length === 0) {
-      const typedMappings = resourceMappings(movements).map(m => m.toTypedMapping());
+      const filteredStacks = await assembly.selectStacksV2(options.stacks ?? ALL_STACKS);
+      const typedMappings = resourceMappings(movements, filteredStacks.stackArtifacts).map(m => m.toTypedMapping());
       await ioHelper.notify(IO.CDK_TOOLKIT_I8900.msg(formatTypedMappings(typedMappings), {
         typedMappings,
       }));

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -967,19 +967,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       throw new ToolkitError('Refactor is not available yet. Too see the proposed changes, use the --dry-run flag.');
     }
 
-    const strategy = options.stacks?.strategy ?? StackSelectionStrategy.ALL_STACKS;
-    if (strategy !== StackSelectionStrategy.ALL_STACKS) {
-      await ioHelper.notify(IO.CDK_TOOLKIT_W8010.msg(
-        'Refactor does not yet support stack selection. Proceeding with the default behavior (considering all stacks).',
-      ));
-    }
     const stacks = await assembly.selectStacksV2(ALL_STACKS);
-
     const sdkProvider = await this.sdkProvider('refactor');
     const movements = await findResourceMovements(stacks.stackArtifacts, sdkProvider);
     const ambiguous = ambiguousMovements(movements);
     if (ambiguous.length === 0) {
-      const typedMappings = resourceMappings(movements).map(m => m.toTypedMapping());
+      const filteredStacks = await assembly.selectStacksV2(options.stacks ?? ALL_STACKS);
+      const typedMappings = resourceMappings(movements, filteredStacks.stackArtifacts).map(m => m.toTypedMapping());
       await ioHelper.notify(IO.CDK_TOOLKIT_I8900.msg(formatTypedMappings(typedMappings), {
         typedMappings,
       }));

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -141,7 +141,7 @@ describe('diff', () => {
       action: 'diff',
       level: 'warn',
       code: 'CDK_TOOLKIT_W0000',
-      message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening)'),
+      message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level'),
     }));
     expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
       action: 'diff',
@@ -322,7 +322,7 @@ describe('diff', () => {
         action: 'diff',
         level: 'warn',
         code: 'CDK_TOOLKIT_W0000',
-        message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level (--require-approval broadening)'),
+        message: expect.stringContaining('This deployment will make potentially sensitive changes according to your current security approval level'),
       }));
       expect(result.Stack1).toMatchObject(expect.objectContaining({
         iamChanges: expect.objectContaining({

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1224,15 +1224,20 @@ export class CdkToolkit {
       return 1;
     }
 
-    if (options.selector.patterns.length > 0) {
-      warning('Refactor does not yet support stack selection. Proceeding with the default behavior (considering all stacks).');
-    }
-
+    // Initially, we select all stacks to find all resource movements.
+    // Otherwise, we might miss some resources that are not in the selected stacks.
+    // Example: resource X was moved from Stack A to Stack B. If we only select Stack A,
+    // we will only see a deletion of resource X, but not the creation of resource X in Stack B.
     const stacks = await this.selectStacksForList([]);
     const movements = await findResourceMovements(stacks.stackArtifacts, this.props.sdkProvider);
     const ambiguous = ambiguousMovements(movements);
+
     if (ambiguous.length === 0) {
-      const typedMappings = resourceMappings(movements).map(m => m.toTypedMapping());
+      // Now we can filter the stacks to only include the ones that are relevant for the user.
+      const patterns = options.selector.allTopLevel ? [] : options.selector.patterns;
+      const filteredStacks = await this.selectStacksForList(patterns);
+      const selectedMappings = resourceMappings(movements, filteredStacks.stackArtifacts);
+      const typedMappings = selectedMappings.map(m => m.toTypedMapping());
       formatTypedMappings(process.stdout, typedMappings);
     } else {
       const e = new AmbiguityError(ambiguous);

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -399,6 +399,20 @@ export async function makeConfig(): Promise<CliConfig> {
       doctor: {
         description: 'Check your set-up for potential problems',
       },
+      refactor: {
+        description: 'Moves resources between stacks or within the same stack',
+        arg: {
+          name: 'STACKS',
+          variadic: true,
+        },
+        options: {
+          'dry-run': {
+            type: 'boolean',
+            desc: 'Do not perform any changes, just show what would be done',
+            default: false,
+          },
+        },
+      },
     },
   };
 }

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -251,6 +251,13 @@ export function convertYargsToUserInput(args: any): UserInput {
     case 'doctor':
       commandOptions = {};
       break;
+
+    case 'refactor':
+      commandOptions = {
+        dryRun: args.dryRun,
+        STACKS: args.STACKS,
+      };
+      break;
   }
   const userInput: UserInput = {
     command: args._[0],
@@ -432,6 +439,9 @@ export function convertConfigToUserInput(config: any): UserInput {
     browser: config.docs?.browser,
   };
   const doctorOptions = {};
+  const refactorOptions = {
+    dryRun: config.refactor?.dryRun,
+  };
   const userInput: UserInput = {
     globalOptions,
     list: listOptions,
@@ -452,6 +462,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     context: contextOptions,
     docs: docsOptions,
     doctor: doctorOptions,
+    refactor: refactorOptions,
   };
 
   return userInput;

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -840,6 +840,13 @@ export function parseCommandLineArguments(args: Array<string>): any {
       }),
     )
     .command('doctor', 'Check your set-up for potential problems')
+    .command('refactor [STACKS..]', 'Moves resources between stacks or within the same stack', (yargs: Argv) =>
+      yargs.option('dry-run', {
+        default: false,
+        type: 'boolean',
+        desc: 'Do not perform any changes, just show what would be done',
+      }),
+    )
     .version(helpers.cliVersion())
     .demandCommand(1, '')
     .recommendCommands()

--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -36,6 +36,7 @@ export enum Command {
   DOCS = 'docs',
   DOC = 'doc',
   DOCTOR = 'doctor',
+  REFACTOR = 'refactor',
 }
 
 const BUNDLING_COMMANDS = [

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -118,6 +118,11 @@ export interface UserInput {
    * Check your set-up for potential problems
    */
   readonly doctor?: {};
+
+  /**
+   * Moves resources between stacks or within the same stack
+   */
+  readonly refactor?: RefactorOptions;
 }
 
 /**
@@ -1333,4 +1338,23 @@ export interface DocsOptions {
    * @default - undefined
    */
   readonly browser?: string;
+}
+
+/**
+ * Moves resources between stacks or within the same stack
+ *
+ * @struct
+ */
+export interface RefactorOptions {
+  /**
+   * Do not perform any changes, just show what would be done
+   *
+   * @default - false
+   */
+  readonly dryRun?: boolean;
+
+  /**
+   * Positional argument for refactor
+   */
+  readonly STACKS?: Array<string>;
 }

--- a/packages/aws-cdk/test/cli/cli-arguments.test.ts
+++ b/packages/aws-cdk/test/cli/cli-arguments.test.ts
@@ -138,6 +138,7 @@ describe('config', () => {
       gc: expect.anything(),
       doctor: expect.anything(),
       docs: expect.anything(),
+      refactor: expect.anything(),
     });
   });
 });


### PR DESCRIPTION
Users can now pass the stacks they want to be considered for refactoring:

    cdk refactor StackA StackB ...

The result will include any mapping that contains at least one of the selected stacks. If no pattern is passed, all stacks are considered.

In this PR I also included the `refactor` command in the command line parsing list, which was missing. It was already working without it, but the command wouldn't show up in the help page, and it wouldn't recognize positional arguments. But the command itself (and its options) could be already used.

Closes https://github.com/aws/aws-cdk-cli/issues/363.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
