### PR TITLE
fix(toolkit-lib): tracing logs on watch action does not close immediately

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -973,6 +973,9 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     return {
       async dispose() {
+        // stop the logs monitor, if it exists
+        await cloudWatchLogMonitor?.deactivate();
+        // close the watcher itself
         await watcher.close();
         // Prevents Node from staying alive. There is no 'end' event that the watcher emits
         // that we can know it's definitely done, so best we can do is tell it to stop watching,

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
@@ -161,7 +161,7 @@ describe('watch', () => {
     // GIVEN
     const cx = await builderFixture(toolkit, 'stack-with-role');
     ioHost.level = 'debug';
-    await toolkit.watch(cx, {
+    const watcher = await toolkit.watch(cx, {
       include: [],
       traceLogs: true,
     });
@@ -174,8 +174,13 @@ describe('watch', () => {
       cloudWatchLogMonitor: expect.anything(), // Not undefined
     }));
 
-    // Deactivate the cloudWatchLogMonitor that we created, otherwise the tests won't exit
-    (deploySpy.mock.calls[0]?.[2] as any).cloudWatchLogMonitor?.deactivate();
+    const logMonitorSpy = jest.spyOn((deploySpy.mock.calls[0]?.[2] as any).cloudWatchLogMonitor, 'deactivate');
+
+    // Deactivate the watcher and cloudWatchLogMonitor that we created, otherwise the tests won't exit
+    await watcher.dispose();
+
+    // ensure the log monitor has been closed
+    expect(logMonitorSpy).toHaveBeenCalled();
   });
 
   test('watch returns an object that can be used to stop the watch', async () => {


### PR DESCRIPTION
Previously the `CloudWatchLogEventMonitor` wasn't closed immediately when the `FileWatcher` returned from `watch()` was disposed. This wasn't super bad, since it would only wait for one additional tick to finish, but also isn't great.

This was discovered by jest reporting open handles. Well done jest!

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
