### PR TITLE
feat(toolkit-lib): emit drift in span

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -73,8 +73,10 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_TOOLKIT_I4000` | Diff stacks is starting | `trace` | {@link StackSelectionDetails} |
 | `CDK_TOOLKIT_I4001` | Output of the diff command | `result` | {@link DiffResult} |
 | `CDK_TOOLKIT_I4002` | The diff for a single stack | `result` | {@link StackDiff} |
-| `CDK_TOOLKIT_I4590` | Results of the drift command | `result` | {@link DriftResultPayload} |
-| `CDK_TOOLKIT_I4591` | Missing drift result fort a stack. | `warn` | {@link SingleStack} |
+| `CDK_TOOLKIT_I4500` | Drift detection is starting | `trace` | {@link StackSelectionDetails} |
+| `CDK_TOOLKIT_I4592` | Results of the drift | `result` | {@link Duration} |
+| `CDK_TOOLKIT_I4590` | Results of a stack drift | `result` | {@link DriftResultPayload} |
+| `CDK_TOOLKIT_W4591` | Missing drift result fort a stack. | `warn` | {@link SingleStack} |
 | `CDK_TOOLKIT_I5000` | Provides deployment times | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I5001` | Provides total time in deploy action, including synth and rollback | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I5002` | Provides time for resource migration | `info` | {@link Duration} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
@@ -499,7 +499,7 @@ async function applyAllHotswapOperations(sdk: SDK, ioSpan: IMessageSpan<any>, ho
     return Promise.resolve([]);
   }
 
-  await ioSpan.notifyDefault('info', `\n${ICON} hotswapping resources:`);
+  await ioSpan.defaults.info(`\n${ICON} hotswapping resources:`);
   const limit = pLimit(10);
   // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
   return Promise.all(hotswappableChanges.map(hotswapOperation => limit(() => {
@@ -594,7 +594,7 @@ async function logRejectedChanges(
   }
   messages.push(''); // newline
 
-  await ioSpan.notifyDefault('info', messages.join('\n'));
+  await ioSpan.defaults.info(messages.join('\n'));
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-helper.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/io-helper.ts
@@ -59,7 +59,7 @@ export class IoHelper implements IIoHost, IActionAwareIoHost {
    * Create a new marker from a given registry entry
    */
   public span<S extends object, E extends SpanEnd>(definition: SpanDefinition<S, E>) {
-    return new SpanMaker(this, definition);
+    return new SpanMaker(this, definition, (ioHost) => IoHelper.fromActionAwareIoHost(ioHost));
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -97,13 +97,23 @@ export const IO = {
   }),
 
   // 4: Drift (45xx - 49xx)
+  CDK_TOOLKIT_I4500: make.trace<StackSelectionDetails>({
+    code: 'CDK_TOOLKIT_I4500',
+    description: 'Drift detection is starting',
+    interface: 'StackSelectionDetails',
+  }),
+  CDK_TOOLKIT_I4509: make.result<Duration>({
+    code: 'CDK_TOOLKIT_I4592',
+    description: 'Results of the drift',
+    interface: 'Duration',
+  }),
   CDK_TOOLKIT_I4590: make.result<DriftResultPayload>({
     code: 'CDK_TOOLKIT_I4590',
-    description: 'Results of the drift command',
+    description: 'Results of a stack drift',
     interface: 'DriftResultPayload',
   }),
-  CDK_TOOLKIT_I4591: make.warn<SingleStack>({
-    code: 'CDK_TOOLKIT_I4591',
+  CDK_TOOLKIT_W4591: make.warn<SingleStack>({
+    code: 'CDK_TOOLKIT_W4591',
     description: 'Missing drift result fort a stack.',
     interface: 'SingleStack',
   }),
@@ -535,6 +545,11 @@ export const SPAN = {
     name: 'Diff',
     start: IO.CDK_TOOLKIT_I4000,
     end: IO.CDK_TOOLKIT_I4001,
+  },
+  DRIFT_APP: {
+    name: 'Drift',
+    start: IO.CDK_TOOLKIT_I4000,
+    end: IO.CDK_TOOLKIT_I4509,
   },
   DESTROY_STACK: {
     name: 'Destroy',

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -283,11 +283,11 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
 
     // NOTE: NOT 'await using' because we return ownership to the caller
-    const assembly = await assemblyFromSource(ioHelper, cx);
+    const assembly = await assemblyFromSource(synthSpan.asHelper, cx);
 
     const stacks = await assembly.selectStacksV2(selectStacks);
     const autoValidateStacks = options.validateStacks ? [assembly.selectStacksForValidation()] : [];
-    await this.validateStacksMetadata(stacks.concat(...autoValidateStacks), ioHelper);
+    await this.validateStacksMetadata(stacks.concat(...autoValidateStacks), synthSpan.asHelper);
     await synthSpan.end();
 
     // if we have a single stack, print it to STDOUT
@@ -328,7 +328,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'diff');
     const selectStacks = options.stacks ?? ALL_STACKS;
     const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
-    await using assembly = await assemblyFromSource(ioHelper, cx);
+    await using assembly = await assemblyFromSource(synthSpan.asHelper, cx);
     const stacks = await assembly.selectStacksV2(selectStacks);
     await synthSpan.end();
 
@@ -340,7 +340,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     let diffs = 0;
 
-    const templateInfos = await prepareDiff(ioHelper, stacks, deployments, await this.sdkProvider('diff'), options);
+    const templateInfos = await prepareDiff(diffSpan.asHelper, stacks, deployments, await this.sdkProvider('diff'), options);
     const templateDiffs: { [name: string]: TemplateDiff } = {};
     for (const templateInfo of templateInfos) {
       const formatter = new DiffFormatter({ templateInfo });
@@ -352,8 +352,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       // We only warn about BROADENING changes
       if (securityDiff.permissionChangeType == PermissionChangeType.BROADENING) {
         const warningMessage = 'This deployment will make potentially sensitive changes according to your current security approval level.\nPlease confirm you intend to make the following modifications:\n';
-        await diffSpan.notifyDefault('warn', warningMessage);
-        await diffSpan.notifyDefault('info', securityDiff.formattedDiff);
+        await diffSpan.defaults.warn(warningMessage);
+        await diffSpan.defaults.info(securityDiff.formattedDiff);
       }
 
       // Stack Diff
@@ -386,7 +386,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'drift');
     const selectStacks = options.stacks ?? ALL_STACKS;
     const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
-    await using assembly = await assemblyFromSource(ioHelper, cx);
+    await using assembly = await assemblyFromSource(synthSpan.asHelper, cx);
     const stacks = await assembly.selectStacksV2(selectStacks);
     await synthSpan.end();
 
@@ -397,7 +397,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     for (const stack of stacks.stackArtifacts) {
       const cfn = (await sdkProvider.forEnvironment(stack.environment, Mode.ForReading)).sdk.cloudFormation();
-      const driftResults = await detectStackDrift(cfn, ioHelper, stack.stackName);
+      const driftResults = await detectStackDrift(cfn, driftSpan.asHelper, stack.stackName);
 
       if (!driftResults.StackResourceDrifts) {
         const stackName = stack.displayName ?? stack.stackName;
@@ -421,20 +421,20 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       allDriftResults[formatter.stackName] = stackDrift;
 
       // header
-      await driftSpan.notifyDefault('info', driftOutput.stackHeader);
+      await driftSpan.defaults.info(driftOutput.stackHeader);
 
       // print the different sections at different levels
       if (driftOutput.unchanged) {
-        await driftSpan.notifyDefault('debug', driftOutput.unchanged);
+        await driftSpan.defaults.debug(driftOutput.unchanged);
       }
       if (driftOutput.unchecked) {
-        await driftSpan.notifyDefault('debug', driftOutput.unchecked);
+        await driftSpan.defaults.debug(driftOutput.unchecked);
       }
       if (driftOutput.modified) {
-        await driftSpan.notifyDefault('info', driftOutput.modified);
+        await driftSpan.defaults.info(driftOutput.modified);
       }
       if (driftOutput.deleted) {
-        await driftSpan.notifyDefault('info', driftOutput.deleted);
+        await driftSpan.defaults.info(driftOutput.deleted);
       }
 
       // main stack result
@@ -449,7 +449,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const totalUnchecked = Object.values(allDriftResults).reduce((total, current) => total + (current.numResourcesUnchecked ?? 0), 0);
     await driftSpan.end(`\n✨  Number of resources with drift: ${totalDrifts}${totalUnchecked ? ` (${totalUnchecked} unchecked)` : ''}`);
     if (unavailableDrifts.length) {
-      await driftSpan.notifyDefault('warn', `\n⚠️  Failed to check drift for ${unavailableDrifts.length} stack(s). Check log for more details.`);
+      await driftSpan.defaults.warn(`\n⚠️  Failed to check drift for ${unavailableDrifts.length} stack(s). Check log for more details.`);
     }
 
     return allDriftResults;

--- a/packages/@aws-cdk/toolkit-lib/test/api/io/span.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/io/span.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import type { IoHelper, SpanDefinition } from '../../../lib/api/io/private';
-import { SpanMaker } from '../../../lib/api/io/private';
+import type { IActionAwareIoHost } from '../../../lib';
+import type { SpanDefinition } from '../../../lib/api/io/private';
+import { IoHelper, SpanMaker } from '../../../lib/api/io/private';
 import * as maker from '../../../lib/api/io/private/message-maker';
+
+const makeHelper = (span: IActionAwareIoHost) => IoHelper.fromActionAwareIoHost(span);
 
 describe('SpanMaker', () => {
   let ioHelper: jest.Mocked<IoHelper>;
@@ -27,7 +30,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     await spanMaker.begin('Test span', {});
@@ -54,7 +57,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     const messageSpan = await spanMaker.begin('Test span', {});
@@ -84,7 +87,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     const messageSpan = await spanMaker.begin('Test span', {});
@@ -119,7 +122,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     const messageSpan = await spanMaker.begin('Test span', {});
@@ -146,7 +149,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     await spanMaker.begin('Test span', { startField: 'test value' });
@@ -171,7 +174,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     const messageSpan =await spanMaker.begin('Test span', {});
@@ -197,7 +200,7 @@ describe('SpanMaker', () => {
         interface: 'stuff',
       }),
     };
-    const spanMaker = new SpanMaker(ioHelper, definition);
+    const spanMaker = new SpanMaker(ioHelper, definition, makeHelper);
 
     // WHEN
     const messageSpan = await spanMaker.begin('Test span', {});


### PR DESCRIPTION
When we merged #442 we forgot to add message spans to the drift command. This PR rectifies this.

Also contains a refactor of `MessageSpan` to be a separate class and to represent itself as `IoHelper`. With that we can now pass a `Span` down into subroutines and have those messages also emitted as part of the span. Start using that in some places.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
