### PR TITLE
chore: update PR lint workflow and projenrc with package scopes

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -32,8 +32,11 @@ jobs:
             docs
             revert
           scopes: |-
+            aws-cdk
             cdk-assets
+            cdk-cli-wrapper
             cli
+            cli-integ
             cli-lib-alpha
             cli-plugin-contract
             cloud-assembly-schema
@@ -43,7 +46,10 @@ jobs:
             docs
             integ-runner
             integ-testing
+            node-bundle
             toolkit-lib
+            toolkit-lib
+            yarn-cling
           requireScope: false
   contributorStatement:
     name: Require Contributor Statement


### PR DESCRIPTION
This PR updates the PR lint workflow and projenrc configuration to dynamically generate the list of allowed scopes based on the monorepo packages.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license