### PR TITLE
chore: add `toolkit-lib` to the set of locally tested packages

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/toolkit-lib":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml
@@ -99,7 +99,7 @@ jobs:
           echo 'registry=http://localhost:4873/' >> ~/.npmrc
       - name: Find an locally publish all tarballs
         run: |-
-          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk-testing/cli-integ}/dist/js/*.tgz; do
+          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk-testing/cli-integ,@aws-cdk/toolkit-lib}/dist/js/*.tgz; do
             npm publish $pkg
           done
       - name: Download and install the test artifact

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -812,6 +812,7 @@ const toolkitLib = configureProject(
         module: 'NodeNext',
       },
     },
+    nextVersionCommand: 'tsx ../../projenrc/next-version.ts maybeRc',
   }),
 );
 
@@ -1669,6 +1670,7 @@ new CdkCliIntegTestsWorkflow(repo, {
     cliLib.name,
     cdkAliasPackage.name,
     cliInteg.name,
+    toolkitLib.name,
   ],
 
   allowUpstreamVersions: [

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -40,6 +40,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/toolkit-lib@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
+        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../cloud-assembly-schema ../cloudformation-diff"
       },
       "steps": [
@@ -257,6 +258,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/toolkit-lib@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
+        "NEXT_VERSION_COMMAND": "tsx ../../projenrc/next-version.ts maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../cloud-assembly-schema ../cloudformation-diff"
       },
       "steps": [


### PR DESCRIPTION
Without these changes we only ever test against the publicly released version of `@aws-cdk/toolkit-lib`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
