### PR TITLE
fix: longer timeout for notices in the testing environment

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -560,6 +560,7 @@ export class TestFixture extends ShellHelper {
       AWS_DEFAULT_REGION: this.aws.region,
       STACK_NAME_PREFIX: this.stackNamePrefix,
       PACKAGE_LAYOUT_VERSION: '2',
+      TESTING_CDK: 'true',
       // In these tests we want to make a distinction between stdout and sterr
       CI: 'false',
       ...awsCreds,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
@@ -44,7 +44,11 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
   }
 
   async fetch(): Promise<Notice[]> {
-    const timeout = 3000;
+    // We are observing lots of timeouts when running in a massively parallel
+    // integration test environment, so wait for a longer timeout there.
+    //
+    // In production, have a short timeout to not hold up the user experience.
+    const timeout = process.env.TESTING_CDK ? 30_000 : 3_000;
 
     const options: RequestOptions = {
       agent: this.agent,


### PR DESCRIPTION
We're observing a lot of these errors in our integration tests:

```
[09:29:38] Could not refresh notices: _ToolkitError: Network error: Request timed out
```

It could be that our timeout is too short on a heavily congested machine. Increase the timeout specifically for those cases to improve the reliability of our tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
