### PR TITLE
fix(toolkit-lib): log monitor error missing from IoMessage

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/logs-monitor/logs-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/logs-monitor/logs-monitor.ts
@@ -163,7 +163,7 @@ export class CloudWatchLogEventMonitor {
         return;
       }
     } catch (e: any) {
-      await this.ioHelper.notify(IO.CDK_TOOLKIT_E5035.msg('Error occurred while monitoring logs: %s', { error: e }));
+      await this.ioHelper.notify(IO.CDK_TOOLKIT_E5035.msg(`Error occurred while monitoring logs: ${String(e)}`, { error: e }));
     }
 
     this.scheduleNextTick();


### PR DESCRIPTION
Fixes the error messages not being include for generic LogMonitor errors.
Also updates the tests to be more reliable.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
