### PR TITLE
feat(toolkit-lib)!: improved types for BaseCredentials

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -738,7 +738,6 @@ const toolkitLib = configureProject(
       `@aws-sdk/ec2-metadata-service@${CLI_SDK_V3_RANGE}`,
       `@aws-sdk/lib-storage@${CLI_SDK_V3_RANGE}`,
       '@smithy/middleware-endpoint',
-      '@smithy/node-http-handler',
       '@smithy/property-provider',
       '@smithy/shared-ini-file-loader',
       '@smithy/util-retry',
@@ -872,7 +871,7 @@ new pj.JsonFile(toolkitLib, 'api-extractor.json', {
           logLevel: 'none',
         },
         'ae-forgotten-export': {
-          logLevel: 'warning', // @todo fix issues and change to error
+          logLevel: 'error',
         },
       },
       tsdocMessageReporting: {

--- a/packages/@aws-cdk/toolkit-lib/.projen/deps.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/deps.json
@@ -294,10 +294,6 @@
       "type": "runtime"
     },
     {
-      "name": "@smithy/node-http-handler",
-      "type": "runtime"
-    },
-    {
       "name": "@smithy/property-provider",
       "type": "runtime"
     },

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -60,7 +60,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/util-stream,@types/fs-extra,@types/jest,@types/jest-when,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-when,license-checker,ts-jest,typedoc,xml-js,@smithy/middleware-endpoint,@smithy/node-http-handler,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-waiter,archiver,cdk-from-cfn,glob,minimatch,semver,split2,uuid"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/util-stream,@types/fs-extra,@types/jest,@types/jest-when,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-when,license-checker,ts-jest,typedoc,xml-js,@smithy/middleware-endpoint,@smithy/property-provider,@smithy/shared-ini-file-loader,@smithy/util-retry,@smithy/util-waiter,archiver,cdk-from-cfn,glob,minimatch,semver,split2,uuid"
         }
       ]
     },

