### PR TITLE
chore: use isolatedModules tsconfig everywhere

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -82,6 +82,7 @@ const defaultTsOptions: NonNullable<TypeScriptWorkspaceOptions['tsconfig']>['com
   incremental: true,
   esModuleInterop: false,
   skipLibCheck: true,
+  isolatedModules: true,
 };
 
 /**
@@ -302,11 +303,6 @@ function genericCdkProps(props: GenericProps = {}) {
     authorUrl: 'https://aws.amazon.com',
     authorOrganization: true,
     releasableCommits: pj.ReleasableCommits.featuresAndFixes('.'),
-    tsJestOptions: {
-      transformOptions: {
-        isolatedModules: true,
-      },
-    },
     jestOptions: {
       configFilePath: 'jest.config.json',
       junitReporting: false,
@@ -320,6 +316,11 @@ function genericCdkProps(props: GenericProps = {}) {
         printWidth: 120,
         singleQuote: true,
         trailingComma: pj.javascript.TrailingComma.ALL,
+      },
+    },
+    tsconfig: {
+      compilerOptions: {
+        ...defaultTsOptions,
       },
     },
     typescriptVersion: TYPESCRIPT_VERSION,
@@ -684,6 +685,14 @@ const TOOLKIT_LIB_EXCLUDE_PATTERNS = [
   'lib/init-templates/*/typescript/*/*.template.ts',
 ];
 
+const toolkitLibTsCompilerOptions = {
+  ...defaultTsOptions,
+  target: 'es2022',
+  lib: ['es2022', 'esnext.disposable'],
+  module: 'NodeNext',
+  declarationMap: true,
+};
+
 const toolkitLib = configureProject(
   new yarn.TypeScriptWorkspace({
     ...genericCdkProps(),
@@ -691,11 +700,6 @@ const toolkitLib = configureProject(
     name: '@aws-cdk/toolkit-lib',
     description: 'AWS CDK Programmatic Toolkit Library',
     srcdir: 'lib',
-    tsconfigDev: {
-      compilerOptions: {
-        rootDir: '.', // shouldn't be required but something broke... check again once we have gotten rid of the tmpToolkitHelpers package
-      },
-    },
     peerDeps: [
       cliPluginContract.customizeReference({ versionType: 'any-minor' }), // allow consumers to easily de-depulicate this
     ],
@@ -791,17 +795,13 @@ const toolkitLib = configureProject(
     }),
     tsconfig: {
       compilerOptions: {
-        ...defaultTsOptions,
-        target: 'es2022',
-        lib: ['es2022', 'esnext.disposable'],
-        module: 'NodeNext',
-        isolatedModules: true,
-        declarationMap: true,
+        ...toolkitLibTsCompilerOptions,
       },
     },
-    tsJestOptions: {
-      transformOptions: {
-        isolatedModules: false, // we use the respective tsc setting
+    tsconfigDev: {
+      compilerOptions: {
+        ...toolkitLibTsCompilerOptions,
+        rootDir: '.', // shouldn't be required but something broke... check again once we have gotten rid of the tmpToolkitHelpers package
       },
     },
     majorVersion: 1,
@@ -1070,12 +1070,6 @@ const cli = configureProject(
       'yaml@^1',
       'yargs@^15',
     ],
-    tsJestOptions: {
-      transformOptions: {
-        // Skips type checking, otherwise tests take too long
-        isolatedModules: true,
-      },
-    },
     tsconfig: {
       compilerOptions: {
         ...defaultTsOptions,
@@ -1096,7 +1090,6 @@ const cli = configureProject(
         esModuleInterop: false,
         skipLibCheck: true,
       },
-
     },
     eslintOptions: {
       dirs: ['lib'],
@@ -1466,13 +1459,6 @@ const integRunner = configureProject(
     tsconfig: {
       compilerOptions: {
         ...defaultTsOptions,
-        lib: ['es2020', 'dom'],
-        isolatedModules: true,
-      },
-    },
-    tsJestOptions: {
-      transformOptions: {
-        isolatedModules: false, // we use the respective tsc setting
       },
     },
     jestOptions: jestOptionsForProject({

--- a/packages/@aws-cdk-testing/cli-integ/jest.config.json
+++ b/packages/@aws-cdk-testing/cli-integ/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk-testing/cli-integ/tsconfig.dev.json
+++ b/packages/@aws-cdk-testing/cli-integ/tsconfig.dev.json
@@ -28,6 +28,7 @@
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk-testing/cli-integ/tsconfig.json
+++ b/packages/@aws-cdk-testing/cli-integ/tsconfig.json
@@ -30,6 +30,7 @@
     "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/cdk-cli-wrapper/jest.config.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/cdk-cli-wrapper/tsconfig.dev.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/cdk-cli-wrapper/tsconfig.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/cli-lib-alpha/jest.config.json
+++ b/packages/@aws-cdk/cli-lib-alpha/jest.config.json
@@ -55,8 +55,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/cli-lib-alpha/tsconfig.dev.json
+++ b/packages/@aws-cdk/cli-lib-alpha/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/cli-plugin-contract/jest.config.json
+++ b/packages/@aws-cdk/cli-plugin-contract/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/cli-plugin-contract/tsconfig.dev.json
+++ b/packages/@aws-cdk/cli-plugin-contract/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/cli-plugin-contract/tsconfig.json
+++ b/packages/@aws-cdk/cli-plugin-contract/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/cloud-assembly-schema/jest.config.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/cloud-assembly-schema/tsconfig.dev.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/tsconfig.dev.json
@@ -3,14 +3,14 @@
   "compilerOptions": {
     "alwaysStrict": true,
     "declaration": true,
-    "esModuleInterop": true,
+    "esModuleInterop": false,
     "experimentalDecorators": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
       "es2020"
     ],
-    "module": "CommonJS",
+    "module": "commonjs",
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -24,6 +24,9 @@
     "strictPropertyInitialization": true,
     "stripInternal": true,
     "target": "ES2020",
+    "incremental": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/cloudformation-diff/jest.config.json
+++ b/packages/@aws-cdk/cloudformation-diff/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/cloudformation-diff/tsconfig.dev.json
+++ b/packages/@aws-cdk/cloudformation-diff/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/cloudformation-diff/tsconfig.json
+++ b/packages/@aws-cdk/cloudformation-diff/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/integ-runner/jest.config.json
+++ b/packages/@aws-cdk/integ-runner/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": false
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/integ-runner/tsconfig.dev.json
+++ b/packages/@aws-cdk/integ-runner/tsconfig.dev.json
@@ -8,8 +8,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2020",
-      "dom"
+      "es2020"
     ],
     "module": "commonjs",
     "noEmitOnError": false,

--- a/packages/@aws-cdk/integ-runner/tsconfig.json
+++ b/packages/@aws-cdk/integ-runner/tsconfig.json
@@ -10,8 +10,7 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2020",
-      "dom"
+      "es2020"
     ],
     "module": "commonjs",
     "noEmitOnError": false,

--- a/packages/@aws-cdk/node-bundle/jest.config.json
+++ b/packages/@aws-cdk/node-bundle/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/node-bundle/tsconfig.dev.json
+++ b/packages/@aws-cdk/node-bundle/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/node-bundle/tsconfig.json
+++ b/packages/@aws-cdk/node-bundle/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/toolkit-lib/jest.config.json
+++ b/packages/@aws-cdk/toolkit-lib/jest.config.json
@@ -64,8 +64,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": false
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/user-input-gen/jest.config.json
+++ b/packages/@aws-cdk/user-input-gen/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/user-input-gen/tsconfig.dev.json
+++ b/packages/@aws-cdk/user-input-gen/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/user-input-gen/tsconfig.json
+++ b/packages/@aws-cdk/user-input-gen/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/@aws-cdk/yarn-cling/jest.config.json
+++ b/packages/@aws-cdk/yarn-cling/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/@aws-cdk/yarn-cling/tsconfig.dev.json
+++ b/packages/@aws-cdk/yarn-cling/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/yarn-cling/tsconfig.json
+++ b/packages/@aws-cdk/yarn-cling/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/aws-cdk/jest.config.json
+++ b/packages/aws-cdk/jest.config.json
@@ -68,8 +68,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/aws-cdk/lib/api-private.ts
+++ b/packages/aws-cdk/lib/api-private.ts
@@ -1,5 +1,6 @@
 /* eslint-disable import/no-relative-packages */
