### PR TITLE
fix(toolkit-lib): create notices cache dir

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/cached-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/cached-data-source.ts
@@ -72,6 +72,7 @@ export class CachedDataSource implements NoticeDataSource {
 
   private async save(cached: CachedNotices): Promise<void> {
     try {
+      await fs.ensureFile(this.fileName);
       await fs.writeJSON(this.fileName, cached);
     } catch (e) {
       await this.ioHelper.defaults.debug(`Failed to store notices in the cache: ${e}`);


### PR DESCRIPTION
Fixes #541

This PR ensures that the notices cache file exists before attempting to write to it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license