### PR TITLE
fix: pin minimatch to 10.0.1

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -114,7 +114,7 @@
     "chokidar": "^3",
     "fs-extra": "^9",
     "glob": "^11.0.2",
-    "minimatch": "^10.0.1",
+    "minimatch": "10.0.1",
     "p-limit": "^3",
     "semver": "^7.7.2",
     "split2": "^4.2.0",

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -122,7 +122,7 @@
     "decamelize": "^5",
     "fs-extra": "^9",
     "glob": "^11.0.2",
-    "minimatch": "^10.0.1",
+    "minimatch": "10.0.1",
     "p-limit": "^3",
     "promptly": "^3.2.0",
     "proxy-agent": "^6.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10026,17 +10026,17 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
+minimatch@10.0.1, minimatch@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
+  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimatch@9.0.3:
   version "9.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.3.tgz#a6e00c3de44c3a542bfaae70abfc22420a6da825"
   integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^10.0.0, minimatch@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.0.1.tgz#ce0521856b453c86e25f2c4c0d03e6ff7ddc440b"
-  integrity sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==
   dependencies:
     brace-expansion "^2.0.1"
 


### PR DESCRIPTION
Fixes #597

10.0.2 has been identified to contain regressions. Pin to 10.0.1.

ref: https://github.com/isaacs/minimatch/issues/257

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
