### PR TITLE
fix(toolkit-lib): MFA token cannot be provided through IoHost

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/toolkit-lib":{"access":"$all","publish":"$all","proxy":"npmjs"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/toolkit-lib":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cli-plugin-contract":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml
@@ -100,7 +100,7 @@ jobs:
           echo 'registry=http://localhost:4873/' >> ~/.npmrc
       - name: Find an locally publish all tarballs
         run: |-
-          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk-testing/cli-integ,@aws-cdk/toolkit-lib}/dist/js/*.tgz; do
+          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk-testing/cli-integ,@aws-cdk/toolkit-lib,@aws-cdk/cli-plugin-contract}/dist/js/*.tgz; do
             npm publish $pkg
           done
       - name: Download and install the test artifact

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1706,6 +1706,7 @@ new CdkCliIntegTestsWorkflow(repo, {
     cdkAliasPackage.name,
     cliInteg.name,
     toolkitLib.name,
+    cliPluginContract.name,
   ],
 
   allowUpstreamVersions: [

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -102,3 +102,4 @@ group: Documents
 | `CDK_SDK_I0000` | An SDK debug message. | `debug` | n/a |
 | `CDK_SDK_W0000` | An SDK warning message. | `warn` | n/a |
 | `CDK_SDK_I0100` | An SDK trace. SDK traces are emitted as traces to the IoHost, but contain the original SDK logging level. | `trace` | {@link SdkTrace} |
+| `CDK_SDK_I1100` | Get an MFA token for an MFA device. | `info` | {@link MfaTokenRequest} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -11,7 +11,7 @@ import type { StackDetailsPayload } from '../../../payloads/list';
 import type { CloudWatchLogEvent, CloudWatchLogMonitorControlEvent } from '../../../payloads/logs-monitor';
 import type { RefactorResult } from '../../../payloads/refactor';
 import type { StackRollbackProgress } from '../../../payloads/rollback';
-import type { SdkTrace } from '../../../payloads/sdk-trace';
+import type { MfaTokenRequest, SdkTrace } from '../../../payloads/sdk';
 import type { StackActivity, StackMonitoringControlEvent } from '../../../payloads/stack-activity';
 import type { StackSelectionDetails } from '../../../payloads/synth';
 import type { AssemblyData, ConfirmationRequest, ContextProviderMessageSource, Duration, ErrorPayload, StackAndAssemblyData } from '../../../payloads/types';
@@ -516,6 +516,11 @@ export const IO = {
     code: 'CDK_SDK_I0100',
     description: 'An SDK trace. SDK traces are emitted as traces to the IoHost, but contain the original SDK logging level.',
     interface: 'SdkTrace',
+  }),
+  CDK_SDK_I1100: make.question<MfaTokenRequest>({
+    code: 'CDK_SDK_I1100',
+    description: 'Get an MFA token for an MFA device.',
+    interface: 'MfaTokenRequest',
   }),
 };
 

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
@@ -2,7 +2,7 @@ export * from './bootstrap-environment-progress';
 export * from './deploy';
 export * from './destroy';
 export * from './list';
-export * from './sdk-trace';
+export * from './sdk';
 export * from './context';
 export * from './rollback';
 export * from './stack-activity';

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/sdk.ts
@@ -1,3 +1,5 @@
+import type { DataRequest } from './types';
+
 /**
  * An SDK logging trace.
  *
@@ -18,4 +20,14 @@ export interface SdkTrace {
    * @see https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/logging-sdk-calls.html
    */
   readonly content: any;
+}
+
+/**
+ * Get an MFA token for an MFA device.
+ */
+export interface MfaTokenRequest extends DataRequest {
+  /**
+   * The ARN of the MFA device a token is required for.
+   */
+  readonly deviceArn: string;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/types.ts
@@ -99,6 +99,18 @@ export interface ConfirmationRequest {
   readonly concurrency?: number;
 }
 
+/**
+ * A generic request for data
+ */
+export interface DataRequest {
+  /**
+   * An optional description of the expected response
+   * Provides additional details on what the response can be.
+   * This can be treated as a direct instruction to end-users when prompting for input.
+   */
+  responseDescription?: string;
+}
+
 export interface ContextProviderMessageSource {
   /**
    * The name of the context provider sending the message

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -357,10 +357,12 @@ export class CliIoHost implements IIoHost {
       const data: {
         motivation?: string;
         concurrency?: number;
+        responseDescription?: string;
       } = msg.data ?? {};
 
       const motivation = data.motivation ?? 'User input is needed';
       const concurrency = data.concurrency ?? 0;
+      const responseDescription = data.responseDescription;
 
       // only talk to user if STDIN is a terminal (otherwise, fail)
       if (!this.isTTY) {
@@ -392,8 +394,10 @@ export class CliIoHost implements IIoHost {
 
       // Asking for a specific value
       const prompt = extractPromptInfo(msg);
-      const answer = await promptly.prompt(`${chalk.cyan(msg.message)} (${prompt.default})`, {
+      const desc = responseDescription ?? prompt.default;
+      const answer = await promptly.prompt(`${chalk.cyan(msg.message)}${desc ? ` (${desc})` : ''}`, {
         default: prompt.default,
+        trim: true,
       });
       return prompt.convertAnswer(answer);
     });


### PR DESCRIPTION
Relates to #396 

Considering this a bug fix, since it is currently not possible to integrate an IoHost with this. While this does affect the CLI, the DX is virtually unchanged. I run the auth test suite to ensure everything is still working as expected.

Before:

<img width="589" alt="before" src="https://github.com/user-attachments/assets/cb5d7d39-ed81-4bef-b859-3eb26d964f59" />

After:

<img width="619" alt="after" src="https://github.com/user-attachments/assets/bf410b53-44c5-4657-ab6b-890ca63fb508" />


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
