### PR TITLE
fix(toolkit-lib): fromCdkApp fails if working directory is given and outdir is relative

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
@@ -80,6 +80,13 @@ export interface AssemblySourceProps {
    * Options to configure loading of the assembly after it has been synthesized
    */
   readonly loadAssemblyOptions?: LoadAssemblyOptions;
+
+  /**
+   * Delete the `outdir` when the assembly is disposed
+   *
+   * @default - `true` if `outdir` is not given, `false` otherwise
+   */
+  readonly disposeOutdir?: boolean;
 }
 
 /**


### PR DESCRIPTION
If a working directory is given and outdir is relative, then the CDK app synths relative to the supplied working directory, but the toolkit tries to load the assembly relative to the process' `cwd` and fails.

Also, the documentation of `fromCdkApp` falsely claimed that by default it will create a temporary directory and clean it up. It does not, by default it emits into a relative `cdk.out` directory which won't get cleaned up. The `cdk.out` directory also was not entirely consistently evaluated, so we specify that it must be evaluated against `workingDirectory`.

While we're at it, immediately add a flag that allows explicit directories to be cleaned up as well so that our tests (which explicitly specify temporary directories and so they don't get cleaned up) don't spam all the way into the system's tempdir.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
