### PR TITLE
chore: new lint rule jsdoc/require-hyphen-before-param-description

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -303,6 +303,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
+++ b/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
@@ -302,6 +302,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk-testing/cli-integ/lib/eventually.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/eventually.ts
@@ -1,6 +1,6 @@
 /**
- * @param maxAttempts the maximum number of attempts
- * @param interval interval in milliseconds to observe between attempts
+ * @param maxAttempts - the maximum number of attempts
+ * @param interval - interval in milliseconds to observe between attempts
  */
 export type EventuallyOptions = {
   maxAttempts?: number;
@@ -18,8 +18,8 @@ const DEFAULT_MAX_ATTEMPTS = 10;
  * Default interval = 1000 milliseconds
  * Default maxAttempts = 10
  *
- * @param fn function to run
- * @param options EventuallyOptions
+ * @param fn - function to run
+ * @param options - EventuallyOptions
  */
 const eventually = async <T>(call: () => Promise<T>, options?: EventuallyOptions): Promise<T> => {
   const opts = {

--- a/packages/@aws-cdk/cdk-cli-wrapper/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/.eslintrc.json
@@ -300,6 +300,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cli-lib-alpha/.eslintrc.json
+++ b/packages/@aws-cdk/cli-lib-alpha/.eslintrc.json
@@ -298,6 +298,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
+++ b/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
@@ -97,8 +97,8 @@ export interface ICloudAssemblyDirectoryProducer {
 export class AwsCdkCli implements IAwsCdkCli {
   /**
    * Create the CLI from a directory containing an AWS CDK app
-   * @param directory the directory of the AWS CDK app. Defaults to the current working directory.
-   * @param props additional configuration properties
+   * @param directory - the directory of the AWS CDK app. Defaults to the current working directory.
+   * @param props - additional configuration properties
    * @returns an instance of `AwsCdkCli`
    */
   public static fromCdkAppDirectory(directory?: string, props: CdkAppDirectoryProps = {}) {

--- a/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
+++ b/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff-template.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff-template.ts
@@ -37,9 +37,9 @@ const DIFF_HANDLERS: HandlerRegistry = {
 /**
  * Compare two CloudFormation templates and return semantic differences between them.
  *
- * @param currentTemplate the current state of the stack.
- * @param newTemplate     the target state of the stack.
- * @param changeSet       the change set for this stack.
+ * @param currentTemplate - the current state of the stack.
+ * @param newTemplate     - the target state of the stack.
+ * @param changeSet       - the change set for this stack.
  *
  * @returns a +types.TemplateDiff+ object that represents the changes that will happen if
  *      a stack which current state is described by +currentTemplate+ is updated with

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/index.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/index.ts
@@ -82,7 +82,7 @@ export function diffUnknown(oldValue: any, newValue: any): types.Difference<any>
 /**
  * Coerces a given value to +string | undefined+.
  *
- * @param value the value to be coerced.
+ * @param value - the value to be coerced.
  *
  * @returns +undefined+ if +value+ is +null+ or +undefined+,
  *      +value+ if it is a +string+,

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
@@ -10,10 +10,10 @@ export type PropertyMap = { [key: string]: any };
 export type ChangeSetResources = { [logicalId: string]: ChangeSetResource };
 
 /**
- * @param beforeContext is the BeforeContext field from the ChangeSet.ResourceChange.BeforeContext. This is the part of the CloudFormation template
+ * @param beforeContext - is the BeforeContext field from the ChangeSet.ResourceChange.BeforeContext. This is the part of the CloudFormation template
  * that defines what the resource is before the change is applied; that is, BeforeContext is CloudFormationTemplate.Resources[LogicalId] before the ChangeSet is executed.
  *
- * @param afterContext same as beforeContext but for after the change is made; that is, AfterContext is CloudFormationTemplate.Resources[LogicalId] after the ChangeSet is executed.
+ * @param afterContext - same as beforeContext but for after the change is made; that is, AfterContext is CloudFormationTemplate.Resources[LogicalId] after the ChangeSet is executed.
  *
  *  * Here is an example of what a beforeContext/afterContext looks like:
  *  '{"Properties":{"Value":"sdflkja","Type":"String","Name":"mySsmParameterFromStack"},"Metadata":{"aws:cdk:path":"cdk/mySsmParameter/Resource"}}'
@@ -336,8 +336,8 @@ export class Difference<ValueType> implements IDifference<ValueType> {
   public isDifferent: boolean;
 
   /**
-   * @param oldValue the old value, cannot be equal (to the sense of +deepEqual+) to +newValue+.
-   * @param newValue the new value, cannot be equal (to the sense of +deepEqual+) to +oldValue+.
+   * @param oldValue - the old value, cannot be equal (to the sense of +deepEqual+) to +newValue+.
+   * @param newValue - the new value, cannot be equal (to the sense of +deepEqual+) to +oldValue+.
    */
   constructor(public readonly oldValue: ValueType | undefined, public readonly newValue: ValueType | undefined) {
     if (oldValue === undefined && newValue === undefined) {
@@ -519,8 +519,8 @@ export enum ResourceImpact {
 /**
  * This function can be used as a reducer to obtain the resource-level impact of a list
  * of property-level impacts.
- * @param one the current worst impact so far.
- * @param two the new impact being considered (can be undefined, as we may not always be
+ * @param one - the current worst impact so far.
+ * @param two - the new impact being considered (can be undefined, as we may not always be
  *      able to determine some properties impact).
  */
 function worstImpact(one: ResourceImpact, two?: ResourceImpact): ResourceImpact {

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/util.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/util.ts
@@ -11,8 +11,8 @@ import type { Resource, SpecDatabase } from '@aws-cdk/service-spec-types';
  * This makes diff consistent with CloudFormation, where a numeric 10 and a literal "10"
  * are considered equivalent.
  *
- * @param lvalue the left operand of the equality comparison.
- * @param rvalue the right operand of the equality comparison.
+ * @param lvalue - the left operand of the equality comparison.
+ * @param rvalue - the right operand of the equality comparison.
  *
  * @returns +true+ if both +lvalue+ and +rvalue+ are equivalent to each other.
  */
@@ -83,8 +83,8 @@ export function deepEqual(lvalue: any, rvalue: any): boolean {
 /**
  * Compares two arguments to DependsOn for equality.
  *
- * @param lvalue the left operand of the equality comparison.
- * @param rvalue the right operand of the equality comparison.
+ * @param lvalue - the left operand of the equality comparison.
+ * @param rvalue - the right operand of the equality comparison.
  *
  * @returns +true+ if both +lvalue+ and +rvalue+ are equivalent to each other.
  */
@@ -122,9 +122,9 @@ function dependsOnEqual(lvalue: any, rvalue: any): boolean {
 /**
  * Produce the differences between two maps, as a map, using a specified diff function.
  *
- * @param oldValue  the old map.
- * @param newValue  the new map.
- * @param elementDiff the diff function.
+ * @param oldValue  - the old map.
+ * @param newValue  - the new map.
+ * @param elementDiff - the diff function.
  *
  * @returns a map representing the differences between +oldValue+ and +newValue+.
  */
@@ -150,8 +150,8 @@ export function diffKeyedEntities<T>(
 /**
  * Computes the union of two sets of strings.
  *
- * @param lv the left set of strings.
- * @param rv the right set of strings.
+ * @param lv - the left set of strings.
+ * @param rv - the right set of strings.
  *
  * @returns a new array containing all elemebts from +lv+ and +rv+, with no duplicates.
  */

--- a/packages/@aws-cdk/cloudformation-diff/lib/format.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format.ts
@@ -22,11 +22,11 @@ export interface FormatStream extends NodeJS.WritableStream {
 /**
  * Renders template differences to the process' console.
  *
- * @param stream           The IO stream where to output the rendered diff.
- * @param templateDiff     TemplateDiff to be rendered to the console.
- * @param logicalToPathMap A map from logical ID to construct path. Useful in
+ * @param stream           - The IO stream where to output the rendered diff.
+ * @param templateDiff     - TemplateDiff to be rendered to the console.
+ * @param logicalToPathMap - A map from logical ID to construct path. Useful in
  *                         case there is no aws:cdk:path metadata in the template.
- * @param context          the number of context lines to use in arbitrary JSON diff (defaults to 3).
+ * @param context          - the number of context lines to use in arbitrary JSON diff (defaults to 3).
  */
 export function formatDifferences(
   stream: FormatStream,
@@ -130,8 +130,8 @@ export class Formatter {
   /**
    * Print a simple difference for a given named entity.
    *
-   * @param logicalId the name of the entity that is different.
-   * @param diff the difference to be rendered.
+   * @param logicalId - the name of the entity that is different.
+   * @param diff - the difference to be rendered.
    */
   public formatDifference(type: string, logicalId: string, diff: Difference<any> | undefined) {
     if (!diff || !diff.isDifferent) {
@@ -156,8 +156,8 @@ export class Formatter {
   /**
    * Print a resource difference for a given logical ID.
    *
-   * @param logicalId the logical ID of the resource that changed.
-   * @param diff      the change to be rendered.
+   * @param logicalId - the logical ID of the resource that changed.
+   * @param diff      - the change to be rendered.
    */
   public formatResourceDifference(_type: string, logicalId: string, diff: ResourceDifference) {
     if (!diff.isDifferent) {
@@ -201,8 +201,8 @@ export class Formatter {
   }
 
   /**
-   * @param value the value to be formatted.
-   * @param color the color to be used.
+   * @param value - the value to be formatted.
+   * @param color - the color to be used.
    *
    * @returns the formatted string, with color applied.
    */
@@ -217,7 +217,7 @@ export class Formatter {
   }
 
   /**
-   * @param impact the impact to be formatted
+   * @param impact - the impact to be formatted
    * @returns a user-friendly, colored string representing the impact.
    */
   public formatImpact(impact: ResourceImpact) {
@@ -241,9 +241,9 @@ export class Formatter {
 
   /**
    * Renders a tree of differences under a particular name.
-   * @param name    the name of the root of the tree.
-   * @param diff    the difference on the tree.
-   * @param last    whether this is the last node of a parent tree.
+   * @param name    - the name of the root of the tree.
+   * @param diff    - the difference on the tree.
+   * @param last    - whether this is the last node of a parent tree.
    */
   public formatTreeDiff(name: string, diff: Difference<any>, last: boolean) {
     let additionalInfo = '';
@@ -262,9 +262,9 @@ export class Formatter {
    * Renders the difference between two objects, looking for the differences as deep as possible,
    * and rendering a tree graph of the path until the difference is found.
    *
-   * @param oldObject  the old object.
-   * @param newObject  the new object.
-   * @param linePrefix a prefix (indent-like) to be used on every line.
+   * @param oldObject  - the old object.
+   * @param newObject  - the new object.
+   * @param linePrefix - a prefix (indent-like) to be used on every line.
    */
   public formatObjectDiff(oldObject: any, newObject: any, linePrefix: string) {
     if ((typeof oldObject !== typeof newObject) || Array.isArray(oldObject) || typeof oldObject === 'string' || typeof oldObject === 'number') {
@@ -307,8 +307,8 @@ export class Formatter {
   }
 
   /**
-   * @param oldValue the old value of a difference.
-   * @param newValue the new value of a difference.
+   * @param oldValue - the old value of a difference.
+   * @param newValue - the new value of a difference.
    *
    * @returns a tag to be rendered in the diff, reflecting whether the difference
    *      was an ADDITION, UPDATE or REMOVAL.
@@ -466,9 +466,9 @@ interface PatchHunk {
 /**
  * Creates a unified diff of two strings.
  *
- * @param oldStr  the "old" version of the string.
- * @param newStr  the "new" version of the string.
- * @param context the number of context lines to use in arbitrary JSON diff.
+ * @param oldStr  - the "old" version of the string.
+ * @param newStr  - the "new" version of the string.
+ * @param context - the number of context lines to use in arbitrary JSON diff.
  *
  * @returns an array of diff lines.
  */

--- a/packages/@aws-cdk/integ-runner/.eslintrc.json
+++ b/packages/@aws-cdk/integ-runner/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
@@ -312,8 +312,8 @@ export class IntegrationTests {
    * Takes an optional list of tests to look for, otherwise
    * it will look for all tests from the directory
    *
-   * @param tests Tests to include or exclude, undefined means include all tests.
-   * @param exclude Whether the 'tests' list is inclusive or exclusive (inclusive by default).
+   * @param tests - Tests to include or exclude, undefined means include all tests.
+   * @param exclude - Whether the 'tests' list is inclusive or exclusive (inclusive by default).
    */
   private async discover(options: IntegrationTestsDiscoveryOptions, ignoreUncompiledTypeScript: boolean = false): Promise<IntegTest[]> {
     const files = await this.readTree();

--- a/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
@@ -118,8 +118,8 @@ export class IntegSnapshotRunner extends IntegRunner {
    * For a given cloud assembly return a collection of all templates
    * that should be part of the snapshot and any required meta data.
    *
-   * @param cloudAssemblyDir The directory of the cloud assembly to look for snapshots
-   * @param pickStacks Pick only these stacks from the cloud assembly
+   * @param cloudAssemblyDir - The directory of the cloud assembly to look for snapshots
+   * @param pickStacks - Pick only these stacks from the cloud assembly
    * @returns A SnapshotAssembly, the collection of all templates in this snapshot and required meta data
    */
   private getSnapshotAssembly(cloudAssemblyDir: string, pickStacks: string[] = []): SnapshotAssembly {
@@ -148,7 +148,7 @@ export class IntegSnapshotRunner extends IntegRunner {
    * For a given stack return all resource types that are allowed to be destroyed
    * as part of a stack update
    *
-   * @param stackId the stack id
+   * @param stackId - the stack id
    * @returns a list of resource types or undefined if none are found
    */
   private getAllowedDestroyTypesForStack(stackId: string): string[] | undefined {

--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -79,8 +79,8 @@ export class MockCdkProvider {
 
   /**
    * Run a test of the testSnapshot method
-   * @param integTestFile This name is used to determined the expected (committed) snapshot
-   * @param actualSnapshot The directory of the snapshot that is used for of the actual (current) app
+   * @param integTestFile - This name is used to determined the expected (committed) snapshot
+   * @param actualSnapshot - The directory of the snapshot that is used for of the actual (current) app
    * @returns Diagnostics as they would be returned by testSnapshot
    */
   public snapshotTest(integTestFile: string, actualSnapshot?: string): {

--- a/packages/@aws-cdk/node-bundle/.eslintrc.json
+++ b/packages/@aws-cdk/node-bundle/.eslintrc.json
@@ -300,6 +300,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -298,6 +298,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -158,8 +158,8 @@ async function changeSetDiff(
  * Appends all properties from obj2 to obj1.
  * obj2 values take priority in the case of collisions.
  *
- * @param obj1 The object to modify
- * @param obj2 The object to consume
+ * @param obj1 - The object to modify
+ * @param obj2 - The object to consume
  *
  * @returns obj1 with all properties from obj2
  */

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/refactor/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/refactor/index.ts
@@ -12,7 +12,7 @@ export class MappingSource {
    * The mapping will be automatically generated based on a comparison of
    * the deployed stacks and the local stacks.
    *
-   * @param exclude A list of resource locations to exclude from the mapping.
+   * @param exclude - A list of resource locations to exclude from the mapping.
    */
   public static auto(exclude: string[] = []): MappingSource {
     const excludeList = new InMemoryExcludeList(exclude);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/account-cache.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/account-cache.ts
@@ -28,7 +28,7 @@ export class AccountAccessKeyCache {
   private readonly debug: (msg: string) => Promise<void>;
 
   /**
-   * @param filePath Path to the cache file
+   * @param filePath - Path to the cache file
    */
   constructor(filePath: string = AccountAccessKeyCache.DEFAULT_PATH, debugFn: (msg: string) => Promise<void>) {
     this.cacheFile = filePath;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -191,7 +191,7 @@ export class AwsCliCompatible {
   /**
    * Looks up the region of the provided profile. If no region is present,
    * it will attempt to lookup the default region.
-   * @param profile The profile to use to lookup the region
+   * @param profile - The profile to use to lookup the region
    * @returns The region for the profile or default profile, if present. Otherwise returns undefined.
    */
   private async getRegionFromIni(profile: string): Promise<string | undefined> {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
@@ -17,7 +17,7 @@ export type Context = { [key: string]: unknown };
  * some cases, synthesis does not require region/account information at all, so that might be perfectly
  * fine in certain scenarios.
  *
- * @param context The context key/value bash.
+ * @param context - The context key/value bash.
  */
 export async function prepareDefaultEnvironment(
   aws: SdkProvider,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -210,7 +210,7 @@ export function writeContextToEnv(env: Env, context: Context) {
 /**
  * Checks if a given assembly supports context overflow, warn otherwise.
  *
- * @param assembly the assembly to check
+ * @param assembly - the assembly to check
  */
 async function checkContextOverflowSupport(assembly: cxapi.CloudAssembly, ioHelper: IoHelper): Promise<void> {
   const traceFn = (msg: string) => ioHelper.defaults.trace(msg);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/template-body-parameter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/template-body-parameter.ts
@@ -28,8 +28,8 @@ const LARGE_TEMPLATE_SIZE_KB = 50;
  * bucket and return its coordinates. If there is no staging bucket, an error
  * is thrown.
  *
- * @param stack     the synthesized stack that provides the CloudFormation template
- * @param toolkitInfo information about the toolkit stack
+ * @param stack     - the synthesized stack that provides the CloudFormation template
+ * @param toolkitInfo - information about the toolkit stack
  */
 export async function makeBodyParameter(
   ioHelper: IoHelper,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -24,10 +24,10 @@ import type { ResourcesToImport } from '../resource-import';
 /**
  * Describe a changeset in CloudFormation, regardless of its current state.
  *
- * @param cfn           a CloudFormation client
- * @param stackName     the name of the Stack the ChangeSet belongs to
- * @param changeSetName the name of the ChangeSet
- * @param fetchAll      if true, fetches all pages of the change set description.
+ * @param cfn           - a CloudFormation client
+ * @param stackName     - the name of the Stack the ChangeSet belongs to
+ * @param changeSetName - the name of the ChangeSet
+ * @param fetchAll      - if true, fetches all pages of the change set description.
  *
  * @returns       CloudFormation information about the ChangeSet
  */
@@ -65,8 +65,8 @@ async function describeChangeSet(
 /**
  * Waits for a function to return non-+undefined+ before returning.
  *
- * @param valueProvider a function that will return a value that is not +undefined+ once the wait should be over
- * @param timeout     the time to wait between two calls to +valueProvider+
+ * @param valueProvider - a function that will return a value that is not +undefined+ once the wait should be over
+ * @param timeout     - the time to wait between two calls to +valueProvider+
  *
  * @returns       the value that was returned by +valueProvider+
  */
@@ -91,10 +91,10 @@ async function waitFor<T>(
  * Will return a changeset that is either ready to be executed or has no changes.
  * Will throw in other cases.
  *
- * @param cfn           a CloudFormation client
- * @param stackName     the name of the Stack that the ChangeSet belongs to
- * @param changeSetName the name of the ChangeSet
- * @param fetchAll      if true, fetches all pages of the ChangeSet before returning.
+ * @param cfn           - a CloudFormation client
+ * @param stackName     - the name of the Stack that the ChangeSet belongs to
+ * @param changeSetName - the name of the ChangeSet
+ * @param fetchAll      - if true, fetches all pages of the ChangeSet before returning.
  *
  * @returns       the CloudFormation description of the ChangeSet
  */
@@ -377,8 +377,8 @@ export function changeSetHasNoChanges(description: DescribeChangeSetCommandOutpu
  * Fails if the stack is in a FAILED state. Will not fail if the stack was
  * already deleted.
  *
- * @param cfn        a CloudFormation client
- * @param stackName      the name of the stack to wait for after a delete
+ * @param cfn        - a CloudFormation client
+ * @param stackName      - the name of the stack to wait for after a delete
  *
  * @returns     the CloudFormation description of the stabilized stack after the delete attempt
  */
@@ -409,8 +409,8 @@ export async function waitForStackDelete(
  *
  * Fails if the stack is in a FAILED state, ROLLBACK state, or DELETED state.
  *
- * @param cfn        a CloudFormation client
- * @param stackName      the name of the stack to wait for after an update
+ * @param cfn        - a CloudFormation client
+ * @param stackName      - the name of the stack to wait for after an update
  *
  * @returns     the CloudFormation description of the stabilized stack after the update attempt
  */

--- a/packages/@aws-cdk/toolkit-lib/lib/api/drift/drift-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/drift/drift-formatter.ts
@@ -142,10 +142,10 @@ export class DriftFormatter {
   /**
    * Renders stack drift information to the given stream
    *
-   * @param driftResults The stack resource drifts from CloudFormation
-   * @param allStackResources A map of all stack resources
-   * @param verbose Whether to output more verbose text (include undrifted resources)
-   * @param logicalToPathMap A map from logical ID to construct path
+   * @param driftResults - The stack resource drifts from CloudFormation
+   * @param allStackResources - A map of all stack resources
+   * @param verbose - Whether to output more verbose text (include undrifted resources)
+   * @param logicalToPathMap - A map from logical ID to construct path
    */
   private formatStackDriftChanges(
     logicalToPathMap: { [logicalId: string]: string } = {}): FormattedDrift {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
@@ -296,7 +296,7 @@ async function classifyResourceChanges(
 /**
  * Returns all changes to resources in the given Stack.
  *
- * @param stackChanges the collection of all changes to a given Stack
+ * @param stackChanges - the collection of all changes to a given Stack
  */
 function getStackResourceDifferences(stackChanges: cfn_diff.TemplateDiff): {
   [logicalId: string]: cfn_diff.ResourceDifference;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/level-priority.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/level-priority.ts
@@ -24,8 +24,8 @@ function compareFn(a: IoMessageLevel, b: IoMessageLevel): number {
 /**
  * Determines if a message is relevant for the given log level.
  *
- * @param msg The message to compare.
- * @param level The level to compare against.
+ * @param msg - The message to compare.
+ * @param level - The level to compare against.
  * @returns true if the message is relevant for the given level.
  */
 export function isMessageRelevantForLevel(msg: { level: IoMessageLevel }, level: IoMessageLevel): boolean {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
@@ -214,7 +214,7 @@ export class Notices {
   /**
    * List all notices available in the data source.
    *
-   * @param includeAcknowlegded Whether to include acknowledged notices.
+   * @param includeAcknowlegded - Whether to include acknowledged notices.
    */
   private noticesFromData(includeAcknowlegded = false): Notice[] {
     const data = Array.from(this.data);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -171,8 +171,8 @@ export class ResourceImporter {
    * Based on the provided resource mapping, prepare CFN structures for import (template,
    * ResourcesToImport structure) and perform the import operation (CloudFormation deployment)
    *
-   * @param importMap Mapping from CDK construct tree path to physical resource import identifiers
-   * @param options Options to pass to CloudFormation deploy operation
+   * @param importMap - Mapping from CDK construct tree path to physical resource import identifiers
+   * @param options - Options to pass to CloudFormation deploy operation
    */
   public async importResourcesFromMap(importMap: ImportMap, options: ImportDeploymentOptions = {}) {
     const resourcesToImport: ResourcesToImport = await this.makeResourcesToImport(importMap);
@@ -186,8 +186,8 @@ export class ResourceImporter {
    * cannot be included in an import change-set for new stacks and performs the import operation,
    * creating the new stack.
    *
-   * @param resourcesToImport The mapping created by cdk migrate
-   * @param options Options to pass to CloudFormation deploy operation
+   * @param resourcesToImport - The mapping created by cdk migrate
+   * @param options - Options to pass to CloudFormation deploy operation
    */
   public async importResourcesFromMigrate(resourcesToImport: ResourcesToImport, options: ImportDeploymentOptions = {}) {
     const updatedTemplate = this.removeNonImportResources();
@@ -428,7 +428,7 @@ export class ResourceImporter {
   /**
    * Convert CloudFormation logical resource ID to CDK construct tree path
    *
-   * @param logicalId CloudFormation logical ID of the resource (the key in the template's Resources section)
+   * @param logicalId - CloudFormation logical ID of the resource (the key in the template's Resources section)
    * @returns Forward-slash separated path of the resource in CDK construct tree, e.g. MyStack/MyBucket/Resource
    */
   private describeResource(logicalId: string): string {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-metadata/resource-metadata.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-metadata/resource-metadata.ts
@@ -18,8 +18,8 @@ export interface ResourceMetadata {
 /**
  * Attempts to read metadata for resources from a CloudFormation stack artifact
  *
- * @param stack The CloudFormation stack to read from
- * @param logicalId The logical ID of the resource to read
+ * @param stack - The CloudFormation stack to read from
+ * @param logicalId - The logical ID of the resource to read
  *
  * @returns The resource metadata, or undefined if the resource was not found
  */

--- a/packages/@aws-cdk/toolkit-lib/lib/context-providers/ssm-parameters.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/context-providers/ssm-parameters.ts
@@ -37,10 +37,10 @@ export class SSMContextProviderPlugin implements ContextProviderPlugin {
 
   /**
    * Gets the value of an SSM Parameter, while not throwin if the parameter does not exist.
-   * @param account       the account in which the SSM Parameter is expected to be.
-   * @param region        the region in which the SSM Parameter is expected to be.
-   * @param parameterName the name of the SSM Parameter
-   * @param lookupRoleArn the ARN of the lookup role.
+   * @param account       - the account in which the SSM Parameter is expected to be.
+   * @param region        - the region in which the SSM Parameter is expected to be.
+   * @param parameterName - the name of the SSM Parameter
+   * @param lookupRoleArn - the ARN of the lookup role.
    *
    * @returns the result of the ``GetParameter`` operation.
    *

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
@@ -20,8 +20,8 @@ export interface ToolkitServices {
  * The caller assumes ownership of the returned `StackAssembly`, and `dispose()`
  * should be called on this object after use.
  *
- * @param assemblySource the source for the cloud assembly
- * @param cache if the assembly should be cached, default: `true`
+ * @param assemblySource - the source for the cloud assembly
+ * @param cache - if the assembly should be cached, default: `true`
  * @returns the CloudAssembly object
  */
 export async function assemblyFromSource(ioHelper: IoHelper, assemblySource: ICloudAssemblySource, cache: boolean = true): Promise<StackAssembly> {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/bool.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/bool.ts
@@ -1,7 +1,7 @@
 /**
  * Converts a boolean into a number.
  *
- * @param bool input boolean
+ * @param bool - input boolean
  * @returns 1 if bool is true, and 0 if false
  */
 export function numberFromBool(bool: boolean): number {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/bytes.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/bytes.ts
@@ -1,8 +1,8 @@
 /**
  * Format bytes as a human readable string
  *
- * @param bytes Number of bytes to format
- * @param decimals Number of decimal places to show (default 2)
+ * @param bytes - Number of bytes to format
+ * @param decimals - Number of decimal places to show (default 2)
  * @returns Formatted string with appropriate unit suffix
  */
 export function formatBytes(bytes: number, decimals: number = 2): string {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/cloudformation.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/cloudformation.ts
@@ -15,8 +15,8 @@ export function stackEventHasErrorMessage(status: string): boolean {
 /**
  * Calculate the maximal length of all resource types for a given template.
  *
- * @param template the stack template to analyze
- * @param startWidth the initial width to start with. Defaults to the length of 'AWS::CloudFormation::Stack'.
+ * @param template - the stack template to analyze
+ * @param startWidth - the initial width to start with. Defaults to the length of 'AWS::CloudFormation::Stack'.
  * @returns the determined width
  */
 export function maxResourceTypeLength(template: any, startWidth = 'AWS::CloudFormation::Stack'.length): number {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
@@ -3,7 +3,7 @@
  * If it is an AggregateError, it will return a string with all the inner errors
  * formatted and separated by a newline.
  *
- * @param error The error to format
+ * @param error - The error to format
  * @returns A string with the error message(s) of the error
  */
 export function formatErrorMessage(error: any): string {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/net.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/net.ts
@@ -1,6 +1,6 @@
 /**
  * Get a human-readable error message for a network error
- * @param error The network error object
+ * @param error - The network error object
  */
 export function humanNetworkError(error: NodeJS.ErrnoException): string {
   switch (error.code) {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/objects.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/objects.ts
@@ -221,9 +221,9 @@ type Exclude = { [key: string]: Exclude | true };
 /**
  * This function transforms all keys (recursively) in the provided `val` object.
  *
- * @param val The object whose keys need to be transformed.
- * @param transform The function that will be applied to each key.
- * @param exclude The keys that will not be transformed and copied to output directly
+ * @param val - The object whose keys need to be transformed.
+ * @param transform - The function that will be applied to each key.
+ * @param exclude - The keys that will not be transformed and copied to output directly
  * @returns A new object with the same values as `val`, but with all keys transformed according to `transform`.
  */
 export function transformObjectKeys(val: any, transform: (str: string) => string, exclude: Exclude = {}): any {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/yaml-cfn.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/yaml-cfn.ts
@@ -5,7 +5,7 @@ import * as yaml_types from 'yaml/types';
 /**
  * Serializes the given data structure into valid YAML.
  *
- * @param obj the data structure to serialize
+ * @param obj - the data structure to serialize
  * @returns a string containing the YAML representation of {@param obj}
  */
 export function serialize(obj: any): string {
@@ -21,7 +21,7 @@ export function serialize(obj: any): string {
 /**
  * Deserialize the YAML into the appropriate data structure.
  *
- * @param str the string containing YAML
+ * @param str - the string containing YAML
  * @returns the data structure the YAML represents
  *   (most often in case of CloudFormation, an object)
  */

--- a/packages/@aws-cdk/user-input-gen/.eslintrc.json
+++ b/packages/@aws-cdk/user-input-gen/.eslintrc.json
@@ -300,6 +300,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/@aws-cdk/yarn-cling/.eslintrc.json
+++ b/packages/@aws-cdk/yarn-cling/.eslintrc.json
@@ -300,6 +300,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -298,6 +298,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1035,9 +1035,9 @@ export class CdkToolkit {
   /**
    * Bootstrap the CDK Toolkit stack in the accounts used by the specified stack(s).
    *
-   * @param userEnvironmentSpecs environment names that need to have toolkit support
+   * @param userEnvironmentSpecs - environment names that need to have toolkit support
    *             provisioned, as a glob filter. If none is provided, all stacks are implicitly selected.
-   * @param options The name, role ARN, bootstrapping parameters, etc. to be used for the CDK Toolkit stack.
+   * @param options - The name, role ARN, bootstrapping parameters, etc. to be used for the CDK Toolkit stack.
    */
   public async bootstrap(
     userEnvironmentSpecs: string[],
@@ -1069,7 +1069,7 @@ export class CdkToolkit {
 
   /**
    * Garbage collects assets from a CDK app's environment
-   * @param options Options for Garbage Collection
+   * @param options - Options for Garbage Collection
    */
   public async garbageCollect(userEnvironmentSpecs: string[], options: GarbageCollectionOptions) {
     const environments = await this.defineEnvironments(userEnvironmentSpecs);
@@ -1125,7 +1125,7 @@ export class CdkToolkit {
 
   /**
    * Migrates a CloudFormation stack/template to a CDK app
-   * @param options Options for CDK app creation
+   * @param options - Options for CDK app creation
    */
   public async migrate(options: MigrateOptions): Promise<void> {
     warning('This command is an experimental feature.');

--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -254,7 +254,7 @@ function expandHomeDir(x: string) {
  * `$HOME/.cdk.json`. Arguments not listed below and accessed via this object
  * can only be specified on the command line.
  *
- * @param argv the received CLI arguments.
+ * @param argv - the received CLI arguments.
  * @returns a new Settings object.
  */
 export function commandLineArgumentsToSettings(argv: Arguments): Settings {

--- a/packages/aws-cdk/lib/cli/util/console-formatters.ts
+++ b/packages/aws-cdk/lib/cli/util/console-formatters.ts
@@ -14,7 +14,7 @@ const stripAnsi = require('strip-ansi');
  * - Each line in between is prepended with '*** ' and appended with ' ***'
  * - The text is indented left, i.e. whitespace is right-padded when the length is shorter than the longest.
  *
- * @param msgs array of strings containing the message lines to be printed in the banner. Returns empty string if array
+ * @param msgs - array of strings containing the message lines to be printed in the banner. Returns empty string if array
  * is empty.
  * @returns array of strings containing the message formatted as a banner
  */

--- a/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
+++ b/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
@@ -8,8 +8,8 @@ export { isCI } from '../io-host';
  * yargs middleware to negate an option if a negative alias is provided
  * E.g. `-R` will imply `--rollback=false`
  *
- * @param optionToNegate The name of the option to negate, e.g. `rollback`
- * @param negativeAlias The alias that should negate the option, e.g. `R`
+ * @param optionToNegate - The name of the option to negate, e.g. `rollback`
+ * @param negativeAlias - The alias that should negate the option, e.g. `R`
  * @returns a middleware function that can be passed to yargs
  */
 export function yargsNegativeAlias<T extends { [x in S | L]: boolean | undefined }, S extends string, L extends string>(

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -108,7 +108,7 @@ export class InitTemplate {
   }
 
   /**
-   * @param name the name that is being checked
+   * @param name - the name that is being checked
    * @returns ``true`` if ``name`` is the name of this template or an alias of it.
    */
   public hasName(name: string): boolean {
@@ -118,8 +118,8 @@ export class InitTemplate {
   /**
    * Creates a new instance of this ``InitTemplate`` for a given language to a specified folder.
    *
-   * @param language    the language to instantiate this template with
-   * @param targetDirectory the directory where the template is to be instantiated into
+   * @param language    - the language to instantiate this template with
+   * @param targetDirectory - the directory where the template is to be instantiated into
    */
   public async install(language: string, targetDirectory: string, stackName?: string, libVersion?: string) {
     if (this.languages.indexOf(language) === -1) {
@@ -294,7 +294,7 @@ export async function availableInitLanguages(): Promise<string[]> {
 }
 
 /**
- * @param dirPath is the directory to be listed.
+ * @param dirPath - is the directory to be listed.
  * @returns the list of file or directory names contained in ``dirPath``, excluding any dot-file, and sorted.
  */
 async function listDirectory(dirPath: string) {
@@ -436,7 +436,7 @@ async function postInstallPython(cwd: string) {
 }
 
 /**
- * @param dir a directory to be checked
+ * @param dir - a directory to be checked
  * @returns true if ``dir`` is within a git repository.
  */
 async function isInGitRepository(dir: string) {
@@ -452,7 +452,7 @@ async function isInGitRepository(dir: string) {
 }
 
 /**
- * @param dir a directory to be checked.
+ * @param dir - a directory to be checked.
  * @returns true if ``dir`` is the root of a filesystem.
  */
 function isRoot(dir: string) {

--- a/packages/aws-cdk/lib/commands/list-stacks.ts
+++ b/packages/aws-cdk/lib/commands/list-stacks.ts
@@ -17,8 +17,8 @@ export interface ListStacksOptions {
 /**
  * List Stacks
  *
- * @param toolkit cdk toolkit
- * @param options list stacks options
+ * @param toolkit - cdk toolkit
+ * @param options - list stacks options
  * @returns StackDetails[]
  */
 export async function listStacks(toolkit: CdkToolkit, options: ListStacksOptions): Promise<StackDetails[]> {

--- a/packages/aws-cdk/lib/commands/migrate.ts
+++ b/packages/aws-cdk/lib/commands/migrate.ts
@@ -33,10 +33,10 @@ const MIGRATE_SUPPORTED_LANGUAGES: readonly string[] = cdk_from_cfn.supported_la
 /**
  * Generates a CDK app from a yaml or json template.
  *
- * @param stackName The name to assign to the stack in the generated app
- * @param stack The yaml or json template for the stack
- * @param language The language to generate the CDK app in
- * @param outputPath The path at which to generate the CDK app
+ * @param stackName - The name to assign to the stack in the generated app
+ * @param stack - The yaml or json template for the stack
+ * @param language - The language to generate the CDK app in
+ * @param outputPath - The path at which to generate the CDK app
  */
 export async function generateCdkApp(
   stackName: string,
@@ -97,9 +97,9 @@ export async function generateCdkApp(
 
 /**
  * Generates a CDK stack file.
- * @param template The template to translate into a CDK stack
- * @param stackName The name to assign to the stack
- * @param language The language to generate the stack in
+ * @param template - The template to translate into a CDK stack
+ * @param stackName - The name to assign to the stack
+ * @param language - The language to generate the stack in
  * @returns A string representation of a CDK stack file
  */
 export function generateStack(template: string, stackName: string, language: string) {
@@ -114,7 +114,7 @@ export function generateStack(template: string, stackName: string, language: str
 /**
  * Reads and returns a stack template from a local path.
  *
- * @param inputPath The location of the template
+ * @param inputPath - The location of the template
  * @returns A string representation of the template if present, otherwise undefined
  */
 export function readFromPath(inputPath: string): string {
@@ -133,9 +133,9 @@ export function readFromPath(inputPath: string): string {
 /**
  * Reads and returns a stack template from a deployed CloudFormation stack.
  *
- * @param stackName The name of the stack
- * @param sdkProvider The sdk provider for making CloudFormation calls
- * @param environment The account and region where the stack is deployed
+ * @param stackName - The name of the stack
+ * @param sdkProvider - The sdk provider for making CloudFormation calls
+ * @param environment - The account and region where the stack is deployed
  * @returns A string representation of the template if present, otherwise undefined
  */
 export async function readFromStack(
@@ -159,7 +159,7 @@ export async function readFromStack(
  * Takes in a stack name and account and region and returns a generated cloudformation template using the cloudformation
  * template generator.
  *
- * @param GenerateTemplateOptions An object containing the stack name, filters, sdkProvider, environment, and newScan flag
+ * @param GenerateTemplateOptions - An object containing the stack name, filters, sdkProvider, environment, and newScan flag
  * @returns a generated cloudformation template
  */
 export async function generateTemplate(options: GenerateTemplateOptions): Promise<GenerateTemplateOutput> {
@@ -241,7 +241,7 @@ async function findLastSuccessfulScan(
 /**
  * Takes a string of filters in the format of key1=value1,key2=value2 and returns a map of the filters.
  *
- * @param filters a string of filters in the format of key1=value1,key2=value2
+ * @param filters - a string of filters in the format of key1=value1,key2=value2
  * @returns a map of the filters
  */
 function parseFilters(filters: string): {
@@ -292,8 +292,8 @@ function parseFilters(filters: string): {
 /**
  * Takes a list of any type and breaks it up into chunks of a specified size.
  *
- * @param list The list to break up
- * @param chunkSize The size of each chunk
+ * @param list - The list to break up
+ * @param chunkSize - The size of each chunk
  * @returns A list of lists of the specified size
  */
 export function chunks(list: any[], chunkSize: number): any[][] {
@@ -306,8 +306,8 @@ export function chunks(list: any[], chunkSize: number): any[][] {
 
 /**
  * Sets the account and region for making CloudFormation calls.
- * @param account The account to use
- * @param region The region to use
+ * @param account - The account to use
+ * @param region - The region to use
  * @returns The environment object
  */
 export function setEnvironment(account?: string, region?: string): Environment {
@@ -353,8 +353,8 @@ export enum FilterType {
 
 /**
  * Validates that exactly one source option has been provided.
- * @param fromPath The content of the flag `--from-path`
- * @param fromStack the content of the flag `--from-stack`
+ * @param fromPath - The content of the flag `--from-path`
+ * @param fromStack - the content of the flag `--from-stack`
  */
 export function parseSourceOptions(fromPath?: string, fromStack?: boolean, stackName?: string): TemplateSource {
   if (fromPath && fromStack) {
@@ -375,7 +375,7 @@ export function parseSourceOptions(fromPath?: string, fromStack?: boolean, stack
 /**
  * Takes a set of resources and removes any with the managedbystack flag set to true.
  *
- * @param resourceList the list of resources provided by the list scanned resources calls
+ * @param resourceList - the list of resources provided by the list scanned resources calls
  * @returns a list of resources not managed by cfn stacks
  */
 function excludeManaged(resourceList: ScannedResource[]): ScannedResourceIdentifier[] {
@@ -391,7 +391,7 @@ function excludeManaged(resourceList: ScannedResource[]): ScannedResourceIdentif
  * Transforms a list of resources into a list of resource identifiers by removing the ManagedByStack flag.
  * Setting the value of the field to undefined effectively removes it from the object.
  *
- * @param resourceList the list of resources provided by the list scanned resources calls
+ * @param resourceList - the list of resources provided by the list scanned resources calls
  * @returns a list of ScannedResourceIdentifier[]
  */
 function resourceIdentifiers(resourceList: ScannedResource[]): ScannedResourceIdentifier[] {
@@ -409,8 +409,8 @@ function resourceIdentifiers(resourceList: ScannedResource[]): ScannedResourceId
 /**
  * Takes a scan id and maintains a progress bar to display the progress of a scan to the user.
  *
- * @param scanId A string representing the scan id
- * @param cloudFormation The CloudFormation sdk client to use
+ * @param scanId - A string representing the scan id
+ * @param cloudFormation - The CloudFormation sdk client to use
  */
 export async function scanProgressBar(scanId: string, cfn: CfnTemplateGeneratorProvider) {
   let curProgress = 0.5;
@@ -433,8 +433,8 @@ export async function scanProgressBar(scanId: string, cfn: CfnTemplateGeneratorP
  * Prints a progress bar to the console. To be used in a while loop to show progress of a long running task.
  * The progress bar deletes the current line on the console and rewrites it with the progress amount.
  *
- * @param width The width of the progress bar
- * @param progress The current progress to display as a percentage of 100
+ * @param width - The width of the progress bar
+ * @param progress - The current progress to display as a percentage of 100
  */
 export function printBar(width: number, progress: number) {
   if (!process.env.MIGRATE_INTEG_TEST) {
@@ -459,8 +459,8 @@ export function printBar(width: number, progress: number) {
  * Prints a message to the console with a series periods appended to it. To be used in a while loop to show progress of a long running task.
  * The message deletes the current line and rewrites it several times to display 1-3 periods to show the user that the task is still running.
  *
- * @param message The message to display
- * @param timeoutx4 The amount of time to wait before printing the next period
+ * @param message - The message to display
+ * @param timeoutx4 - The amount of time to wait before printing the next period
  */
 export async function printDots(message: string, timeoutx4: number) {
   if (!process.env.MIGRATE_INTEG_TEST) {
@@ -482,7 +482,7 @@ export async function printDots(message: string, timeoutx4: number) {
  * Rewrites the current line on the console and writes a new message to it.
  * This is a helper funciton for printDots and printBar.
  *
- * @param message The message to display
+ * @param message - The message to display
  */
 export function rewriteLine(message: string) {
   process.stdout.clearLine(0);
@@ -493,8 +493,8 @@ export function rewriteLine(message: string) {
 /**
  * Prints the time difference between two dates in days, hours, and minutes.
  *
- * @param time1 The first date to compare
- * @param time2 The second date to compare
+ * @param time1 - The first date to compare
+ * @param time2 - The second date to compare
  */
 export function displayTimeDiff(time1: Date, time2: Date): void {
   const diff = Math.abs(time1.getTime() - time2.getTime());
@@ -509,9 +509,9 @@ export function displayTimeDiff(time1: Date, time2: Date): void {
 /**
  * Writes a migrate.json file to the output directory.
  *
- * @param outputPath The path to write the migrate.json file to
- * @param stackName The name of the stack
- * @param generatedOutput The output of the template generator
+ * @param outputPath - The path to write the migrate.json file to
+ * @param stackName - The name of the stack
+ * @param generatedOutput - The output of the template generator
  */
 export function writeMigrateJsonFile(
   outputPath: string | undefined,
@@ -532,7 +532,7 @@ export function writeMigrateJsonFile(
 /**
  * Takes a string representing the from-scan flag and returns a FromScan enum value.
  *
- * @param scanType A string representing the from-scan flag
+ * @param scanType - A string representing the from-scan flag
  * @returns A FromScan enum value
  */
 export function getMigrateScanType(scanType: string) {
@@ -553,7 +553,7 @@ export function getMigrateScanType(scanType: string) {
 /**
  * Takes a generatedTemplateOutput objct and returns a boolean representing whether there are any warnings on any rescources.
  *
- * @param generatedTemplateOutput A GenerateTemplateOutput object
+ * @param generatedTemplateOutput - A GenerateTemplateOutput object
  * @returns A boolean representing whether there are any warnings on any rescources
  */
 export function isThereAWarning(generatedTemplateOutput: GenerateTemplateOutput) {
@@ -570,8 +570,8 @@ export function isThereAWarning(generatedTemplateOutput: GenerateTemplateOutput)
 /**
  * Builds the GenerateTemplateOutput object from the DescribeGeneratedTemplateOutput and the template body.
  *
- * @param generatedTemplateSummary The output of the describe generated template call
- * @param templateBody The body of the generated template
+ * @param generatedTemplateSummary - The output of the describe generated template call
+ * @param templateBody - The body of the generated template
  * @returns A GenerateTemplateOutput object
  */
 export function buildGenertedTemplateOutput(
@@ -600,8 +600,8 @@ export function buildGenertedTemplateOutput(
 /**
  * Builds a CloudFormation sdk client for making requests with the CFN template generator.
  *
- * @param sdkProvider The sdk provider for making CloudFormation calls
- * @param environment The account and region where the stack is deployed
+ * @param sdkProvider - The sdk provider for making CloudFormation calls
+ * @param environment - The account and region where the stack is deployed
  * @returns A CloudFormation sdk client
  */
 export async function buildCfnClient(sdkProvider: SdkProvider, environment: Environment) {
@@ -613,8 +613,8 @@ export async function buildCfnClient(sdkProvider: SdkProvider, environment: Envi
 /**
  * Appends a list of warnings to a readme file.
  *
- * @param filepath The path to the readme file
- * @param resources A list of resources to append warnings for
+ * @param filepath - The path to the readme file
+ * @param resources - A list of resources to append warnings for
  */
 export function appendWarningsToReadme(filepath: string, resources: ResourceDetail[]) {
   const readme = fs.readFileSync(filepath, 'utf8');
@@ -647,7 +647,7 @@ export function appendWarningsToReadme(filepath: string, resources: ResourceDeta
 /**
  * takes a list of resources and returns a list of unique resources based on the resource type and logical resource id.
  *
- * @param resources A list of resources to deduplicate
+ * @param resources - A list of resources to deduplicate
  * @returns A list of unique resources
  */
 function deduplicateResources(resources: ResourceDetail[]) {
@@ -695,8 +695,8 @@ export class CfnTemplateGeneratorProvider {
    * Retrieves a tokenized list of resources and their associated scan. If a token is present the function
    * will loop through all pages and combine them into a single list of ScannedRelatedResources
    *
-   * @param scanId scan id for the to list resources for
-   * @param resources A list of resources to find related resources for
+   * @param scanId - scan id for the to list resources for
+   * @param resources - A list of resources to find related resources for
    */
   async getResourceScanRelatedResources(
     scanId: string,
@@ -765,8 +765,8 @@ export class CfnTemplateGeneratorProvider {
    * will loop through all pages and combine them into a single list of ScannedResource[].
    * Additionally will apply any filters provided by the customer.
    *
-   * @param scanId scan id for the to list resources for
-   * @param filters a string of filters in the format of key1=value1,key2=value2
+   * @param scanId - scan id for the to list resources for
+   * @param filters - a string of filters in the format of key1=value1,key2=value2
    * @returns a combined list of all resources from the scan
    */
   async listResourceScanResources(scanId: string, filters: string[] = []): Promise<ScannedResourceIdentifier[]> {
@@ -826,7 +826,7 @@ export class CfnTemplateGeneratorProvider {
   /**
    * Retrieves information about a resource scan.
    *
-   * @param scanId scan id for the to list resources for
+   * @param scanId - scan id for the to list resources for
    * @returns information about the scan
    */
   async describeResourceScan(scanId: string): Promise<DescribeResourceScanCommandOutput> {
@@ -838,7 +838,7 @@ export class CfnTemplateGeneratorProvider {
   /**
    * Describes the current status of the template being generated.
    *
-   * @param templateId A string representing the template id
+   * @param templateId - A string representing the template id
    * @returns DescribeGeneratedTemplateOutput an object containing the template status and results
    */
   async describeGeneratedTemplate(templateId: string): Promise<DescribeGeneratedTemplateCommandOutput> {
@@ -856,8 +856,8 @@ export class CfnTemplateGeneratorProvider {
   /**
    * Retrieves a completed generated cloudformation template from the template generator.
    *
-   * @param templateId A string representing the template id
-   * @param cloudFormation The CloudFormation sdk client to use
+   * @param templateId - A string representing the template id
+   * @param cloudFormation - The CloudFormation sdk client to use
    * @returns DescribeGeneratedTemplateOutput an object containing the template status and body
    */
   async getGeneratedTemplate(templateId: string): Promise<GetGeneratedTemplateCommandOutput> {
@@ -869,8 +869,8 @@ export class CfnTemplateGeneratorProvider {
   /**
    * Kicks off a template generation for a set of resources.
    *
-   * @param stackName The name of the stack
-   * @param resources A list of resources to generate the template from
+   * @param stackName - The name of the stack
+   * @param resources - A list of resources to generate the template from
    * @returns CreateGeneratedTemplateOutput an object containing the template arn to query on later
    */
   async createGeneratedTemplate(stackName: string, resources: ResourceDefinition[]) {
@@ -888,7 +888,7 @@ export class CfnTemplateGeneratorProvider {
   /**
    * Deletes a generated template from the template generator.
    *
-   * @param templateArn The arn of the template to delete
+   * @param templateArn - The arn of the template to delete
    * @returns A promise that resolves when the template has been deleted
    */
   async deleteGeneratedTemplate(templateArn: string): Promise<void> {
@@ -921,11 +921,11 @@ export enum FromScan {
 /**
  * Interface for the options object passed to the generateTemplate function
  *
- * @param stackName The name of the stack
- * @param filters A list of filters to apply to the scan
- * @param fromScan An enum value specifying whether a new scan should be started or the most recent successful scan should be used
- * @param sdkProvider The sdk provider for making CloudFormation calls
- * @param environment The account and region where the stack is deployed
+ * @param stackName - The name of the stack
+ * @param filters - A list of filters to apply to the scan
+ * @param fromScan - An enum value specifying whether a new scan should be started or the most recent successful scan should be used
+ * @param sdkProvider - The sdk provider for making CloudFormation calls
+ * @param environment - The account and region where the stack is deployed
  */
 export interface GenerateTemplateOptions {
   stackName: string;
@@ -938,8 +938,8 @@ export interface GenerateTemplateOptions {
 /**
  * Interface for the output of the generateTemplate function
  *
- * @param migrateJson The generated Migrate.json file
- * @param resources The generated template
+ * @param migrateJson - The generated Migrate.json file
+ * @param resources - The generated template
  */
 export interface GenerateTemplateOutput {
   migrateJson: MigrateJsonFormat;
@@ -950,9 +950,9 @@ export interface GenerateTemplateOutput {
 /**
  * Interface defining the format of the generated Migrate.json file
  *
- * @param TemplateBody The generated template
- * @param Source The source of the template
- * @param Resources A list of resources that were used to generate the template
+ * @param TemplateBody - The generated template
+ * @param Source - The source of the template
+ * @param Resources - A list of resources that were used to generate the template
  */
 export interface MigrateJsonFormat {
   templateBody: string;
@@ -963,9 +963,9 @@ export interface MigrateJsonFormat {
 /**
  * Interface representing the format of a resource identifier required for resource import
  *
- * @param ResourceType The type of resource
- * @param LogicalResourceId The logical id of the resource
- * @param ResourceIdentifier The resource identifier of the resource
+ * @param ResourceType - The type of resource
+ * @param LogicalResourceId - The logical id of the resource
+ * @param ResourceIdentifier - The resource identifier of the resource
  */
 export interface GeneratedResourceImportIdentifier {
   // cdk deploy expects the migrate.json resource identifiers to be PascalCase, not camelCase.

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -65,7 +65,7 @@ export class CloudExecutable implements ICloudAssemblySource {
   /**
    * Synthesize a set of stacks.
    *
-   * @param cacheCloudAssembly whether to cache the Cloud Assembly after it has been first synthesized.
+   * @param cacheCloudAssembly - whether to cache the Cloud Assembly after it has been first synthesized.
    *   This is 'true' by default, and only set to 'false' for 'cdk watch',
    *   which needs to re-synthesize the Assembly each time it detects a change to the project files
    */

--- a/packages/aws-cdk/lib/cxapp/environments.ts
+++ b/packages/aws-cdk/lib/cxapp/environments.ts
@@ -55,7 +55,7 @@ export function environmentsFromDescriptors(envSpecs: string[]): cxapi.Environme
  * De-duplicates a list of environments, such that a given account and region is only represented exactly once
  * in the result.
  *
- * @param envs the possibly full-of-duplicates list of environments.
+ * @param envs - the possibly full-of-duplicates list of environments.
  *
  * @return a de-duplicated list of environments.
  */

--- a/packages/aws-cdk/lib/legacy-logging-source.ts
+++ b/packages/aws-cdk/lib/legacy-logging-source.ts
@@ -112,8 +112,8 @@ export type LoggerFunction = (fmt: string, ...args: unknown[]) => void;
 /**
  * Create a logger output that features a constant prefix string.
  *
- * @param prefixString the prefix string to be appended before any log entry.
- * @param fn   the logger function to be used (typically one of the other functions in this module)
+ * @param prefixString - the prefix string to be appended before any log entry.
+ * @param fn   - the logger function to be used (typically one of the other functions in this module)
  *
  * @returns a new LoggerFunction.
  */

--- a/packages/cdk-assets/.eslintrc.json
+++ b/packages/cdk-assets/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/packages/cdk-assets/lib/progress.ts
+++ b/packages/cdk-assets/lib/progress.ts
@@ -93,7 +93,7 @@ export enum EventType {
 
 /**
  * A helper function to convert shell events to asset progress events
- * @param event a shell event
+ * @param event - a shell event
  * @returns an {@link EventType}
  */
 export function shellEventToEventType(event: ShellEventType): EventType {

--- a/packages/cdk-assets/lib/publishing.ts
+++ b/packages/cdk-assets/lib/publishing.ts
@@ -221,7 +221,7 @@ export class AssetPublishing implements IPublishProgress {
 
   /**
    * publish an asset (used by 'publish()')
-   * @param asset The asset to publish
+   * @param asset - The asset to publish
    * @returns false when publishing should stop
    */
   private async publishAsset(asset: IManifestEntry, options: PublishOptions = {}) {

--- a/packages/cdk/.eslintrc.json
+++ b/packages/cdk/.eslintrc.json
@@ -301,6 +301,9 @@
     "jsdoc/check-alignment": [
       "error"
     ],
+    "jsdoc/require-hyphen-before-param-description": [
+      "error"
+    ],
     "jest/expect-expect": "off",
     "jest/no-conditional-expect": "off",
     "jest/no-done-callback": "off",

--- a/projenrc/eslint/jsdoc.ts
+++ b/projenrc/eslint/jsdoc.ts
@@ -4,4 +4,5 @@ export default {
   'jsdoc/require-property-description': ['error'],
   'jsdoc/require-returns-description': ['error'],
   'jsdoc/check-alignment': ['error'],
+  'jsdoc/require-hyphen-before-param-description': ['error'],
 };


### PR DESCRIPTION
API Extractor wants that, so we might as well have it everywhere.

I just added the rule, fixes are automatically done by eslint.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
