### PR TITLE
fix(toolkit-lib): dependency constraints are too strict

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -601,7 +601,7 @@ const cdkAssets = configureProject(
     description: 'CDK Asset Publishing Tool',
     srcdir: 'lib',
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'any-future' }),
       cxApi,
       'archiver',
       'glob',
@@ -708,13 +708,13 @@ const toolkitLib = configureProject(
       },
     },
     peerDeps: [
-      cliPluginContract.customizeReference({ versionType: 'major' }), // allow consumers to easily de-depulicate this
+      cliPluginContract.customizeReference({ versionType: 'any-minor' }), // allow consumers to easily de-depulicate this
     ],
     deps: [
-      cloudAssemblySchema, // @todo need to find the minmal required version
-      cloudFormationDiff.customizeReference({ versionType: 'major' }), // allow consumers with old toolkit-lib versions to get upgrades
-      cdkAssets.customizeReference({ versionType: 'major' }), // allow consumers with old toolkit-lib versions to get upgrades
-      `${cxApi}@^2`, // allow consumers with old toolkit-lib versions to get upgrades
+      cloudAssemblySchema.customizeReference({ versionType: 'any-future' }), // needs to be newer than what this was build with
+      cloudFormationDiff.customizeReference({ versionType: 'any-minor' }), // stay within the same MV, otherwise any should work
+      cdkAssets.customizeReference({ versionType: 'any-minor' }), // stay within the same MV, otherwise any should work
+      `${cxApi}@^2`, // stay within the same MV, otherwise any should work
       `@aws-sdk/client-appsync@${CLI_SDK_V3_RANGE}`,
       `@aws-sdk/client-cloudformation@${CLI_SDK_V3_RANGE}`,
       `@aws-sdk/client-cloudwatch-logs@${CLI_SDK_V3_RANGE}`,
@@ -1047,7 +1047,7 @@ const cli = configureProject(
       'xml-js',
     ],
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'any-future' }),
       cloudFormationDiff.customizeReference({ versionType: 'exact' }),
       cxApi,
       toolkitLib,
@@ -1466,7 +1466,7 @@ const integRunner = configureProject(
     description: 'CDK Integration Testing Tool',
     srcdir: 'lib',
     deps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'minimal' }),
+      cloudAssemblySchema.customizeReference({ versionType: 'any-future' }),
       cxApi,
       cdkCliWrapper.customizeReference({ versionType: 'exact' }),
       cli.customizeReference({ versionType: 'exact' }),

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@types/node": "ts5.6",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "cdklabs-projen-project-types": "^0.2.17",
+    "cdklabs-projen-project-types": "^0.3.0",
     "constructs": "^10.0.0",
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.10.1",

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -100,7 +100,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=minimal @aws-cdk/cdk-cli-wrapper=exact aws-cdk=exact cdk-assets=exact @aws-cdk/cloudformation-diff=exact",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=any-future @aws-cdk/cdk-cli-wrapper=exact aws-cdk=exact cdk-assets=exact @aws-cdk/cloudformation-diff=exact",
           "receiveArgs": true
         }
       ]

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -121,7 +121,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=major @aws-cdk/cloudformation-diff=major cdk-assets=major @aws-cdk/cli-plugin-contract=major",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=any-future @aws-cdk/cloudformation-diff=any-minor cdk-assets=any-minor @aws-cdk/cli-plugin-contract=any-minor",
           "receiveArgs": true
         }
       ]

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -105,7 +105,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=minimal @aws-cdk/cloudformation-diff=exact @aws-cdk/toolkit-lib=major cdk-assets=major",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cli-plugin-contract=exact @aws-cdk/node-bundle=exact @aws-cdk/user-input-gen=exact @aws-cdk/cloud-assembly-schema=any-future @aws-cdk/cloudformation-diff=exact @aws-cdk/toolkit-lib=future-minor cdk-assets=future-minor",
           "receiveArgs": true
         }
       ]

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -105,7 +105,7 @@
       "name": "gather-versions",
       "steps": [
         {
-          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=minimal",
+          "exec": "node -e \"require(require.resolve('cdklabs-projen-project-types/lib/yarn/gather-versions.exec.js')).cliMain()\" @aws-cdk/cloud-assembly-schema=any-future",
           "receiveArgs": true
         }
       ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5934,12 +5934,12 @@ cdk-from-cfn@^0.214.0:
   resolved "https://registry.yarnpkg.com/cdk-from-cfn/-/cdk-from-cfn-0.214.0.tgz#ee4a0f93fc4cb323766f7761b99aafbc2b6e5e30"
   integrity sha512-k0kaf0QhzfzKp7E/GZ6eoFFqVdK/Bjl5hs+kEIKvtur92gRvAq4Ehs4fSOqDksVWYxT9of50qFEzQPTxUzR02A==
 
-cdklabs-projen-project-types@^0.2.17:
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.2.17.tgz#87e966a1f3d520bb405fe30a552dd72c4b322151"
-  integrity sha512-2T86p1DgH0H0mr2bCDfk85Mx3uPFhakUcWqXvBs04km+NVWnFSDuAL2k3ibREc/llcD/s39W5NqMh04zQcw1Bg==
+cdklabs-projen-project-types@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/cdklabs-projen-project-types/-/cdklabs-projen-project-types-0.3.0.tgz#7a43393941338a72cc834f4657c889adab9f9323"
+  integrity sha512-i2XMdt6OKNRyBeez5TLbr4ZOc36g/5kxlmJsjxAhjj80yovEtSPlXV8Hf5r+jO0dl5ARY/u2o+S/Et4fIJjm/Q==
   dependencies:
-    yaml "^2.7.1"
+    yaml "^2.8.0"
 
 chai@^5.2.0:
   version "5.2.0"
@@ -13764,7 +13764,7 @@ yaml@1, yaml@1.10.2, yaml@^1:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.2.2, yaml@^2.6.0, yaml@^2.7.1:
+yaml@^2.2.2, yaml@^2.6.0, yaml@^2.7.1, yaml@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
   integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==


### PR DESCRIPTION
Due to a bug, we set constraints for dependency for other monorepo packages to "any future minor version" (i.e. `^1.2.3`) forcing consumers to always use latest packages with the toolkit-lib.

What we wanted to do is constrain the use to "any minor version", including already published ones, i.e. `^1`.

This change needed an upgrade of our projen Monorepo project type, which is also part of this PR. The API changed slightly here, hence the update of other values.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
