### PR TITLE
refactor(toolkit-lib): all default messages go through IoHelper

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -74,10 +74,6 @@ group: Documents
 | `CDK_TOOLKIT_W0101` | A notice that is marked as a warning | `warn` | n/a |
 | `CDK_TOOLKIT_E0101` | A notice that is marked as an error | `error` | n/a |
 | `CDK_TOOLKIT_I0101` | A notice that is marked as informational | `info` | n/a |
-| `CDK_ASSEMBLY_I0000` | Default trace messages emitted from Cloud Assembly operations | `trace` | n/a |
-| `CDK_ASSEMBLY_I0000` | Default debug messages emitted from Cloud Assembly operations | `debug` | n/a |
-| `CDK_ASSEMBLY_I0000` | Default info messages emitted from Cloud Assembly operations | `info` | n/a |
-| `CDK_ASSEMBLY_W0000` | Default warning messages emitted from Cloud Assembly operations | `warn` | n/a |
 | `CDK_ASSEMBLY_I0010` | Generic environment preparation debug messages | `debug` | n/a |
 | `CDK_ASSEMBLY_W0010` | Emitted if the found framework version does not support context overflow | `warn` | n/a |
 | `CDK_ASSEMBLY_I0042` | Writing updated context | `debug` | {@link UpdatedContext} |
@@ -94,7 +90,5 @@ group: Documents
 | `CDK_ASSEMBLY_I9999` | Annotations emitted by the cloud assembly | `info` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_W9999` | Warnings emitted by the cloud assembly | `warn` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_E9999` | Errors emitted by the cloud assembly | `error` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
-| `CDK_SDK_I0000` | An SDK debug message. | `debug` | n/a |
-| `CDK_SDK_W0000` | An SDK warning message. | `warn` | n/a |
 | `CDK_SDK_I0100` | An SDK trace. SDK traces are emitted as traces to the IoHost, but contain the original SDK logging level. | `trace` | {@link SdkTrace} |
 | `CDK_SDK_I1100` | Get an MFA token for an MFA device. | `info` | {@link MfaTokenRequest} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -156,9 +156,9 @@ export class AwsCliCompatible {
 
     if (!region) {
       const usedProfile = !profile ? '' : ` (profile: "${profile}")`;
-      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(
+      await this.ioHelper.sdkDefaults.debug(
         `Unable to determine AWS region from environment or AWS configuration${usedProfile}, defaulting to '${defaultRegion}'`,
-      ));
+      );
       return defaultRegion;
     }
 
