### PR TITLE
fix(cli-integ): avoid capturing stderr when querying NPM

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
@@ -28,6 +28,7 @@ export async function npmQueryInstalledVersion(packageName: string, dir: string)
   const reportStr = await shell(['node', require.resolve('npm'), 'list', '--json', '--depth', '0', packageName], {
     cwd: dir,
     show: 'error',
+    captureStderr: false,
   });
   const report = JSON.parse(reportStr);
   return report.dependencies[packageName].version;


### PR DESCRIPTION
In some environments NPM prints to `stderr` when doing `npm list --json`, which we need to explicitly tell the `shell()` function to ignore.

Fixes broken canary tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
