### PR TITLE
chore: fix logs upload for Node smoke tests

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -144,7 +144,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: logs-${{ matrix.suite }}
+          name: logs-${{ matrix.suite }}-${{ matrix.node }}
           path: logs/
           overwrite: "true"
       - name: Append artifact URL

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -461,7 +461,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           uses: 'actions/upload-artifact@v4.4.0',
           id: 'logupload',
           with: {
-            name: 'logs-${{ matrix.suite }}',
+            name: 'logs-${{ matrix.suite }}-${{ matrix.node }}',
             path: 'logs/',
             overwrite: 'true',
           },


### PR DESCRIPTION
We used to upload logs with the name of the suite we're running, but now that we are running the same suite multiple times with different node versions it's possible to get the following error:

```
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

We need to make the logs entirely unique by including all matrix parameters.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
