### PR TITLE
chore: run Amplify smoke tests only on Node 20

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -168,6 +168,11 @@ jobs:
             node: "20"
           - suite: toolkit-lib-integ-tests
             node: "22"
+          - suite: tool-integrations
+            node: 20
+        exclude:
+          - suite: tool-integrations
+            node: lts/*
         suite:
           - cli-integ-tests
           - toolkit-lib-integ-tests

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -265,6 +265,17 @@ export class CdkCliIntegTestsWorkflow extends Component {
 
     // We create a matrix job for the test.
     // This job will run all the different test suites in parallel.
+    const matrixInclude: github.workflows.JobMatrix['include'] = [];
+    const matrixExclude: github.workflows.JobMatrix['exclude'] = [];
+
+    // In addition to the default runs, run these suites under different Node versions
+    matrixInclude.push(...['init-typescript-app', 'toolkit-lib-integ-tests'].flatMap(
+      suite => (props.additionalNodeVersionsToTest ?? []).map(node => ({ suite, node }))));
+
+    // We are finding that Amplify works on Node 20, but fails on Node >=22.10. Remove the 'lts/*' test and use a Node 20 for now.
+    matrixExclude.push({ suite: 'tool-integrations', node: 'lts/*' });
+    matrixInclude.push({ suite: 'tool-integrations', node: 20 });
+
     const JOB_INTEG_MATRIX = 'integ_matrix';
     runTestsWorkflow.addJob(JOB_INTEG_MATRIX, {
       environment: props.testEnvironment,
@@ -307,7 +318,8 @@ export class CdkCliIntegTestsWorkflow extends Component {
             ],
             node: ['lts/*'],
           },
-          include: ['init-typescript-app', 'toolkit-lib-integ-tests'].flatMap(suite => (props.additionalNodeVersionsToTest ?? []).map(node => ({ suite, node }))),
+          include: matrixInclude,
+          exclude: matrixExclude,
         },
       },
       steps: [


### PR DESCRIPTION
On recent Node 22s, they fail with the following weird error:

```
 [BackendBuildError] Unable to deploy due to CDK Assembly Error
    ∟ Caused by: [_AssemblyError] Assembly builder failed
  Error: aused by: [Error] ENOENT: no such file or directory, open '/tmp/cdk-integ-0dbc757n71oo/node_modules/@aws-amplify/backend-output-storage/lib/index.js?tsx-namespace=1749655833950'
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
