### PR TITLE
chore: add npm cache to setup-node in integ workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: lts/*
+          cache: npm
       - name: Install dependencies
         run: yarn install --check-files
       - name: Bump to realistic versions

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -194,6 +194,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           uses: 'actions/setup-node@v4',
           with: {
             'node-version': 'lts/*',
+            'cache': 'npm',
           },
         },
         {


### PR DESCRIPTION
This PR adds npm caching to the setup-node action in the integration workflow, which should help speed up the workflow by caching npm dependencies.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

*100% of code written by human and PR description generated by AI with human input*