### PR TITLE
fix(cli-integ): error removing symlinked library

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
@@ -35,7 +35,7 @@ export class RunnerLibraryGlobalInstallSource implements IRunnerSource<ITestLibr
       version,
       async dispose() {
         // Remove the symlink again
-        await fs.rm(symlinkPath);
+        await fs.unlink(symlinkPath);
       },
       serialize: () => {
         return [TestLibraryGlobalInstallSource, [this.packageName, version]];


### PR DESCRIPTION
`fs.rm` tries to remove the thing the symlink points to, instead of removing the symlink itself.

Use `fs.unlink` instead.

Still necessary to fix the canaries.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
