### PR TITLE
chore: slugify artifact ID

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -139,12 +139,19 @@ jobs:
           if compgen -G "logs/md/*.md" > /dev/null; then
             cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;
           fi
+      - name: Slugify artifact id
+        id: artifactid
+        env:
+          INPUT: logs-${{ matrix.suite }}-${{ matrix.node }}
+        run: |-
+          slug=$(node -p 'process.env.INPUT.replace(/[^a-z0-9._-]/gi, "-")')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
       - name: Upload logs
         id: logupload
         if: always()
         uses: actions/upload-artifact@v4.4.0
         with:
-          name: logs-${{ matrix.suite }}-${{ matrix.node }}
+          name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
           overwrite: "true"
       - name: Append artifact URL

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -455,13 +455,25 @@ export class CdkCliIntegTestsWorkflow extends Component {
             'fi',
           ].join('\n'),
         },
+        // Slugify artifact ID, because matrix.node will contain invalid chars
+        {
+          name: 'Slugify artifact id',
+          id: 'artifactid',
+          run: [
+            'slug=$(node -p \'process.env.INPUT.replace(/[^a-z0-9._-]/gi, "-")\')',
+            'echo "slug=$slug" >> "$GITHUB_OUTPUT"',
+          ].join('\n'),
+          env: {
+            INPUT: 'logs-${{ matrix.suite }}-${{ matrix.node }}',
+          },
+        },
         {
           name: 'Upload logs',
           if: 'always()',
           uses: 'actions/upload-artifact@v4.4.0',
           id: 'logupload',
           with: {
-            name: 'logs-${{ matrix.suite }}-${{ matrix.node }}',
+            name: '${{ steps.artifactid.outputs.slug }}',
             path: 'logs/',
             overwrite: 'true',
           },


### PR DESCRIPTION
In #613 we made the artifact ID unique for different Node versions, but the characters in `lts/*` aren't all safe for inclusion in the artifact ID.

Slugify the artifact ID first before using it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
