### PR TITLE
refactor(toolkit-lib): remove unnecessary bundling

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -776,8 +776,6 @@ const toolkitLib = configureProject(
       'aws-cdk-lib',
       'aws-sdk-client-mock',
       'aws-sdk-client-mock-jest',
-      'dts-bundle-generator@9.3.1', // use this specific version because newer versions are much slower. This is a temporary arrangement we hope to remove soon anyway.
-      'esbuild',
       'fast-check',
       'jest-environment-node',
       'nock@13',
@@ -904,11 +902,8 @@ const registryTask = toolkitLib.addTask('registry', { exec: 'tsx scripts/gen-cod
 toolkitLib.postCompileTask.spawn(registryTask);
 toolkitLib.postCompileTask.exec('build-tools/build-info.sh');
 toolkitLib.postCompileTask.exec('node build-tools/bundle.mjs');
-// Smoke test built JS files
+// Smoke test exported js files
 toolkitLib.postCompileTask.exec('node ./lib/index.js >/dev/null 2>/dev/null </dev/null');
-toolkitLib.postCompileTask.exec('node ./lib/api/shared-public.js >/dev/null 2>/dev/null </dev/null');
-toolkitLib.postCompileTask.exec('node ./lib/api/shared-private.js >/dev/null 2>/dev/null </dev/null');
-toolkitLib.postCompileTask.exec('node ./lib/private/util.js >/dev/null 2>/dev/null </dev/null');
 
 // Do include all .ts files inside init-templates
 toolkitLib.npmignore?.addPatterns(

--- a/packages/@aws-cdk/toolkit-lib/.projen/deps.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/deps.json
@@ -87,15 +87,6 @@
       "type": "build"
     },
     {
-      "name": "dts-bundle-generator",
-      "version": "9.3.1",
-      "type": "build"
-    },
-    {
-      "name": "esbuild",
-      "type": "build"
-    },
-    {
       "name": "eslint-config-prettier",
       "type": "build"
     },

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -59,7 +59,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/types,@smithy/util-stream,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,license-checker,ts-jest,typedoc,xml-js,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-waiter,archiver,cdk-from-cfn,glob,minimatch,promptly,proxy-agent,semver,split2,uuid"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/types,@smithy/util-stream,@types/fs-extra,@types/jest,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,license-checker,ts-jest,typedoc,xml-js,@aws-cdk/cx-api,@aws-cdk/region-info,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-waiter,archiver,cdk-from-cfn,glob,minimatch,promptly,proxy-agent,semver,split2,uuid"
         }
       ]
     },
@@ -195,15 +195,6 @@
         },
         {
           "exec": "node ./lib/index.js >/dev/null 2>/dev/null </dev/null"
-        },
-        {
-          "exec": "node ./lib/api/shared-public.js >/dev/null 2>/dev/null </dev/null"
-        },
-        {
-          "exec": "node ./lib/api/shared-private.js >/dev/null 2>/dev/null </dev/null"
-        },
-        {
-          "exec": "node ./lib/private/util.js >/dev/null 2>/dev/null </dev/null"
         }
       ]
     },

--- a/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
+++ b/packages/@aws-cdk/toolkit-lib/build-tools/bundle.mjs
@@ -1,8 +1,6 @@
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import * as esbuild from 'esbuild';
 import * as fs from 'fs-extra';
-import { generateDtsBundle } from 'dts-bundle-generator';
 
 // copy files
 const require = createRequire(import.meta.url);
@@ -19,29 +17,6 @@ const copyFromServiceSpec = (from, to = undefined) => {
   return fs.copy(path.join(serviceSpecPkg, ...from), path.join(process.cwd(), ...(to ?? from)));
 };
 
-// declaration bundling
-dtsBundleLogging(false);
-const bundleDeclarations = async (entryPoints) => {
-  const results = generateDtsBundle(entryPoints.map(filePath => ({
-    filePath,
-    output: {
-      noBanner: true,
-      exportReferencedTypes: false,
-    },
-  })), { preferredConfigPath: 'tsconfig.dts.json' });
-
-  const files = [];
-  for (const [idx, declaration] of results.entries()) {
-    const outputPath = path.format({ ...path.parse(entryPoints[idx]), base: '', ext: '.d.ts' });
-    files.push(fs.promises.writeFile(outputPath, declaration));
-  }
-
-  return Promise.all(files);
-}
-
-// for the shared public API we also need to bundle the types
-const declarations = bundleDeclarations(['lib/api/shared-public.ts']);
-
 
 // This is a build script, we are fine
 // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
