### PR TITLE
feat(integ-tests): add integ tests for the toolkit library

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -145,6 +145,7 @@ jobs:
       matrix:
         suite:
           - cli-integ-tests
+          - toolkit-lib-integ-tests
           - init-csharp
           - init-fsharp
           - init-go

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1573,6 +1573,7 @@ const cliInteg = configureProject(
     ],
     devDeps: [
       yarnCling,
+      toolkitLib,
       '@types/semver@^7',
       '@types/yargs@^16',
       '@types/fs-extra@^9',
@@ -1613,6 +1614,8 @@ const cliInteg = configureProject(
   }),
 );
 cliInteg.eslint?.addIgnorePattern('resources/**/*.ts');
+
+cliInteg.deps.addDependency('@aws-cdk/toolkit-lib', pj.DependencyType.OPTIONAL);
 
 const compiledDirs = ['tests', 'test', 'lib'];
 for (const compiledDir of compiledDirs) {

--- a/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
@@ -1,6 +1,10 @@
 {
   "dependencies": [
     {
+      "name": "@aws-cdk/toolkit-lib",
+      "type": "build"
+    },
+    {
       "name": "@aws-cdk/yarn-cling",
       "type": "build"
     },
@@ -117,6 +121,10 @@
       "name": "typescript",
       "version": "5.6",
       "type": "build"
+    },
+    {
+      "name": "@aws-cdk/toolkit-lib",
+      "type": "optional"
     },
     {
       "name": "@aws-sdk/client-cloudformation",

--- a/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
@@ -102,7 +102,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/yarn-cling=exact",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/toolkit-lib=exact @aws-cdk/yarn-cling=exact",
           "receiveArgs": true
         }
       ]

--- a/packages/@aws-cdk-testing/cli-integ/README.md
+++ b/packages/@aws-cdk-testing/cli-integ/README.md
@@ -45,11 +45,12 @@ inject these dependencies into tests. Users can specify component versions, but
 Test Authors are responsible for taking these parameters and using it to set up
 the right environment for the tests.
 
-| Component             | Command-line argument                | Default     | Treatment by runner        | Treatment in test                         |
-|-----------------------|--------------------------------------|-------------|----------------------------|-------------------------------------------|
-| CDK Construct Library | `--framework-version=VERSION`        | Latest      | Nothing                    | `npm install` into temporary project dir. |
-| CDK CLI               | `--cli-version=VERSION`              | Auto source | `npm install` into tempdir | Add to `$PATH`.                           |
+| Component             | Command-line argument                | Default     | Treatment by runner        | Treatment in test                             |
+|-----------------------|--------------------------------------|-------------|----------------------------|-----------------------------------------------|
+| CDK Construct Library | `--framework-version=VERSION`        | Latest      | Nothing                    | `npm install` into temporary project dir.     |
+| CDK CLI               | `--cli-version=VERSION`              | Auto source | `npm install` into tempdir | Add to `$PATH`.                               |
 |                       | `--cli-source=ROOT` or `auto`        | Auto source |                            | Add `<ROOT>/packages/aws-cdk/bin` to `$PATH`. |
+| Toolkit Library       | `--toolkit-lib-version=VERSION`      | Devdep      | Install into its own deps  | Nothing
 
 ### Running a test suite
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
@@ -24,6 +24,15 @@ export async function npmMostRecentMatching(packageName: string, range: string) 
   return output[output.length - 1];
 }
 
+export async function npmQueryInstalledVersion(packageName: string, dir: string) {
+  const reportStr = await shell(['node', require.resolve('npm'), 'list', '--json', '--depth', '0', packageName], {
+    cwd: dir,
+    show: 'error',
+  });
+  const report = JSON.parse(reportStr);
+  return report.dependencies[packageName].version;
+}
+
 /**
  * Use NPM preinstalled on the machine to look up a list of TypeScript versions
  */

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-npm-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-npm-source.ts
@@ -2,6 +2,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs-extra';
 import type { IRunnerSource, ITestCliSource, IPreparedRunnerSource } from './source';
