### PR TITLE
chore: `yarn-cling` dependency is incorrectly set to `*`

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -39,7 +39,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/yarn-cling": "*",
+    "@aws-cdk/yarn-cling": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@stylistic/eslint-plugin": "^3",
     "@types/fs-extra": "^9",


### PR DESCRIPTION
This breaks the [release](https://github.com/aws/aws-cdk-cli/actions/runs/14752077174/job/41411691499):

```console
> @aws-cdk-testing/cli-integ
yarn run v1.22.22
warning package.json: "dependencies" has dependency "jest" with range "^29" that collides with a dependency in "devDependencies" of the same name with version "^29.7.0"
warning package.json: "dependencies" has dependency "jest-junit" with range "^15" that collides with a dependency in "devDependencies" of the same name with version "^16"
warning package.json: "dependencies" has dependency "ts-jest" with range "^29" that collides with a dependency in "devDependencies" of the same name with version "^29.2.5"
$ npx projen unbump
👾 unbump | "/opt/hostedtoolcache/node/22.14.0/x64/bin/node" "/home/runner/work/aws-cdk-cli/aws-cdk-cli/node_modules/projen/lib/release/reset-version.task.js"
👾 unbump » gather-versions | node -e "require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()" @aws-cdk/yarn-cling=exact
Updated versions {
  "name": "@aws-cdk-testing/cli-integ",
  "version": "0.0.0",
  "devDependencies": {
    "@aws-cdk/yarn-cling": "^0.0.0"
  }
}
Done in 4.24s.
Done in 61.43s.
👾 release | git diff --ignore-space-at-eol --exit-code
diff --git a/packages/@aws-cdk-testing/cli-integ/package.json b/packages/@aws-cdk-testing/cli-integ/package.json
index f150439..8a1337a 100644
--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -39,7 +39,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/yarn-cling": "*",
+    "@aws-cdk/yarn-cling": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@stylistic/eslint-plugin": "^3",
     "@types/fs-extra": "^9",
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
