### PR TITLE
chore: also rc-bump version of the cli-integ package when testing

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1603,6 +1603,9 @@ const cliInteg = configureProject(
         },
       },
     }),
+
+    // Append a specific version string for testing
+    nextVersionCommand: 'tsx ../../../projenrc/next-version.ts maybeRc',
   }),
 );
 cliInteg.eslint?.addIgnorePattern('resources/**/*.ts');

--- a/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
@@ -32,6 +32,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk-testing/cli-integ@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
+        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
         "MAJOR": "3"
       },
@@ -196,6 +197,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk-testing/cli-integ@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
+        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
       },
       "steps": [


### PR DESCRIPTION
This look confusing, because the tests will have a real-looking version in logs (and not an obviously fake version ending in `.999`).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
