### PR TITLE
chore(toolkit-lib): include declaration maps so that API extractor can locate the source file

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -807,6 +807,7 @@ const toolkitLib = configureProject(
         lib: ['es2022', 'esnext.disposable'],
         module: 'NodeNext',
         isolatedModules: true,
+        declarationMap: true,
       },
     },
     tsJestOptions: {

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.dev.json
@@ -28,6 +28,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "declarationMap": true,
     "rootDir": ".",
     "composite": true,
     "outDir": "lib"

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.dts.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.dts.json
@@ -1,9 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": null,
-    "composite": false
-  },
-  "include": ["lib/**/*.ts"],
-  "exclude": []
-}

--- a/packages/@aws-cdk/toolkit-lib/tsconfig.json
+++ b/packages/@aws-cdk/toolkit-lib/tsconfig.json
@@ -30,6 +30,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "declarationMap": true,
     "composite": true
   },
   "include": [


### PR DESCRIPTION
With this change

```
"fileUrlPath": "lib/payloads/hotswap.d.ts",
```

becomes

```
"fileUrlPath": "lib/payloads/hotswap.ts",
```

in `toolkit-lib.api.json`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