-export { deployStack, DeployStackOptions as DeployStackApiOptions } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
+export { deployStack } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
+export type { DeployStackOptions as DeployStackApiOptions } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
 export * as cfnApi from '../../@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api';
 export * from '../../@aws-cdk/toolkit-lib/lib/api/io/private';
 export * from '../../@aws-cdk/toolkit-lib/lib/api/tags/private';

--- a/packages/aws-cdk/lib/api/index.ts
+++ b/packages/aws-cdk/lib/api/index.ts
@@ -11,7 +11,7 @@ export * from '../../../@aws-cdk/toolkit-lib/lib/api/diff';
 export * from '../../../@aws-cdk/toolkit-lib/lib/api/io';
 export * from '../../../@aws-cdk/toolkit-lib/lib/api/logs-monitor';
 export * from '../../../@aws-cdk/toolkit-lib/lib/api/resource-import';
-export { RWLock, IReadLock } from '../../../@aws-cdk/toolkit-lib/lib/api/rwlock';
+export { RWLock, type IReadLock } from '../../../@aws-cdk/toolkit-lib/lib/api/rwlock';
 export * from '../../../@aws-cdk/toolkit-lib/lib/api/toolkit-info';
 export { loadTree, some } from '../../../@aws-cdk/toolkit-lib/lib/api/tree';
 export * from '../../../@aws-cdk/toolkit-lib/lib/api/work-graph';

--- a/packages/aws-cdk/tsconfig.dev.json
+++ b/packages/aws-cdk/tsconfig.dev.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/aws-cdk/tsconfig.json
+++ b/packages/aws-cdk/tsconfig.json
@@ -29,6 +29,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/cdk-assets/jest.config.json
+++ b/packages/cdk-assets/jest.config.json
@@ -60,8 +60,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/cdk-assets/tsconfig.dev.json
+++ b/packages/cdk-assets/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/cdk-assets/tsconfig.json
+++ b/packages/cdk-assets/tsconfig.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [

--- a/packages/cdk/jest.config.json
+++ b/packages/cdk/jest.config.json
@@ -59,8 +59,7 @@
     "^.+\\.[t]sx?$": [
       "ts-jest",
       {
-        "tsconfig": "tsconfig.dev.json",
-        "isolatedModules": true
+        "tsconfig": "tsconfig.dev.json"
       }
     ]
   },

--- a/packages/cdk/tsconfig.dev.json
+++ b/packages/cdk/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/cdk/tsconfig.json
+++ b/packages/cdk/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "incremental": true,
     "skipLibCheck": true,
+    "isolatedModules": true,
     "composite": true
   },
   "include": [


### PR DESCRIPTION
Replaces the deprecated `ts-jest` config of the same name.

Also includes some small alignments of `tsconfig.dev.json` files with their corresponding parent, where previously missed.
Also removes `dom` from `integ-runner` since this is not needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
