### PR TITLE
chore: ensure correct major version for some more packages

### DIFF
--- a/packages/@aws-cdk/cli-plugin-contract/.projen/tasks.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.projen/tasks.json
@@ -32,7 +32,8 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/cli-plugin-contract@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
+        "MAJOR": "2"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/cloudformation-diff/.projen/tasks.json
+++ b/packages/@aws-cdk/cloudformation-diff/.projen/tasks.json
@@ -33,7 +33,8 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts maybeRc",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
+        "MAJOR": "2"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -32,7 +32,8 @@
         "RELEASE_TAG_PREFIX": "@aws-cdk/integ-runner@",
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- . ../../aws-cdk ../cloud-assembly-schema ../cloudformation-diff ../toolkit-lib",
+        "MAJOR": "2"
       },
       "steps": [
         {


### PR DESCRIPTION
Definitely keeping the following additional packages on the current major version:

```
@aws-cdk/cli-plugin-contract
@aws-cdk/cloudformation-diff
@aws-cdk/integ-runner
```


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
