### PR TITLE
fix(integ-testing): use specificied library version in init tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-csharp/init-csharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-csharp/init-csharp.integtest.ts
@@ -7,7 +7,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'csharp', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'csharp', template]);
     await context.library.initializeDotnetPackages(context.integTestDir);
     await shell.shell(['cdk', 'synth']);
   })));

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-fsharp/init-fsharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-fsharp/init-fsharp.integtest.ts
@@ -7,7 +7,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'fsharp', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'fsharp', template]);
     await context.library.initializeDotnetPackages(context.integTestDir);
     await shell.shell(['cdk', 'synth']);
   })));

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
@@ -8,7 +8,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'go', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'go', template]);
 
     // Canaries will use the generated go.mod as is
     // For pipeline tests we replace the source with the locally build one

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-java/init-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-java/init-java.integtest.ts
@@ -7,7 +7,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'java', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'java', template]);
     await shell.shell(['mvn', 'package']);
     await shell.shell(['cdk', 'synth']);
   })));

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-javascript/init-javascript.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-javascript/init-javascript.integtest.ts
@@ -7,7 +7,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'javascript', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'javascript', template]);
     await shell.shell(['npm', 'prune']);
     await shell.shell(['npm', 'ls']); // this will fail if we have unmet peer dependencies
     await shell.shell(['npm', 'run', 'test']);
@@ -21,7 +21,7 @@ integTest('Test importing CDK from ESM', withTemporaryDirectory(withPackages(asy
   const shell = ShellHelper.fromContext(context);
   await context.cli.makeCliAvailable();
 
-  await shell.shell(['cdk', 'init', '-l', 'javascript', 'app']);
+  await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'javascript', 'app']);
 
   // Rewrite some files
   await fs.writeFile(path.join(context.integTestDir, 'new-entrypoint.mjs'), `

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-python/init-python.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-python/init-python.integtest.ts
@@ -8,7 +8,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'python', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'python', template]);
     const venvPath = path.resolve(context.integTestDir, '.venv');
     const venv = { PATH: `${venvPath}/bin:${process.env.PATH}`, VIRTUAL_ENV: venvPath };
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -9,7 +9,7 @@ import { typescriptVersionsSync, typescriptVersionsYoungerThanDaysSync } from '.
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
-    await shell.shell(['cdk', 'init', '-l', 'typescript', template]);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', template]);
 
     await shell.shell(['npm', 'prune']);
     await shell.shell(['npm', 'ls']); // this will fail if we have unmet peer dependencies
@@ -36,7 +36,7 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     await shell.shell(['node', '--version']);
     await shell.shell(['npm', '--version']);
 
-    await shell.shell(['cdk', 'init', '-l', 'typescript', 'app', '--generate-only']);
+    await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'app', '--generate-only']);
 
     // Necessary because recent versions of ts-jest require TypeScript>=4.3 but we
     // still want to test with older versions as well.

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/init-typescript-lib.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/init-typescript-lib.integtest.ts
@@ -4,7 +4,7 @@ integTest('typescript init lib', withTemporaryDirectory(withPackages(async (cont
   const shell = ShellHelper.fromContext(context);
   await context.cli.makeCliAvailable();
 
-  await shell.shell(['cdk', 'init', '-l', 'typescript', 'lib']);
+  await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'lib']);
 
   await shell.shell(['npm', 'prune']);
   await shell.shell(['npm', 'ls']); // this will fail if we have unmet peer dependencies


### PR DESCRIPTION
The init tests used always to use the library version that was baked into the CLI. The CLI has since grown a `--lib-version` flag that allow specifying the library version.

Respect the library-under-test version that is being given to the integ tests, and use that version to test with.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
