### PR TITLE
chore(toolkit-lib): silence expected error in api-extractor config

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -999,7 +999,7 @@ const apiExtractorDocsTask = toolkitLib.addTask('api-extractor-docs', {
     // Copy the API model to the directory (with error handling)
     'if [ -f dist/toolkit-lib.api.json ]; then cp dist/toolkit-lib.api.json dist/api-extractor-docs/cdk/api/toolkit-lib/; else echo "Warning: API JSON file not found"; fi',
     // Add version file
-    '(cat dist/version.txt || echo "latest") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION',
+    '(cat dist/version.txt 2>/dev/null || echo "latest") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION',
     // Copy README.md if it exists
     'if [ -f README.md ]; then cp README.md dist/api-extractor-docs/cdk/api/toolkit-lib/; fi',
     // Copy all files from docs directory if it exists

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -4,7 +4,7 @@
       "name": "api-extractor-docs",
       "steps": [
         {
-          "exec": "api-extractor run || true && mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib && if [ -f dist/toolkit-lib.api.json ]; then cp dist/toolkit-lib.api.json dist/api-extractor-docs/cdk/api/toolkit-lib/; else echo \"Warning: API JSON file not found\"; fi && (cat dist/version.txt || echo \"latest\") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION && if [ -f README.md ]; then cp README.md dist/api-extractor-docs/cdk/api/toolkit-lib/; fi && if [ -d docs ]; then mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib/docs && cp -r docs/* dist/api-extractor-docs/cdk/api/toolkit-lib/docs/; fi && cd dist/api-extractor-docs && zip -r -q ../api-extractor-docs.zip cdk"
+          "exec": "api-extractor run || true && mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib && if [ -f dist/toolkit-lib.api.json ]; then cp dist/toolkit-lib.api.json dist/api-extractor-docs/cdk/api/toolkit-lib/; else echo \"Warning: API JSON file not found\"; fi && (cat dist/version.txt 2>/dev/null || echo \"latest\") > dist/api-extractor-docs/cdk/api/toolkit-lib/VERSION && if [ -f README.md ]; then cp README.md dist/api-extractor-docs/cdk/api/toolkit-lib/; fi && if [ -d docs ]; then mkdir -p dist/api-extractor-docs/cdk/api/toolkit-lib/docs && cp -r docs/* dist/api-extractor-docs/cdk/api/toolkit-lib/docs/; fi && cd dist/api-extractor-docs && zip -r -q ../api-extractor-docs.zip cdk"
         }
       ]
     },


### PR DESCRIPTION
This PR adds stderr redirection to the cat command when reading version.txt to prevent error messages from appearing in the VERSION file when the file doesn't exist.\n\nThe change affects both the .projenrc.ts file and the generated tasks.json file.