### PR TITLE
feat(cli): allow change set imports resources that already exist

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/import-app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/import-app/app.js
@@ -1,0 +1,38 @@
+const cdk = require('aws-cdk-lib/core');
+const dynamodb = require('aws-cdk-lib/aws-dynamodb');
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+if (!stackPrefix) {
+  throw new Error(`the STACK_NAME_PREFIX environment variable is required`);
+}
+
+class BaseStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    // Create a random table name with prefix
+    if (process.env.VERSION == 'v2') {
+      new dynamodb.TableV2(this, 'MyGlobalTable', {
+        partitionKey: {
+          name: 'PK',
+          type: dynamodb.AttributeType.STRING,
+        },
+        tableName: 'integ-test-import-app-base-table-1',
+      });
+    } else {
+      new dynamodb.Table(this, 'MyTable', {
+        partitionKey: {
+          name: 'PK',
+          type: dynamodb.AttributeType.STRING,
+        },
+        tableName: 'integ-test-import-app-base-table-1',
+        removalPolicy: process.env.VERSION == 'v1' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      });
+    }
+  }
+}
+
+const app = new cdk.App();
+new BaseStack(app, `${stackPrefix}-base-1`);
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/import-app/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/import-app/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "node app.js",
+  "versionReporting": false,
+  "context": {
+    "aws-cdk:enableDiffNoFail": "true"
+  }
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
@@ -19,6 +19,7 @@ integTest(
       },
     });
 
+    console.log('first diff' + diff);
     // Assert there are no changes and diff shows import
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[←]');
@@ -31,6 +32,7 @@ integTest(
       },
     });
 
+    console.log('second diff' + diff);
     // Assert there are no changes and diff shows add
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[+]');

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
@@ -1,0 +1,45 @@
+import { integTest, withSpecificFixture } from '../../lib';
+
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
+integTest(
+  'cdk diff --import-existing-resources show resource being imported',
+  withSpecificFixture('import-app', async (fixture) => {
+    // GIVEN
+    await fixture.cdkDeploy('base-1', {
+      modEnv: {
+        VERSION: 'v1',
+      },
+    });
+
+    // THEN
+    let diff = await fixture.cdk(['diff --import-existing-resources', fixture.fullStackName('base-1')], {
+      modEnv: {
+        VERSION: 'v2',
+      },
+    });
+
+    // Assert there are no changes and diff shows import
+    expect(diff).not.toContain('There were no differences');
+    expect(diff).toContain('[←]');
+    expect(diff).toContain('import');
+
+    // THEN
+    diff = await fixture.cdk(['diff', fixture.fullStackName('base-1')], {
+      modEnv: {
+        VERSION: 'v2',
+      },
+    });
+
+    // Assert there are no changes and diff shows add
+    expect(diff).not.toContain('There were no differences');
+    expect(diff).toContain('[+]');
+
+    // Deploy the stack with v3 to set table removal policy as destroy
+    await fixture.cdkDeploy('base-1', {
+      modEnv: {
+        VERSION: 'v3',
+      },
+    });
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
@@ -13,13 +13,12 @@ integTest(
     });
 
     // THEN
-    let diff = await fixture.cdk(['diff --import-existing-resources', fixture.fullStackName('base-1')], {
+    let diff = await fixture.cdk(['diff', '--import-existing-resources', fixture.fullStackName('base-1')], {
       modEnv: {
         VERSION: 'v2',
       },
     });
 
-    fixture.log('first diff' + diff);
     // Assert there are no changes and diff shows import
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[←]');
@@ -32,7 +31,6 @@ integTest(
       },
     });
 
-    fixture.log('second diff' + diff);
     // Assert there are no changes and diff shows add
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[+]');

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
@@ -19,7 +19,7 @@ integTest(
       },
     });
 
-    console.log('first diff' + diff);
+    fixture.log('first diff' + diff);
     // Assert there are no changes and diff shows import
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[←]');
@@ -32,7 +32,7 @@ integTest(
       },
     });
 
