### PR TITLE
fix: prevent coverage threshold failures in CI

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,6 +23,8 @@ jobs:
           node-version: lts/*
       - name: Install dependencies
         run: yarn install
+      - name: Reset coverage thresholds
+        run: find . -name "jest.config.json" -type f -exec chmod +w {} \; -exec node -e "const fs=require('fs'); const file=process.argv[1]; const data=JSON.parse(fs.readFileSync(file)); data.coverageThreshold={ }; fs.writeFileSync(file, JSON.stringify(data, null, 2));" {} \;
       - name: Build and test CLI
         run: yarn nx run aws-cdk:build
       - name: Upload results to Codecov

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -41,6 +41,10 @@ export class CodeCovWorkflow extends Component {
           run: 'yarn install',
         },
         {
+          name: 'Reset coverage thresholds',
+          run: 'find . -name "jest.config.json" -type f -exec chmod +w {} \\; -exec node -e "const fs=require(\'fs\'); const file=process.argv[1]; const data=JSON.parse(fs.readFileSync(file)); data.coverageThreshold={ }; fs.writeFileSync(file, JSON.stringify(data, null, 2));" {} \\;',
+        },
+        {
           name: 'Build and test CLI',
           // The 'build' job includes running tests
           run: `yarn nx run ${props.packages.map(p => `${p}:build`).join(' ')}`,


### PR DESCRIPTION
This PR adds a step to the codecov workflow that resets all coverage thresholds to empty objects before running tests. This ensures that the codecov job never fails due to coverage thresholds not being met, allowing it to simply collect and report coverage data to codecov.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license