### PR TITLE
chore(toolkit-lib): improve CCAPI context provider error handling

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -794,7 +794,10 @@ const toolkitLib = configureProject(
           lines: 87,
         },
         testEnvironment: './test/_helpers/jest-bufferedconsole.ts',
-        setupFilesAfterEnv: ['<rootDir>/test/_helpers/jest-setup-after-env.ts'],
+        setupFilesAfterEnv: [
+          '<rootDir>/test/_helpers/jest-setup-after-env.ts',
+          '<rootDir>/test/_helpers/jest-custom-matchers.ts',
+        ],
       },
     }),
     tsconfig: {

--- a/packages/@aws-cdk/toolkit-lib/jest.config.json
+++ b/packages/@aws-cdk/toolkit-lib/jest.config.json
@@ -48,7 +48,8 @@
   ],
   "randomize": true,
   "setupFilesAfterEnv": [
-    "<rootDir>/test/_helpers/jest-setup-after-env.ts"
+    "<rootDir>/test/_helpers/jest-setup-after-env.ts",
+    "<rootDir>/test/_helpers/jest-custom-matchers.ts"
   ],
   "clearMocks": true,
   "coverageDirectory": "coverage",

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
@@ -4,6 +4,7 @@ const TOOLKIT_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.ToolkitError');
 const AUTHENTICATION_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.AuthenticationError');
 const ASSEMBLY_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.AssemblyError');
 const CONTEXT_PROVIDER_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.ContextProviderError');
