### PR TITLE
docs(toolkit-lib): update README to use `getStackByName` for retrieving stack template

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/README.md
+++ b/packages/@aws-cdk/toolkit-lib/README.md
@@ -114,7 +114,7 @@ You can also query information about the synthesized _Cloud Assembly_:
 
 ```ts
 const cloudAssembly = await cx.produce();
-const template = cloudAssembly.getStack("my-stack").template;
+const template = cloudAssembly.getStackByName("my-stack").template;
 ```
 
 ### list


### PR DESCRIPTION
Now because `getStack` is deprecated. I replaced `getStack` by `getStackByName`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
