### PR TITLE
chore(toolkit-lib): set test timeout to 10s

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -774,8 +774,9 @@ const toolkitLib = configureProject(
     },
     jestOptions: jestOptionsForProject({
       jestConfig: {
+        // Tests that synth an assembly usually need a bit longer
+        testTimeout: 10_000,
         coverageThreshold: {
-          // this is very sad but we will get better
           statements: 87,
           branches: 83,
           functions: 82,

--- a/packages/@aws-cdk/toolkit-lib/jest.config.json
+++ b/packages/@aws-cdk/toolkit-lib/jest.config.json
@@ -47,6 +47,7 @@
     ]
   ],
   "randomize": true,
+  "testTimeout": 10000,
   "setupFilesAfterEnv": [
     "<rootDir>/test/_helpers/jest-setup-after-env.ts",
     "<rootDir>/test/_helpers/jest-custom-matchers.ts"

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
@@ -1,8 +1,6 @@
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, TestIoHost } from '../_helpers';
 
-jest.setTimeout(10_000);
-
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy-trace-logs.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy-trace-logs.test.ts
@@ -5,8 +5,6 @@ import { Toolkit } from '../../lib/toolkit';
 import { TestIoHost, builderFixture } from '../_helpers';
 import { MockSdk } from '../_helpers/mock-sdk';
 
-jest.setTimeout(10_000);
-
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -4,8 +4,6 @@ import * as deployments from '../../lib/api/deployments';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, cdkOutFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
 
-jest.setTimeout(10_000);
-
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
 let mockDeployStack: jest.SpyInstance<Promise<DeployStackResult>, [DeployStackOptions]>;

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -9,9 +9,6 @@ import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
 import { MockSdk, restoreSdkMocksToDefault, setDefaultSTSMocks } from '../_helpers/mock-sdk';
 
-// tests using fixtures can sometimes take a bit longer
-jest.setTimeout(10_000);
-
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -4,9 +4,6 @@ import { SdkProvider } from '../../lib/api/aws-auth/private';
 import { builderFixture, TestIoHost } from '../_helpers';
 import { mockCloudFormationClient, MockSdk } from '../_helpers/mock-sdk';
 
-// these tests often run a bit longer than the default
-jest.setTimeout(10_000);
-
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost, unstableFeatures: ['refactor'] });
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/synth.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/synth.test.ts
@@ -1,9 +1,6 @@
 import { Toolkit } from '../../lib/toolkit';
 import { appFixture, builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
 
-// these tests often run a bit longer than the default
-jest.setTimeout(10_000);
-
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/source-builder.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/source-builder.test.ts
@@ -8,9 +8,6 @@ import { Toolkit } from '../../../lib/toolkit/toolkit';
 import { ToolkitError } from '../../../lib/toolkit/toolkit-error';
 import { appFixture, appFixtureConfig, autoCleanOutDir, builderFixture, builderFunctionFromFixture, cdkOutFixture, TestIoHost } from '../../_helpers';
 
-// these tests often run a bit longer than the default
-jest.setTimeout(10_000);
-
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
 


### PR DESCRIPTION
Any tests that synth an assembly require a little longer to run. Let's just acknowledge that. Otherwise we keep running into test failures due to timeouts locally.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
