### PR TITLE
fix: property references are skipped when `DependsOn` is present (refactor)

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -49,16 +49,16 @@ export function computeResourceDigests(template: CloudFormationTemplate): Record
       const refTarget = Array.isArray(value['Fn::GetAtt']) ? value['Fn::GetAtt'][0] : value['Fn::GetAtt'].split('.')[0];
       return [refTarget];
     }
+    const result = [];
     if ('DependsOn' in value) {
-      const result = Object.values(value).flatMap(findDependencies);
       if (Array.isArray(value.DependsOn)) {
         result.push(...value.DependsOn);
       } else {
         result.push(value.DependsOn);
       }
-      return result;
     }
-    return Object.values(value).flatMap(findDependencies);
+    result.push(...Object.values(value).flatMap(findDependencies));
+    return result;
   };
 
   for (const [id, res] of Object.entries(resources)) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -50,7 +50,13 @@ export function computeResourceDigests(template: CloudFormationTemplate): Record
       return [refTarget];
     }
     if ('DependsOn' in value) {
-      return [value.DependsOn];
+      const result = Object.values(value).flatMap(findDependencies);
+      if (Array.isArray(value.DependsOn)) {
+        result.push(...value.DependsOn);
+      } else {
+        result.push(value.DependsOn);
+      }
+      return result;
     }
     return Object.values(value).flatMap(findDependencies);
   };

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -199,6 +199,42 @@ describe('computeResourceDigests', () => {
     expect(result.Topic1).toEqual(result.Topic2);
   });
 
+  test('different resources - DependsOn plus Ref in properties', () => {
+    const template = {
+      Resources: {
+        Bucket1: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { Prop: 'my-bucket' },
+        },
+        Bucket2: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { Prop: 'my-bucket' },
+        },
+        Bucket3: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { AnotherProp: 'foobar' },
+        },
+        Topic1: {
+          Type: 'AWS::SNS::Topic',
+          DependsOn: 'Bucket1',
+          Properties: {
+            DisplayName: 'my-topic',
+          },
+        },
+        Topic2: {
+          Type: 'AWS::SNS::Topic',
+          DependsOn: 'Bucket2',
+          Properties: {
+            DisplayName: 'my-topic',
+            SomeRef: { Ref: 'Bucket3' },
+          },
+        },
+      },
+    };
+    const result = computeResourceDigests(template);
+    expect(result.Topic1).not.toEqual(result.Topic2);
+  });
+
   test('different resources - DependsOn', () => {
     const template = {
       Resources: {


### PR DESCRIPTION
When computing the graph for the stack, if there is a `DependsOn`, the algorithm will ignore other dependencies. Also, `DependsOn` may be a string or an array, and this was not being properly handled.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
