### PR TITLE
fix: unstable=toolkit-lib-engine has no effect

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
@@ -136,6 +136,7 @@ export async function runIntegrationTestsInParallel(
         dryRun: options.dryRun,
         verbosity: options.verbosity,
         updateWorkflow: options.updateWorkflow,
+        engine: options.engine,
       }], {
         on: printResults,
       });


### PR DESCRIPTION
The `engine` field is not being passed on when passing the call to the worker pool.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
