### PR TITLE
fix(cdk-assets): indicate correct docker command that failed to execute

### DIFF
--- a/packages/cdk-assets/lib/private/docker.ts
+++ b/packages/cdk-assets/lib/private/docker.ts
@@ -226,7 +226,7 @@ export class Docker {
     } catch (e: any) {
       if (e.code === 'ENOENT') {
         throw new Error(
-          "Unable to execute 'docker' in order to build a container asset. Please install 'docker' and try again.",
+          `Unable to execute '${getDockerCmd()}' in order to build a container asset. Please install '${getDockerCmd()}' and try again.`,
         );
       }
       throw e;

--- a/packages/cdk-assets/lib/private/docker.ts
+++ b/packages/cdk-assets/lib/private/docker.ts
@@ -226,7 +226,7 @@ export class Docker {
     } catch (e: any) {
       if (e.code === 'ENOENT') {
         throw new Error(
-          `Unable to execute '${getDockerCmd()}' in order to build a container asset. Please install '${getDockerCmd()}' and try again.`,
+          `Failed to find and execute '${getDockerCmd()}' while attempting to build a container asset. Please install '${getDockerCmd()}' and try again. (Or set the 'CDK_DOCKER ' environment variable to choose a different compatible container client.)`,
         );
       }
       throw e;


### PR DESCRIPTION
Users may override the executable used (instead of `docker`) by setting the CDK_DOCKER environment variable, but the message of the error thrown when such an executable does not exist was not similarly dynamic. Align the contents of the message with the executable invoked.

Fixes #282.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
