### PR TITLE
chore: fix typo

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -62,7 +62,7 @@ export interface CliIoHostProps {
    */
   readonly requireDeployApproval?: RequireApproval;
 
-  /*
+  /**
    * The initial Toolkit action the hosts starts with.
    *
    * @default StackActivityProgress.BAR


### PR DESCRIPTION
There should be a linter rule against this but I don't have time to write it. Without the extra `*` the documentation does not become part of the docstring for the property.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
