### PR TITLE
chore(toolkit-lib): use `isolatedModules` from tsconfig instead of `ts-jest`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -828,8 +828,14 @@ const toolkitLib = configureProject(
       compilerOptions: {
         ...defaultTsOptions,
         target: 'es2022',
-        lib: ['es2022', 'esnext.disposable', 'dom'],
+        lib: ['es2022', 'esnext.disposable'],
         module: 'NodeNext',
+        isolatedModules: true,
+      },
+    },
+    tsJestOptions: {
+      transformOptions: {
+        isolatedModules: false, // we use the respective tsc setting
       },
     },
     nextVersionCommand: 'tsx ../../../projenrc/next-version.ts maybeRc',

--- a/packages/@aws-cdk/toolkit-lib/jest.config.json
+++ b/packages/@aws-cdk/toolkit-lib/jest.config.json
@@ -63,7 +63,7 @@
       "ts-jest",
       {
         "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "isolatedModules": false
       }
     ]
   },

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/index.ts
@@ -1,5 +1,5 @@
-export { ExpandStackSelection, StackSelectionStrategy, StackSelector } from './stack-selector';
+export { ExpandStackSelection, StackSelectionStrategy } from './stack-selector';
+export type { StackSelector } from './stack-selector';
 export * from './cached-source';
 export * from './source-builder';
 export * from './types';
-

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/deploy.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/deploy.ts
@@ -5,7 +5,7 @@ import type { PermissionChangeType } from './diff';
 import type { ConfirmationRequest } from './types';
 
 // re-export so they are part of the public API
-export { DeployStackResult, SuccessfulDeployStackResult, NeedRollbackFirstDeployStackResult, ReplacementRequiresRollbackStackResult } from '../api/deployments/deployment-result';
+export type { DeployStackResult, SuccessfulDeployStackResult, NeedRollbackFirstDeployStackResult, ReplacementRequiresRollbackStackResult } from '../api/deployments/deployment-result';
 
 export interface StackDeployProgress {
   /**

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
@@ -9,8 +9,7 @@
     "inlineSources": true,
     "lib": [
       "es2022",
-      "esnext.disposable",
-      "dom"
+      "esnext.disposable"
     ],
     "module": "NodeNext",
     "noEmitOnError": false,
@@ -28,6 +27,7 @@
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "rootDir": ".",
     "composite": true,
     "outDir": "lib"

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.json
@@ -11,8 +11,7 @@
     "inlineSources": true,
     "lib": [
       "es2022",
-      "esnext.disposable",
-      "dom"
+      "esnext.disposable"
     ],
     "module": "NodeNext",
     "noEmitOnError": false,
@@ -30,6 +29,7 @@
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [


### PR DESCRIPTION
`isolatedModules` is a tsconfig that can help improve the performance of tools interpreting .ts files in single-file transpilation processes. In our case that's what `ts-jest` is doing. We are currently getting something like this behavior by settings  ts-jest's `isolatedModules` setting (and yes: that's a different setting with the same goal). However we are also getting a bunch of warnings about this setting from `ts-jest` as it will be deprecated in the next version.

This change serves as a testing ground to see if and how we can enable tsc's `isolatedModules` for all packages. It enables TypeScript's `isolatedModules` and disables `ts-jest`'s `isolatedModules`. To make this change work, a few minor changes had to be made to the `toolkit-lib` code. I then manually benchmarked the time it takes for tests to run, and there seems to be no performance difference.

Reference: https://www.typescriptlang.org/tsconfig/#isolatedModules

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
