### PR TITLE
fix(toolkit-lib): drift detection options are unnecessarily required

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/drift/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/drift/index.ts
@@ -2,7 +2,9 @@ import type { StackSelector } from '../../api/cloud-assembly';
 
 export interface DriftOptions {
   /**
-   * Criteria for selecting stacks to check for drift
+   * Select stacks to check for drift
+   *
+   * @default - all stacks
    */
   readonly stacks?: StackSelector;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/drift/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/drift/index.ts
@@ -4,7 +4,7 @@ export interface DriftOptions {
   /**
    * Criteria for selecting stacks to check for drift
    */
-  readonly stacks: StackSelector;
+  readonly stacks?: StackSelector;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -382,7 +382,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   /**
    * Drift Action
    */
-  public async drift(cx: ICloudAssemblySource, options: DriftOptions): Promise<{ [name: string]: DriftResult }> {
+  public async drift(cx: ICloudAssemblySource, options: DriftOptions = {}): Promise<{ [name: string]: DriftResult }> {
     const ioHelper = asIoHelper(this.ioHost, 'drift');
     const selectStacks = options.stacks ?? ALL_STACKS;
     const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });

--- a/packages/@aws-cdk/toolkit-lib/test/actions/drift.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/drift.test.ts
@@ -73,4 +73,19 @@ describe('drift', () => {
     ioHost.expectMessage({ containing: 'Modified Resources', level: 'info' });
     ioHost.expectMessage({ containing: '[~] AWS::S3::Bucket MyBucket MyBucketF68F3FF0', level: 'info' });
   });
+
+  test('can invoke drift action without options', async () => {
+    // GIVEN
+    mockCloudFormationClient.on(DetectStackDriftCommand).resolves({ StackDriftDetectionId: '12345' });
+    mockCloudFormationClient.on(DescribeStackDriftDetectionStatusCommand).resolves({ DetectionStatus: 'DETECTION_COMPLETE' });
+    mockCloudFormationClient.on(DescribeStackResourceDriftsCommand).resolvesOnce({});
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-bucket');
+    const result = await toolkit.drift(cx);
+
+    // THEN
+    expect(Object.keys(result).length).toBe(0);
+    ioHost.expectMessage({ containing: 'No drift results available' });
+  });
 });


### PR DESCRIPTION
## Description

This PR improves the drift detection implementation in the CDK toolkit-lib by making the 'stacks' parameter optional in the DriftOptions interface and providing default options in the toolkit.drift() method. These changes enhance the API's usability and consistency.

### Changes:

1. Made 'stacks' parameter optional in DriftOptions interface
2. Added default empty options object to toolkit.drift() method
3. Added a test case to verify that drift action can be invoked without options

These changes make the drift detection API more flexible and consistent with other toolkit methods that typically provide default options.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license