### PR TITLE
fix(toolkit-lib)!: directory handling is unexpected for libraries

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -14,6 +14,7 @@ jobs:
     environment: integ-approval
     env:
       CI: "true"
+      DEBUG: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -3,6 +3,7 @@ import { yarn } from 'cdklabs-projen-project-types';
 import { TypeScriptWorkspace, type TypeScriptWorkspaceOptions } from 'cdklabs-projen-project-types/lib/yarn';
 import * as pj from 'projen';
 import { Stability } from 'projen/lib/cdk';
+import type { Job } from 'projen/lib/github/workflows-model';
 import { AdcPublishing } from './projenrc/adc-publishing';
 import { BundleCli } from './projenrc/bundle';
 import { CdkCliIntegTestsWorkflow } from './projenrc/cdk-cli-integ-tests';
@@ -1743,5 +1744,7 @@ new PrLabeler(repo);
 new LargePrChecker(repo, {
   excludeFiles: ['*.md', '*.test.ts', '*.yml', '*.lock'],
 });
+
+((repo.github?.tryFindWorkflow('integ')?.getJob('prepare') as Job | undefined)?.env ?? {}).DEBUG = 'true';
 
 repo.synth();

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1646,7 +1646,7 @@ const cliInteg = configureProject(
     }),
 
     // Append a specific version string for testing
-    nextVersionCommand: 'tsx ../../../projenrc/next-version.ts maybeRc',
+    nextVersionCommand: 'tsx ../../../projenrc/next-version.ts neverMajor maybeRc',
   }),
 );
 cliInteg.eslint?.addIgnorePattern('resources/**/*.ts');

--- a/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
@@ -32,7 +32,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk-testing/cli-integ@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts maybeRc",
+        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts neverMajor maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
         "MAJOR": "3"
       },
@@ -197,7 +197,7 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk-testing/cli-integ@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts maybeRc",
+        "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts neverMajor maybeRc",
         "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
       },
       "steps": [

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
@@ -38,16 +38,9 @@ export interface AssemblyDirectoryProps {
  */
 export interface AssemblySourceProps {
   /**
-   * Execute the application in this working directory.
+   * Emits the synthesized cloud assembly into the given directory
    *
-   * @default - current working directory
-   */
-  readonly workingDirectory?: string;
-
-  /**
-   * Emits the synthesized cloud assembly into a directory
-   *
-   * @default cdk.out
+   * @default "cdk.out"
    */
   readonly outdir?: string;
 
@@ -93,6 +86,13 @@ export interface AssemblySourceProps {
  * Options for the `fromCdkApp` Assembly Source constructor
  */
 export interface FromCdkAppOptions extends AssemblySourceProps {
+  /**
+   * Execute the application in this working directory.
+   *
+   * @default - current working directory
+   */
+  readonly workingDirectory?: string;
+
   /**
    * Additional environment variables
    *


### PR DESCRIPTION
Two changes:

- `fromAssemblyBuilder`: no longer takes a `workingDirectory` argument. It is not safe to `process.chdir()` in a process where multiple builders could be running in parallel.
- `fromCdkApp`: `outdir` is resolved w.r.t. the current working directory, instead of w.r.t the subprocess' `workingDirectory`.

In basically all APIs of all libraries and tools everywhere, a relative filename is evaluated with respect to the current working directory, not with respect to some hypothetical future directory we might `chdir` into.

Make `fromCdkApp` behave that way as well.

The behavior of the most common case (`outdir` is not supplied) remains unchanged: `cdk.out` will be written underneath the supplied app's working directory. It's only the interpretation of a supplied relative path name that has changed, in order to be more logical.

```ts
// Old
const outdir = path.resolve(props.workingDirectory, props.outdir ?? 'cdk.out');

// New
const outdir = props.outdir ?? path.resolve(props.workingDirectory, 'cdk.out');
```

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
