### PR TITLE
fix: revert "retain type of context values and not convert them to string"

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
@@ -453,8 +453,7 @@ class LambdaStack extends cdk.Stack {
   constructor(parent, id, props) {
     // sometimes we need to specify the custom bootstrap bucket to use
     // see the 'upgrade legacy bootstrap stack' test
-    const useLegacy = [true, 'true'].includes(parent.node.tryGetContext('legacySynth'));
-    const synthesizer = useLegacy ?
+    const synthesizer = parent.node.tryGetContext('legacySynth') === 'true' ?
       new LegacyStackSynthesizer({
         fileAssetsBucketName: parent.node.tryGetContext('bootstrapBucket'),
       })
@@ -478,8 +477,7 @@ class LambdaStack extends cdk.Stack {
 
 class DriftableStack extends cdk.Stack {
   constructor(parent, id, props) {
-    const useLegacy = [true, 'true'].includes(parent.node.tryGetContext('legacySynth'));
-    const synthesizer = useLegacy ?
+    const synthesizer = parent.node.tryGetContext('legacySynth') === 'true' ?
       new LegacyStackSynthesizer({
         fileAssetsBucketName: parent.node.tryGetContext('bootstrapBucket'),
       })

--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -341,13 +341,7 @@ function parseStringContextListToObject(argv: Arguments): any {
           `User-provided context cannot use keys prefixed with 'aws:', but ${parts[0]} was provided.`,
         );
       }
-      let parsedValue: any = parts[1];
-      try {
-        parsedValue = JSON.parse(parts[1]);
-      } catch {
-        debug('Non-JSON context value for %s, leaving as string: %s', parts[0], parts[1]);
-      }
-      context[parts[0]] = parsedValue;
+      context[parts[0]] = parts[1];
     } else {
       warning(
         'Context argument is not an assignment (key=value): %s',

--- a/packages/aws-cdk/test/cli/configuration.test.ts
+++ b/packages/aws-cdk/test/cli/configuration.test.ts
@@ -116,23 +116,3 @@ test('providing a build arg', () => {
   // THEN
   expect(settings.get(['build'])).toEqual('mvn package');
 });
-
-test('can parse boolean context from command line arguments', () => {
-  // GIVEN
-  const settings1 = commandLineArgumentsToSettings({ context: ['foo=true'], _: [Command.DEPLOY] });
-  const settings2 = commandLineArgumentsToSettings({ context: ['foo=false'], _: [Command.DEPLOY] });
-
-  // THEN
-  expect(settings1.get(['context']).foo).toEqual( true );
-  expect(settings2.get(['context']).foo).toEqual( false );
-});
-
-test('can parse number context from command line arguments', () => {
-  // GIVEN
-  const settings1 = commandLineArgumentsToSettings({ context: ['foo=5'], _: [Command.DEPLOY] });
-  const settings2 = commandLineArgumentsToSettings({ context: ['foo=3.14'], _: [Command.DEPLOY] });
-
-  // THEN
-  expect(settings1.get(['context']).foo).toEqual( 5 );
-  expect(settings2.get(['context']).foo).toEqual( 3.14 );
-});


### PR DESCRIPTION
Some users are relying on context values always being a string.

Fixes https://github.com/aws/aws-cdk-cli/issues/629 and https://github.com/aws/aws-cdk-cli/issues/626

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
