### PR TITLE
chore: unbump introduces a diff

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1598,7 +1598,7 @@ const cliInteg = configureProject(
     ],
     devDeps: [
       yarnCling,
-      toolkitLib,
+      toolkitLib.customizeReference({ versionType: 'exact' }),
       '@types/semver@^7',
       '@types/yargs@^16',
       '@types/fs-extra@^9',

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -39,7 +39,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/toolkit-lib": "0.0.0",
+    "@aws-cdk/toolkit-lib": "^0.0.0",
     "@aws-cdk/yarn-cling": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@stylistic/eslint-plugin": "^3",


### PR DESCRIPTION
Get rid of a diff that's caused by a bump/unbump cycle

```
   "devDependencies": {
-    "@aws-cdk/toolkit-lib": "0.0.0",
+    "@aws-cdk/toolkit-lib": "^0.0.0",
```

This is blocking the release.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
