### PR TITLE
chore: stack refactor code re-organization

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/mappings.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/mappings.ts
@@ -8,27 +8,39 @@ export interface TypedMapping {
   readonly destinationPath: string;
 }
 
-export function formatTypedMappings(stream: NodeJS.WritableStream, mappings: TypedMapping[]) {
+export function formatMappingsHeader(stream: NodeJS.WritableStream) {
+  const formatter = new Formatter(stream, {});
+  formatter.printSectionHeader('The following resources were moved or renamed:\n');
+}
+
+export function formatTypedMappings(stream: NodeJS.WritableStream, mappings: TypedMapping[], env: string) {
   const header = [['Resource Type', 'Old Construct Path', 'New Construct Path']];
   const rows = mappings.map((m) => [m.type, m.sourcePath, m.destinationPath]);
 
   const formatter = new Formatter(stream, {});
   if (mappings.length > 0) {
-    formatter.printSectionHeader('The following resources were moved or renamed:');
+    formatter.print(`${env}:`);
     formatter.print(chalk.green(formatTable(header.concat(rows), undefined)));
+    formatter.print(' ');
   } else {
     formatter.print('Nothing to refactor.');
   }
 }
 
+export function formatAmbiguitySectionHeader(stream: NodeJS.WritableStream) {
+  const formatter = new Formatter(stream, {});
+  formatter.printSectionHeader('Ambiguous Resource Name Changes:\n');
+}
+
 export function formatAmbiguousMappings(
   stream: NodeJS.WritableStream,
   pairs: [string[], string[]][],
+  env: string,
 ) {
   const tables = pairs.map(renderTable);
   const formatter = new Formatter(stream, {});
 
-  formatter.printSectionHeader('Ambiguous Resource Name Changes');
+  formatter.print(`${env}:`);
   formatter.print(tables.join('\n\n'));
   formatter.printSectionFooter();
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
@@ -1,0 +1,169 @@
+import type { Environment } from '@aws-cdk/cx-api';
+import type { CloudFormationStack } from './cloudformation';
+import { ResourceLocation, ResourceMapping } from './cloudformation';
+import { computeResourceDigests } from './digest';
+import { ToolkitError } from '../../toolkit/toolkit-error';
+
+/**
+ * Represents a set of possible moves of a resource from one location
+ * to another. In the ideal case, there is only one source and only one
+ * destination.
+ */
+type ResourceMove = [ResourceLocation[], ResourceLocation[]];
+
+export interface RefactorManagerOptions {
+  environment: Environment;
+  localStacks: CloudFormationStack[];
+  deployedStacks: CloudFormationStack[];
+  mappings?: ResourceMapping[];
+  filteredStacks?: CloudFormationStack[];
+}
+
+/**
+ * Encapsulates the information for refactoring resources in a single environment.
+ */
+export class RefactoringContext {
+  private readonly _mappings: ResourceMapping[] = [];
+  private readonly ambiguousMoves: ResourceMove[] = [];
+  public readonly environment: Environment;
+
+  constructor(props: RefactorManagerOptions) {
+    this.environment = props.environment;
+    if (props.mappings != null) {
+      this._mappings = props.mappings;
+    } else {
+      const moves = resourceMoves(props.deployedStacks, props.localStacks);
+      this.ambiguousMoves = ambiguousMoves(moves);
+
+      if (!this.isAmbiguous) {
+        this._mappings = resourceMappings(resourceMoves(props.deployedStacks, props.localStacks), props.filteredStacks);
+      }
+    }
+  }
+
+  public get isAmbiguous(): boolean {
+    return this.ambiguousMoves.length > 0;
+  }
+
+  public get ambiguousPaths(): [string[], string[]][] {
+    return this.ambiguousMoves.map(([a, b]) => [convert(a), convert(b)]);
+
+    function convert(locations: ResourceLocation[]): string[] {
+      return locations.map((l) => l.toPath());
+    }
+  }
+
+  public get mappings(): ResourceMapping[] {
+    if (this.isAmbiguous) {
+      throw new ToolkitError(
+        'Cannot access mappings when there are ambiguous resource moves. Please resolve the ambiguity first.',
+      );
+    }
+    return this._mappings;
+  }
+}
+
+function resourceMoves(before: CloudFormationStack[], after: CloudFormationStack[]): ResourceMove[] {
+  return Object.values(
+    removeUnmovedResources(zip(groupByKey(resourceDigests(before)), groupByKey(resourceDigests(after)))),
+  );
+}
+
+function removeUnmovedResources(m: Record<string, ResourceMove>): Record<string, ResourceMove> {
+  const result: Record<string, ResourceMove> = {};
+  for (const [hash, [before, after]] of Object.entries(m)) {
+    const common = before.filter((b) => after.some((a) => a.equalTo(b)));
+    result[hash] = [
+      before.filter((b) => !common.some((c) => b.equalTo(c))),
+      after.filter((a) => !common.some((c) => a.equalTo(c))),
+    ];
+  }
+
+  return result;
+}
+
+/**
+ * For each hash, identifying a single resource, zip the two lists of locations,
+ * producing a resource move
+ */
+function zip(
+  m1: Record<string, ResourceLocation[]>,
+  m2: Record<string, ResourceLocation[]>,
+): Record<string, ResourceMove> {
+  const result: Record<string, ResourceMove> = {};
+
+  for (const [hash, locations] of Object.entries(m1)) {
+    if (hash in m2) {
+      result[hash] = [locations, m2[hash]];
+    } else {
+      result[hash] = [locations, []];
+    }
+  }
+
+  for (const [hash, locations] of Object.entries(m2)) {
+    if (!(hash in m1)) {
+      result[hash] = [[], locations];
+    }
+  }
+
+  return result;
+}
+
+function groupByKey<A>(entries: [string, A][]): Record<string, A[]> {
+  const result: Record<string, A[]> = {};
+
+  for (const [hash, location] of entries) {
+    if (hash in result) {
+      result[hash].push(location);
+    } else {
+      result[hash] = [location];
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Computes a list of pairs [digest, location] for each resource in the stack.
+ */
+function resourceDigests(stacks: CloudFormationStack[]): [string, ResourceLocation][] {
+  // index stacks by name
+  const stacksByName = new Map<string, CloudFormationStack>();
+  for (const stack of stacks) {
+    stacksByName.set(stack.stackName, stack);
+  }
+
+  const digests = computeResourceDigests(stacks);
+
+  return Object.entries(digests).map(([loc, digest]) => {
+    const [stackName, logicalId] = loc.split('.');
+    const location: ResourceLocation = new ResourceLocation(stacksByName.get(stackName)!, logicalId);
+    return [digest, location];
+  });
+}
+
+function ambiguousMoves(movements: ResourceMove[]) {
+  // A move is considered ambiguous if two conditions are met:
+  //  1. Both sides have at least one element (otherwise, it's just addition or deletion)
+  //  2. At least one side has more than one element
+  return movements
+    .filter(([pre, post]) => pre.length > 0 && post.length > 0)
+    .filter(([pre, post]) => pre.length > 1 || post.length > 1);
+}
+
+function resourceMappings(movements: ResourceMove[], stacks?: CloudFormationStack[]): ResourceMapping[] {
+  const stacksPredicate =
+    stacks == null
+      ? () => true
+      : (m: ResourceMapping) => {
+        // Any movement that involves one of the selected stacks (either moving from or to)
+        // is considered a candidate for refactoring.
+        const stackNames = [m.source.stack.stackName, m.destination.stack.stackName];
+        return stacks.some((stack) => stackNames.includes(stack.stackName));
+      };
+
+  return movements
+    .filter(([pre, post]) => pre.length === 1 && post.length === 1 && !pre[0].equalTo(post[0]))
+    .map(([pre, post]) => new ResourceMapping(pre[0], post[0]))
+    .filter(stacksPredicate);
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/index.ts
@@ -1,7 +1,9 @@
 import type { TypedMapping } from '@aws-cdk/cloudformation-diff';
 import {
   formatAmbiguousMappings as fmtAmbiguousMappings,
+  formatMappingsHeader as fmtMappingsHeader,
   formatTypedMappings as fmtTypedMappings,
+  formatAmbiguitySectionHeader as fmtAmbiguitySectionHeader,
 } from '@aws-cdk/cloudformation-diff';
 import type * as cxapi from '@aws-cdk/cx-api';
 import type { StackSummary } from '@aws-sdk/client-cloudformation';
@@ -11,47 +13,10 @@ import { Mode } from '../plugin';
 import { StringWriteStream } from '../streams';
 import type { CloudFormationStack } from './cloudformation';
 import { ResourceLocation, ResourceMapping } from './cloudformation';
-import { computeResourceDigests, hashObject } from './digest';
-import { type ExcludeList, NeverExclude } from './exclude';
 import type { MappingGroup } from '../../actions';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 
 export * from './exclude';
-
-/**
- * Represents a set of possible movements of a resource from one location
- * to another. In the ideal case, there is only one source and only one
- * destination.
- */
-export type ResourceMovement = [ResourceLocation[], ResourceLocation[]];
-
-export class AmbiguityError extends Error {
-  constructor(public readonly movements: ResourceMovement[]) {
-    super('Ambiguous resource mappings');
-  }
-
-  public paths(): [string[], string[]][] {
-    return this.movements.map(([a, b]) => [convert(a), convert(b)]);
-
-    function convert(locations: ResourceLocation[]): string[] {
-      return locations.map((l) => l.toPath());
-    }
-  }
-}
-
-function groupByKey<A>(entries: [string, A][]): Record<string, A[]> {
-  const result: Record<string, A[]> = {};
-
-  for (const [hash, location] of entries) {
-    if (hash in result) {
-      result[hash].push(location);
-    } else {
-      result[hash] = [location];
-    }
-  }
-
-  return result;
-}
 
 export async function usePrescribedMappings(
   mappingGroups: MappingGroup[],
@@ -140,140 +105,7 @@ export async function usePrescribedMappings(
   }
 }
 
-export function resourceMovements(before: CloudFormationStack[], after: CloudFormationStack[]): ResourceMovement[] {
-  return Object.values(
-    removeUnmovedResources(
-      zip(groupByKey(resourceDigests(before)), groupByKey(resourceDigests(after))),
-    ),
-  );
-}
-
-export function ambiguousMovements(movements: ResourceMovement[]) {
-  // A movement is considered ambiguous if these two conditions are met:
-  //  1. Both sides have at least one element (otherwise, it's just addition or deletion)
-  //  2. At least one side has more than one element
-  return movements
-    .filter(([pre, post]) => pre.length > 0 && post.length > 0)
-    .filter(([pre, post]) => pre.length > 1 || post.length > 1);
-}
-
-/**
- * Converts a list of unambiguous resource movements into a list of resource mappings.
- *
- */
-export function resourceMappings(movements: ResourceMovement[], stacks?: CloudFormationStack[]): ResourceMapping[] {
-  const stacksPredicate =
-    stacks == null
-      ? () => true
-      : (m: ResourceMapping) => {
-        // Any movement that involves one of the selected stacks (either moving from or to)
-        // is considered a candidate for refactoring.
-        const stackNames = [m.source.stack.stackName, m.destination.stack.stackName];
-        return stacks.some((stack) => stackNames.includes(stack.stackName));
-      };
-
-  return movements
-    .filter(([pre, post]) => pre.length === 1 && post.length === 1 && !pre[0].equalTo(post[0]))
-    .map(([pre, post]) => new ResourceMapping(pre[0], post[0]))
-    .filter(stacksPredicate);
-}
-
-function removeUnmovedResources(m: Record<string, ResourceMovement>): Record<string, ResourceMovement> {
-  const result: Record<string, ResourceMovement> = {};
-  for (const [hash, [before, after]] of Object.entries(m)) {
-    const common = before.filter((b) => after.some((a) => a.equalTo(b)));
-    result[hash] = [
-      before.filter((b) => !common.some((c) => b.equalTo(c))),
-      after.filter((a) => !common.some((c) => a.equalTo(c))),
-    ];
-  }
-
-  return result;
-}
-
-/**
- * For each hash, identifying a single resource, zip the two lists of locations,
- * producing a resource movement
- */
-function zip(
-  m1: Record<string, ResourceLocation[]>,
-  m2: Record<string, ResourceLocation[]>,
-): Record<string, ResourceMovement> {
-  const result: Record<string, ResourceMovement> = {};
-
-  for (const [hash, locations] of Object.entries(m1)) {
-    if (hash in m2) {
-      result[hash] = [locations, m2[hash]];
-    } else {
-      result[hash] = [locations, []];
-    }
-  }
-
-  for (const [hash, locations] of Object.entries(m2)) {
-    if (!(hash in m1)) {
-      result[hash] = [[], locations];
-    }
-  }
-
-  return result;
-}
-
-/**
- * Computes a list of pairs [digest, location] for each resource in the stack.
- */
-function resourceDigests(stacks: CloudFormationStack[]): [string, ResourceLocation][] {
-  // index stacks by name
-  const stacksByName = new Map<string, CloudFormationStack>();
-  for (const stack of stacks) {
-    stacksByName.set(stack.stackName, stack);
-  }
-
-  const digests = computeResourceDigests(stacks);
-
-  return Object.entries(digests).map(([loc, digest]) => {
-    const [stackName, logicalId] = loc.split('.');
-    const location: ResourceLocation = new ResourceLocation(stacksByName.get(stackName)!, logicalId);
-    return [digest, location];
-  });
-}
-
-/**
- * Compares the deployed state to the cloud assembly state, and finds all resources
- * that were moved from one location (stack + logical ID) to another. The comparison
- * is done per environment.
- */
-export async function findResourceMovements(
-  stacks: CloudFormationStack[],
-  sdkProvider: SdkProvider,
-  exclude: ExcludeList = new NeverExclude(),
-): Promise<ResourceMovement[]> {
-  const stackGroups: Map<string, [CloudFormationStack[], CloudFormationStack[]]> = new Map();
-
-  // Group stacks by environment
-  for (const stack of stacks) {
-    const environment = stack.environment;
-    const key = hashObject(environment);
-    if (stackGroups.has(key)) {
-      stackGroups.get(key)![1].push(stack);
-    } else {
-      // The first time we see an environment, we need to fetch all stacks deployed to it.
-      const before = await getDeployedStacks(sdkProvider, environment);
-      stackGroups.set(key, [before, [stack]]);
-    }
-  }
-
-  const result: ResourceMovement[] = [];
-  for (const [_, [before, after]] of stackGroups) {
-    result.push(...resourceMovements(before, after));
-  }
-
-  return result.filter((mov) => {
-    const after = mov[1];
-    return after.every((l) => !exclude.isExcluded(l));
-  });
-}
-
-async function getDeployedStacks(
+export async function getDeployedStacks(
   sdkProvider: SdkProvider,
   environment: cxapi.Environment,
 ): Promise<CloudFormationStack[]> {
@@ -303,14 +135,30 @@ async function getDeployedStacks(
   return Promise.all(summaries.map(normalize));
 }
 
-export function formatTypedMappings(mappings: TypedMapping[]): string {
-  const stream = new StringWriteStream();
-  fmtTypedMappings(stream, mappings);
-  return stream.toString();
+export function formatMappingsHeader(): string {
+  return formatToStream(fmtMappingsHeader);
 }
 
-export function formatAmbiguousMappings(paths: [string[], string[]][]): string {
+export function formatTypedMappings(environment: cxapi.Environment, mappings: TypedMapping[]): string {
+  return formatToStream((stream) => {
+    const env = `aws://${environment.account}/${environment.region}`;
+    fmtTypedMappings(stream, mappings, env);
+  });
+}
+
+export function formatAmbiguitySectionHeader(): string {
+  return formatToStream(fmtAmbiguitySectionHeader);
+}
+
+export function formatAmbiguousMappings(environment: cxapi.Environment, paths: [string[], string[]][]): string {
+  return formatToStream((stream) => {
+    const env = `aws://${environment.account}/${environment.region}`;
+    fmtAmbiguousMappings(stream, paths, env);
+  });
+}
+
+function formatToStream(cb: (stream: NodeJS.WritableStream) => void): string {
   const stream = new StringWriteStream();
-  fmtAmbiguousMappings(stream, paths);
+  cb(stream);
   return stream.toString();
 }

--- a/packages/@aws-cdk/toolkit-lib/test/_fixtures/multiple-environments/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_fixtures/multiple-environments/index.ts
@@ -1,0 +1,22 @@
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as core from 'aws-cdk-lib/core';
+
+export default async () => {
+  const app = new core.App({ autoSynth: false });
+  const stack1 = new core.Stack(app, 'Stack1', {
+    env: {
+      account: '123456789012',
+      region: 'us-east-1',
+    },
+  });
+  new s3.Bucket(stack1, 'NewBucketNameInStack1');
+
+  const stack2 = new core.Stack(app, 'Stack2', {
+    env: {
+      account: '123456789012',
+      region: 'us-east-2',
+    },
+  });
+  new s3.Bucket(stack2, 'NewBucketNameInStack2');
+  return app.synth();
+};

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/context.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/context.test.ts
@@ -1,0 +1,636 @@
+import type {
+  ResourceLocation as CfnResourceLocation,
+  ResourceMapping as CfnResourceMapping,
+} from '@aws-sdk/client-cloudformation/dist-types/models/models_0';
+import { expect } from '@jest/globals';
+import type { ResourceLocation, ResourceMapping } from '../../../lib/api/refactoring/cloudformation';
+import { RefactoringContext } from '../../../lib/api/refactoring/context';
+
+describe('typed mappings', () => {
+  // The environment isn't important for these tests
+  // Using the same for all stacks
+  const environment = {
+    name: 'prod',
+    account: '123456789012',
+    region: 'us-east-1',
+  };
+
+  test('returns empty mappings for identical sets of stacks', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings).toEqual([]);
+  });
+
+  test('returns empty mappings when there are only removals', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        // Resource was removed
+        Resources: {},
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings).toEqual([]);
+  });
+
+  test('returns empty mappings when there are only additions', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {},
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        // Resource was added
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings).toEqual([]);
+  });
+
+  test('normal updates are not mappings', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'old value' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      // Same stack name
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          // Same resource name
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            // Updated property
+            Properties: { Prop: 'old value' },
+          },
+        },
+      },
+    };
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings).toEqual([]);
+  });
+
+  test('moving resources across stacks', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Bar',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Source: { LogicalResourceId: 'Bucket1', StackName: 'Foo' },
+        Destination: { LogicalResourceId: 'Bucket1', StackName: 'Bar' },
+      },
+    ]);
+  });
+
+  test('renaming resources in the same stack', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          OldName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          NewName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Source: { LogicalResourceId: 'OldName', StackName: 'Foo' },
+        Destination: { LogicalResourceId: 'NewName', StackName: 'Foo' },
+      },
+    ]);
+  });
+
+  test('moving and renaming resources across stacks', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          OldName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Bar',
+      template: {
+        Resources: {
+          NewName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Source: { LogicalResourceId: 'OldName', StackName: 'Foo' },
+        Destination: { LogicalResourceId: 'NewName', StackName: 'Bar' },
+      },
+    ]);
+  });
+
+  test('type is also part of the resources contents', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          OldName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {
+              Xyz: 123,
+            },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Bar',
+      template: {
+        Resources: {
+          NewName: {
+            Type: 'AWS::EC2::Instance',
+            Properties: {
+              Xyz: 123,
+            },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+
+    // We don't consider that a resource was moved from Foo.OldName to Bar.NewName,
+    // even though they have the same properties. Since they have different types,
+    // they are considered different resources.
+    expect(context.mappings).toEqual([]);
+  });
+
+  test('ambiguous resources from multiple stacks', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Stack1',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Stack2',
+      template: {
+        Resources: {
+          Bucket2: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+        },
+      },
+    };
+
+    const stack3 = {
+      environment,
+      stackName: 'Stack3',
+      template: {
+        Resources: {
+          Bucket3: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1, stack2],
+      localStacks: [stack3],
+    });
+    expect(context.ambiguousPaths).toEqual([[['Stack1.Bucket1', 'Stack2.Bucket2'], ['Stack3.Bucket3']]]);
+  });
+
+  test('ambiguous pairs', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+          Bucket2: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Bar',
+      template: {
+        Resources: {
+          Bucket3: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+          Bucket4: {
+            Type: 'AWS::S3::Bucket',
+            Properties: {},
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.ambiguousPaths).toEqual([
+      [
+        ['Foo.Bucket1', 'Foo.Bucket2'],
+        ['Bar.Bucket3', 'Bar.Bucket4'],
+      ],
+    ]);
+  });
+
+  test('combines addition, deletion, update, and rename', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          OldName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'OldBucket' },
+          },
+          ToBeDeleted: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'DeleteMe' },
+          },
+          ToBeUpdated: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'UpdateMe' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          NewName: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'OldBucket' },
+          },
+          ToBeAdded: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'NewBucket' },
+          },
+          ToBeUpdated: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'UpdatedBucket' },
+          },
+        },
+      },
+    };
+
+    const context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Source: { LogicalResourceId: 'OldName', StackName: 'Foo' },
+        Destination: { LogicalResourceId: 'NewName', StackName: 'Foo' },
+      },
+    ]);
+  });
+
+  test('stack filtering', () => {
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    const environment = {
+      name: 'prod',
+      account: '123456789012',
+      region: 'us-east-1',
+    };
+
+    // Scenario:
+    //  Foo.Bucket1 -> Bar.Bucket1
+    //  Zee.OldName -> Zee.NewName
+
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Bar',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'XXXXXXXXX' },
+          },
+        },
+      },
+    };
+
+    const stack3 = {
+      environment,
+      stackName: 'Zee',
+      template: {
+        Resources: {
+          OldName: {
+            Type: 'AWS::SQS::Queue',
+            Properties: { Prop: 'YYYYYYYYY' },
+          },
+        },
+      },
+    };
+
+    const stack4 = {
+      environment,
+      stackName: 'Zee',
+      template: {
+        Resources: {
+          NewName: {
+            Type: 'AWS::SQS::Queue',
+            Properties: { Prop: 'YYYYYYYYY' },
+          },
+        },
+      },
+    };
+
+    // Testing different filters:
+
+    // Only Foo. Should include Foo and Bar
+    let context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1, stack3],
+      localStacks: [stack2, stack4],
+      filteredStacks: [stack1],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Destination: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Bar',
+        },
+        Source: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Foo',
+        },
+      },
+    ]);
+
+    // Only Bar. Should include Foo and Bar
+    context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1, stack3],
+      localStacks: [stack2, stack4],
+      filteredStacks: [stack2],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Destination: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Bar',
+        },
+        Source: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Foo',
+        },
+      },
+    ]);
+
+    // Only Zee. Should include Zee
+    context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1, stack3],
+      localStacks: [stack2, stack4],
+      filteredStacks: [stack3],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Destination: {
+          LogicalResourceId: 'NewName',
+          StackName: 'Zee',
+        },
+        Source: {
+          LogicalResourceId: 'OldName',
+          StackName: 'Zee',
+        },
+      },
+    ]);
+
+    // Foo and Zee. Should include all
+    context = new RefactoringContext({
+      environment,
+      deployedStacks: [stack1, stack3],
+      localStacks: [stack2, stack4],
+      filteredStacks: [stack1, stack3],
+    });
+    expect(context.mappings.map(toCfnMapping)).toEqual([
+      {
+        Destination: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Bar',
+        },
+        Source: {
+          LogicalResourceId: 'Bucket1',
+          StackName: 'Foo',
+        },
+      },
+      {
+        Destination: {
+          LogicalResourceId: 'NewName',
+          StackName: 'Zee',
+        },
+        Source: {
+          LogicalResourceId: 'OldName',
+          StackName: 'Zee',
+        },
+      },
+    ]);
+  });
+});
+
+function toCfnMapping(m: ResourceMapping): CfnResourceMapping {
+  return {
+    Source: toCfnLocation(m.source),
+    Destination: toCfnLocation(m.destination),
+  };
+}
+
+function toCfnLocation(loc: ResourceLocation): CfnResourceLocation {
+  return {
+    LogicalResourceId: loc.logicalResourceId,
+    StackName: loc.stack.stackName,
+  };
+}


### PR DESCRIPTION
This is a major re-organization of the stack refactoring code. The core change was the introduction of the `RefactoringContext`, that encapsulates the data and operations needed for a refactor, for a single environment. In future changes, this class will also start exposing methods to execute the refactor.

No behavior was changed, except in the presentation layer: before, all mappings were grouped in a single table. Now, there is a section for each environment, with its own table, to make it clearer to the user that each one is a different refactor operation:

![Screenshot 2025-05-30 at 11 02 25](https://github.com/user-attachments/assets/d4ac65e6-7d7c-4e3e-9438-a5973b27e572)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
