### PR TITLE
fix: stack definitions for refactor are incorrect when matching resources are different

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/execution.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/execution.ts
@@ -232,7 +232,7 @@ function indexExports(stacks: CloudFormationStack[]): Record<string, ResourceRef
   return Object.fromEntries(
     stacks.flatMap((s) =>
       Object.values(s.template.Outputs ?? {})
-        .filter((o) => typeof o.Export?.Name === 'string')
+        .filter((o) => typeof o.Export?.Name === 'string' && (o.Value.Ref != null || o.Value['Fn::GetAtt'] != null))
         .map((o) => {
           const ref = resourceReferenceFromCfn(s.stackName, o.Value);
           return [o.Export.Name, ref];

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/execution.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/execution.ts
@@ -1,9 +1,11 @@
 import type { StackDefinition } from '@aws-sdk/client-cloudformation';
-import type {
-  CloudFormationResource,
-  CloudFormationStack,
-  CloudFormationTemplate,
-  ResourceMapping,
+import {
+  resourceReferenceFromCfn,
+  type CloudFormationResource,
+  type CloudFormationStack,
+  type CloudFormationTemplate,
+  type ResourceMapping,
+  type ResourceReference,
 } from './cloudformation';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 
@@ -16,32 +18,38 @@ export function generateStackDefinitions(
   deployedStacks: CloudFormationStack[],
   localStacks: CloudFormationStack[],
 ): StackDefinition[] {
-  const localTemplates = Object.fromEntries(
-    localStacks.map((s) => [s.stackName, JSON.parse(JSON.stringify(s.template)) as CloudFormationTemplate]),
-  );
-  const deployedTemplates = Object.fromEntries(
-    deployedStacks.map((s) => [s.stackName, JSON.parse(JSON.stringify(s.template)) as CloudFormationTemplate]),
-  );
+  const localTemplates = cloneTemplates(localStacks);
+  const localExports = indexExports(localStacks);
+
+  const deployedTemplates = cloneTemplates(deployedStacks);
+  const deployedExports = indexExports(deployedStacks);
 
   // First, remove from the local templates any resources that are not in the deployed templates
   iterate(localTemplates, (stackName, logicalResourceId) => {
-    const location = searchLocation(stackName, logicalResourceId, 'destination', 'source');
+    const location = correspondingLocation(stackName, logicalResourceId, 'backward');
 
-    const deployedResource = deployedStacks.find((s) => s.stackName === location.stackName)?.template
-      .Resources?.[location.logicalResourceId];
+    const deployedResource = deployedStacks.find((s) => s.stackName === location.stackName)?.template.Resources?.[
+      location.logicalResourceId
+    ];
 
     if (deployedResource == null) {
       delete localTemplates[stackName].Resources?.[logicalResourceId];
+    } else {
+      // We've got a deployed resource matching a local resource.
+      // The final template should contain the deployed resource, but with local references.
+      localTemplates[stackName].Resources![logicalResourceId] = updateReferences(
+        deployedResource,
+        location.stackName,
+        mapper(mappings),
+      );
     }
   });
 
   // Now do the opposite: add to the local templates any resources that are in the deployed templates
   iterate(deployedTemplates, (stackName, logicalResourceId, deployedResource) => {
-    const location = searchLocation(stackName, logicalResourceId, 'source', 'destination');
+    const location = correspondingLocation(stackName, logicalResourceId, 'forward');
 
-    const resources = Object
-      .entries(localTemplates)
-      .find(([name, _]) => name === location.stackName)?.[1].Resources;
+    const resources = Object.entries(localTemplates).find(([name, _]) => name === location.stackName)?.[1].Resources;
     const localResource = resources?.[location.logicalResourceId];
 
     if (localResource == null) {
@@ -56,7 +64,83 @@ export function generateStackDefinitions(
     }
   });
 
-  function searchLocation(stackName: string, logicalResourceId: string, from: 'source' | 'destination', to: 'source' | 'destination') {
+  for (const [stackName, template] of Object.entries(localTemplates)) {
+    if (Object.keys(template.Resources ?? {}).length === 0) {
+      // CloudFormation does not allow empty stacks
+      throw new ToolkitError(
+        `Stack ${stackName} has no resources after refactor. You must add a resource to this stack. This resource can be a simple one, like a waitCondition resource type.`,
+      );
+    }
+  }
+
+  return Object.entries(localTemplates)
+    .filter(([stackName, _]) =>
+      mappings.some((m) => {
+        // Only send templates for stacks that are part of the mappings
+        return m.source.stack.stackName === stackName || m.destination.stack.stackName === stackName;
+      }),
+    )
+    .map(([stackName, template]) => ({
+      StackName: stackName,
+      TemplateBody: JSON.stringify(template),
+    }));
+
+  /**
+   * Recursively updates references in the given value using the provided mapping function
+   * to transform every reference found.
+   */
+  function updateReferences(
+    value: any,
+    stackName: string,
+    mapReference: (r: ResourceReference) => ResourceReference,
+  ): any {
+    if (!value || typeof value !== 'object') return value;
+    if (Array.isArray(value)) {
+      return value.map((x) => updateReferences(x, stackName, mapReference));
+    }
+
+    if ('Ref' in value || 'Fn::GetAtt' in value) {
+      const ref = resourceReferenceFromCfn(stackName, value);
+      return resolveLocalReference(ref);
+    }
+
+    if ('Fn::ImportValue' in value) {
+      const exportName = value['Fn::ImportValue'];
+      const ref = deployedExports[exportName];
+      return resolveLocalReference(ref);
+    }
+    const result: any = {};
+    for (const [k, v] of Object.entries(value)) {
+      result[k] = updateReferences(v, stackName, mapReference);
+    }
+    return result;
+
+    /**
+     * Given a deployed reference, resolve the corresponding local reference
+     * as a CloudFormation import value or a local reference.
+     */
+    function resolveLocalReference(deployedRef: ResourceReference) {
+      const localRef = mapReference(deployedRef);
+      const exp = Object.entries(localExports).find(([_, r]) => localRef.equals(r));
+      if (exp != null) {
+        return { 'Fn::ImportValue': exp[0] };
+      }
+      return localRef.toCfn();
+    }
+  }
+
+  /**
+   * The location of a resource in the opposite set of stacks (local vs. deployed).
+   */
+  function correspondingLocation(
+    stackName: string,
+    logicalResourceId: string,
+    direction: 'forward' | 'backward',
+  ) {
+    // forward: source -> destination
+    // backward: destination -> source
+    const from = direction === 'forward' ? 'source' : 'destination';
+    const to = direction === 'forward' ? 'destination' : 'source';
     const mapping = mappings.find(
       (m) => m[from].stack.stackName === stackName && m[from].logicalResourceId === logicalResourceId,
     );
@@ -75,24 +159,36 @@ export function generateStackDefinitions(
       });
     });
   }
+}
 
-  for (const [stackName, template] of Object.entries(localTemplates)) {
-    if (Object.keys(template.Resources ?? {}).length === 0) {
-      throw new ToolkitError(
-        `Stack ${stackName} has no resources after refactor. You must add a resource to this stack. This resource can be a simple one, like a waitCondition resource type.`,
-      );
+function mapper(mappings: ResourceMapping[]): (r: ResourceReference) => ResourceReference {
+  return (r: ResourceReference): ResourceReference => {
+    for (const mapping of mappings) {
+      if (mapping.source.logicalResourceId === r.logicalResourceId && mapping.source.stack.stackName === r.stackName) {
+        const logicalResourceId = mapping.destination.logicalResourceId;
+        const stackName = mapping.destination.stack.stackName;
+        return r.map(stackName, logicalResourceId);
+      }
     }
-  }
+    return r;
+  };
+}
 
-  return Object.entries(localTemplates)
-    .filter(([stackName, _]) =>
-      mappings.some((m) => {
-        // Only send templates for stacks that are part of the mappings
-        return m.source.stack.stackName === stackName || m.destination.stack.stackName === stackName;
-      }),
-    )
-    .map(([stackName, template]) => ({
-      StackName: stackName,
-      TemplateBody: JSON.stringify(template),
-    }));
+function indexExports(stacks: CloudFormationStack[]): Record<string, ResourceReference> {
+  return Object.fromEntries(
+    stacks.flatMap((s) =>
+      Object.values(s.template.Outputs ?? {})
+        .filter((o) => o.Export?.Name != null)
+        .map((o) => {
+          const ref = resourceReferenceFromCfn(s.stackName, o.Value);
+          return [o.Export.Name, ref];
+        }),
+    ),
+  );
+}
+
+function cloneTemplates(stacks: CloudFormationStack[]) {
+  return Object.fromEntries(
+    stacks.map((s) => [s.stackName, JSON.parse(JSON.stringify(s.template)) as CloudFormationTemplate]),
+  );
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -3279,6 +3279,7 @@ describe(generateStackDefinitions, () => {
                 Prop2: { 'Fn::GetAtt': ['C', 'Banana'] },
                 Foo: 123,
               },
+              DependsOn: ['D'],
             },
             B: {
               Type: 'AWS::B::B',
@@ -3290,6 +3291,12 @@ describe(generateStackDefinitions, () => {
               Type: 'AWS::C::C',
               Properties: {
                 Banana: 'BananaValue',
+              },
+            },
+            D: {
+              Type: 'AWS::D::D',
+              Properties: {
+                Foo: 123,
               },
             },
           },
@@ -3308,6 +3315,7 @@ describe(generateStackDefinitions, () => {
                 Prop2: { 'Fn::GetAtt': ['Cn', 'Banana'] },
                 Bar: 456, // Different property
               },
+              DependsOn: ['Dn'],
             },
             Bn: {
               Type: 'AWS::B::B',
@@ -3321,6 +3329,12 @@ describe(generateStackDefinitions, () => {
                 Banana: 'BananaValue',
               },
             },
+            Dn: {
+              Type: 'AWS::D::D',
+              Properties: {
+                Bar: 456,
+              },
+            },
           },
         },
       };
@@ -3328,6 +3342,7 @@ describe(generateStackDefinitions, () => {
       const mappings: ResourceMapping[] = [
         new ResourceMapping(new ResourceLocation(deployedStack, 'B'), new ResourceLocation(deployedStack, 'Bn')),
         new ResourceMapping(new ResourceLocation(deployedStack, 'C'), new ResourceLocation(deployedStack, 'Cn')),
+        new ResourceMapping(new ResourceLocation(deployedStack, 'D'), new ResourceLocation(deployedStack, 'Dn')),
       ];
 
       const result = generateStackDefinitions(mappings, [deployedStack], [localStack]);
@@ -3343,6 +3358,7 @@ describe(generateStackDefinitions, () => {
                   Prop2: { 'Fn::GetAtt': ['Cn', 'Banana'] },
                   Foo: 123,
                 },
+                DependsOn: ['Dn'],
               },
               Bn: {
                 Type: 'AWS::B::B',
@@ -3354,6 +3370,12 @@ describe(generateStackDefinitions, () => {
                 Type: 'AWS::C::C',
                 Properties: {
                   Banana: 'BananaValue',
+                },
+              },
+              Dn: {
+                Type: 'AWS::D::D',
+                Properties: {
+                  Foo: 123,
                 },
               },
             },
@@ -3374,6 +3396,7 @@ describe(generateStackDefinitions, () => {
                 Prop: { Ref: 'B' }, // Reference to a resource in the same stack
                 Foo: 123,
               },
+              DependsOn: 'B',
             },
             B: {
               Type: 'AWS::B::B',
@@ -3440,6 +3463,7 @@ describe(generateStackDefinitions, () => {
                   Prop: { 'Fn::ImportValue': 'BFromOtherStack' }, // Reference to the moved resource
                   Foo: 123, // But we keep the original property from the deployed stack
                 },
+                // Note the absence of DependsOn
               },
             },
           }),
@@ -3468,7 +3492,7 @@ describe(generateStackDefinitions, () => {
       ]);
     });
 
-    test('cross -> witihin', () => {
+    test('cross -> within', () => {
       const deployedStack1: CloudFormationStack = {
         environment: environment,
         stackName: 'Foo',

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -3277,6 +3277,7 @@ describe(generateStackDefinitions, () => {
               Properties: {
                 Prop: { Ref: 'B' },
                 Prop2: { 'Fn::GetAtt': ['C', 'Banana'] },
+                Prop3: { 'Fn::Sub': ['${C}'] },
                 Foo: 123,
               },
               DependsOn: ['D'],
@@ -3313,6 +3314,7 @@ describe(generateStackDefinitions, () => {
               Properties: {
                 Prop: { Ref: 'Bn' },
                 Prop2: { 'Fn::GetAtt': ['Cn', 'Banana'] },
+                Prop3: { 'Fn::Sub': ['${Cn}'] },
                 Bar: 456, // Different property
               },
               DependsOn: ['Dn'],
@@ -3356,6 +3358,7 @@ describe(generateStackDefinitions, () => {
                 Properties: {
                   Prop: { Ref: 'Bn' },
                   Prop2: { 'Fn::GetAtt': ['Cn', 'Banana'] },
+                  Prop3: { 'Fn::Sub': ['${Cn}', {}] },
                   Foo: 123,
                 },
                 DependsOn: ['Dn'],


### PR DESCRIPTION
In most cases, when a resource exists both in the deployed stacks and the local stacks, they will be identical (up to references). But if a resource has a physical ID defined, we take use it to identify the resource, instead of computing a hash from the resource's contents. This allows the toolkit to detect correspondence between these resources even if users changed some properties while refactoring.

When it comes to generating the stacks to send to the refactor API, we need to take this into account. This means taking the deployed resource as the source of truth, and only updating its references, taking them from the local stacks. To do this, we traverse the deployed resource, and every time we find a reference (either within the same stack or cross-stack), transform it to the corresponding local one (also either within- or cross-stack), using the set of resource mappings we already have.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
