### PR TITLE
chore(integ-testing): update Verdaccio config and refactor integration tests workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Create Verdaccio config
         run: |-
           mkdir -p $HOME/.config/verdaccio
-          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/toolkit-lib":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cli-plugin-contract":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
+          echo '{"storage":"./storage","auth":{"htpasswd":{"file":"./htpasswd"}},"uplinks":{"npmjs":{"url":"https://registry.npmjs.org/"}},"packages":{"@aws-cdk/cloud-assembly-schema":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cloudformation-diff":{"access":"$all","publish":"$all","proxy":"npmjs"},"@aws-cdk/cli-plugin-contract":{"access":"$all","publish":"$all","proxy":"none"},"cdk-assets":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/toolkit-lib":{"access":"$all","publish":"$all","proxy":"npmjs"},"aws-cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/cli-lib-alpha":{"access":"$all","publish":"$all","proxy":"none"},"cdk":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk/integ-runner":{"access":"$all","publish":"$all","proxy":"none"},"@aws-cdk-testing/cli-integ":{"access":"$all","publish":"$all","proxy":"none"},"**":{"access":"$all","proxy":"npmjs"}}}' > $HOME/.config/verdaccio/config.yaml
       - name: Start Verdaccio
         run: |-
           pm2 start verdaccio -- --config $HOME/.config/verdaccio/config.yaml
@@ -101,7 +101,7 @@ jobs:
           echo 'registry=http://localhost:4873/' >> ~/.npmrc
       - name: Find an locally publish all tarballs
         run: |-
-          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,cdk-assets,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk-testing/cli-integ,@aws-cdk/toolkit-lib,@aws-cdk/cli-plugin-contract}/dist/js/*.tgz; do
+          for pkg in packages/{@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cli-plugin-contract,cdk-assets,@aws-cdk/toolkit-lib,aws-cdk,@aws-cdk/cli-lib-alpha,cdk,@aws-cdk/integ-runner,@aws-cdk-testing/cli-integ}/dist/js/*.tgz; do
             npm publish $pkg
           done
       - name: Download and install the test artifact

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1699,23 +1699,11 @@ new CdkCliIntegTestsWorkflow(repo, {
   buildRunsOn: POWERFUL_RUNNER,
   testRunsOn: POWERFUL_RUNNER,
 
-  localPackages: [
-    cloudAssemblySchema.name,
-    cloudFormationDiff.name,
-    cdkAssets.name,
-    cli.name,
-    cliLibAlpha.name,
-    cdkAliasPackage.name,
-    cliInteg.name,
-    toolkitLib.name,
-    cliPluginContract.name,
-  ],
-
   allowUpstreamVersions: [
     // cloud-assembly-schema gets referenced under multiple versions
     // - Candidate version for cdk-assets
     // - Previously released version for aws-cdk-lib
-    cloudAssemblySchema.name,
+    cloudAssemblySchema,
 
     // toolkit-lib can get referenced under multiple versions,
     // and during the 0.x period most likely *will*.
@@ -1726,7 +1714,13 @@ new CdkCliIntegTestsWorkflow(repo, {
     //   unless we are releasing a breaking change, in which case they will depend
     //   on `^1` but we will be testing `2.0.999`, so the upstream still needs to
     //   be available to make this test succeed.
-    toolkitLib.name,
+    toolkitLib,
+
+    // The `tool-integrations` job installs the amplify-cli package,
+    // which depends on @aws-cdk/cloudformation-diff as a transitive dependency through toolkit-lib
+    // Since we are not enforcing the use of the local version of toolkit-lib in this test,
+    // it might attempt to install a version of @aws-cdk/cloudformation-diff that's not locally available.
+    cloudFormationDiff,
   ],
   enableAtmosphere: {
     oidcRoleArn: '${{ vars.CDK_ATMOSPHERE_PROD_OIDC_ROLE }}',


### PR DESCRIPTION
Updates the Verdaccio configuration in the integration tests workflow to include @aws-cdk/integ-runner and fix proxy settings for @aws-cdk/cloudformation-diff.

Refactors the CdkCliIntegTestsWorkflow to automatically detect local packages instead of requiring manual specification.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license