### PR TITLE
chore(integ-testing): test CDK on multiple versions of Node

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -66,6 +66,11 @@ jobs:
         with:
           name: build-artifact
           path: packages
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
       - name: Set up JDK 18
         if: matrix.suite == 'init-java' || matrix.suite == 'cli-integ-tests'
         uses: actions/setup-java@v4
@@ -151,6 +156,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        include:
+          - suite: init-typescript-app
+            node: 18.17.0
+          - suite: init-typescript-app
+            node: "20"
+          - suite: init-typescript-app
+            node: "22"
+          - suite: toolkit-lib-integ-tests
+            node: 18.17.0
+          - suite: toolkit-lib-integ-tests
+            node: "20"
+          - suite: toolkit-lib-integ-tests
+            node: "22"
         suite:
           - cli-integ-tests
           - toolkit-lib-integ-tests
@@ -163,6 +181,8 @@ jobs:
           - init-typescript-app
           - init-typescript-lib
           - tool-integrations
+        node:
+          - lts/*
   integ:
     needs:
       - prepare

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1705,6 +1705,11 @@ new CdkCliIntegTestsWorkflow(repo, {
     endpoint: '${{ vars.CDK_ATMOSPHERE_PROD_ENDPOINT }}',
     pool: '${{ vars.CDK_INTEG_ATMOSPHERE_POOL }}',
   },
+  additionalNodeVersionsToTest: [
+    // 18.18 introduces `Symbol.dispose`, and we need to make sure that we work on older versions as well
+    '18.17.0',
+    '20', '22',
+  ],
 });
 
 new CodeCovWorkflow(repo, {

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -77,6 +77,15 @@ export interface CdkCliIntegTestsWorkflowProps {
    * @default - the cli integ test package determines a sensible default
    */
   readonly maxWorkers?: string;
+
+  /**
+   * Additional Node versions to some particular suites against.
+   *
+   * Use the version syntax of `setup-node`. `'lts/*'` is always included automatically.
+   *
+   * @see https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax
+   */
+  readonly additionalNodeVersionsToTest?: string[];
 }
 
 /**
@@ -296,7 +305,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
               'init-typescript-lib',
               'tool-integrations',
             ],
+            node: ['lts/*'],
           },
+          include: ['init-typescript-app', 'toolkit-lib-integ-tests'].flatMap(suite => (props.additionalNodeVersionsToTest ?? []).map(node => ({ suite, node }))),
         },
       },
       steps: [
@@ -306,6 +317,14 @@ export class CdkCliIntegTestsWorkflow extends Component {
           with: {
             name: 'build-artifact',
             path: 'packages',
+          },
+        },
+        {
+          name: 'Setup Node.js',
+          uses: 'actions/setup-node@v4',
+          with: {
+            'node-version': '${{ matrix.node }}',
+            'cache': 'npm',
           },
         },
         {


### PR DESCRIPTION
We weren't running our integ tests on all Node versions. Add that.

Unfortunately, the success or failure of the integ test run on this PR means nothing, because the workflow only takes effect after merging to `main`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
