### PR TITLE
refactor(cli): create `ProxyAgent` in the CLI in preparation of `proxy-agent` removal from toolkit-lib

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -1,3 +1,4 @@
+import type { Agent } from 'node:https';
 import { format } from 'node:util';
 import type { SDKv3CompatibleCredentialProvider } from '@aws-cdk/cli-plugin-contract';
 import { createCredentialChain, fromEnv, fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -270,13 +271,16 @@ export interface CredentialChainOptions {
   readonly logger?: ISdkLogger;
 }
 
-export async function makeRequestHandler(ioHelper: IoHelper, options: SdkHttpOptions = {}): Promise<NodeHttpHandlerOptions> {
-  const agent = await new ProxyAgentProvider(ioHelper).create(options);
-
+export function sdkRequestHandler(agent?: Agent): NodeHttpHandlerOptions {
   return {
     connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
     requestTimeout: DEFAULT_TIMEOUT,
     httpsAgent: agent,
     httpAgent: agent,
   };
+}
+
+export async function makeRequestHandler(ioHelper: IoHelper, options: SdkHttpOptions = {}): Promise<NodeHttpHandlerOptions> {
+  const agent = await new ProxyAgentProvider(ioHelper).create(options);
+  return sdkRequestHandler(agent);
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
@@ -1,6 +1,6 @@
+import type { Agent } from 'https';
 import * as path from 'path';
 import { cdkCacheDir } from '../../util';
-import type { SdkHttpOptions } from '../aws-auth';
 import type { Context } from '../context';
 import type { IIoHost } from '../io';
 import { CachedDataSource } from './cached-data-source';
@@ -12,6 +12,20 @@ import type { IoHelper } from '../io/private';
 import { IO, asIoHelper } from '../io/private';
 
 const CACHE_FILE_PATH = path.join(cdkCacheDir(), 'notices.json');
+
+/**
+ * Options for the HTTPS requests made by Notices
+ */
+export interface NoticesHttpsOptions {
+  /**
+   * The agent responsible for making the network requests.
+   *
+   * Use this so set up a proxy connection.
+   *
+   * @default - uses the shared global node agent
+   */
+  readonly agent?: Agent;
+}
 
 export interface NoticesProps {
   /**
@@ -27,9 +41,9 @@ export interface NoticesProps {
   readonly output?: string;
 
   /**
-   * Options for the HTTP request
+   * Options for the HTTPS requests made by Notices
    */
-  readonly httpOptions?: SdkHttpOptions;
+  readonly httpsOptions?: NoticesHttpsOptions;
 
   /**
    * Where messages are going to be sent
@@ -100,7 +114,7 @@ export class Notices {
   private readonly context: Context;
   private readonly output: string;
   private readonly acknowledgedIssueNumbers: Set<Number>;
-  private readonly httpOptions: SdkHttpOptions;
+  private readonly httpsOptions: NoticesHttpsOptions;
   private readonly ioHelper: IoHelper;
   private readonly cliVersion: string;
 
@@ -113,7 +127,7 @@ export class Notices {
     this.context = props.context;
     this.acknowledgedIssueNumbers = new Set(this.context.get('acknowledged-issue-numbers') ?? []);
     this.output = props.output ?? 'cdk.out';
-    this.httpOptions = props.httpOptions ?? {};
+    this.httpsOptions = props.httpsOptions ?? {};
     this.ioHelper = asIoHelper(props.ioHost, 'notices' as any /* forcing a CliAction to a ToolkitAction */);
     this.cliVersion = props.cliVersion;
   }
@@ -141,14 +155,14 @@ export class Notices {
    * @throws on failure to refresh the data source
    */
   public async refresh(options: NoticesRefreshOptions = {}) {
-    const innerDataSource = options.dataSource ?? new WebsiteNoticeDataSource(this.ioHelper, this.httpOptions);
+    const innerDataSource = options.dataSource ?? new WebsiteNoticeDataSource(this.ioHelper, this.httpsOptions);
     const dataSource = new CachedDataSource(this.ioHelper, CACHE_FILE_PATH, innerDataSource, options.force ?? false);
     const notices = await dataSource.fetch();
     this.data = new Set(notices);
   }
 
   /**
-   * Filter the data sourece for relevant notices
+   * Filter the data source for relevant notices
    */
   public filter(options: NoticesDisplayOptions = {}): Promise<FilteredNotice[]> {
     return new NoticesFilter(this.ioHelper).filter({

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
@@ -16,7 +16,7 @@ const CACHE_FILE_PATH = path.join(cdkCacheDir(), 'notices.json');
 /**
  * Options for the HTTPS requests made by Notices
  */
-export interface NoticesHttpsOptions {
+export interface NoticesHttpOptions {
   /**
    * The agent responsible for making the network requests.
    *
@@ -43,7 +43,7 @@ export interface NoticesProps {
   /**
    * Options for the HTTPS requests made by Notices
    */
-  readonly httpsOptions?: NoticesHttpsOptions;
+  readonly httpOptions?: NoticesHttpOptions;
 
   /**
    * Where messages are going to be sent
@@ -114,7 +114,7 @@ export class Notices {
   private readonly context: Context;
   private readonly output: string;
   private readonly acknowledgedIssueNumbers: Set<Number>;
-  private readonly httpsOptions: NoticesHttpsOptions;
+  private readonly httpOptions: NoticesHttpOptions;
   private readonly ioHelper: IoHelper;
   private readonly cliVersion: string;
 
@@ -127,7 +127,7 @@ export class Notices {
     this.context = props.context;
     this.acknowledgedIssueNumbers = new Set(this.context.get('acknowledged-issue-numbers') ?? []);
     this.output = props.output ?? 'cdk.out';
-    this.httpsOptions = props.httpsOptions ?? {};
+    this.httpOptions = props.httpOptions ?? {};
     this.ioHelper = asIoHelper(props.ioHost, 'notices' as any /* forcing a CliAction to a ToolkitAction */);
     this.cliVersion = props.cliVersion;
   }
@@ -155,7 +155,7 @@ export class Notices {
    * @throws on failure to refresh the data source
    */
   public async refresh(options: NoticesRefreshOptions = {}) {
-    const innerDataSource = options.dataSource ?? new WebsiteNoticeDataSource(this.ioHelper, this.httpsOptions);
+    const innerDataSource = options.dataSource ?? new WebsiteNoticeDataSource(this.ioHelper, this.httpOptions);
     const dataSource = new CachedDataSource(this.ioHelper, CACHE_FILE_PATH, innerDataSource, options.force ?? false);
     const notices = await dataSource.fetch();
     this.data = new Set(notices);

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -136,9 +136,15 @@ export enum AssetBuildTime {
   JUST_IN_TIME = 'just-in-time',
 }
 
+/**
+ * Custom implementation of the public Toolkit to integrate with the legacy CdkToolkit
+ *
+ * This overwrites how an sdkProvider is acquired
+ * in favor of the one provided directly to CdkToolkit.
+ */
 class InternalToolkit extends Toolkit {
   private readonly _sdkProvider: SdkProvider;
-  public constructor(sdkProvider: SdkProvider, options: ToolkitOptions) {
+  public constructor(sdkProvider: SdkProvider, options: Omit<ToolkitOptions, 'sdkConfig'>) {
     super(options);
     this._sdkProvider = sdkProvider;
   }
@@ -172,10 +178,8 @@ export class CdkToolkit {
       color: true,
       emojis: true,
       ioHost: this.ioHost,
-      sdkConfig: {},
       toolkitStackName: this.toolkitStackName,
     });
-    this.toolkit; // aritifical use of this.toolkit to satisfy TS, we want to prepare usage of the new toolkit without using it just yet
   }
 
   public async metadata(stackName: string, json: boolean) {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -16,7 +16,7 @@ import * as version from './version';
 import { asIoHelper } from '../../lib/api-private';
 import type { IReadLock } from '../api';
 import { ToolkitInfo, Notices } from '../api';
-import { SdkProvider, IoHostSdkLogger, setSdkTracing, makeRequestHandler } from '../api/aws-auth';
+import { SdkProvider, IoHostSdkLogger, setSdkTracing, sdkRequestHandler } from '../api/aws-auth';
 import type { BootstrapSource } from '../api/bootstrap';
 import { Bootstrapper } from '../api/bootstrap';
 import { Deployments } from '../api/deployments';
@@ -29,6 +29,7 @@ import { cliInit, printAvailableTemplates } from '../commands/init';
 import { getMigrateScanType } from '../commands/migrate';
 import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
+import { ProxyAgentProvider } from './proxy-agent';
 
 if (!process.stdout.isTTY) {
   // Disable chalk color highlighting
@@ -89,6 +90,12 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
   const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
 
+  // Always create and use ProxyAgent to support configuration via env vars
+  const proxyAgent = await new ProxyAgentProvider(ioHelper).create({
+    proxyAddress: configuration.settings.get(['proxy']),
+    caBundlePath: configuration.settings.get(['caBundlePath']),
+  });
+
   const shouldDisplayNotices = configuration.settings.get(['notices']);
   // Notices either go to stderr, or nowhere
   ioHost.noticesDestination = shouldDisplayNotices ? 'stderr' : 'drop';
@@ -96,10 +103,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     ioHost,
     context: configuration.context,
     output: configuration.settings.get(['outdir']),
-    httpOptions: {
-      proxyAddress: configuration.settings.get(['proxy']),
-      caBundlePath: configuration.settings.get(['caBundlePath']),
-    },
+    httpsOptions: { agent: proxyAgent },
     cliVersion: version.versionNumber(),
   });
   const refreshNotices = (async () => {
@@ -116,10 +120,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   const sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
     ioHelper,
     profile: configuration.settings.get(['profile']),
-    requestHandler: await makeRequestHandler(ioHelper, {
-      proxyAddress: argv.proxy,
-      caBundlePath: argv['ca-bundle-path'],
-    }),
+    requestHandler: sdkRequestHandler(proxyAgent),
     logger: new IoHostSdkLogger(asIoHelper(ioHost, ioHost.currentAction as any)),
     pluginHost: GLOBAL_PLUGIN_HOST,
   });

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -103,7 +103,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     ioHost,
     context: configuration.context,
     output: configuration.settings.get(['outdir']),
-    httpsOptions: { agent: proxyAgent },
+    httpOptions: { agent: proxyAgent },
     cliVersion: version.versionNumber(),
   });
   const refreshNotices = (async () => {

--- a/packages/aws-cdk/lib/cli/proxy-agent.ts
+++ b/packages/aws-cdk/lib/cli/proxy-agent.ts
@@ -1,0 +1,73 @@
+import * as fs from 'fs-extra';
+import { ProxyAgent } from 'proxy-agent';
+import type { IoHelper } from '../api-private';
+
+/**
+ * Options for proxy-agent SDKs
+ */
+interface ProxyAgentOptions {
+  /**
+   * Proxy address to use
+   *
+   * @default No proxy
+   */
+  readonly proxyAddress?: string;
+
+  /**
+   * A path to a certificate bundle that contains a cert to be trusted.
+   *
+   * @default No certificate bundle
+   */
+  readonly caBundlePath?: string;
+}
+
+export class ProxyAgentProvider {
+  private readonly ioHelper: IoHelper;
+
+  public constructor(ioHelper: IoHelper) {
+    this.ioHelper = ioHelper;
+  }
+
+  public async create(options: ProxyAgentOptions) {
+    // Force it to use the proxy provided through the command line.
+    // Otherwise, let the ProxyAgent auto-detect the proxy using environment variables.
+    const getProxyForUrl = options.proxyAddress != null
+      ? () => Promise.resolve(options.proxyAddress!)
+      : undefined;
+
+    return new ProxyAgent({
+      ca: await this.tryGetCACert(options.caBundlePath),
+      getProxyForUrl,
+    });
+  }
+
+  private async tryGetCACert(bundlePath?: string) {
+    const path = bundlePath || this.caBundlePathFromEnvironment();
+    if (path) {
+      await this.ioHelper.defaults.debug(`Using CA bundle path: ${path}`);
+      try {
+        if (!fs.pathExistsSync(path)) {
+          return undefined;
+        }
+        return fs.readFileSync(path, { encoding: 'utf-8' });
+      } catch (e: any) {
+        await this.ioHelper.defaults.debug(String(e));
+        return undefined;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Find and return a CA certificate bundle path to be passed into the SDK.
+   */
+  private caBundlePathFromEnvironment(): string | undefined {
+    if (process.env.aws_ca_bundle) {
+      return process.env.aws_ca_bundle;
+    }
+    if (process.env.AWS_CA_BUNDLE) {
+      return process.env.AWS_CA_BUNDLE;
+    }
+    return undefined;
+  }
+}


### PR DESCRIPTION
Updates the `CdkToolkit` and `Notices` APIs to take a Node https.Agent instead of options. This gives more flexibility to integrators while retaining proxy support. We can make the changes to `Notices` since it is not a public API.

The CLI changed need to be split out from the toolkit-lib changes, so the latter can be safely marked as breaking without touching CLI files. The respective `toolkit-lib` changes are in #533 

Relates to #398 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