@@ -51,32 +26,7 @@ const resources = Promise.all([
   copyFromCli(['lib', 'api', 'bootstrap', 'bootstrap-template.yaml']),
 ]);
 
-// bundle entrypoints from the library packages
-const bundle = esbuild.build({
-  outdir: 'lib',
-  entryPoints: [
-    'lib/api/shared-public.ts', 
-    'lib/api/shared-private.ts', 
-    'lib/private/util.ts',
-  ],
-  target: 'node18',
-  platform: 'node',
-  packages: 'external',
-  sourcemap: true,
-  bundle: true,
-});
-
 // Do all the work in parallel
 await Promise.all([
-  bundle,
   resources,
-  declarations
 ]);
-
-
-function dtsBundleLogging(enable) {
-  if (enable) {
-    const { enableVerbose } = require('dts-bundle-generator/dist/logger');
-    enableVerbose();
-  }
-}

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/sdk-logger.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/sdk-logger.ts
@@ -1,9 +1,9 @@
 
 import { inspect } from 'util';
 import type { Logger } from '@smithy/types';
-import { replacerBufferWithInfo } from '../../../private/util';
-import type { IoHelper } from '../../shared-private';
-import { IO } from '../../shared-private';
+import type { IoHelper } from './io-helper';
+import { IO } from './messages';
+import { replacerBufferWithInfo } from '../../../util';
 
 export function asSdkLogger(ioHost: IoHelper): Logger {
   return new class implements Logger {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/plugin/plugin.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/plugin/plugin.ts
@@ -2,7 +2,7 @@ import { inspect } from 'util';
 import type { CredentialProviderSource, IPluginHost, Plugin } from '@aws-cdk/cli-plugin-contract';
 import { type ContextProviderPlugin, isContextProviderPlugin } from './context-provider-plugin';
 import type { IIoHost } from '../io';
-import { IoDefaultMessages, IoHelper } from '../private';
+import { IoDefaultMessages, IoHelper } from '../io/private';
 import { ToolkitError } from '../toolkit-error';
 
 export let TESTING = false;

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -55,8 +55,6 @@
     "aws-sdk-client-mock-jest": "^4.1.0",
     "commit-and-tag-version": "^12",
     "constructs": "^10.0.0",
-    "dts-bundle-generator": "9.3.1",
-    "esbuild": "^0.25.2",
     "eslint": "^9",
     "eslint-config-prettier": "^10.1.2",
     "eslint-import-resolver-typescript": "^3.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6704,14 +6704,6 @@ dotgitignore@^2.1.0:
     find-up "^3.0.0"
     minimatch "^3.0.4"
 
-dts-bundle-generator@9.3.1:
-  version "9.3.1"
-  resolved "https://registry.npmjs.org/dts-bundle-generator/-/dts-bundle-generator-9.3.1.tgz"
-  integrity sha512-1/nMT7LFOkXbrL1ZvLpzrjNbfX090LZ64nLIXVmet557mshFCGP/oTiQiZenafJZ6GsmRQLTYKSlQnkxK8tsTw==
-  dependencies:
-    typescript ">=5.0.2"
-    yargs "^17.6.0"
-
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
@@ -12935,7 +12927,7 @@ typescript@5.8.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz"
   integrity sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==
 
-typescript@>=5.0.2, typescript@^5.7.3:
+typescript@^5.7.3:
   version "5.8.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz"
   integrity sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==
@@ -13500,7 +13492,7 @@ yargs@^16, yargs@^16.0.0, yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
-yargs@^17, yargs@^17.1.1, yargs@^17.3.1, yargs@^17.6.0, yargs@^17.6.2, yargs@^17.7.2:
+yargs@^17, yargs@^17.1.1, yargs@^17.3.1, yargs@^17.6.2, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==


### PR DESCRIPTION
We previously bundled some entrypoints and their type declarations because they containted code that lived in the 
not published shared helper package. With that package now remove, bundling is no longer needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
