### PR TITLE
chore: also write logs if integ tests fail

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -128,15 +128,18 @@ jobs:
           INTEG_LOGS: logs
         run: npx run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
       - name: Set workflow summary
+        if: always()
         run: cat logs/md/*.md >> $GITHUB_STEP_SUMMARY
       - name: Upload logs
         id: logupload
+        if: always()
         uses: actions/upload-artifact@v4.4.0
         with:
           name: logs-${{ matrix.suite }}
           path: logs/
           overwrite: "true"
       - name: Append artifact URL
+        if: always()
         run: |-
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -417,12 +417,14 @@ export class CdkCliIntegTestsWorkflow extends Component {
         },
         {
           name: 'Set workflow summary',
+          if: 'always()',
           run: [
             'cat logs/md/*.md >> $GITHUB_STEP_SUMMARY',
           ].join('\n'),
         },
         {
           name: 'Upload logs',
+          if: 'always()',
           uses: 'actions/upload-artifact@v4.4.0',
           id: 'logupload',
           with: {
@@ -433,6 +435,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         },
         {
           name: 'Append artifact URL',
+          if: 'always()',
           run: [
             'echo "" >> $GITHUB_STEP_SUMMARY',
             'echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY',


### PR DESCRIPTION
Currently, if the integ test suite fails, the step summary doesn't get written and the logs don't get uploaded.

Add

```
if: always()
```

To the steps to make sure they always run, even if the job is failing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
