### PR TITLE
fix(cloud-assembly-schema): add a valid example for CcApiContextQuery

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/context-queries.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/context-queries.ts
@@ -356,6 +356,21 @@ export interface KeyContextQuery extends ContextLookupRoleOptions {
 
 /**
  * Query input for lookup up CloudFormation resources using CC API
+ *
+ * The example below is required to successfully compile CDK (otherwise,
+ * the CDK build will generate a synthetic example for the below, but it
+ * doesn't have enough type information about the literal string union
+ * to generate a validly compiling example).
+ *
+ * @example
+ * const x: CcApiContextQuery = {
+ *   typeName: 'AWS::Some::Type',
+ *   expectedMatchCount: 'exactly-one',
+ *   propertiesToReturn: ['SomeProp'],
+ *   account: '11111111111',
+ *   region: 'us-east-1',
+ * };
+ * console.log(x);
  */
 export interface CcApiContextQuery extends ContextLookupRoleOptions {
   /**

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/cloud-assembly.schema.json
@@ -1024,7 +1024,7 @@
             ]
         },
         "CcApiContextQuery": {
-            "description": "Query input for lookup up CloudFormation resources using CC API",
+            "description": "Query input for lookup up CloudFormation resources using CC API\n\nThe example below is required to successfully compile CDK (otherwise,\nthe CDK build will generate a synthetic example for the below, but it\ndoesn't have enough type information about the literal string union\nto generate a validly compiling example).",
             "type": "object",
             "properties": {
                 "typeName": {

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,4 +1,4 @@
 {
-  "schemaHash": "96958a4c40e0a00e850f0c14dd6e9c0fc8db0b075f1f155cea41ab198c0514be",
-  "revision": 43
+  "schemaHash": "5dcc6511e8b96c378ad35c391cdc2dcbaa52d08a8015760692eaad73efc9a949",
+  "revision": 44
 }


### PR DESCRIPTION
This type is being exposed as-is in the CDK library, by copying it into the public API surface. It therefore gets processed by jsii, and examples get generated for it.

Because we don't have an example for this type and jsii cannot express string literal types, the automatically generated example is based off the type `string` and looks like this:

```ts
{
  expectedMatchCount: 'expectedMatchCount',
}
```

This example does not compile because the generated value does not conform to the actual declared type.

To solve this, we add a valid example here into the base code.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