+const NO_RESULTS_FOUND_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.NoResultsFoundError');
 
 /**
  * Represents a general toolkit error in the AWS CDK Toolkit.
@@ -132,6 +133,13 @@ export class AssemblyError extends ToolkitError {
  */
 export class ContextProviderError extends ToolkitError {
   /**
+   * Determines if a given error is an instance of AssemblyError.
+   */
+  public static isNoResultsFoundError(x: any): x is NoResultsFoundError {
+    return this.isContextProviderError(x) && NO_RESULTS_FOUND_ERROR_SYMBOL in x;
+  }
+
+  /**
    * Denotes the source of the error as user.
    */
   public readonly source = 'user';
@@ -140,5 +148,16 @@ export class ContextProviderError extends ToolkitError {
     super(message, 'context-provider');
     Object.setPrototypeOf(this, ContextProviderError.prototype);
     Object.defineProperty(this, CONTEXT_PROVIDER_ERROR_SYMBOL, { value: true });
+  }
+}
+
+/**
+ * A specific context provider lookup failure indicating no results where found for a context query
+ */
+export class NoResultsFoundError extends ContextProviderError {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, NoResultsFoundError.prototype);
+    Object.defineProperty(this, NO_RESULTS_FOUND_ERROR_SYMBOL, { value: true });
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
@@ -21,25 +21,25 @@ export class ToolkitError extends Error {
    * Determines if a given error is an instance of AuthenticationError.
    */
   public static isAuthenticationError(x: any): x is AuthenticationError {
-    return this.isToolkitError(x) && AUTHENTICATION_ERROR_SYMBOL in x;
+    return ToolkitError.isToolkitError(x) && AUTHENTICATION_ERROR_SYMBOL in x;
   }
 
   /**
    * Determines if a given error is an instance of AssemblyError.
    */
   public static isAssemblyError(x: any): x is AssemblyError {
-    return this.isToolkitError(x) && ASSEMBLY_ERROR_SYMBOL in x;
+    return ToolkitError.isToolkitError(x) && ASSEMBLY_ERROR_SYMBOL in x;
   }
 
   /**
-   * Determines if a given error is an instance of AssemblyError.
+   * Determines if a given error is an instance of ContextProviderError.
    */
   public static isContextProviderError(x: any): x is ContextProviderError {
-    return this.isToolkitError(x) && CONTEXT_PROVIDER_ERROR_SYMBOL in x;
+    return ToolkitError.isToolkitError(x) && CONTEXT_PROVIDER_ERROR_SYMBOL in x;
   }
 
   /**
-   * An AssemblyError with an original error as cause
+   * A ToolkitError with an original error as cause
    */
   public static withCause(message: string, error: unknown): ToolkitError {
     return new ToolkitError(message, 'toolkit', error);
@@ -133,10 +133,17 @@ export class AssemblyError extends ToolkitError {
  */
 export class ContextProviderError extends ToolkitError {
   /**
-   * Determines if a given error is an instance of AssemblyError.
+   * Determines if a given error is an instance of NoResultsFoundError.
    */
   public static isNoResultsFoundError(x: any): x is NoResultsFoundError {
-    return this.isContextProviderError(x) && NO_RESULTS_FOUND_ERROR_SYMBOL in x;
+    return ToolkitError.isContextProviderError(x) && NO_RESULTS_FOUND_ERROR_SYMBOL in x;
+  }
+
+  /**
+   * A ContextProviderError with an original error as cause
+   */
+  public static withCause(message: string, error: unknown): ContextProviderError {
+    return new ContextProviderError(message, error);
   }
 
   /**
@@ -144,8 +151,8 @@ export class ContextProviderError extends ToolkitError {
    */
   public readonly source = 'user';
 
-  constructor(message: string) {
-    super(message, 'context-provider');
+  constructor(message: string, cause?: unknown) {
+    super(message, 'context-provider', cause);
     Object.setPrototypeOf(this, ContextProviderError.prototype);
     Object.defineProperty(this, CONTEXT_PROVIDER_ERROR_SYMBOL, { value: true });
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
@@ -1,3 +1,5 @@
+import { ToolkitError } from '../toolkit/toolkit-error';
+
 /**
  * Takes in an error and returns a correctly formatted string of its error message.
  * If it is an AggregateError, it will return a string with all the inner errors
@@ -12,6 +14,10 @@ export function formatErrorMessage(error: any): string {
       .map((innerError: { message: any; toString: () => any }) => (innerError?.message || innerError?.toString()))
       .join('\n');
     return `AggregateError: ${innerMessages}`;
+  }
+
+  if (ToolkitError.isToolkitError(error) && error.cause) {
+    return `${error.message}\n${formatErrorMessage(error.cause)}`;
   }
 
   // Fallback for regular Error or other types

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-custom-matchers.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-custom-matchers.ts
@@ -1,0 +1,52 @@
+import * as assert from 'assert';
+
+type TestableError = string | RegExp | Error;
+
+declare global {
+  namespace jest {
+    interface AsymmetricMatchers {
+      toThrowWithCause(error: TestableError, cause: TestableError): void;
+    }
+
+    interface Matchers<R> {
+      toThrowWithCause(error: TestableError, cause: TestableError): R;
+    }
+  }
+}
+
+/**
+ * @type {ExpectExtendMap & MatchersExtend<any>}
+ */
+const customMatchers = {
+  toThrowWithCause(received: any, error: TestableError, cause: TestableError) {
+    // check the main error first
+    expect(() => {
+      throw received;
+    }).toThrow(error);
+
+    let pass = true;
+    try {
+      assert(received.cause);
+      expect(() => {
+        throw received.cause;
+      }).toThrow(cause);
+    } catch {
+      pass = false;
+    }
+
+    const actualCause = String(received && received.cause ? `got: ${received.cause}` : 'no cause was found');
+
+    return {
+      pass,
+      message: pass
+        // not.toThrowWithCause
+        ? () => `Expected callback not to throw an Error with cause '${cause}'`
+        // .toThrowWithCause
+        : () => `Expected callback to throw an Error with cause '${cause}', but ${actualCause}`,
+    };
+  },
+};
+
+expect.extend(customMatchers);
+
+export {};

--- a/packages/@aws-cdk/toolkit-lib/test/context-providers/cc-api-provider.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/context-providers/cc-api-provider.test.ts
@@ -76,7 +76,7 @@ test('looks up RDS instance using CC API getResource - error in CC API', async (
       exactIdentifier: 'bad-identifier',
       propertiesToReturn: ['DBInstanceArn', 'StorageEncrypted'],
     }),
-  ).rejects.toThrow('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier'); // THEN
+  ).rejects.toThrowWithCause('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier', 'No data found'); // THEN
 });
 
 test('looks up RDS instance using CC API listResources', async () => {
@@ -386,7 +386,7 @@ describe('dummy value', () => {
           },
       ],
     }),
-  ).rejects.toThrow('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier');
+  ).rejects.toThrowWithCause('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier', 'Other error');
   });
 
   test('throws error when CC API listResources fails but the error is not ResourceNotFoundException', async () => {
@@ -409,7 +409,7 @@ describe('dummy value', () => {
           },
         ],
       }),
