### PR TITLE
chore(node-bundle): produce a bundle metafile by default

### DIFF
--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -140,7 +140,7 @@
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "node-bundle pack --destination dist/js --external @aws-cdk/aws-service-spec:runtime --external aws-cdk:runtime --external fsevents:optional --allowed-license \"Apache-2.0\" --allowed-license \"MIT\" --allowed-license \"BSD-3-Clause\" --allowed-license \"ISC\" --allowed-license \"BSD-2-Clause\" --allowed-license \"0BSD\" --allowed-license \"MIT OR Apache-2.0\" --dont-attribute '^@aws-cdk/|^@cdklabs/|^cdk-assets$|^cdk-cli-wrapper$' --test 'bin/integ-runner --version' --entrypoint 'lib/index.js' --entrypoint 'lib/workers/extract/index.js'"
+          "exec": "node-bundle pack --destination dist/js --external @aws-cdk/aws-service-spec:runtime --external aws-cdk:runtime --external fsevents:optional --allowed-license \"Apache-2.0\" --allowed-license \"MIT\" --allowed-license \"BSD-3-Clause\" --allowed-license \"ISC\" --allowed-license \"BSD-2-Clause\" --allowed-license \"0BSD\" --allowed-license \"MIT OR Apache-2.0\" --dont-attribute '^@aws-cdk/|^@cdklabs/|^cdk-assets$|^cdk-cli-wrapper$' --test 'bin/integ-runner --version' --entrypoint 'lib/index.js' --entrypoint 'lib/workers/extract/index.js' --metafile dist/metafile.json"
         }
       ]
     },

--- a/packages/@aws-cdk/node-bundle/src/api/bundle.ts
+++ b/packages/@aws-cdk/node-bundle/src/api/bundle.ts
@@ -113,6 +113,13 @@ export interface BundleProps {
    * @default false
    */
   readonly minifySyntax?: boolean;
+
+  /**
+   * Write the metafile into this location.
+   *
+   * @default - no metafile is written
+   */
+  readonly metafile?: string;
 }
 
 /**
@@ -192,6 +199,7 @@ export class Bundle {
   private readonly minifyWhitespace?: boolean;
   private readonly minifyIdentifiers?: boolean;
   private readonly minifySyntax?: boolean;
+  private readonly metafile?: string;
 
   private _bundle?: esbuild.BuildResult;
   private _dependencies?: Package[];
@@ -214,6 +222,7 @@ export class Bundle {
     this.minifyWhitespace = props.minifyWhitespace;
     this.minifyIdentifiers = props.minifyIdentifiers;
     this.minifySyntax = props.minifySyntax;
+    this.metafile = props.metafile;
 
     const entryPoints = props.entryPoints ?? (this.manifest.main ? [this.manifest.main] : []);
 
@@ -437,7 +446,7 @@ export class Bundle {
       target: 'node14',
       platform: 'node',
       sourcemap: this.sourcemap,
-      metafile: true,
+      metafile: true, // this is always required for some of our validation rules
       minify: this.minify,
       minifyWhitespace: this.minifyWhitespace,
       minifyIdentifiers: this.minifyIdentifiers,
@@ -449,6 +458,11 @@ export class Bundle {
       outdir: this.packageDir,
       allowOverwrite: true,
     });
+
+    // Write metafile only when requested
+    if (this.metafile) {
+      fs.writeFileSync(this.metafile, JSON.stringify(bundle.metafile, null, 2));
+    }
 
     if (bundle.warnings.length > 0) {
       // esbuild warnings are usually important, lets try to be strict here.

--- a/packages/@aws-cdk/node-bundle/src/cli-main.ts
+++ b/packages/@aws-cdk/node-bundle/src/cli-main.ts
@@ -18,6 +18,7 @@ export async function cliMain(cliArgs: string[]) {
     .option('dont-attribute', { type: 'string', desc: 'Dependencies matching this regular expressions wont be added to the notice file' })
     .option('test', { type: 'string', desc: 'Validation command to sanity test the bundle after its created' })
     .option('minify-whitespace', { type: 'boolean', default: false, desc: 'Minify whitespace' })
+    .option('metafile', { type: 'string', desc: 'Produce a metafile about the build that can be analyzed' })
     .command('validate', 'Validate the package is ready for bundling', args => args
       .option('fix', { type: 'boolean', default: false, alias: 'f', desc: 'Fix any fixable violations' }),
     )
@@ -83,6 +84,7 @@ export async function cliMain(cliArgs: string[]) {
     dontAttribute: argv['dont-attribute'],
     test: argv.test,
     minifyWhitespace: argv['minify-whitespace'],
+    metafile: argv.metafile,
   };
 
   const bundle = new Bundle(props);

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -145,7 +145,7 @@
           "exec": "mkdir -p dist/js"
         },
         {
-          "exec": "node-bundle pack --destination dist/js --external fsevents:optional --allowed-license \"Apache-2.0\" --allowed-license \"MIT\" --allowed-license \"BSD-3-Clause\" --allowed-license \"ISC\" --allowed-license \"BSD-2-Clause\" --allowed-license \"0BSD\" --allowed-license \"MIT OR Apache-2.0\" --dont-attribute '^@aws-cdk/|^@cdklabs/|^cdk-assets$|^cdk-cli-wrapper$' --test 'bin/cdk --version' --entrypoint 'lib/index.js'"
+          "exec": "node-bundle pack --destination dist/js --external fsevents:optional --allowed-license \"Apache-2.0\" --allowed-license \"MIT\" --allowed-license \"BSD-3-Clause\" --allowed-license \"ISC\" --allowed-license \"BSD-2-Clause\" --allowed-license \"0BSD\" --allowed-license \"MIT OR Apache-2.0\" --dont-attribute '^@aws-cdk/|^@cdklabs/|^cdk-assets$|^cdk-cli-wrapper$' --test 'bin/cdk --version' --entrypoint 'lib/index.js' --metafile dist/metafile.json"
         }
       ]
     },

--- a/projenrc/bundle.ts
+++ b/projenrc/bundle.ts
@@ -90,6 +90,13 @@ export interface BundleProps {
    * @default false
    */
   readonly minifySyntax?: boolean;
+
+  /**
+   * Write a meatafile to the dist directory.
+   *
+   * @default false
+   */
+  readonly metafile?: boolean;
 }
 
 /**
@@ -138,9 +145,13 @@ export class BundleCli extends pj.Component {
     project.postCompileTask.exec(['node-bundle', 'validate', '--fix', ...args].join(' '));
 
     // `node-bundle` replaces `npm pack`
+    const packArgs = [
+      ...args,
+      ...(options.metafile ?? true) ? ['--metafile dist/metafile.json'] : [],
+    ];
     project.packageTask.reset();
     project.packageTask.exec('mkdir -p dist/js');
-    project.packageTask.exec(['node-bundle', 'pack', '--destination', 'dist/js', ...args].join(' '));
+    project.packageTask.exec(['node-bundle', 'pack', '--destination', 'dist/js', ...packArgs].join(' '));
   }
 }
 


### PR DESCRIPTION
Small QoL improvement so that engineers always have an esbuild bundle metafile available to [analyze](https://esbuild.github.io/analyze/).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
