### PR TITLE
fix(integ-testing): proxy+notices test sometimes fails

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/proxy/cdk-requests-go-through-a-proxy-when-configured.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/proxy/cdk-requests-go-through-a-proxy-when-configured.integtest.ts
@@ -1,5 +1,4 @@
 import { promises as fs } from 'fs';
-import * as os from 'os';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 import { awsActionsFromRequests, startProxyServer } from '../../../lib/proxy';
@@ -10,8 +9,10 @@ integTest('requests go through a proxy when configured',
   withDefaultFixture(async (fixture) => {
     const proxyServer = await startProxyServer();
     try {
+      // Matches CDK_HOME below.
+      const cdkCacheDir = path.join(fixture.integTestDir, 'cache');
       // Delete notices cache if it exists
-      await fs.rm(path.join(process.env.HOME ?? os.userInfo().homedir, '.cdk/cache/notices.json'), { force: true });
+      await fs.rm(path.join(cdkCacheDir, 'notices.json'), { force: true });
 
       await fixture.cdkDeploy('test-2', {
         captureStderr: true,


### PR DESCRIPTION
The test that checks that notices are fetched through the proxy sometimes fails; it is correctly cleaning the `notices.json` file from a temporary directory before running the command that should fetch notices, but the temporary directory is wrong.

When running the command it is setting `CDK_HOME` to a directory, and `CDK_HOME` will be used to determine the location of the notices cache; but when removing the file it is removing it from the user's home directory, as if `CDK_HOME` was never set.

What's not clear to me is why this wouldn't *always* fail... but I'm pretty sure the new behavior is correct.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