-    ).rejects.toThrow('Encountered CC API error while listing AWS::RDS::DBInstance resources matching {\"StorageEncrypted\":\"true\"}');
+    ).rejects.toThrowWithCause('Encountered CC API error while listing AWS::RDS::DBInstance resources matching {\"StorageEncrypted\":\"true\"}', 'Other error');
   });
 
   test('throws error when CC API fails and ignoreErrorOnMissingContext is not provided', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/context-providers/cc-api-provider.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/context-providers/cc-api-provider.test.ts
@@ -386,7 +386,7 @@ describe('dummy value', () => {
           },
       ],
     }),
-  ).rejects.toThrow('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier: Other error');
+  ).rejects.toThrow('Encountered CC API error while getting AWS::RDS::DBInstance resource bad-identifier');
   });
 
   test('throws error when CC API listResources fails but the error is not ResourceNotFoundException', async () => {
@@ -409,7 +409,7 @@ describe('dummy value', () => {
           },
         ],
       }),
-    ).rejects.toThrow('Encountered CC API error while listing AWS::RDS::DBInstance resources matching {\"StorageEncrypted\":\"true\"}: Other error');
+    ).rejects.toThrow('Encountered CC API error while listing AWS::RDS::DBInstance resources matching {\"StorageEncrypted\":\"true\"}');
   });
 
   test('throws error when CC API fails and ignoreErrorOnMissingContext is not provided', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit-error.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit-error.test.ts
@@ -1,4 +1,4 @@
-import { AssemblyError, AuthenticationError, ContextProviderError, ToolkitError } from '../../lib/toolkit/toolkit-error';
+import { AssemblyError, AuthenticationError, ContextProviderError, NoResultsFoundError, ToolkitError } from '../../lib/toolkit/toolkit-error';
 
 describe('toolkit error', () => {
   let toolkitError = new ToolkitError('Test toolkit error');
@@ -7,6 +7,7 @@ describe('toolkit error', () => {
   let contextProviderError = new ContextProviderError('Test context provider error');
   let assemblyError = AssemblyError.withStacks('Test authentication error', []);
   let assemblyCauseError = AssemblyError.withCause('Test authentication error', new Error('other error'));
+  let noResultsError = new NoResultsFoundError('Test no results error');
 
   test('types are correctly assigned', async () => {
     expect(toolkitError.type).toBe('toolkit');
@@ -14,6 +15,7 @@ describe('toolkit error', () => {
     expect(assemblyError.type).toBe('assembly');
     expect(assemblyCauseError.type).toBe('assembly');
     expect(contextProviderError.type).toBe('context-provider');
+    expect(noResultsError.type).toBe('context-provider');
   });
 
   test('isToolkitError works', () => {
@@ -62,7 +64,19 @@ describe('toolkit error', () => {
     expect(contextProviderError.source).toBe('user');
 
     expect(ToolkitError.isContextProviderError(contextProviderError)).toBe(true);
+    expect(ToolkitError.isContextProviderError(noResultsError)).toBe(true);
     expect(ToolkitError.isContextProviderError(toolkitError)).toBe(false);
     expect(ToolkitError.isContextProviderError(authError)).toBe(false);
+  });
+
+  test('NoResultsFoundError works', () => {
+    expect(noResultsError.source).toBe('user');
+
+    expect(ContextProviderError.isNoResultsFoundError(noResultsError)).toBe(true);
+    expect(ToolkitError.isContextProviderError(noResultsError)).toBe(true);
+    expect(ToolkitError.isToolkitError(noResultsError)).toBe(true);
+
+    expect(ToolkitError.isAssemblyError(noResultsError)).toBe(false);
+    expect(ToolkitError.isAuthenticationError(noResultsError)).toBe(false);
   });
 });


### PR DESCRIPTION
Just noticed some missed opportunities in the error handling for the CCAPI provider.

This only has limited end-user impact:
- instead of `error: cause` it's now `error\ncause`
- Some not enough results found error messages now include the expectation

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license