### PR TITLE
chore(cli): type `currentAction` as `CliAction`

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/toolkit-action.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/toolkit-action.ts
@@ -1,5 +1,5 @@
 /**
- * The current action being performed by the Toolkit or CLI.
+ * The current action being performed by the Toolkit.
  */
 export type ToolkitAction =
 | 'assembly'

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/toolkit-action.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/toolkit-action.ts
@@ -1,5 +1,5 @@
 /**
- * The current action being performed by the CLI. 'none' represents the absence of an action.
+ * The current action being performed by the Toolkit or CLI.
  */
 export type ToolkitAction =
 | 'assembly'

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -13,7 +13,7 @@ export type { IIoHost, IoMessage, IoMessageCode, IoMessageLevel, IoRequest };
 /**
  * The current action being performed by the CLI. 'none' represents the absence of an action.
  */
-export type CliAction =
+type CliAction =
 | ToolkitAction
 | 'context'
 | 'docs'

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -10,7 +10,10 @@ import { StackActivityProgress } from '../../commands/deploy';
 
 export type { IIoHost, IoMessage, IoMessageCode, IoMessageLevel, IoRequest };
 
-type CliAction =
+/**
+ * The current action being performed by the CLI. 'none' represents the absence of an action.
+ */
+export type CliAction =
 | ToolkitAction
 | 'context'
 | 'docs'
@@ -24,7 +27,7 @@ export interface CliIoHostProps {
    *
    * @default 'none'
    */
-  readonly currentAction?: ToolkitAction;
+  readonly currentAction?: CliAction;
 
   /**
    * Determines the verbosity of the output.


### PR DESCRIPTION
`CliAction` type feels slightly off as it should be `CliAction` and not `ToolkitAction`. This makes the default make sense. Either way, the internal property of `CliIoHost` is typed to `CliAction`.
 
In practice this probably doesn't matter because I don't think we are initializing `CliIoHost` with anything but `none`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
