### PR TITLE
chore(integ-testing): fix testing workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -70,7 +70,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-          cache: npm
       - name: Set up JDK 18
         if: matrix.suite == 'init-java' || matrix.suite == 'cli-integ-tests'
         uses: actions/setup-java@v4

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -324,7 +324,6 @@ export class CdkCliIntegTestsWorkflow extends Component {
           uses: 'actions/setup-node@v4',
           with: {
             'node-version': '${{ matrix.node }}',
-            'cache': 'npm',
           },
         },
         {


### PR DESCRIPTION
We can't use the `cache` property of `actions/setup-node` if there's no lockfile in the current directory, apparently.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
