### PR TITLE
fix(toolkit-lib): `refactor` feature is not marked as unstable

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -150,7 +150,7 @@ interface StackGroup {
  * Names of toolkit features that are still under development, and may change in
  * the future.
  */
-export type UnstableFeature = 'refactor' | 'gc';
+export type UnstableFeature = 'refactor';
 
 /**
  * The AWS CDK Programmatic Toolkit

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -131,6 +131,13 @@ export interface ToolkitOptions {
    * @default - A fresh plugin host
    */
   readonly pluginHost?: PluginHost;
+
+  /**
+   * Set of unstable features to opt into. If you are using an unstable feature,
+   * you must explicitly acknowledge that you are aware of the risks of using it,
+   * by passing it in this set.
+   */
+  readonly unstableFeatures?: Array<UnstableFeature>;
 }
 
 interface StackGroup {
@@ -138,6 +145,12 @@ interface StackGroup {
   localStacks: CloudFormationStack[];
   deployedStacks: CloudFormationStack[];
 }
+
+/**
+ * Names of toolkit features that are still under development, and may change in
+ * the future.
+ */
+export type UnstableFeature = 'refactor' | 'gc';
 
 /**
  * The AWS CDK Programmatic Toolkit
@@ -165,6 +178,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
   private baseCredentials: IBaseCredentialsProvider;
 
+  private readonly unstableFeatures: Array<UnstableFeature>;
+
   public constructor(private readonly props: ToolkitOptions = {}) {
     super();
     this.toolkitStackName = props.toolkitStackName ?? DEFAULT_TOOLKIT_STACK_NAME;
@@ -183,6 +198,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     this.ioHost = withTrimmedWhitespace(ioHost);
 
     this.baseCredentials = props.sdkConfig?.baseCredentials ?? BaseCredentials.awsCliCompatible();
+    this.unstableFeatures = props.unstableFeatures ?? [];
   }
 
   /**
@@ -1051,6 +1067,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * Refactor Action. Moves resources from one location (stack + logical ID) to another.
    */
   public async refactor(cx: ICloudAssemblySource, options: RefactorOptions = {}): Promise<void> {
+    this.requireUnstableFeature('refactor');
+
     const ioHelper = asIoHelper(this.ioHost, 'refactor');
     const assembly = await assemblyFromSource(ioHelper, cx);
     return this._refactor(assembly, ioHelper, options);
@@ -1282,6 +1300,12 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       await this._deploy(assembly, 'watch', deployOptions);
     } catch {
       // just continue - deploy will show the error
+    }
+  }
+
+  private requireUnstableFeature(requestedFeature: UnstableFeature) {
+    if (!this.unstableFeatures.includes(requestedFeature)) {
+      throw new ToolkitError(`Unstable feature '${requestedFeature}' is not enabled. Please enable it under 'unstableFeatures'`);
     }
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -8,7 +8,7 @@ import { mockCloudFormationClient, MockSdk } from '../_helpers/mock-sdk';
 jest.setTimeout(10_000);
 
 const ioHost = new TestIoHost();
-const toolkit = new Toolkit({ ioHost });
+const toolkit = new Toolkit({ ioHost, unstableFeatures: ['refactor'] });
 
 jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
 
@@ -16,6 +16,19 @@ beforeEach(() => {
   ioHost.notifySpy.mockClear();
   ioHost.requestSpy.mockClear();
   mockCloudFormationClient.reset();
+});
+
+test('requires acknowledgment that the feature is unstable', async () => {
+  // GIVEN
+  const tk = new Toolkit({ ioHost /* unstable not acknowledged */ });
+  const cx = await builderFixture(tk, 'stack-with-bucket');
+
+  // WHEN
+  await expect(
+    tk.refactor(cx, {
+      dryRun: true,
+    }),
+  ).rejects.toThrow("Unstable feature 'refactor' is not enabled. Please enable it under 'unstableFeatures'");
 });
 
 test('detects the same resource in different locations', async () => {

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -179,7 +179,7 @@ export class CdkToolkit {
       emojis: true,
       ioHost: this.ioHost,
       toolkitStackName: this.toolkitStackName,
-      unstableFeatures: ['refactor', 'gc'],
+      unstableFeatures: ['refactor'],
     });
   }
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -179,6 +179,7 @@ export class CdkToolkit {
       emojis: true,
       ioHost: this.ioHost,
       toolkitStackName: this.toolkitStackName,
+      unstableFeatures: ['refactor', 'gc'],
     });
   }
 


### PR DESCRIPTION
This introduces the concept of unstable featues to the toolkit. The CLI always opts into it because it has its own similar flag.

Over time, the type `UnstableFeature` will change according to the features that are unstable at the moment. All commands that are considered unstable should call the `requireUnstableFeature` method.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
