### PR TITLE
chore(integ-testing): skip "amplify integration" test because it is failing due to an upstream error

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/skip-tests.txt
+++ b/packages/@aws-cdk-testing/cli-integ/skip-tests.txt
@@ -6,3 +6,4 @@
 # when performing a certain version's regression tests.
 #
 # Put a test name on a line by itself to skip it.
+amplify integration


### PR DESCRIPTION
Upstream problem: https://github.com/aws-amplify/amplify-backend/issues/2849

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