@@ -173,7 +173,7 @@ export class AwsCliCompatible {
    * @returns The region for the instance identity
    */
   private async regionFromMetadataService() {
-    await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg('Looking up AWS region in the EC2 Instance Metadata Service (IMDS).'));
+    await this.ioHelper.sdkDefaults.debug('Looking up AWS region in the EC2 Instance Metadata Service (IMDS).');
     try {
       const metadataService = new MetadataService({
         httpOptions: {
@@ -185,7 +185,7 @@ export class AwsCliCompatible {
       const document = await metadataService.request('/latest/dynamic/instance-identity/document', {});
       return JSON.parse(document).region;
     } catch (e) {
-      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Unable to retrieve AWS region from IMDS: ${e}`));
+      await this.ioHelper.sdkDefaults.debug(`Unable to retrieve AWS region from IMDS: ${e}`);
     }
   }
 
@@ -223,7 +223,7 @@ export class AwsCliCompatible {
    * Result is send to callback function for SDK to authorize the request
    */
   private async tokenCodeFn(deviceArn: string): Promise<string> {
-    const debugFn = (msg: string, ...args: any[]) => this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(format(msg, ...args)));
+    const debugFn = (msg: string, ...args: any[]) => this.ioHelper.sdkDefaults.debug(format(msg, ...args));
     await debugFn('Require MFA token from MFA device with ARN', deviceArn);
     try {
       const token: string = await this.ioHelper.requestResponse(IO.CDK_SDK_I1100.req(`MFA token for ${deviceArn}`, {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/proxy-agent.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/proxy-agent.ts
@@ -26,14 +26,14 @@ export class ProxyAgentProvider {
   private async tryGetCACert(bundlePath?: string) {
     const path = bundlePath || this.caBundlePathFromEnvironment();
     if (path) {
-      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Using CA bundle path: ${path}`));
+      await this.ioHelper.sdkDefaults.debug(`Using CA bundle path: ${path}`);
       try {
         if (!fs.pathExistsSync(path)) {
           return undefined;
         }
         return fs.readFileSync(path, { encoding: 'utf-8' });
       } catch (e: any) {
-        await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(String(e)));
+        await this.ioHelper.sdkDefaults.debug(String(e));
         return undefined;
       }
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/proxy-agent.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/proxy-agent.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 import { ProxyAgent } from 'proxy-agent';
 import type { SdkHttpOptions } from './types';
-import { IO, type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export class ProxyAgentProvider {
   private readonly ioHelper: IoHelper;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
@@ -173,12 +173,12 @@ export class SdkProvider {
       // feed the CLI credentials which are sufficient by themselves. Prefer to assume the correct role if we can,
       // but if we can't then let's just try with available credentials anyway.
       if (baseCreds.source === 'correctDefault' || baseCreds.source === 'plugin') {
-        await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(err.message));
+        await this.ioHelper.sdkDefaults.debug(err.message);
 
-        const maker = quiet ? IO.DEFAULT_SDK_DEBUG : IO.DEFAULT_SDK_WARN;
-        await this.ioHelper.notify(maker.msg(
+        const level = quiet ? 'debug' : 'warn';
+        await this.ioHelper.sdkDefaults[level](
           `${fmtObtainedCredentials(baseCreds)} could not be used to assume '${options.assumeRoleArn}', but are for the right account. Proceeding anyway.`,
-        ));
+        );
         return {
           sdk: this._makeSdk(baseCreds.credentials, env.region),
           didAssumeRole: false,
@@ -252,13 +252,13 @@ export class SdkProvider {
         // they are complaining about if we fail 'cdk synth' on them. We loudly complain in order to show that
         // the current situation is probably undesirable, but we don't fail.
         if (e.name === 'ExpiredToken') {
-          await this.ioHelper.notify(IO.DEFAULT_SDK_WARN.msg(
+          await this.ioHelper.sdkDefaults.warn(
             'There are expired AWS credentials in your environment. The CDK app will synth without current account information.',
-          ));
+          );
           return undefined;
         }
 
-        await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Unable to determine the default AWS account (${e.name}): ${formatErrorMessage(e)}`));
+        await this.ioHelper.sdkDefaults.debug(`Unable to determine the default AWS account (${e.name}): ${formatErrorMessage(e)}`);
         return undefined;
       }
     });
@@ -320,7 +320,7 @@ export class SdkProvider {
     additionalOptions?: AssumeRoleAdditionalOptions,
     region?: string,
   ): Promise<SDK> {
-    await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Assuming role '${roleArn}'.`));
+    await this.ioHelper.sdkDefaults.debug(`Assuming role '${roleArn}'.`);
 
     region = region ?? this.defaultRegion;
 
@@ -354,7 +354,7 @@ export class SdkProvider {
         throw err;
       }
 
-      await this.ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(`Assuming role failed: ${err.message}`));
+      await this.ioHelper.sdkDefaults.debug(`Assuming role failed: ${err.message}`);
       throw new AuthenticationError(
         [
           'Could not assume role in target account',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
@@ -14,7 +14,7 @@ import { SDK } from './sdk';
 import { callTrace, traceMemberMethods } from './tracing';
 import { AuthenticationError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
-import { IO, type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import { PluginHost, Mode } from '../plugin';
 import type { ISdkLogger } from './sdk-logger';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -351,7 +351,7 @@ import { traceMemberMethods } from './tracing';
 import { defaultCliUserAgent } from './user-agent';
 import { AuthenticationError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
-import { IO, type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export interface S3ClientOptions {
   /**
@@ -593,7 +593,7 @@ export class SDK {
     ioHelper: IoHelper,
     logger?: ISdkLogger,
   ) {
-    const debugFn = async (msg: string) => ioHelper.notify(IO.DEFAULT_SDK_DEBUG.msg(msg));
+    const debugFn = async (msg: string) => ioHelper.sdkDefaults.debug(msg);
     this.accountCache = new AccountAccessKeyCache(AccountAccessKeyCache.DEFAULT_PATH, debugFn);
     this.debug = debugFn;
     this.config = {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/bootstrap-environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/bootstrap-environment.ts
@@ -7,7 +7,7 @@ import { ToolkitError } from '../../toolkit/toolkit-error';
 import { bundledPackageRootDir, loadStructuredFile, serializeStructure } from '../../util';
 import type { SDK, SdkProvider } from '../aws-auth/private';
 import type { SuccessfulDeployStackResult } from '../deployments';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import { Mode } from '../plugin';
 import { DEFAULT_TOOLKIT_STACK_NAME } from '../toolkit-info';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
@@ -16,7 +16,7 @@ import type { SuccessfulDeployStackResult } from '../deployments';
 import { assertIsSuccessfulDeployStackResult } from '../deployments';
 import { deployStack } from '../deployments/deploy-stack';
 import { NoBootstrapStackEnvironmentResources } from '../environment';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import { Mode } from '../plugin';
 import { DEFAULT_TOOLKIT_STACK_NAME, ToolkitInfo } from '../toolkit-info';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -60,7 +60,7 @@ export class ExecutionEnvironment implements AsyncDisposable {
   ) {
     this.ioHelper = services.ioHelper;
     this.sdkProvider = services.sdkProvider;
-    this.debugFn = (msg: string) => this.ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg(msg));
+    this.debugFn = (msg: string) => this.ioHelper.assemblyDefaults.debug(msg);
     this.lock = lock;
     this.shouldClean = outDirIsTemporary;
   }
@@ -228,7 +228,7 @@ export class ExecutionEnvironment implements AsyncDisposable {
  * @param assembly the assembly to check
  */
 async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly, ioHelper: IoHelper): Promise<void> {
-  const traceFn = (msg: string) => ioHelper.notify(IO.DEFAULT_ASSEMBLY_TRACE.msg(msg));
+  const traceFn = (msg: string) => ioHelper.assemblyDefaults.trace(msg);
   const tree = await loadTree(assembly, traceFn);
   const frameworkDoesNotSupportContextOverflow = some(tree, node => {
     const fqn = node.constructInfo?.fqn;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
@@ -3,7 +3,6 @@ import * as chalk from 'chalk';
 import { minimatch } from 'minimatch';
 import { StackCollection } from './stack-collection';
 import { flatten } from '../../util';
-import { IO } from '../io/private';
 import type { IoHelper } from '../io/private/io-helper';
 
 export interface IStackAssembly {
@@ -149,7 +148,7 @@ async function includeDownstreamStacks(
   } while (madeProgress);
 
   if (added.length > 0) {
-    await ioHelper.notify(IO.DEFAULT_ASSEMBLY_INFO.msg(`Including depending stacks: ${chalk.bold(added.join(', '))}`));
+    await ioHelper.assemblyDefaults.info(`Including depending stacks: ${chalk.bold(added.join(', '))}`);
   }
 }
 
@@ -181,6 +180,6 @@ async function includeUpstreamStacks(
   }
 
   if (added.length > 0) {
-    await ioHelper.notify(IO.DEFAULT_ASSEMBLY_INFO.msg(`Including dependency stacks: ${chalk.bold(added.join(', '))}`));
+    await ioHelper.assemblyDefaults.info(`Including dependency stacks: ${chalk.bold(added.join(', '))}`);
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/template-body-parameter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/template-body-parameter.ts
@@ -9,7 +9,7 @@ import { ToolkitError } from '../../toolkit/toolkit-error';
 import { contentHash, toYAML } from '../../util';
 import type { AssetManifestBuilder } from '../deployments';
 import type { EnvironmentResources } from '../environment';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export type TemplateBodyParameter = {
   TemplateBody?: string;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/assets.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/assets.ts
@@ -5,7 +5,7 @@ import * as chalk from 'chalk';
 import type { AssetManifestBuilder } from './asset-manifest-builder';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { EnvironmentResources } from '../environment';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import type { ToolkitInfo } from '../toolkit-info';
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -18,7 +18,7 @@ import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { ICloudFormationClient, SdkProvider } from '../aws-auth/private';
 import type { Template, TemplateBodyParameter, TemplateParameter } from '../cloudformation';
 import { CloudFormationStack, makeBodyParameter } from '../cloudformation';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/checks.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/checks.ts
@@ -1,6 +1,6 @@
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { SDK } from '../aws-auth/private';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export async function determineAllowCrossAccountAssetPublishing(
   sdk: SDK,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -35,7 +35,7 @@ import { makeBodyParameter, CfnEvaluationException, CloudFormationStack } from '
 import type { EnvironmentResources, StringWithoutPlaceholders } from '../environment';
 import { HotswapMode, HotswapPropertyOverrides, ICON } from '../hotswap/common';
 import { tryHotswapDeployment } from '../hotswap/hotswap-deployments';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -31,7 +31,7 @@ import {
 } from '../cloudformation';
 import { type EnvironmentResources, EnvironmentAccess } from '../environment';
 import type { HotswapMode, HotswapPropertyOverrides } from '../hotswap/common';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import type { ResourceIdentifierSummaries, ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor, StackEventPoller, RollbackChoice } from '../stack-events';
 import type { Tag } from '../tags';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-access.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-access.ts
@@ -6,7 +6,7 @@ import { replaceEnvPlaceholders } from './placeholders';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
 import type { SDK, CredentialsOptions, SdkForEnvironment, SdkProvider } from '../aws-auth/private';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import { Mode } from '../plugin';
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-resources.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-resources.ts
@@ -2,7 +2,7 @@ import type { Environment } from '@aws-cdk/cx-api';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
 import type { SDK } from '../aws-auth/private';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import { Notices } from '../notices';
 import { type EcrRepositoryInfo, ToolkitInfo } from '../toolkit-info';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/progress-printer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/progress-printer.ts
@@ -1,7 +1,7 @@
 import * as chalk from 'chalk';
 import type { GcAsset as GCAsset } from './garbage-collector';
 import { ToolkitError } from '../../toolkit/toolkit-error';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export class ProgressPrinter {
   private ioHelper: IoHelper;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/stack-refresh.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/stack-refresh.ts
@@ -1,7 +1,7 @@
 import type { ParameterDeclaration } from '@aws-sdk/client-cloudformation';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { ICloudFormationClient } from '../aws-auth/private';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 
 export class ActiveAssetCache {
   private readonly stacks: Set<string> = new Set();

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-default-messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-default-messages.ts
@@ -1,6 +1,6 @@
 import * as util from 'util';
 import type { ActionLessMessage, ActionLessRequest, IoHelper } from './io-helper';
-import type { IoMessageLevel } from '../io-message';
+import type { IoMessageCode, IoMessageLevel } from '../io-message';
 
 /**
  * Helper class to emit standard log messages to an IoHost
@@ -10,15 +10,17 @@ import type { IoMessageLevel } from '../io-message';
  */
 export class IoDefaultMessages {
   private readonly ioHelper: IoHelper;
+  private readonly category: 'TOOLKIT' | 'ASSEMBLY' | 'SDK';
 
-  constructor(ioHelper: IoHelper) {
+  constructor(ioHelper: IoHelper, category: 'TOOLKIT' | 'ASSEMBLY' | 'SDK') {
     this.ioHelper = ioHelper;
+    this.category = category;
   }
 
   public async notify(msg: Omit<ActionLessMessage<unknown>, 'code'>): Promise<void> {
     return this.ioHelper.notify({
       ...msg,
-      code: levelToCode(msg.level),
+      code: levelToCode(this.category, msg.level),
     });
   }
 
@@ -63,7 +65,7 @@ export class IoDefaultMessages {
 
     return {
       time: new Date(),
-      code: levelToCode(level),
+      code: levelToCode(this.category, level),
       level,
       message,
       data: undefined,
@@ -75,13 +77,13 @@ export class IoDefaultMessages {
   }
 }
 
-function levelToCode(level: IoMessageLevel) {
+function levelToCode(category: string, level: IoMessageLevel): IoMessageCode {
   switch (level) {
     case 'error':
-      return 'CDK_TOOLKIT_E0000';
+      return `CDK_${category}_E0000`;
     case 'warn':
-      return 'CDK_TOOLKIT_W0000';
+      return `CDK_${category}_W0000`;
     default:
-      return 'CDK_TOOLKIT_I0000';
+      return `CDK_${category}_I0000`;
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-helper.ts
@@ -20,6 +20,8 @@ export class IoHelper implements IIoHost {
    * Simplified access to emit default messages.
    */
   public readonly defaults: IoDefaultMessages;
+  public readonly assemblyDefaults: IoDefaultMessages;
+  public readonly sdkDefaults: IoDefaultMessages;
 
   private readonly ioHost: IIoHost;
   private readonly action: ToolkitAction;
@@ -27,7 +29,9 @@ export class IoHelper implements IIoHost {
   private constructor(ioHost: IIoHost, action: ToolkitAction) {
     this.ioHost = ioHost;
     this.action = action;
-    this.defaults = new IoDefaultMessages(this);
+    this.defaults = new IoDefaultMessages(this, 'TOOLKIT');
+    this.assemblyDefaults = new IoDefaultMessages(this, 'ASSEMBLY');
+    this.sdkDefaults = new IoDefaultMessages(this, 'SDK');
   }
 
   /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -390,23 +390,6 @@ export const IO = {
   }),
 
   // Assembly codes
-  DEFAULT_ASSEMBLY_TRACE: make.trace({
-    code: 'CDK_ASSEMBLY_I0000',
-    description: 'Default trace messages emitted from Cloud Assembly operations',
-  }),
-  DEFAULT_ASSEMBLY_DEBUG: make.debug({
-    code: 'CDK_ASSEMBLY_I0000',
-    description: 'Default debug messages emitted from Cloud Assembly operations',
-  }),
-  DEFAULT_ASSEMBLY_INFO: make.info({
-    code: 'CDK_ASSEMBLY_I0000',
-    description: 'Default info messages emitted from Cloud Assembly operations',
-  }),
-  DEFAULT_ASSEMBLY_WARN: make.warn({
-    code: 'CDK_ASSEMBLY_W0000',
-    description: 'Default warning messages emitted from Cloud Assembly operations',
-  }),
-
   CDK_ASSEMBLY_I0010: make.debug({
     code: 'CDK_ASSEMBLY_I0010',
     description: 'Generic environment preparation debug messages',
@@ -486,14 +469,6 @@ export const IO = {
   }),
 
   // SDK codes
-  DEFAULT_SDK_DEBUG: make.debug({
-    code: 'CDK_SDK_I0000',
-    description: 'An SDK debug message.',
-  }),
-  DEFAULT_SDK_WARN: make.warn({
-    code: 'CDK_SDK_W0000',
-    description: 'An SDK warning message.',
-  }),
   CDK_SDK_I0100: make.trace<SdkTrace>({
     code: 'CDK_SDK_I0100',
     description: 'An SDK trace. SDK traces are emitted as traces to the IoHost, but contain the original SDK logging level.',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
@@ -1,5 +1,5 @@
 import * as semver from 'semver';
-import { IO, type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 import type { ConstructTreeNode } from '../tree';
 import { loadTreeFromDir } from '../tree';
 import type { BootstrappedEnvironment, Component, Notice } from './types';
@@ -193,7 +193,7 @@ export class NoticesFilter {
    * Load the construct tree from the given directory and return its components
    */
   private async constructTreeComponents(manifestDir: string): Promise<ActualComponent[]> {
-    const tree = await loadTreeFromDir(manifestDir, (msg: string) => this.ioHelper.notify(IO.DEFAULT_ASSEMBLY_TRACE.msg(msg)));
+    const tree = await loadTreeFromDir(manifestDir, (msg: string) => this.ioHelper.assemblyDefaults.trace(msg));
     if (!tree) {
       return [];
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/toolkit-info.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/toolkit-info.ts
@@ -13,7 +13,7 @@ import {
 import type { CloudFormationStack } from './cloudformation';
 import { ToolkitError } from '../toolkit/toolkit-error';
 import { stabilizeStack } from './deployments/cfn-api';
-import { type IoHelper } from './io/private';
+import type { IoHelper } from './io/private';
 
 export const DEFAULT_TOOLKIT_STACK_NAME = 'CDKToolkit';
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/work-graph/work-graph.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/work-graph/work-graph.ts
@@ -2,7 +2,7 @@ import type { WorkNode, StackNode, AssetBuildNode, AssetPublishNode } from './wo
 import { DeploymentState } from './work-graph-types';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import { parallelPromises } from '../../util';
-import { type IoHelper } from '../io/private';
+import type { IoHelper } from '../io/private';
 export type Concurrency = number | Record<WorkNode['type'], number>;
 
 export class WorkGraph {

--- a/packages/@aws-cdk/toolkit-lib/lib/context-providers/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/context-providers/index.ts
@@ -120,7 +120,7 @@ export async function provideContextValues(
       value = { [cxapi.PROVIDER_ERROR_KEY]: formatErrorMessage(e), [TRANSIENT_CONTEXT_KEY]: true };
     }
     context.set(key, value);
-    await ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg(`Setting "${key}" context to ${JSON.stringify(value)}`));
+    await ioHelper.assemblyDefaults.debug(`Setting "${key}" context to ${JSON.stringify(value)}`);
   }
 }
 

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -3,7 +3,7 @@ import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import { CloudAssembly } from './cloud-assembly';
 import type { ICloudAssemblySource, IReadableCloudAssembly } from '../../lib/api';
 import type { IoHelper } from '../../lib/api-private';
-import { BorrowedAssembly, IO } from '../../lib/api-private';
+import { BorrowedAssembly } from '../../lib/api-private';
 import type { SdkProvider } from '../api/aws-auth';
 import { GLOBAL_PLUGIN_HOST } from '../cli/singleton-plugin-host';
 import type { Configuration } from '../cli/user-configuration';

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -97,14 +97,14 @@ export class CloudExecutable implements ICloudAssemblySource {
 
         let tryLookup = true;
         if (previouslyMissingKeys && setsEqual(missingKeys, previouslyMissingKeys)) {
-          await this.props.ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg('Not making progress trying to resolve environmental context. Giving up.'));
+          await this.props.ioHelper.assemblyDefaults.debug('Not making progress trying to resolve environmental context. Giving up.');
           tryLookup = false;
         }
 
         previouslyMissingKeys = missingKeys;
 
         if (tryLookup) {
-          await this.props.ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg('Some context information is missing. Fetching...'));
+          await this.props.ioHelper.assemblyDefaults.debug('Some context information is missing. Fetching...');
 
           await contextproviders.provideContextValues(
             assembly.manifest.missing,

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -7,7 +7,7 @@ import * as cxapi from '@aws-cdk/cx-api';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
-import { IO, type IoHelper } from '../../lib/api-private';
+import type { IoHelper } from '../../lib/api-private';
 import type { SdkProvider, IReadLock } from '../api';
 import { RWLock, guessExecutable, loadTree, prepareContext, prepareDefaultEnvironment, some, spaceAvailableForContext } from '../api';
 import type { Configuration } from '../cli/user-configuration';
@@ -22,7 +22,7 @@ export interface ExecProgramResult {
 
 /** Invokes the cloud executable and returns JSON output */
 export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: Configuration): Promise<ExecProgramResult> {
-  const debugFn = (msg: string) => ioHelper.notify(IO.DEFAULT_ASSEMBLY_DEBUG.msg(msg));
+  const debugFn = (msg: string) => ioHelper.assemblyDefaults.debug(msg);
   const env = await prepareDefaultEnvironment(aws, debugFn);
   const context = await prepareContext(config.settings, config.context.all, env, debugFn);
 
@@ -168,7 +168,7 @@ async function contextOverflowCleanup(
   if (location) {
     fs.removeSync(path.dirname(location));
 
-    const tree = await loadTree(assembly, (msg: string) => ioHelper.notify(IO.DEFAULT_ASSEMBLY_TRACE.msg(msg)));
+    const tree = await loadTree(assembly, (msg: string) => ioHelper.assemblyDefaults.trace(msg));
     const frameworkDoesNotSupportContextOverflow = some(tree, node => {
       const fqn = node.constructInfo?.fqn;
       const version = node.constructInfo?.version;
@@ -179,7 +179,7 @@ async function contextOverflowCleanup(
     // We're dealing with an old version of the framework here. It is unaware of the temporary
     // file, which means that it will ignore the context overflow.
     if (frameworkDoesNotSupportContextOverflow) {
-      await ioHelper.notify(IO.DEFAULT_ASSEMBLY_WARN.msg('Part of the context could not be sent to the application. Please update the AWS CDK library to the latest version.'));
+      await ioHelper.assemblyDefaults.warn('Part of the context could not be sent to the application. Please update the AWS CDK library to the latest version.');
     }
   }
 }


### PR DESCRIPTION
Follow-up to #513 and #518 this PR removes the remaining default message codes for SDK and ASSEMBLY in favor of all calls going through the `IoHelper`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
