### PR TITLE
fix(cli): logs entire environment

### DIFF
--- a/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
+++ b/packages/@aws-cdk/cli-lib-alpha/lib/cli.ts
@@ -137,7 +137,7 @@ export class AwsCdkCli implements IAwsCdkCli {
           ...params.env,
         };
 
-        const cleanupContext = await writeContextToEnv(env, fullCtx);
+        const cleanupContext = await writeContextToEnv(env, fullCtx, 'env-is-complete');
         try {
           return await withEnv(async() => createAssembly(await producer.produce(fullCtx)), env);
         } finally {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
@@ -333,7 +333,7 @@ export abstract class CloudAssemblySourceBuilder {
             ...synthParams.env,
           });
 
-          const cleanupContextTemp = writeContextToEnv(env, fullContext);
+          const cleanupContextTemp = writeContextToEnv(env, fullContext, 'env-is-complete');
           using _cleanupEnv = (props.clobberEnv ?? true) ? temporarilyWriteEnv(env) : undefined;
           let assembly;
           try {
@@ -486,7 +486,7 @@ export abstract class CloudAssemblySourceBuilder {
             // Environment variables derived from settings
             ...synthParams.env,
           });
-          const cleanupTemp = writeContextToEnv(env, fullContext);
+          const cleanupTemp = writeContextToEnv(env, fullContext, 'env-is-complete');
           try {
             await execInChildProcess(commandLine.join(' '), {
               eventPublisher: async (type, line) => {

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -29,14 +29,12 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
   await debugFn(format('context:', context));
 
   const env: Record<string, string> = noUndefined({
-    // Need to start with full env of `writeContextToEnv` will not be able to do the size
-    // calculation correctly.
-    ...process.env,
     // Versioning, outdir, default account and region
     ...await prepareDefaultEnvironment(aws, debugFn),
     // Environment variables derived from settings
     ...params.env,
   });
+
   const build = config.settings.get(['build']);
   if (build) {
     await exec(build);
@@ -73,6 +71,7 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
   }
 
   await debugFn(`outdir: ${outdir}`);
+
   env[cxapi.OUTDIR_ENV] = outdir;
 
   // Acquire a lock on the output directory
@@ -84,7 +83,7 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
 
   await debugFn(format('env:', env));
 
-  const cleanupTemp = writeContextToEnv(env, context);
+  const cleanupTemp = writeContextToEnv(env, context, 'add-process-env-later');
   try {
     await exec(commandLine.join(' '));
 


### PR DESCRIPTION
Right now the CLI logs the entire environment to debug logging.  This is a lot of data, and potentially also includes tokens we'd rather don't end up in logging.

Instead, just log our additions to the existing environment.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
