### PR TITLE
chore(toolkit-lib): add caret to aws-cdk/cli-plugin-contract devDep to unblock release

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@aws-cdk/aws-service-spec": "^0.1.72",
-    "@aws-cdk/cli-plugin-contract": "0.0.0",
+    "@aws-cdk/cli-plugin-contract": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.3.2",
     "@jest/environment": "^29.7.0",
     "@jest/globals": "^29.7.0",


### PR DESCRIPTION
At the end of the release process build we are restoring versions for local monorepo packages. This is currently hard-coded to always include a caret `^`. While not ideal, it doesn't matter in our case. Before we do a proper fix, unblock the release by just adding the caret.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
