### PR TITLE
fix(cli-lib-alpha): deprecate package

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Here are the packages in this repository. See the README of each package for mor
 | [@aws-cdk/cloud-assembly-schema](./packages/@aws-cdk//cloud-assembly-schema/) | The contract between the CDK construct library and the CDK toolkit | Yes | Yes |
 | [@aws-cdk/cloudformation-diff](./packages/@aws-cdk/cloudformation-diff/) | CLI component for diffing CloudFormation templates | Yes | Yes |
 | [@aws-cdk/cli-lib-alpha](./packages/@aws-cdk/cli-lib-alpha/) | A deprecated attempt at building a programmatic interface for the CLI | Yes | No |
-| [@aws-cdk/toolkit-lib](./packages/@aws-cdk/toolkit-lib/) | A work-in-progress programmatic interface for the CLI | No | Yes |
+| [@aws-cdk/toolkit-lib](./packages/@aws-cdk/toolkit-lib/) | A programmatic interface for the CDK Toolkit | Yes | Yes |
 | [@aws-cdk/cli-plugin-contract](./packages/@aws-cdk/cli-plugin-contract/) | TypeScript types for CLI plugins. | No | Yes |
 | [@aws-cdk/cdk-cli-wrapper](./packages/@aws-cdk/cdk-cli-wrapper/) | A deprecated attempt at building a programmatic interface for the CLI | No | No |
 | [@aws-cdk/node-bundle](./packages/@aws-cdk/node-bundle/) | A tool to build CLI bundles that include license attributions. | No | Yes |

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-npm-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/cli-npm-source.ts
@@ -18,6 +18,7 @@ export class RunnerCliNpmSource implements IRunnerSource<ITestCliSource> {
 
     await shell(['node', require.resolve('npm'), 'install', `aws-cdk@${this.range}`], {
       cwd: tempDir,
+      show: 'error',
     });
     const installedVersion = await npmQueryInstalledVersion('aws-cdk', tempDir);
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/library-globalinstall-source.ts
@@ -23,6 +23,7 @@ export class RunnerLibraryGlobalInstallSource implements IRunnerSource<ITestLibr
 
     await shell(['node', require.resolve('npm'), 'install', `${this.packageName}@${this.range}`], {
       cwd: tempDir,
+      show: 'error',
     });
 
     const symlinkPath = path.join(__dirname, '..', '..', 'node_modules', this.packageName);

--- a/packages/@aws-cdk/cli-lib-alpha/README.md
+++ b/packages/@aws-cdk/cli-lib-alpha/README.md
@@ -1,31 +1,27 @@
-# AWS CDK CLI Library
+# AWS CDK CLI Library (deprecated)
+
 <!--BEGIN STABILITY BANNER-->
 
 ---
 
-![cdk-constructs: Experimental](https://img.shields.io/badge/cdk--constructs-experimental-important.svg?style=for-the-badge)
+![@aws-cdk/cli-lib-lpha: Deprecated](https://img.shields.io/badge/@aws--cdk/cli--lib--alpha-deprectated-red.svg?style=for-the-badge)
 
-> The APIs of higher level constructs in this module are experimental and under active development.
-> They are subject to non-backward compatible changes or removal in any future version. These are
-> not subject to the [Semantic Versioning](https://semver.org/) model and breaking changes will be
-> announced in the release notes. This means that while you may use them, you may need to update
-> your source code when upgrading to a newer version of this package.
+> This package has been deprecated in favor of [@aws-cdk/toolkit-lib](https://github.com/aws/aws-cdk-cli/issues/155),
+> a newer approach providing similar functionality to what this package offered.
+> Please migrate as soon as possible.
+> For any migration problems, please open [an issue](https://github.com/aws/aws-cdk-cli/issues/new/choose).
+> We are committed to supporting the same feature set that this package offered.
 
 ---
 
 <!--END STABILITY BANNER-->
 
-## ⚠️ Experimental module
+## ⚠️ Deprecated module
 
-This package is highly experimental. Expect frequent API changes and incomplete features.
-Known issues include:
+This package is has been deprecated.
+Already published versions can be used, but no support is provided whatsoever and we will soon stop publishing new versions.
 
-- **JavaScript/TypeScript only**\
-  The jsii packages are currently not in a working state.
-- **No useful return values**\
-  All output is currently printed to stdout/stderr
-- **Missing or Broken options**\
-  Some CLI options might not be available in this package or broken
+Instead, please use [@aws-cdk/toolkit-lib](https://github.com/aws/aws-cdk-cli/issues/155).
 
 ## Overview
 
@@ -37,6 +33,17 @@ Currently the package includes implementations for:
 - `cdk bootstrap`
 - `cdk destroy`
 - `cdk list`
+
+## Known issues
+
+- **JavaScript/TypeScript only**\
+  The jsii packages are currently not in a working state.
+- **No useful return values**\
+  All output is currently printed to stdout/stderr
+- **Missing or Broken options**\
+  Some CLI options might not be available in this package or broken
+
+Due to the deprecation of the package, this issues will not be resolved.
 
 ## Setup
 

--- a/packages/@aws-cdk/cli-lib-alpha/package.json
+++ b/packages/@aws-cdk/cli-lib-alpha/package.json
@@ -83,7 +83,8 @@
   },
   "version": "0.0.0",
   "types": "lib/index.d.ts",
-  "stability": "experimental",
+  "stability": "deprecated",
+  "deprecated": "Deprecated in favor of @aws-cdk/toolkit-lib, a newer approach providing similar functionality to this package. Please migrate.",
   "jsii": {
     "outdir": "dist",
     "targets": {
@@ -99,7 +100,8 @@
         "module": "aws_cdk.cli_lib_alpha",
         "classifiers": [
           "Framework :: AWS CDK",
-          "Framework :: AWS CDK :: 2"
+          "Framework :: AWS CDK :: 2",
+          "Development Status :: 7 - Inactive"
         ]
       },
       "dotnet": {


### PR DESCRIPTION
Deprecated in favor of @aws-cdk/toolkit-lib, a newer approach providing similar functionality to this package. Please migrate.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
