### PR TITLE
fix(cli): allow [a] to confirm garbage collection of all asset batches

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -72,6 +72,7 @@ group: Documents
 | `CDK_TOOLKIT_W8010` | Refactor execution not yet supported | `warn` | n/a |
 | `CDK_TOOLKIT_I9000` | Provides bootstrap times | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I9100` | Bootstrap progress | `info` | {@link BootstrapEnvironmentProgress} |
+| `CDK_TOOLKIT_I9210` | Confirm the deletion of a batch of assets | `info` | {@link AssetBatchDeletionRequest} |
 | `CDK_TOOLKIT_I9900` | Bootstrap results on success | `result` | [cxapi.Environment](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.Environment.html) |
 | `CDK_TOOLKIT_E9900` | Bootstrap failed | `error` | {@link ErrorPayload} |
 | `CDK_TOOLKIT_I0100` | Notices decoration (the header or footer of a list of notices) | `info` | n/a |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -6,6 +6,7 @@ import type { BootstrapEnvironmentProgress } from '../../../payloads/bootstrap-e
 import type { MissingContext, UpdatedContext } from '../../../payloads/context';
 import type { BuildAsset, DeployConfirmationRequest, PublishAsset, StackDeployProgress, SuccessfulDeployStackResult } from '../../../payloads/deploy';
 import type { StackDestroy, StackDestroyProgress } from '../../../payloads/destroy';
+import type { AssetBatchDeletionRequest } from '../../../payloads/gc';
 import type { HotswapDeploymentDetails, HotswapDeploymentAttempt, HotswappableChange, HotswapResult } from '../../../payloads/hotswap';
 import type { StackDetailsPayload } from '../../../payloads/list';
 import type { CloudWatchLogEvent, CloudWatchLogMonitorControlEvent } from '../../../payloads/logs-monitor';
@@ -362,7 +363,7 @@ export const IO = {
     description: 'Refactor execution not yet supported',
   }),
 
-  // 9: Bootstrap (9xxx)
+  // 9: Bootstrap  & gc (9xxx)
   CDK_TOOLKIT_I9000: make.info<Duration>({
     code: 'CDK_TOOLKIT_I9000',
     description: 'Provides bootstrap times',
@@ -372,6 +373,13 @@ export const IO = {
     code: 'CDK_TOOLKIT_I9100',
     description: 'Bootstrap progress',
     interface: 'BootstrapEnvironmentProgress',
+  }),
+
+  // gc (92xx)
+  CDK_TOOLKIT_I9210: make.question<AssetBatchDeletionRequest>({
+    code: 'CDK_TOOLKIT_I9210',
+    description: 'Confirm the deletion of a batch of assets',
+    interface: 'AssetBatchDeletionRequest',
   }),
 
   CDK_TOOLKIT_I9900: make.result<{ environment: cxapi.Environment }>({

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/gc.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/gc.ts
@@ -1,0 +1,13 @@
+import type { DataRequest } from './types';
+
+/**
+ * Request to confirm or deny the deletion of an assets batch marked for garbage collection.
+ */
+export interface AssetBatchDeletionRequest extends DataRequest {
+  readonly batch: {
+    readonly type: 'image' | 'object';
+    readonly count: number;
+    readonly rollbackBufferDays: number;
+    readonly createdBufferDays: number;
+  };
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
@@ -15,3 +15,4 @@ export * from './stack-details';
 export * from './diff';
 export * from './logs-monitor';
 export * from './hotswap';
+export * from './gc';


### PR DESCRIPTION
Relates to https://github.com/aws/aws-cdk-cli/issues/396

Mainly a refactor to use the IoHost instead of `promptly` library. However it also slightly improves the user experience on the CLI. 

This code path is not currently accessible by any public `toolkit-lib` API, hence it's not scoped for it.

Before:

<img width="610" alt="image" src="https://github.com/user-attachments/assets/47700f0f-4202-4784-b26a-2ee5ead4f593" />


After:

<img width="667" alt="image" src="https://github.com/user-attachments/assets/8896505f-df1a-4d29-869d-93facc7cf8d3" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
