### PR TITLE
chore: log test durations to Markdown table

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -129,7 +129,10 @@ jobs:
         run: npx run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
       - name: Set workflow summary
         if: always()
-        run: cat logs/md/*.md >> $GITHUB_STEP_SUMMARY
+        run: |-
+          if compgen -G "logs/md/*.md" > /dev/null; then
+            cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;
+          fi
       - name: Upload logs
         id: logupload
         if: always()

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
@@ -41,7 +41,11 @@ export function withAws<A extends TestContext>(
       const atmosphere = new AtmosphereClient(atmosphereEndpoint(), {
         logStream: context.output,
       });
+
+      const start = Date.now();
       const allocation = await atmosphere.acquire({ pool: atmospherePool(), requester: context.name, timeoutSeconds: 60 * 30 });
+      context.reportWaitTime(Date.now() - start);
+
       const aws = await AwsClients.forIdentity(allocation.environment.region, {
         accessKeyId: allocation.credentials.accessKeyId,
         secretAccessKey: allocation.credentials.secretAccessKey,

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -420,7 +420,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
           name: 'Set workflow summary',
           if: 'always()',
           run: [
-            'cat logs/md/*.md >> $GITHUB_STEP_SUMMARY',
+            // Don't fail the glob expensaion if there are no .md files
+            'if compgen -G "logs/md/*.md" > /dev/null; then',
+            '  cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;',
+            'fi',
           ].join('\n'),
         },
         {


### PR DESCRIPTION
The Markdown table contains test information. Add the time taken for the test to run, as well as the total time spent waiting for Atmosphere allocations.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
