### PR TITLE
feat: drop support for Node.js 14 and 16

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -30,7 +30,7 @@ const TYPESCRIPT_VERSION = '5.6';
  */
 function configureProject<A extends pj.typescript.TypeScriptProject>(x: A): A {
   // currently supported min node version
-  x.package.addEngine('node', '>= 14.15.0');
+  x.package.addEngine('node', '>= 18.0.0');
 
   x.addDevDeps(
     'jest-junit@^16',

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "5.6"
   },
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -107,7 +107,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cdk-cli-wrapper/package.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/package.json
@@ -55,7 +55,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cli-lib-alpha/package.json
+++ b/packages/@aws-cdk/cli-lib-alpha/package.json
@@ -74,7 +74,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/main.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cli-plugin-contract/package.json
+++ b/packages/@aws-cdk/cli-plugin-contract/package.json
@@ -58,7 +58,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cloud-assembly-schema/package.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/package.json
@@ -82,7 +82,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/cloudformation-diff/package.json
+++ b/packages/@aws-cdk/cloudformation-diff/package.json
@@ -72,7 +72,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/integ-runner/package.json
+++ b/packages/@aws-cdk/integ-runner/package.json
@@ -83,7 +83,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/node-bundle/package.json
+++ b/packages/@aws-cdk/node-bundle/package.json
@@ -70,7 +70,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -127,7 +127,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/user-input-gen/package.json
+++ b/packages/@aws-cdk/user-input-gen/package.json
@@ -64,7 +64,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/@aws-cdk/yarn-cling/package.json
+++ b/packages/@aws-cdk/yarn-cling/package.json
@@ -65,7 +65,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -139,7 +139,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/cdk-assets/package.json
+++ b/packages/cdk-assets/package.json
@@ -89,7 +89,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -64,7 +64,7 @@
     "cdk"
   ],
   "engines": {
-    "node": ">= 14.15.0"
+    "node": ">= 18.0.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
Since May 30th, 2025, these versions are [no longer supported](https://aws.amazon.com/blogs/devops/announcing-the-end-of-support-for-node-js-14-x-and-16-x-in-aws-cdk/).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