-    console.log('second diff' + diff);
+    fixture.log('second diff' + diff);
     // Assert there are no changes and diff shows add
     expect(diff).not.toContain('There were no differences');
     expect(diff).toContain('[+]');

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/index.ts
@@ -26,6 +26,13 @@ export interface ChangeSetDiffOptions extends CloudFormationDiffOptions {
    * @default - no parameters
    */
   readonly parameters?: { [name: string]: string | undefined };
+
+  /**
+   * Whether or not the change set imports resources that already exist
+   *
+   * @default false
+   */
+  readonly importExistingResources?: boolean;
 }
 
 export interface LocalFileDiffOptions {

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -89,6 +89,7 @@ async function cfnDiff(
       resourcesToImport,
       methodOptions.parameters,
       methodOptions.fallbackToTemplate,
+      methodOptions.importExistingResources,
     ) : undefined;
 
     templateInfos.push({
@@ -111,6 +112,7 @@ async function changeSetDiff(
   resourcesToImport?: ResourcesToImport,
   parameters: { [name: string]: string | undefined } = {},
   fallBackToTemplate: boolean = true,
+  importExistingResources: boolean = false,
 ): Promise<any | undefined> {
   let stackExists = false;
   try {
@@ -139,6 +141,7 @@ async function changeSetDiff(
       parameters: parameters,
       resourcesToImport,
       failOnError: !fallBackToTemplate,
+      importExistingResources,
     });
   } else {
     if (!fallBackToTemplate) {

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -132,6 +132,7 @@ async function changeSetDiff(
   }
 
   if (stackExists) {
+    await ioHelper.notify(IO.DEFAULT_TOOLKIT_DEBUG.msg(`Doing a changeset diff with importExistingResources: ${importExistingResources}\n`));
     return cfnApi.createDiffChangeSet(ioHelper, {
       stack,
       uuid: uuid.v4(),

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -132,7 +132,6 @@ async function changeSetDiff(
   }
 
   if (stackExists) {
-    await ioHelper.notify(IO.DEFAULT_TOOLKIT_DEBUG.msg(`Doing a changeset diff with importExistingResources: ${importExistingResources}\n`));
     return cfnApi.createDiffChangeSet(ioHelper, {
       stack,
       uuid: uuid.v4(),

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -330,6 +330,8 @@ export async function createChangeSet(
   });
   await cleanupOldChangeset(options.cfn, ioHelper, options.changeSetName, options.stack.stackName);
 
+  new IoDefaultMessages(ioHelper).info(`XXX ChangeSet looks like ${JSON.stringify(createdChangeSet, undefined, 2)}`);
+
   return createdChangeSet;
 }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -18,7 +18,7 @@ import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { ICloudFormationClient, SdkProvider } from '../aws-auth/private';
 import type { Template, TemplateBodyParameter, TemplateParameter } from '../cloudformation';
 import { CloudFormationStack, makeBodyParameter } from '../cloudformation';
-import { IO, IoDefaultMessages, type IoHelper } from '../io/private';
+import { IO, type IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 
 /**
@@ -173,8 +173,6 @@ export async function createDiffChangeSet(
   ioHelper: IoHelper,
   options: PrepareChangeSetOptions,
 ): Promise<DescribeChangeSetCommandOutput | undefined> {
-  new IoDefaultMessages(ioHelper).info(`XXX in createDiffChagneSet options ${options.importExistingResources}`);
-
   // `options.stack` has been modified to include any nested stack templates directly inline with its own template, under a special `NestedTemplate` property.
   // Thus the parent template's Resources section contains the nested template's CDK metadata check, which uses Fn::Equals.
   // This causes CreateChangeSet to fail with `Template Error: Fn::Equals cannot be partially collapsed`.
@@ -238,7 +236,6 @@ async function uploadBodyParameterAndCreateChangeSet(
       'Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)\n',
     ));
 
-    new IoDefaultMessages(ioHelper).info(`XXX in about to call createChangeSet ${options.importExistingResources}`);
     return await createChangeSet(ioHelper, {
       cfn,
       changeSetName: 'cdk-diff-change-set',
@@ -305,8 +302,6 @@ export async function createChangeSet(
   const templateParams = TemplateParameters.fromTemplate(options.stack.template);
   const stackParams = templateParams.supplyAll(options.parameters);
 
-  new IoDefaultMessages(ioHelper).info(`XXX in createChangeSet ${options.importExistingResources}`);
-
   const changeSet = await options.cfn.createChangeSet({
     StackName: options.stack.stackName,
     ChangeSetName: options.changeSetName,
@@ -329,8 +324,6 @@ export async function createChangeSet(
     fetchAll: options.willExecute,
   });
   await cleanupOldChangeset(options.cfn, ioHelper, options.changeSetName, options.stack.stackName);
-
-  new IoDefaultMessages(ioHelper).info(`XXX ChangeSet looks like ${JSON.stringify(createdChangeSet, undefined, 2)}`);
 
   return createdChangeSet;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -18,7 +18,7 @@ import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { ICloudFormationClient, SdkProvider } from '../aws-auth/private';
 import type { Template, TemplateBodyParameter, TemplateParameter } from '../cloudformation';
 import { CloudFormationStack, makeBodyParameter } from '../cloudformation';
-import { IO, type IoHelper } from '../io/private';
+import { IO, IoDefaultMessages, type IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 
 /**
@@ -173,6 +173,8 @@ export async function createDiffChangeSet(
   ioHelper: IoHelper,
   options: PrepareChangeSetOptions,
 ): Promise<DescribeChangeSetCommandOutput | undefined> {
+  new IoDefaultMessages(ioHelper).info(`XXX in createDiffChagneSet options ${options.importExistingResources}`);
+
   // `options.stack` has been modified to include any nested stack templates directly inline with its own template, under a special `NestedTemplate` property.
   // Thus the parent template's Resources section contains the nested template's CDK metadata check, which uses Fn::Equals.
   // This causes CreateChangeSet to fail with `Template Error: Fn::Equals cannot be partially collapsed`.
@@ -236,6 +238,7 @@ async function uploadBodyParameterAndCreateChangeSet(
       'Hold on while we create a read-only change set to get a diff with accurate replacement information (use --no-change-set to use a less accurate but faster template-only diff)\n',
     ));
 
+    new IoDefaultMessages(ioHelper).info(`XXX in about to call createChangeSet ${options.importExistingResources}`);
     return await createChangeSet(ioHelper, {
       cfn,
       changeSetName: 'cdk-diff-change-set',
@@ -301,6 +304,8 @@ export async function createChangeSet(
 
   const templateParams = TemplateParameters.fromTemplate(options.stack.template);
   const stackParams = templateParams.supplyAll(options.parameters);
+
+  new IoDefaultMessages(ioHelper).info(`XXX in createChangeSet ${options.importExistingResources}`);
 
   const changeSet = await options.cfn.createChangeSet({
     StackName: options.stack.stackName,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -142,6 +142,7 @@ export type PrepareChangeSetOptions = {
   sdkProvider: SdkProvider;
   parameters: { [name: string]: string | undefined };
   resourcesToImport?: ResourcesToImport;
+  importExistingResources?: boolean;
   /**
    * Default behavior is to log AWS CloudFormation errors and move on. Set this property to true to instead
    * fail on errors received by AWS CloudFormation.
@@ -161,6 +162,7 @@ export type CreateChangeSetOptions = {
   bodyParameter: TemplateBodyParameter;
   parameters: { [name: string]: string | undefined };
   resourcesToImport?: ResourceToImport[];
+  importExistingResources?: boolean;
   role?: string;
 };
 
@@ -244,6 +246,7 @@ async function uploadBodyParameterAndCreateChangeSet(
       bodyParameter,
       parameters: options.parameters,
       resourcesToImport: options.resourcesToImport,
+      importExistingResources: options.importExistingResources,
       role: executionRoleArn,
     });
   } catch (e: any) {
@@ -309,6 +312,7 @@ export async function createChangeSet(
     TemplateBody: options.bodyParameter.TemplateBody,
     Parameters: stackParams.apiParameters,
     ResourcesToImport: options.resourcesToImport,
+    ImportExistingResources: options.importExistingResources,
     RoleARN: options.role,
     Tags: toCfnTags(options.stack.tags),
     Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -189,6 +189,23 @@ The `change-set` flag will make `diff` create a change set and extract resource 
 The `--no-change-set` mode will consider any change to a property that requires replacement to be a resource replacement,
 even if the change is purely cosmetic (like replacing a resource reference with a hardcoded arn).
 
+The `--import-existing-resources` option will make `diff` create a change set and compare it using
+the CloudFormation resource import mechanism. This allows CDK to detect changes and show report of resources that
+will be imported rather added.U se this flag when preparing to import existing resources into a CDK stack to
+ensure the changes are correctly reflected and safe to apply.
+
+```console
+$ cdk diff
+[+] AWS::DynamoDB::GlobalTable MyGlobalTable MyGlobalTable5DC12DB4
+
+$ cdk diff --import-existing-resources
+[←] AWS::DynamoDB::GlobalTable MyGlobalTable MyGlobalTable5DC12DB4 import
+```
+
+In the output above:
+[+] indicates a new resource that would be created.
+[←] indicates a resource that would be imported into the stack instead.
+
 ### `cdk deploy`
 
 Deploys a stack of your CDK app to its environment. During the deployment, the toolkit will output progress

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -191,8 +191,8 @@ even if the change is purely cosmetic (like replacing a resource reference with 
 
 The `--import-existing-resources` option will make `diff` create a change set and compare it using
 the CloudFormation resource import mechanism. This allows CDK to detect changes and show report of resources that
-will be imported rather added.U se this flag when preparing to import existing resources into a CDK stack to
-ensure the changes are correctly reflected and safe to apply.
+will be imported rather added. Use this flag when preparing to import existing resources into a CDK stack to
+ensure and validate the changes are correctly reflected by showing 'import'.
 
 ```console
 $ cdk diff

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -213,6 +213,12 @@ export class CdkToolkit {
         throw new ToolkitError(`There is no file at ${options.templatePath}`);
       }
 
+      if (options.importExistingResources) {
+        throw new ToolkitError(
+          'Can only use --import-existing-resources flag when comparing against deployed stacks.',
+        );
+      }
+
       const template = deserializeStructure(await fs.readFile(options.templatePath, { encoding: 'UTF-8' }));
       const formatter = new DiffFormatter({
         ioHelper: asIoHelper(this.ioHost, 'diff'),
@@ -287,6 +293,7 @@ export class CdkToolkit {
               sdkProvider: this.props.sdkProvider,
               parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
               resourcesToImport,
+              importExistingResources: options.importExistingResources,
             });
           } else {
             debug(
@@ -1487,6 +1494,13 @@ export interface DiffOptions {
    * @default true
    */
   readonly changeSet?: boolean;
+
+  /**
+   * Whether or not the change set imports resources that already exist.
+   *
+   * @default false
+   */
+  readonly importExistingResources?: boolean;
 }
 
 interface CfnDeployOptions {

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -219,6 +219,8 @@ export class CdkToolkit {
         );
       }
 
+      debug(`XXX in cli.diff importExistingResources ${options.importExistingResources}`);
+
       const template = deserializeStructure(await fs.readFile(options.templatePath, { encoding: 'UTF-8' }));
       const formatter = new DiffFormatter({
         ioHelper: asIoHelper(this.ioHost, 'diff'),

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -219,8 +219,6 @@ export class CdkToolkit {
         );
       }
 
-      debug(`XXX in cli.diff importExistingResources ${options.importExistingResources}`);
-
       const template = deserializeStructure(await fs.readFile(options.templatePath, { encoding: 'UTF-8' }));
       const formatter = new DiffFormatter({
         ioHelper: asIoHelper(this.ioHost, 'diff'),

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -336,6 +336,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'processed': { type: 'boolean', desc: 'Whether to compare against the template with Transforms already processed', default: false },
           'quiet': { type: 'boolean', alias: 'q', desc: 'Do not print stack name and default message when there is no diff to stdout', default: false },
           'change-set': { type: 'boolean', alias: 'changeset', desc: 'Whether to create a changeset to analyze resource replacements. In this mode, diff will use the deploy role instead of the lookup role.', default: true },
+          'import-existing-resources': { type: 'boolean', desc: 'Whether or not the change set imports resources that already exist', default: false },
         },
       },
       metadata: {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -246,7 +246,6 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
       case 'diff':
         ioHost.currentAction = 'diff';
         const enableDiffNoFail = isFeatureEnabled(configuration, cxapi.ENABLE_DIFF_NO_FAIL_CONTEXT);
-        ioHost.defaults.info('XXX about to call cli.diff');
         return cli.diff({
           stackNames: args.STACKS,
           exclusively: args.exclusively,

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -258,6 +258,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           quiet: args.quiet,
           changeSet: args['change-set'],
           toolkitStackName: toolkitStackName,
+          importExistingResources: args.importExistingResources,
         });
 
       case 'refactor':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -246,6 +246,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
       case 'diff':
         ioHost.currentAction = 'diff';
         const enableDiffNoFail = isFeatureEnabled(configuration, cxapi.ENABLE_DIFF_NO_FAIL_CONTEXT);
+        ioHost.defaults.info('XXX about to call cli.diff');
         return cli.diff({
           stackNames: args.STACKS,
           exclusively: args.exclusively,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -191,6 +191,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         processed: args.processed,
         quiet: args.quiet,
         changeSet: args.changeSet,
+        importExistingResources: args.importExistingResources,
         STACKS: args.STACKS,
       };
       break;
@@ -419,6 +420,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     processed: config.diff?.processed,
     quiet: config.diff?.quiet,
     changeSet: config.diff?.changeSet,
+    importExistingResources: config.diff?.importExistingResources,
   };
   const metadataOptions = {};
   const acknowledgeOptions = {};

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -744,6 +744,11 @@ export function parseCommandLineArguments(args: Array<string>): any {
             type: 'boolean',
             alias: 'changeset',
             desc: 'Whether to create a changeset to analyze resource replacements. In this mode, diff will use the deploy role instead of the lookup role.',
+          })
+          .option('import-existing-resources', {
+            default: false,
+            type: 'boolean',
+            desc: 'Whether or not the change set imports resources that already exist',
           }),
     )
     .command('metadata [STACK]', 'Returns all metadata associated with this stack')

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1153,6 +1153,13 @@ export interface DiffOptions {
   readonly changeSet?: boolean;
 
   /**
+   * Whether or not the change set imports resources that already exist
+   *
+   * @default - false
+   */
+  readonly importExistingResources?: boolean;
+
+  /**
    * Positional argument for diff
    */
   readonly STACKS?: Array<string>;

--- a/packages/aws-cdk/test/commands/diff.test.ts
+++ b/packages/aws-cdk/test/commands/diff.test.ts
@@ -96,8 +96,8 @@ describe('fixed template', () => {
     });
 
     // THEN
-    const plainTextOutput = notifySpy.mock.calls[0][0].message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
-    expect(plainTextOutput.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')).toContain(`Resources
+    const plainTextOutput = notifySpy.mock.calls.map(x => x[0].message).join('\n').replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+    expect(plainTextOutput).toContain(`Resources
 [~] AWS::SomeService::SomeResource SomeResource
  └─ [~] Something
      ├─ [-] old-value

--- a/packages/aws-cdk/test/commands/diff.test.ts
+++ b/packages/aws-cdk/test/commands/diff.test.ts
@@ -111,6 +111,200 @@ describe('fixed template', () => {
   });
 });
 
+describe('import existing resources', () => {
+  let createDiffChangeSet: jest.SpyInstance<
+    Promise<DescribeChangeSetCommandOutput | undefined>,
+    [ioHelper: IoHelper, options: cfnApi.PrepareChangeSetOptions],
+    any
+  >;
+
+  beforeEach(() => {
+    // Default implementations
+    cloudFormation = instanceMockFrom(Deployments);
+    cloudFormation.readCurrentTemplateWithNestedStacks.mockImplementation(
+      (_stackArtifact: CloudFormationStackArtifact) => {
+        return Promise.resolve({
+          deployedRootTemplate: {
+            Resources: {
+              MyTable: {
+                Type: 'AWS::DynamoDB::Table',
+                Properties: {
+                  TableName: 'MyTableName-12345ABC',
+                },
+                DeletionPolicy: 'Retain',
+              },
+            },
+          },
+          nestedStacks: {},
+        });
+      },
+    );
+    cloudFormation.stackExists = jest.fn().mockReturnValue(Promise.resolve(true));
+    cloudExecutable = new MockCloudExecutable({
+      stacks: [
+        {
+          stackName: 'A',
+          template: {
+            Resources: {
+              MyGlobalTable: {
+                Type: 'AWS::DynamoDB::GlobalTable',
+                Properties: {
+                  TableName: 'MyTableName-12345ABC',
+                },
+              },
+            },
+          },
+        },
+      ],
+    }, undefined, ioHost);
+
+    toolkit = new CdkToolkit({
+      cloudExecutable,
+      deployments: cloudFormation,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+    });
+  });
+
+  test('import action in change set output', async () => {
+    createDiffChangeSet = jest.spyOn(cfnApi, 'createDiffChangeSet').mockImplementationOnce(async () => {
+      return {
+        $metadata: {},
+        Changes: [
+          {
+            ResourceChange: {
+              Action: 'Import',
+              LogicalResourceId: 'MyGlobalTable',
+            },
+          },
+        ],
+      };
+    });
+
+    // WHEN
+    const exitCode = await toolkit.diff({
+      stackNames: ['A'],
+      changeSet: true,
+      importExistingResources: true,
+    });
+
+    expect(createDiffChangeSet).toHaveBeenCalled();
+
+    // THEN
+    const plainTextOutput = notifySpy.mock.calls[0][0].message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+    expect(plainTextOutput.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')).toContain(`
+Resources
+[-] AWS::DynamoDB::Table MyTable orphan
+[←] AWS::DynamoDB::GlobalTable MyGlobalTable import
+`);
+
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('✨  Number of stacks with differences: 1'),
+    }));
+    expect(exitCode).toBe(0);
+  });
+
+  test('import action in change set output when not using --import-exsting-resources', async () => {
+    createDiffChangeSet = jest.spyOn(cfnApi, 'createDiffChangeSet').mockImplementationOnce(async () => {
+      return {
+        $metadata: {},
+        Changes: [
+          {
+            ResourceChange: {
+              Action: 'Add',
+              LogicalResourceId: 'MyGlobalTable',
+            },
+          },
+        ],
+      };
+    });
+
+    // WHEN
+    const exitCode = await toolkit.diff({
+      stackNames: ['A'],
+      changeSet: true,
+      importExistingResources: false,
+    });
+
+    expect(createDiffChangeSet).toHaveBeenCalled();
+
+    // THEN
+    const plainTextOutput = notifySpy.mock.calls[0][0].message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+    expect(plainTextOutput.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')).toContain(`
+Resources
+[-] AWS::DynamoDB::Table MyTable orphan
+[+] AWS::DynamoDB::GlobalTable MyGlobalTable
+`);
+
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('✨  Number of stacks with differences: 1'),
+    }));
+    expect(exitCode).toBe(0);
+  });
+
+  test('when invoked with no changeSet flag', async () => {
+    // WHEN
+    createDiffChangeSet = jest.spyOn(cfnApi, 'createDiffChangeSet').mockImplementationOnce(async () => {
+      return {
+        $metadata: {},
+        Changes: [
+          {
+            ResourceChange: {
+              Action: 'Add',
+              LogicalResourceId: 'MyGlobalTable',
+            },
+          },
+        ],
+      };
+    });
+
+    const exitCode = await toolkit.diff({
+      stackNames: ['A'],
+      changeSet: undefined,
+      importExistingResources: true,
+    });
+
+    expect(createDiffChangeSet).not.toHaveBeenCalled();
+
+    // THEN
+    const plainTextOutput = notifySpy.mock.calls[0][0].message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+    expect(plainTextOutput.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '')).toContain(`
+Resources
+[-] AWS::DynamoDB::Table MyTable orphan
+[+] AWS::DynamoDB::GlobalTable MyGlobalTable
+`);
+
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('✨  Number of stacks with differences: 1'),
+    }));
+    expect(exitCode).toBe(0);
+  });
+
+  test('when invoked with local template path', async () => {
+    const templatePath = 'oldTemplate.json';
+    const oldTemplate = {
+      Resources: {
+        SomeResource: {
+          Type: 'AWS::SomeService::SomeResource',
+          Properties: {
+            Something: 'old-value',
+          },
+        },
+      },
+    };
+    fs.writeFileSync(templatePath, JSON.stringify(oldTemplate));
+    // WHEN
+    await expect(async () => {
+      await toolkit.diff({
+        stackNames: ['A'],
+        changeSet: undefined,
+        templatePath: templatePath,
+        importExistingResources: true,
+      });
+    }).rejects.toThrow(/Can only use --import-existing-resources flag when comparing against deployed stacks/);
+  });
+});
+
 describe('imports', () => {
   let createDiffChangeSet: jest.SpyInstance<
     Promise<DescribeChangeSetCommandOutput | undefined>,


### PR DESCRIPTION
Allow `cdk diff` command to create a change set that imports existing resources.

The current `cdk diff` command implicitly calls
CloudFormation change set creation, providing high-level details such as "add", "delete", "modify", "import",
and etc. like the following:

```s
$ cdk diff
[-] AWS::DynamoDB::Table MyTable orphan
[+] AWS::DynamoDB::GlobalTable MyGlobalTable add
```

However, when the resource is meant to be imported, the `cdk diff` command still shows this as add. Adding `cdk diff --import-existing-resources` flag to show the new resource being imported instead of `add`.

```s
$ cdk diff --import-existing-resources
[-] AWS::DynamoDB::Table MyTable orphan
[←] AWS::DynamoDB::GlobalTable MyGlobalTable import
```

Here is the underlying CFN change set JSON output
```json
[
  {
    "type": "Resource",
    "resourceChange": {
      "action": "Import", # NOTE THAT THIS SHOWS "Import"
      "logicalResourceId": "MyTable794EDED1",
      "physicalResourceId": "DemoStack-MyTable794EDED1-11W4MR8VZ0UPE",
      "resourceType": "AWS::DynamoDB::GlobalTable",
      "replacement": "True",
      "scope": [],
      "details": [],
      "afterContext": "..."
    }
  },
  {
    "type": "Resource",
    "resourceChange": {
      "policyAction": "Retain", # Note that this is "Retain"
      "action": "Remove",
      "logicalResourceId": "MyTable794EDED1",
      "physicalResourceId": "DemoStack-MyTable794EDED1-11W4MR8VZ0UPE",
      "resourceType": "AWS::DynamoDB::Table",
      "scope": [],
      "details": [],
      "beforeContext": "..."
    }
  }
]
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
