### PR TITLE
fix(cli): gc does not delete isolated assets when rollback-buffer-days is set

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
@@ -1,10 +1,10 @@
 import { ListObjectsV2Command, PutObjectTaggingCommand } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap, randomString } from '../../lib';
-import { S3_ISOLATED_TAG } from '../../../../@aws-cdk/toolkit-lib/lib/api';
 
 jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
 
 const DAY = 24 * 60 * 60 * 1000;
+const S3_ISOLATED_TAG = 'aws-cdk:isolated';
 
 integTest(
   'Garbage Collection deletes unused s3 objects with rollback-buffer-days',
@@ -39,8 +39,8 @@ integTest(
 
     // Pretend the asset was tagged with an old date > 1 day ago so that garbage collection
     // should pick up and delete asset even with rollbackBufferDays=1
-    const result = await fixture.aws.s3.send(new ListObjectsV2Command({ Bucket: bootstrapBucketName }));
-    const key = result.Contents!.filter((c) => c.Key?.split('.')[1] == 'zip')[0].Key; // fancy footwork to make sure we have the asset key
+    const res = await fixture.aws.s3.send(new ListObjectsV2Command({ Bucket: bootstrapBucketName }));
+    const key = res.Contents!.filter((c) => c.Key?.split('.')[1] == 'zip')[0].Key; // fancy footwork to make sure we have the asset key
     await fixture.aws.s3.send(new PutObjectTaggingCommand({
       Bucket: bootstrapBucketName,
       Key: key,

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
@@ -1,0 +1,68 @@
+import { ListObjectsV2Command, PutObjectTaggingCommand } from '@aws-sdk/client-s3';
+import { integTest, withoutBootstrap, randomString } from '../../lib';
+import { S3_ISOLATED_TAG } from '../../../../@aws-cdk/toolkit-lib/lib/api';
+
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
+const DAY = 24 * 60 * 60 * 1000;
+
+integTest(
+  'Garbage Collection deletes unused s3 objects with rollback-buffer-days',
+  withoutBootstrap(async (fixture) => {
+    const toolkitStackName = fixture.bootstrapStackName;
+    const bootstrapBucketName = `aws-cdk-garbage-collect-integ-test-bckt-${randomString()}`;
+    fixture.rememberToDeleteBucket(bootstrapBucketName); // just in case
+
+    await fixture.cdkBootstrapModern({
+      toolkitStackName,
+      bootstrapBucketName,
+    });
+
+    await fixture.cdkDeploy('lambda', {
+      options: [
+        '--context', `bootstrapBucket=${bootstrapBucketName}`,
+        '--context', `@aws-cdk/core:bootstrapQualifier=${fixture.qualifier}`,
+        '--toolkit-stack-name', toolkitStackName,
+        '--force',
+      ],
+    });
+    fixture.log('Setup complete!');
+
+    await fixture.cdkDestroy('lambda', {
+      options: [
+        '--context', `bootstrapBucket=${bootstrapBucketName}`,
+        '--context', `@aws-cdk/core:bootstrapQualifier=${fixture.qualifier}`,
+        '--toolkit-stack-name', toolkitStackName,
+        '--force',
+      ],
+    });
+
+    // Pretend the asset was tagged with an old date > 1 day ago so that garbage collection
+    // should pick up and delete asset even with rollbackBufferDays=1
+    const result = await fixture.aws.s3.send(new ListObjectsV2Command({ Bucket: bootstrapBucketName }));
+    const key = result.Contents!.filter((c) => c.Key?.split('.')[1] == 'zip')[0].Key; // fancy footwork to make sure we have the asset key
+    await fixture.aws.s3.send(new PutObjectTaggingCommand({
+      Bucket: bootstrapBucketName,
+      Key: key,
+      Tagging: {
+        TagSet: [{
+          Key: S3_ISOLATED_TAG,
+          Value: String(Date.now() - (30 * DAY)),
+        }],
+      },
+    }));
+
+    await fixture.cdkGarbageCollect({
+      rollbackBufferDays: 1,
+      type: 's3',
+      bootstrapStackName: toolkitStackName,
+    });
+    fixture.log('Garbage collection complete!');
+
+    // assert that the bootstrap bucket is empty
+    await fixture.aws.s3.send(new ListObjectsV2Command({ Bucket: bootstrapBucketName }))
+      .then((result) => {
+        expect(result.Contents).toBeUndefined();
+      });
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
@@ -55,7 +55,8 @@ export class ImageAsset {
     if (!dateIsolated || dateIsolated == '') {
       return false;
     }
-    return new Date(dateIsolated) < date;
+
+    return new Date(Number(dateIsolated)) < date;
   }
 
   public buildImageTag(inc: number) {
@@ -115,7 +116,8 @@ export class ObjectAsset {
     if (!tagValue || tagValue == '') {
       return false;
     }
-    return new Date(tagValue) < date;
+
+    return new Date(Number(tagValue)) < date;
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
@@ -916,7 +916,7 @@ describe('Garbage Collection with large # of objects', () => {
     // of the 2000 in use assets, 1000 are tagged.
     s3Client.on(GetObjectTaggingCommand).callsFake((params) => ({
       TagSet: Number(params.Key[params.Key.length - 5]) % 2 === 0
-        ? [{ Key: S3_ISOLATED_TAG, Value: new Date(2000, 1, 1).toISOString() }]
+        ? [{ Key: S3_ISOLATED_TAG, Value: new Date(2000, 1, 1).getTime() }]
         : [],
     }));
   }


### PR DESCRIPTION
The `Date` class allows the following for values: `new Date(value: number | string | Date)`, but sometimes does not work as expected. That's essentially what we are doing because we are storing the string value of the date in the tags and the conversion back to a date doesn't work correctly.

The issue with Dates:

```ts
console.log(new Date(1747346265800)) // 2025-05-15T21:57:45.800Z
console.log(new Date('1747346265800')) // Invalid Date
```

I seem to have been unlucky with how I tried to create the date from a string.

This _was_ attempted to be unit tested but in the unit test I mistakenly mocked the tag to be an ISO String which _is_ a string so it had no problem getting converted into a Date. This test has been updated.

Because we pessimistically handle errors; we just treated this as a nondeletable asset. I have added an integ test that tests this scenario and confirmed on my own local set up that this fixes the issue.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