--- a/packages/@aws-cdk/toolkit-lib/api-extractor.json
+++ b/packages/@aws-cdk/toolkit-lib/api-extractor.json
@@ -30,7 +30,7 @@
         "logLevel": "none"
       },
       "ae-forgotten-export": {
-        "logLevel": "warning"
+        "logLevel": "error"
       }
     },
     "tsdocMessageReporting": {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -3,8 +3,8 @@ import { format } from 'node:util';
 import type { SDKv3CompatibleCredentialProvider } from '@aws-cdk/cli-plugin-contract';
 import { createCredentialChain, fromEnv, fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
-import type { NodeHttpHandlerOptions } from '@smithy/node-http-handler';
 import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
+import type { RequestHandlerSettings } from './base-credentials';
 import { makeCachingProvider } from './provider-caching';
 import type { ISdkLogger } from './sdk-logger';
 import { AuthenticationError } from '../../toolkit/toolkit-error';
@@ -23,10 +23,10 @@ const DEFAULT_TIMEOUT = 300000;
  */
 export class AwsCliCompatible {
   private readonly ioHelper: IoHelper;
-  private readonly requestHandler: NodeHttpHandlerOptions;
+  private readonly requestHandler: RequestHandlerSettings;
   private readonly logger?: ISdkLogger;
 
-  public constructor(ioHelper: IoHelper, requestHandler: NodeHttpHandlerOptions, logger?: ISdkLogger) {
+  public constructor(ioHelper: IoHelper, requestHandler: RequestHandlerSettings, logger?: ISdkLogger) {
     this.ioHelper = ioHelper;
     this.requestHandler = requestHandler;
     this.logger = logger;
@@ -269,7 +269,7 @@ export interface CredentialChainOptions {
   readonly logger?: ISdkLogger;
 }
 
-export function sdkRequestHandler(agent?: Agent): NodeHttpHandlerOptions {
+export function sdkRequestHandler(agent?: Agent): RequestHandlerSettings {
   return {
     connectionTimeout: DEFAULT_CONNECTION_TIMEOUT,
     requestTimeout: DEFAULT_TIMEOUT,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/base-credentials.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/base-credentials.ts
@@ -1,0 +1,165 @@
+import type * as http from 'node:http';
+import type * as https from 'node:https';
+import type { SDKv3CompatibleCredentialProvider } from '@aws-cdk/cli-plugin-contract';
+import { AwsCliCompatible } from './awscli-compatible';
+import { AuthenticationError } from '../../toolkit/toolkit-error';
+import type { IActionAwareIoHost } from '../io';
+import { IoHostSdkLogger } from './sdk-logger';
+import { IoHelper } from '../io/private';
+
+/**
+ * Settings for the request handle
+ */
+export interface RequestHandlerSettings {
+  /**
+   * The maximum time in milliseconds that the connection phase of a request
+   * may take before the connection attempt is abandoned.
+   *
+   * Defaults to 0, which disables the timeout.
+   */
+  connectionTimeout?: number;
+  /**
+   * The number of milliseconds a request can take before automatically being terminated.
+   * Defaults to 0, which disables the timeout.
+   */
+  requestTimeout?: number;
+  /**
+   * An http.Agent to be used
+   */
+  httpAgent?: http.Agent;
+  /**
+   * An https.Agent to be used
+   */
+  httpsAgent?: https.Agent;
+}
+
+/**
+ * An SDK config that
+ */
+export interface SdkBaseConfig {
+  /**
+   * The credential provider to use for SDK calls.
+   */
+  readonly credentialProvider: SDKv3CompatibleCredentialProvider;
+  /**
+   * The default region to use for SDK calls.
+   */
+  readonly defaultRegion?: string;
+}
+
+export interface SdkBaseClientConfig {
+  requestHandler?: RequestHandlerSettings;
+}
+
+export interface IBaseCredentialsProvider {
+  sdkBaseConfig(ioHost: IActionAwareIoHost, clientConfig: SdkBaseClientConfig): Promise<SdkBaseConfig>;
+}
+
+export class BaseCredentials {
+  /**
+   * Use no base credentials
+   *
+   * There will be no current account and no current region during synthesis. To
+   * successfully deploy with this set of base credentials:
+   *
+   * - The CDK app must provide concrete accounts and regions during synthesis
+   * - Credential plugins must be installed to provide credentials for those
+   *   accounts.
+   */
+  public static none(): IBaseCredentialsProvider {
+    return new class implements IBaseCredentialsProvider {
+      public async sdkBaseConfig() {
+        return {
+          credentialProvider: () => {
+            throw new AuthenticationError('No credentials available due to BaseCredentials.none()');
+          },
+        };
+      }
+
+      public toString() {
+        return 'BaseCredentials.none()';
+      }
+    };
+  }
+
+  /**
+   * Obtain base credentials and base region the same way the AWS CLI would
+   *
+   * Credentials and region will be read from the environment first, falling back
+   * to INI files or other sources if available.
+   *
+   * The profile name is configurable.
+   */
+  public static awsCliCompatible(options: AwsCliCompatibleOptions = {}): IBaseCredentialsProvider {
+    return new class implements IBaseCredentialsProvider {
+      public sdkBaseConfig(ioHost: IActionAwareIoHost, clientConfig: SdkBaseClientConfig) {
+        const ioHelper = IoHelper.fromActionAwareIoHost(ioHost);
+        const awsCli = new AwsCliCompatible(ioHelper, clientConfig.requestHandler ?? {}, new IoHostSdkLogger(ioHelper));
+        return awsCli.baseConfig(options.profile);
+      }
+
+      public toString() {
+        return `BaseCredentials.awsCliCompatible(${JSON.stringify(options)})`;
+      }
+    };
+  }
+
+  /**
+   * Use a custom SDK identity provider for the base credentials
+   *
+   * If your provider uses STS calls to obtain base credentials, you must make
+   * sure to also configure the necessary HTTP options (like proxy and user
+   * agent) and the region on the STS client directly; the toolkit code cannot
+   * do this for you.
+   */
+  public static custom(options: CustomBaseCredentialsOption): IBaseCredentialsProvider {
+    return new class implements IBaseCredentialsProvider {
+      public sdkBaseConfig(): Promise<SdkBaseConfig> {
+        return Promise.resolve({
+          credentialProvider: options.provider,
+          defaultRegion: options.region,
+        });
+      }
+
+      public toString() {
+        return `BaseCredentials.custom(${JSON.stringify({
+          ...options,
+          provider: '...',
+        })})`;
+      }
+    };
+  }
+}
+
+export interface AwsCliCompatibleOptions {
+  /**
+   * The profile to read from `~/.aws/credentials`.
+   *
+   * If not supplied the environment variable AWS_PROFILE will be used.
+   *
+   * @default - Use environment variable if set.
+   */
+  readonly profile?: string;
+}
+
+export interface CustomBaseCredentialsOption {
+  /**
+   * The credentials provider to use to obtain base credentials
+   *
+   * If your provider uses STS calls to obtain base credentials, you must make
+   * sure to also configure the necessary HTTP options (like proxy and user
+   * agent) on the STS client directly; the toolkit code cannot do this for you.
+   */
+  readonly provider: SDKv3CompatibleCredentialProvider;
+
+  /**
+   * The default region to synthesize for
+   *
+   * CDK applications can override this region. NOTE: this region will *not*
+   * affect any STS calls made by the given provider, if any. You need to configure
+   * your credential provider separately.
+   *
+   * @default 'us-east-1'
+   */
+  readonly region?: string;
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/index.ts
@@ -1,1 +1,2 @@
 export * from './types';
+export * from './base-credentials';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -352,10 +352,10 @@ import {
 import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts';
 import { Upload } from '@aws-sdk/lib-storage';
 import { getEndpointFromInstructions } from '@smithy/middleware-endpoint';
-import type { NodeHttpHandlerOptions } from '@smithy/node-http-handler';
 import { ConfiguredRetryStrategy } from '@smithy/util-retry';
 import type { WaiterResult } from '@smithy/util-waiter';
 import { AccountAccessKeyCache } from './account-cache';
+import type { RequestHandlerSettings } from './base-credentials';
 import { cachedAsync } from './cached';
 import type { ISdkLogger } from './sdk-logger';
 import type { Account } from './sdk-provider';
@@ -395,7 +395,7 @@ export interface SdkOptions {
 export interface ConfigurationOptions {
   region: string;
   credentials: SDKv3CompatibleCredentialProvider;
-  requestHandler: NodeHttpHandlerOptions;
+  requestHandler: RequestHandlerSettings;
   retryStrategy: ConfiguredRetryStrategy;
   customUserAgent: string;
   logger?: ISdkLogger;
@@ -605,7 +605,7 @@ export class SDK {
   constructor(
     private readonly credProvider: SDKv3CompatibleCredentialProvider,
     region: string,
-    requestHandler: NodeHttpHandlerOptions,
+    requestHandler: RequestHandlerSettings,
     ioHelper: IoHelper,
     logger?: ISdkLogger,
   ) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/types.ts
@@ -1,7 +1,5 @@
-import type { Agent } from 'node:https';
-import type { SDKv3CompatibleCredentialProvider } from '@aws-cdk/cli-plugin-contract';
-import { AwsCliCompatible } from './awscli-compatible';
-import type { SdkProviderServices } from './sdk-provider';
+import type * as https from 'node:https';
+import type { IBaseCredentialsProvider } from './base-credentials';
 
 /**
  * Options for the default SDK provider
@@ -12,15 +10,7 @@ export interface SdkConfig {
    *
    * @default BaseCredentials.awsCliCompatible()
    */
-  readonly baseCredentials?: BaseCredentials;
-
-  /**
-   * Profile to read from ~/.aws for base credentials
-   *
-   * @default - No profile
-   * @deprecated Use `baseCredentials` instead
-   */
-  readonly profile?: string;
+  readonly baseCredentials?: IBaseCredentialsProvider;
 
   /**
    * HTTP options for SDK
@@ -39,125 +29,5 @@ export interface SdkHttpOptions {
    *
    * @default - uses the shared global node agent
    */
-  readonly agent?: Agent;
-}
-
-export abstract class BaseCredentials {
-  /**
-   * Use no base credentials
-   *
-   * There will be no current account and no current region during synthesis. To
-   * successfully deploy with this set of base credentials:
-   *
-   * - The CDK app must provide concrete accounts and regions during synthesis
-   * - Credential plugins must be installed to provide credentials for those
-   *   accounts.
-   */
-  public static none(): BaseCredentials {
-    return new class extends BaseCredentials {
-      public async makeSdkConfig(): Promise<SdkBaseConfig> {
-        return {
-          credentialProvider: () => {
-            // eslint-disable-next-line @cdklabs/no-throw-default-error
-            throw new Error('No credentials available due to BaseCredentials.none()');
-          },
-        };
-      }
-
-      public toString() {
-        return 'BaseCredentials.none()';
-      }
-    };
-  }
-
-  /**
-   * Obtain base credentials and base region the same way the AWS CLI would
-   *
-   * Credentials and region will be read from the environment first, falling back
-   * to INI files or other sources if available.
-   *
-   * The profile name is configurable.
-   */
-  public static awsCliCompatible(options: AwsCliCompatibleOptions = {}): BaseCredentials {
-    return new class extends BaseCredentials {
-      public makeSdkConfig(services: SdkProviderServices): Promise<SdkBaseConfig> {
-        const awsCli = new AwsCliCompatible(services.ioHelper, services.requestHandler ?? {}, services.logger);
-        return awsCli.baseConfig(options.profile);
-      }
-
-      public toString() {
-        return `BaseCredentials.awsCliCompatible(${JSON.stringify(options)})`;
-      }
-    };
-  }
-
-  /**
-   * Use a custom SDK identity provider for the base credentials
-   *
-   * If your provider uses STS calls to obtain base credentials, you must make
-   * sure to also configure the necessary HTTP options (like proxy and user
-   * agent) and the region on the STS client directly; the toolkit code cannot
-   * do this for you.
-   */
-  public static custom(options: CustomBaseCredentialsOption): BaseCredentials {
-    return new class extends BaseCredentials {
-      public makeSdkConfig(): Promise<SdkBaseConfig> {
-        return Promise.resolve({
-          credentialProvider: options.provider,
-          defaultRegion: options.region,
-        });
-      }
-
-      public toString() {
-        return `BaseCredentials.custom(${JSON.stringify({
-          ...options,
-          provider: '...',
-        })})`;
-      }
-    };
-  }
-
-  /**
-   * Make SDK config from the BaseCredentials settings
-   */
-  public abstract makeSdkConfig(services: SdkProviderServices): Promise<SdkBaseConfig>;
-}
-
-export interface AwsCliCompatibleOptions {
-  /**
-   * The profile to read from `~/.aws/credentials`.
-   *
-   * If not supplied the environment variable AWS_PROFILE will be used.
-   *
-   * @default - Use environment variable if set.
-   */
-  readonly profile?: string;
-}
-
-export interface CustomBaseCredentialsOption {
-  /**
-   * The credentials provider to use to obtain base credentials
-   *
-   * If your provider uses STS calls to obtain base credentials, you must make
-   * sure to also configure the necessary HTTP options (like proxy and user
-   * agent) on the STS client directly; the toolkit code cannot do this for you.
-   */
-  readonly provider: SDKv3CompatibleCredentialProvider;
-
-  /**
-   * The default region to synthesize for
-   *
-   * CDK applications can override this region. NOTE: this region will *not*
-   * affect any STS calls made by the given provider, if any. You need to configure
-   * your credential provider separately.
-   *
-   * @default 'us-east-1'
-   */
-  readonly region?: string;
-}
-
-export interface SdkBaseConfig {
-  readonly credentialProvider: SDKv3CompatibleCredentialProvider;
-
-  readonly defaultRegion?: string;
+  readonly agent?: https.Agent;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/io-host.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/io-host.ts
@@ -13,5 +13,21 @@ export interface IIoHost {
    * If the host does not return a response the suggested
    * default response from the input message will be used.
    */
-  requestResponse<T, U>(msg: IoRequest<T, U>): Promise<U>;
+  requestResponse<T>(msg: IoRequest<unknown, T>): Promise<T>;
+}
+
+export interface IActionAwareIoHost {
+  /**
+   * Notifies the host of a message.
+   * The caller waits until the notification completes.
+   */
+  notify(msg: Omit<IoMessage<unknown>, 'action'>): Promise<void>;
+
+  /**
+   * Notifies the host of a message that requires a response.
+   *
+   * If the host does not return a response the suggested
+   * default response from the input message will be used.
+   */
+  requestResponse<T>(msg: Omit<IoRequest<unknown, T>, 'action'>): Promise<T>;
 }

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -105,7 +105,6 @@
     "@aws-sdk/ec2-metadata-service": "^3",
     "@aws-sdk/lib-storage": "^3",
     "@smithy/middleware-endpoint": "^4.1.7",
-    "@smithy/node-http-handler": "^4.0.5",
     "@smithy/property-provider": "^4.0.3",
     "@smithy/shared-ini-file-loader": "^4.0.3",
     "@smithy/util-retry": "^4.0.4",

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-provider.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-provider.test.ts
@@ -833,7 +833,7 @@ function isProfileRole(x: ProfileUser | ProfileRole): x is ProfileRole {
 }
 
 async function providerFromProfile(profile: string | undefined) {
-  return SdkProvider.withAwsCliCompatibleDefaults({ ioHelper, profile, logger: console, pluginHost: pluginHost });
+  return SdkProvider.withAwsCliCompatibleDefaults({ ioHelper, logger: console, pluginHost: pluginHost }, profile);
 }
 
 async function exerciseCredentials(provider: SdkProvider, e: cxapi.Environment, mode: Mode = Mode.ForReading,

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/base-credentials.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/base-credentials.test.ts
@@ -1,5 +1,5 @@
+import { BaseCredentials } from '../../lib/api/aws-auth';
 import { SdkProvider } from '../../lib/api/aws-auth/private';
-import { BaseCredentials } from '../../lib/api/aws-auth/types';
 import { Toolkit } from '../../lib/toolkit/toolkit';
 import { appFixture, TestIoHost } from '../_helpers';
 import { MockSdk } from '../_helpers/mock-sdk';

--- a/packages/@aws-cdk/toolkit-lib/typedoc.json
+++ b/packages/@aws-cdk/toolkit-lib/typedoc.json
@@ -6,7 +6,7 @@
     }
   ],
   "treatValidationWarningsAsErrors": true,
-  "intentionallyNotExported": ["SdkProviderServices"],
+  "intentionallyNotExported": [],
   "excludeExternals": true,
   "excludePrivate": true,
   "excludeProtected": true,

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -119,11 +119,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
   const sdkProvider = await SdkProvider.withAwsCliCompatibleDefaults({
     ioHelper,
-    profile: configuration.settings.get(['profile']),
     requestHandler: sdkRequestHandler(proxyAgent),
     logger: new IoHostSdkLogger(asIoHelper(ioHost, ioHost.currentAction as any)),
     pluginHost: GLOBAL_PLUGIN_HOST,
-  });
+  }, configuration.settings.get(['profile']));
 
   let outDirLock: IReadLock | undefined;
   const cloudExecutable = new CloudExecutable({

--- a/packages/aws-cdk/lib/legacy-aws-auth.ts
+++ b/packages/aws-cdk/lib/legacy-aws-auth.ts
@@ -98,7 +98,7 @@ export class SdkProvider {
       ...options,
       ioHelper: CliIoHost.instance().asIoHelper(),
       pluginHost: GLOBAL_PLUGIN_HOST,
-    });
+    }, options.profile);
   }
 
   public constructor(
@@ -110,7 +110,7 @@ export class SdkProvider {
     return new SdkProviderCurrentVersion(defaultCredentialProvider, defaultRegion, {
       pluginHost: GLOBAL_PLUGIN_HOST,
       ioHelper: CliIoHost.instance().asIoHelper(),
-      requestHandler,
+      requestHandler: requestHandler as any, // this is fine it's passed through to the SDK
       logger,
     });
   }


### PR DESCRIPTION
This PR refactors the `BaseCredentials` implementation to provide better type safety and a cleaner API surface. By converting from an abstract class to a static factory pattern with proper interfaces, we improve the developer experience and make the code more maintainable.

The changes also reduce external dependencies by removing the direct dependency on `@smithy/node-http-handler` and creating our own simplified interface for request handler settings.

Reason for this change is that in the previous version `SdkProviderServices` was used but not publicly exported since this interface wasn't meant for public consumption. That however made it difficult to implement custom `BaseCredentials` solutions. Instead of `SdkProviderServices` we have no reduced the public API surface to the exactly needed properties.

BREAKING CHANGE: Custom implementations of `BaseCredentials` have changed. If you previously extended the abstract `BaseCredentials` class and implemented the abstract method, you can now pass any object implementing the new `IBaseCredentialsProvider` interface. The method name change to `sdkBaseConfig` and it now receives two parameters: an `ioHost` that can be used to emit messages and a `clientConfig` to should be honored for all SDK requests. However the `clientConfig` may be extended as needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