+import { npmQueryInstalledVersion } from '../npm';
 import { addToShellPath, rimraf, shell } from '../shell';
 
 export class RunnerCliNpmSource implements IRunnerSource<ITestCliSource> {
@@ -18,13 +19,7 @@ export class RunnerCliNpmSource implements IRunnerSource<ITestCliSource> {
     await shell(['node', require.resolve('npm'), 'install', `aws-cdk@${this.range}`], {
       cwd: tempDir,
     });
-
-    const reportStr = await shell(['node', require.resolve('npm'), 'list', '--json', '--depth', '0', 'aws-cdk'], {
-      cwd: tempDir,
-      show: 'error',
-    });
-    const report = JSON.parse(reportStr);
-    const installedVersion = report.dependencies['aws-cdk'].version;
+    const installedVersion = await npmQueryInstalledVersion('aws-cdk', tempDir);
 
     return {
       version: installedVersion,

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-repo-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-repo-source.ts
@@ -10,11 +10,11 @@ import { addToShellPath } from '../shell';
  */
 export class RunnerCliRepoSource implements IRunnerSource<ITestCliSource> {
   public readonly sourceDescription: string;
-  private readonly cliPath: string;
+  private readonly cliBinPath: string;
 
   constructor(private readonly repoRoot: string) {
-    this.cliPath = path.join(this.repoRoot, 'packages', 'aws-cdk', 'bin');
-    this.sourceDescription = this.cliPath;
+    this.cliBinPath = path.join(this.repoRoot, 'packages', 'aws-cdk', 'bin');
+    this.sourceDescription = this.cliBinPath;
   }
 
   public async runnerPrepare(): Promise<IPreparedRunnerSource<ITestCliSource>> {
@@ -22,11 +22,13 @@ export class RunnerCliRepoSource implements IRunnerSource<ITestCliSource> {
       throw new Error(`${this.repoRoot}: does not look like the repository root`);
     }
 
+    const pj = JSON.parse(await fs.readFile(path.join(this.cliBinPath, '..', 'package.json'), 'utf-8'));
+
     return {
-      version: '*',
+      version: pj.version,
       dispose: () => Promise.resolve(),
       serialize: () => {
-        return [TestCliRepoSource, [this.cliPath]];
+        return [TestCliRepoSource, [this.cliBinPath]];
       },
     };
   }

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
@@ -1,0 +1,70 @@
+import { promises as fs } from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type { IRunnerSource, IPreparedRunnerSource, ITestLibrarySource } from './source';
+import { copyDirectoryContents } from '../files';
+import { npmQueryInstalledVersion } from '../npm';
+import { shell } from '../shell';
+
+/**
+ * A library dependency that cli-integ installs into its own `node_modules`.
+ */
+export class RunnerLibraryGlobalInstallSource implements IRunnerSource<ITestLibrarySource> {
+  public readonly sourceDescription: string;
+
+  constructor(private readonly packageName: string, private readonly range: string) {
+    this.sourceDescription = `${this.packageName}@${this.range}`;
+  }
+
+  public async runnerPrepare(): Promise<IPreparedRunnerSource<ITestLibrarySource>> {
+    // Create a tempdir where we install the requested package, then symlink into our `node_modules`
+    const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tmpcdk'));
+    await fs.mkdir(tempDir, { recursive: true });
+
+    await shell(['node', require.resolve('npm'), 'install', `${this.packageName}@${this.range}`], {
+      cwd: tempDir,
+    });
+
+    const symlinkPath = path.join(__dirname, '..', '..', 'node_modules', this.packageName);
+    await fs.mkdir(path.dirname(symlinkPath), { recursive: true });
+    await fs.symlink(path.join(tempDir, 'node_modules', this.packageName), symlinkPath, 'junction');
+
+    const version = await npmQueryInstalledVersion(this.packageName, tempDir);
+
+    return {
+      version,
+      async dispose() {
+        // Remove the symlink again
+        await fs.rm(symlinkPath);
+      },
+      serialize: () => {
+        return [TestLibraryGlobalInstallSource, [this.packageName, version]];
+      },
+    };
+  }
+}
+
+export class TestLibraryGlobalInstallSource implements ITestLibrarySource {
+  constructor(public readonly packageName: string, private readonly version: string) {
+  }
+
+  public requestedVersion(): string {
+    return this.version;
+  }
+
+  public assertJsiiPackagesAvailable(): void {
+    // FIXME: Always a no-op.
+  }
+
+  public async initializeDotnetPackages(currentDir: string): Promise<void> {
+    // FIXME: this code has nothing to do with the package source, really, so shouldn't be here.
+    if (process.env.CWD_FILES_DIR) {
+      await copyDirectoryContents(process.env.CWD_FILES_DIR, currentDir);
+    }
+  }
+
+  public requestedAlphaVersion(): string {
+    return this.version;
+  }
+}
+

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-preinstalled-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-preinstalled-source.ts
@@ -1,0 +1,78 @@
+import { readFile } from 'fs/promises';
+import * as path from 'path';
+import type { IRunnerSource, IPreparedRunnerSource, ITestLibrarySource } from './source';
+import { copyDirectoryContents } from '../files';
+
+/**
+ * A library dependency that should already be installed via `cli-integ`'s dependencies.
+ */
+export class RunnerLibraryPreinstalledSource implements IRunnerSource<ITestLibrarySource> {
+  public static async preinstalledVersion(packageName: string): Promise<string> {
+    // Pretend to be in the test directory and resolve the package
+    const searchPath = path.resolve(__dirname, '../../tests');
+
+    let resolvedPjPath;
+    try {
+      resolvedPjPath = require.resolve(`${packageName}/package.json`, {
+        paths: [searchPath],
+      });
+    } catch (e) {
+      throw new Error(`${packageName} not found preinstalled (searching from ${searchPath}): ${e}`);
+    }
+    const pj = JSON.parse(await readFile(resolvedPjPath, 'utf-8'));
+    return pj.version;
+  }
+
+  public static async isPreinstalled(packageName: string) {
+    try {
+      await RunnerLibraryPreinstalledSource.preinstalledVersion(packageName);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public readonly sourceDescription: string;
+
+  constructor(private readonly packageName: string) {
+    this.sourceDescription = `${this.packageName} from preinstalled deps`;
+  }
+
+  public async runnerPrepare(): Promise<IPreparedRunnerSource<ITestLibrarySource>> {
+    const version = await RunnerLibraryPreinstalledSource.preinstalledVersion(this.packageName);
+
+    return {
+      version,
+      async dispose() {
+      },
+      serialize: () => {
+        return [TestLibraryPreinstalledSource, [this.packageName, version]];
+      },
+    };
+  }
+}
+
+export class TestLibraryPreinstalledSource implements ITestLibrarySource {
+  constructor(public readonly packageName: string, private readonly version: string) {
+  }
+
+  public requestedVersion(): string {
+    return this.version;
+  }
+
+  public assertJsiiPackagesAvailable(): void {
+    // FIXME: Always a no-op.
+  }
+
+  public async initializeDotnetPackages(currentDir: string): Promise<void> {
+    // FIXME: this code has nothing to do with the package source, really, so shouldn't be here.
+    if (process.env.CWD_FILES_DIR) {
+      await copyDirectoryContents(process.env.CWD_FILES_DIR, currentDir);
+    }
+  }
+
+  public requestedAlphaVersion(): string {
+    return this.version;
+  }
+}
+

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/subprocess.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/subprocess.ts
@@ -6,6 +6,7 @@ import type { Constructor, IPreparedRunnerSource, ITestCliSource, ITestLibrarySo
 export interface PreparedSources {
   readonly cli: IPreparedRunnerSource<ITestCliSource>;
   readonly library: IPreparedRunnerSource<ITestLibrarySource>;
+  readonly toolkitLib: IPreparedRunnerSource<ITestLibrarySource>;
 }
 
 type SourceType<A> = A extends IPreparedRunnerSource<infer T> ? T : unknown;

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -39,6 +39,7 @@
     "organization": true
   },
   "devDependencies": {
+    "@aws-cdk/toolkit-lib": "0.0.0",
     "@aws-cdk/yarn-cling": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@stylistic/eslint-plugin": "^3",

--- a/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
@@ -3,6 +3,7 @@ const os = require('os');
 
 const rootDir = path.resolve(__dirname, '..', 'tests', process.env.TEST_SUITE_NAME);
 
+/** @type {import('jest').Config} */
 module.exports = {
   rootDir,
   testMatch: [`**/*.integtest.js`],
@@ -39,7 +40,7 @@ function maxWorkers() {
 
   // empirically observed. this includes:
   // - 150 jest test process
-  // - 140 app synthesis subprocess  
+  // - 140 app synthesis subprocess
   // - 200 cli subprocess
   const maxWorkerMemoryMB = 500;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-can-cdk-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-can-cdk-deploy.integtest.ts
@@ -1,0 +1,21 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import * as toolkit from '@aws-cdk/toolkit-lib';
+import { assemblyFromCdkAppDir, toolkitFromFixture } from './toolkit-helpers';
+import { integTest, withDefaultFixture } from '../../lib';
+
+integTest(
+  'toolkit can cdk deploy',
+  withDefaultFixture(async (fixture) => {
+    const tk = toolkitFromFixture(fixture);
+
+    const assembly = await assemblyFromCdkAppDir(tk, fixture);
+
+    const stacks: toolkit.StackSelector = {
+      strategy: toolkit.StackSelectionStrategy.PATTERN_MUST_MATCH_SINGLE,
+      patterns: [fixture.fullStackName('test-1')],
+    };
+
+    await tk.deploy(assembly, { stacks });
+    await tk.destroy(assembly, { stacks });
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-helpers.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-helpers.ts
@@ -1,0 +1,44 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import * as toolkit from '@aws-cdk/toolkit-lib';
+import type { AwsContext, TestFixture } from '../../lib';
+
+/**
+ * Create a toolkit that's initialized from the given fixture
+ *
+ * Will use specific (Atmosphere-provided) credentials if they're available, and
+ * fall back to SDK-compatible credentials otherwise.
+ */
+export function toolkitFromFixture(fixture: AwsContext, options?: Omit<toolkit.ToolkitOptions, 'sdkConfig'>) {
+  return new toolkit.Toolkit({
+    ...options,
+    sdkConfig: {
+      baseCredentials: fixture.aws.identity
+        ? toolkit.BaseCredentials.custom({
+          region: fixture.aws.region,
+          provider: () => Promise.resolve(fixture.aws.identity!),
+        })
+        : undefined,
+    },
+  });
+}
+
+/**
+ * Helper function to convert a CDK app directory into an Assembly Source
+ *
+ * This will eventually become part of the toolkit itself, but isn't yet.
+ */
+export async function assemblyFromCdkAppDir(tk: toolkit.Toolkit, fixture: TestFixture) {
+  const cdkAppDir = fixture.integTestDir;
+  const cdkJson = await JSON.parse(await fs.readFile(path.join(cdkAppDir, 'cdk.json'), 'utf-8'));
+  const app = cdkJson.app;
+
+  return tk.fromCdkApp(app, {
+    workingDirectory: cdkAppDir,
+    env: {
+      STACK_NAME_PREFIX: fixture.stackNamePrefix,
+      PACKAGE_LAYOUT_VERSION: '2',
+    },
+  });
+}

--- a/packages/@aws-cdk-testing/cli-integ/tsconfig.dev.json
+++ b/packages/@aws-cdk-testing/cli-integ/tsconfig.dev.json
@@ -43,6 +43,9 @@
   "references": [
     {
       "path": "../../@aws-cdk/yarn-cling"
+    },
+    {
+      "path": "../../@aws-cdk/toolkit-lib"
     }
   ]
 }

--- a/packages/@aws-cdk-testing/cli-integ/tsconfig.json
+++ b/packages/@aws-cdk-testing/cli-integ/tsconfig.json
@@ -42,6 +42,9 @@
   "references": [
     {
       "path": "../../@aws-cdk/yarn-cling"
+    },
+    {
+      "path": "../../@aws-cdk/toolkit-lib"
     }
   ]
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -57,7 +57,7 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
       if (code === 0) {
         return ok();
       } else {
-        return fail(new ToolkitError(`Subprocess exited with error ${code}`));
+        return fail(new ToolkitError(`${commandAndArgs}: Subprocess exited with error ${code}`));
       }
     });
   });

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -129,7 +129,7 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
           if (code === 0) {
             return ok();
           } else {
-            return fail(new ToolkitError(`Subprocess exited with error ${code}`));
+            return fail(new ToolkitError(`${commandAndArgs}: Subprocess exited with error ${code}`));
           }
         });
       });

--- a/packages/aws-cdk/test/cxapp/exec.test.ts
+++ b/packages/aws-cdk/test/cxapp/exec.test.ts
@@ -226,7 +226,7 @@ test('cli throws when the `build` script fails', async () => {
   });
 
   // WHEN
-  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toEqual(new Error('Subprocess exited with error 127'));
+  await expect(execProgram(sdkProvider, ioHelper, config)).rejects.toThrow(/Subprocess exited with error 127/);
 }, TEN_SECOND_TIMEOUT);
 
 test('cli does not throw when the `build` script succeeds', async () => {

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -286,6 +286,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           domain: {
             suite: [
               'cli-integ-tests',
+              'toolkit-lib-integ-tests',
               'init-csharp',
               'init-fsharp',
               'init-go',


### PR DESCRIPTION
Add integration tests for the toolkit library.

Introduces the toolkit library as a new "component under test". 

Because we want to promote writing integ tests against the toolkit library the same way we would write normal production code, the setup is like this:

- The toolkit lib is installed as a `devDependency` into the integ test package. This will allow writing tests as if the toolkit lib is "just" a dependency.
- At runtime, a version of the toolkit library can be selected and it will be installed into the dependency closure by the runner before the tests are run, so that the imports will still function properly.

To signal this, we'll mark `@aws-cdk/toolkit-lib` as an `optionalDependency` as well.

(PR includes https://github.com/aws/aws-cdk-cli/pull/444)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
