### PR TITLE
feat: digest computation for refactor considers cross-stack references

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/cloudformation.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/cloudformation.ts
@@ -1,14 +1,17 @@
 import type { TypedMapping } from '@aws-cdk/cloudformation-diff';
 import type * as cxapi from '@aws-cdk/cx-api';
 
+export interface CloudFormationResource {
+  Type: string;
+  Properties?: any;
+  Metadata?: Record<string, any>;
+}
+
 export interface CloudFormationTemplate {
   Resources?: {
-    [logicalId: string]: {
-      Type: string;
-      Properties?: any;
-      Metadata?: Record<string, any>;
-    };
+    [logicalId: string]: CloudFormationResource;
   };
+  Outputs?: Record<string, any>;
 }
 
 export interface CloudFormationStack {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -130,8 +130,6 @@ function stripReferences(value: any, exports: { [p: string]: { stackName: string
     } else if ('Fn::GetAtt' in v) {
       return { __cloud_ref__: 'Fn::GetAtt' };
     }
-    // Should not happen
-    throw new ToolkitError(`Unrecognized reference value: ${JSON.stringify(value)}`);
   }
   const result: any = {};
   for (const [k, v] of Object.entries(value)) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'node:crypto';
 import { loadResourceModel } from '@aws-cdk/cloudformation-diff/lib/diff/util';
-import type { CloudFormationTemplate } from './cloudformation';
+import type { CloudFormationResource, CloudFormationStack } from './cloudformation';
+import { ToolkitError } from '../../toolkit/toolkit-error';
 
 /**
  * Computes the digest for each resource in the template.
@@ -25,8 +26,23 @@ import type { CloudFormationTemplate } from './cloudformation';
  * CloudFormation template form a directed acyclic graph, this function is
  * well-defined.
  */
-export function computeResourceDigests(template: CloudFormationTemplate): Record<string, string> {
-  const resources = template.Resources || {};
+export function computeResourceDigests(stacks: CloudFormationStack[]): Record<string, string> {
+  const exports: { [p: string]: { stackName: string; value: any } } = Object.fromEntries(
+    stacks.flatMap((s) =>
+      Object.values(s.template.Outputs ?? {})
+        .filter((o) => o.Export != null && typeof o.Export.Name === 'string')
+        .map((o) => [o.Export.Name, { stackName: s.stackName, value: o.Value }] as [string, { stackName: string; value: any }]),
+    ),
+  );
+
+  const resources = Object.fromEntries(
+    stacks.flatMap((s) =>
+      Object.entries(s.template.Resources ?? {}).map(
+        ([id, res]) => [`${s.stackName}.${id}`, res] as [string, CloudFormationResource],
+      ),
+    ),
+  );
+
   const graph: Record<string, Set<string>> = {};
   const reverseGraph: Record<string, Set<string>> = {};
 
@@ -37,32 +53,45 @@ export function computeResourceDigests(template: CloudFormationTemplate): Record
   }
 
   // 2. Detect dependencies by searching for Ref/Fn::GetAtt
-  const findDependencies = (value: any): string[] => {
+  const findDependencies = (stackName: string, value: any): string[] => {
     if (!value || typeof value !== 'object') return [];
     if (Array.isArray(value)) {
-      return value.flatMap(findDependencies);
+      return value.flatMap(res => findDependencies(stackName, res));
     }
     if ('Ref' in value) {
-      return [value.Ref];
+      return [`${stackName}.${value.Ref}`];
     }
     if ('Fn::GetAtt' in value) {
       const refTarget = Array.isArray(value['Fn::GetAtt']) ? value['Fn::GetAtt'][0] : value['Fn::GetAtt'].split('.')[0];
-      return [refTarget];
+      return [`${stackName}.${refTarget}`];
     }
-    const result = [];
+    if ('Fn::ImportValue' in value) {
+      const exp = exports[value['Fn::ImportValue']];
+      const v = exp.value;
+      if ('Fn::GetAtt' in v) {
+        const id = Array.isArray(v['Fn::GetAtt']) ? v['Fn::GetAtt'][0] : v['Fn::GetAtt'].split('.')[0];
+        return [`${exp.stackName}.${id}`];
+      }
+      if ('Ref' in v) {
+        return [`${exp.stackName}.${v.Ref}`];
+      }
+      throw new ToolkitError(`Unrecognized export value: ${JSON.stringify(value)}`);
+    }
+    const result: string[] = [];
     if ('DependsOn' in value) {
       if (Array.isArray(value.DependsOn)) {
-        result.push(...value.DependsOn);
+        result.push(...value.DependsOn.map((r: string) => `${stackName}.${r}`));
       } else {
-        result.push(value.DependsOn);
+        result.push(`${stackName}.${value.DependsOn}`);
       }
     }
-    result.push(...Object.values(value).flatMap(findDependencies));
+    result.push(...Object.values(value).flatMap(res => findDependencies(stackName, res)));
     return result;
   };
 
   for (const [id, res] of Object.entries(resources)) {
-    const deps = findDependencies(res || {});
+    const stackName = id.split('.')[0];
+    const deps = findDependencies(stackName, res || {});
     for (const dep of deps) {
       if (dep in resources && dep !== id) {
         graph[id].add(dep);
@@ -113,7 +142,7 @@ export function computeResourceDigests(template: CloudFormationTemplate): Record
       // The resource does not have a physical ID defined, so we need to
       // compute the digest based on its properties and dependencies.
       const depDigests = Array.from(graph[id]).map((d) => result[d]);
-      const propertiesHash = hashObject(stripReferences(stripConstructPath(resource)));
+      const propertiesHash = hashObject(stripReferences(stripConstructPath(resource), exports));
       toHash = resource.Type + propertiesHash + depDigests.join('');
     }
 
@@ -153,10 +182,10 @@ export function hashObject(obj: any): string {
  * Removes sub-properties containing Ref or Fn::GetAtt to avoid hashing
  * references themselves but keeps the property structure.
  */
-function stripReferences(value: any): any {
+function stripReferences(value: any, exports: { [p: string]: { stackName: string; value: any } }): any {
   if (!value || typeof value !== 'object') return value;
   if (Array.isArray(value)) {
-    return value.map(stripReferences);
+    return value.map(x => stripReferences(x, exports));
   }
   if ('Ref' in value) {
     return { __cloud_ref__: 'Ref' };
@@ -167,9 +196,20 @@ function stripReferences(value: any): any {
   if ('DependsOn' in value) {
     return { __cloud_ref__: 'DependsOn' };
   }
+  if ('Fn::ImportValue' in value) {
+    const v = exports[value['Fn::ImportValue']].value;
+    // Treat Fn::ImportValue as if it were a reference with the same stack
+    if ('Ref' in v) {
+      return { __cloud_ref__: 'Ref' };
+    } else if ('Fn::GetAtt' in v) {
+      return { __cloud_ref__: 'Fn::GetAtt' };
+    }
+    // Should not happen
+    throw new ToolkitError(`Unrecognized reference value: ${JSON.stringify(value)}`);
+  }
   const result: any = {};
   for (const [k, v] of Object.entries(value)) {
-    result[k] = stripReferences(v);
+    result[k] = stripReferences(v, exports);
   }
   return result;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -2,7 +2,6 @@ import * as crypto from 'node:crypto';
 import { loadResourceModel } from '@aws-cdk/cloudformation-diff/lib/diff/util';
 import type { CloudFormationResource, CloudFormationStack } from './cloudformation';
 import { ResourceGraph } from './graph';
-import { ToolkitError } from '../../toolkit/toolkit-error';
 
 /**
  * Computes the digest for each resource in the template.

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
@@ -1,0 +1,135 @@
+import type { CloudFormationResource, CloudFormationStack } from './cloudformation';
+import { ToolkitError } from '../../toolkit/toolkit-error';
+
+/**
+ * An immutable directed graph of resources from multiple CloudFormation stacks.
+ */
+export class ResourceGraph {
+  private readonly edges: Record<string, Set<string>> = {};
+  private readonly reverseEdges: Record<string, Set<string>> = {};
+  private readonly _sortedNodes: string[] = [];
+
+  constructor(stacks: Omit<CloudFormationStack, 'environment'>[]) {
+    const exports: { [p: string]: { stackName: string; value: any } } = Object.fromEntries(
+      stacks.flatMap((s) =>
+        Object.values(s.template.Outputs ?? {})
+          .filter((o) => o.Export != null && typeof o.Export.Name === 'string')
+          .map(
+            (o) =>
+              [o.Export.Name, { stackName: s.stackName, value: o.Value }] as [
+                string,
+                {
+                  stackName: string;
+                  value: any;
+                },
+              ],
+          ),
+      ),
+    );
+
+    const resources = Object.fromEntries(
+      stacks.flatMap((s) =>
+        Object.entries(s.template.Resources ?? {}).map(
+          ([id, res]) => [`${s.stackName}.${id}`, res] as [string, CloudFormationResource],
+        ),
+      ),
+    );
+
+    // 1. Build adjacency lists
+    for (const id of Object.keys(resources)) {
+      this.edges[id] = new Set();
+      this.reverseEdges[id] = new Set();
+    }
+
+    // 2. Detect dependencies by searching for Ref/Fn::GetAtt
+    const findDependencies = (stackName: string, value: any): string[] => {
+      if (!value || typeof value !== 'object') return [];
+      if (Array.isArray(value)) {
+        return value.flatMap((res) => findDependencies(stackName, res));
+      }
+      if ('Ref' in value) {
+        return [`${stackName}.${value.Ref}`];
+      }
+      if ('Fn::GetAtt' in value) {
+        const refTarget = Array.isArray(value['Fn::GetAtt'])
+          ? value['Fn::GetAtt'][0]
+          : value['Fn::GetAtt'].split('.')[0];
+        return [`${stackName}.${refTarget}`];
+      }
+      if ('Fn::ImportValue' in value) {
+        const exp = exports[value['Fn::ImportValue']];
+        const v = exp.value;
+        if ('Fn::GetAtt' in v) {
+          const id = Array.isArray(v['Fn::GetAtt']) ? v['Fn::GetAtt'][0] : v['Fn::GetAtt'].split('.')[0];
+          return [`${exp.stackName}.${id}`];
+        }
+        if ('Ref' in v) {
+          return [`${exp.stackName}.${v.Ref}`];
+        }
+        throw new ToolkitError(`Unrecognized export value: ${JSON.stringify(value)}`);
+      }
+      const result: string[] = [];
+      if ('DependsOn' in value) {
+        if (Array.isArray(value.DependsOn)) {
+          result.push(...value.DependsOn.map((r: string) => `${stackName}.${r}`));
+        } else {
+          result.push(`${stackName}.${value.DependsOn}`);
+        }
+      }
+      result.push(...Object.values(value).flatMap((res) => findDependencies(stackName, res)));
+      return result;
+    };
+
+    for (const [id, res] of Object.entries(resources)) {
+      const stackName = id.split('.')[0];
+      const deps = findDependencies(stackName, res || {});
+      for (const dep of deps) {
+        if (dep in resources && dep !== id) {
+          this.edges[id].add(dep);
+          this.reverseEdges[dep].add(id);
+        }
+      }
+    }
+
+    // 3. Topological sort
+    const outDegree = Object.keys(this.edges).reduce((acc, k) => {
+      acc[k] = this.edges[k].size;
+      return acc;
+    }, {} as Record<string, number>);
+
+    const queue = Object.keys(outDegree).filter((k) => outDegree[k] === 0);
+    // const order: string[] = [];
+
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      this._sortedNodes.push(node);
+      for (const nxt of this.reverseEdges[node]) {
+        outDegree[nxt]--;
+        if (outDegree[nxt] === 0) {
+          queue.push(nxt);
+        }
+      }
+    }
+  }
+
+  /**
+   * Returns the sorted nodes in topological order.
+   */
+  get sortedNodes(): string[] {
+    return this._sortedNodes;
+  }
+
+  public inNeighbors(node: string): string[] {
+    if (!(node in this.edges)) {
+      throw new ToolkitError(`Node ${node} not found in the graph`);
+    }
+    return Array.from(this.reverseEdges[node] || []);
+  }
+
+  public outNeighbors(node: string): string[] {
+    if (!(node in this.edges)) {
+      throw new ToolkitError(`Node ${node} not found in the graph`);
+    }
+    return Array.from(this.edges[node] || []);
+  }
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
@@ -66,7 +66,7 @@ export class ResourceGraph {
         if ('Ref' in v) {
           return [`${exp.stackName}.${v.Ref}`];
         }
-        throw new ToolkitError(`Unrecognized export value: ${JSON.stringify(value)}`);
+        return [`${exp.stackName}.${v}`];
       }
       const result: string[] = [];
       if ('DependsOn' in value) {


### PR DESCRIPTION
Previously the digest computation was being done stack by stack. One of the implications of this is that cross-stack references were ignored. Specifically, `Fn::ImportValue` was treated as a regular value, rather than as a reference.

Change that, so we consider all stacks at once, and treating cross-stack references in the same way as within-stack references are treated, for the purposes of computing the digests of all resources. 

While we're at it, the purely graph related code was extracted to its own class, `ResourceGraph`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
