### PR TITLE
chore: use AWS_MANAGED_KEY for integ tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -737,7 +737,7 @@ export async function ensureBootstrapped(fixture: TestFixture) {
 }
 
 async function doBootstrap(envSpecifier: string, fixture: TestFixture, allowErrExit: boolean) {
-  return fixture.cdk(['bootstrap', envSpecifier], {
+  return fixture.cdk(['bootstrap', '--bootstrap-kms-key-id', 'AWS_MANAGED_KEY', envSpecifier], {
     modEnv: {
       // Even for v1, use new bootstrap
       CDK_NEW_BOOTSTRAP: '1',

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -77,7 +77,7 @@ export async function makeConfig(): Promise<CliConfig> {
         description: 'Deploys the CDK toolkit stack into an AWS environment',
         options: {
           'bootstrap-bucket-name': { type: 'string', alias: ['b', 'toolkit-bucket-name'], desc: 'The name of the CDK toolkit bucket; bucket will be created and must not exist', default: undefined },
-          'bootstrap-kms-key-id': { type: 'string', desc: 'AWS KMS master key ID used for the SSE-KMS encryption', default: undefined, conflicts: 'bootstrap-customer-key' },
+          'bootstrap-kms-key-id': { type: 'string', desc: 'AWS KMS master key ID used for the SSE-KMS encryption (specify AWS_MANAGED_KEY to use an AWS-managed key)', default: undefined, conflicts: 'bootstrap-customer-key' },
           'example-permissions-boundary': { type: 'boolean', alias: 'epb', desc: 'Use the example permissions boundary.', default: undefined, conflicts: 'custom-permissions-boundary' },
           'custom-permissions-boundary': { type: 'string', alias: 'cpb', desc: 'Use the permissions boundary specified by name.', default: undefined, conflicts: 'example-permissions-boundary' },
           'bootstrap-customer-key': { type: 'boolean', desc: 'Create a Customer Master Key (CMK) for the bootstrap bucket (you will be charged but can customize permissions, modern bootstrapping only)', default: undefined, conflicts: 'bootstrap-kms-key-id' },

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -201,7 +201,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
         .option('bootstrap-kms-key-id', {
           default: undefined,
           type: 'string',
-          desc: 'AWS KMS master key ID used for the SSE-KMS encryption',
+          desc: 'AWS KMS master key ID used for the SSE-KMS encryption (specify AWS_MANAGED_KEY to use an AWS-managed key)',
           conflicts: 'bootstrap-customer-key',
         })
         .option('example-permissions-boundary', {

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -394,7 +394,7 @@ export interface BootstrapOptions {
   readonly bootstrapBucketName?: string;
 
   /**
-   * AWS KMS master key ID used for the SSE-KMS encryption
+   * AWS KMS master key ID used for the SSE-KMS encryption (specify AWS_MANAGED_KEY to use an AWS-managed key)
    *
    * @default - undefined
    */


### PR DESCRIPTION
Use an AWS-managed KMS key for bucket encryption in the bootstrapping of integ tests.

This should shave ~1 minute off of the bootstrapping of every environment.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
