### PR TITLE
fix(cli-integ): CI=true test fails when jsii prints to stderr

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-true-output-to-stdout.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-true-output-to-stdout.integtest.ts
@@ -11,9 +11,14 @@ integTest(
       onlyStderr: true,
       modEnv: {
         CI: 'true',
+
+        // Disable all Node.js version warnings
         JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION: 'true',
         JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: 'true',
         JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: 'true',
+
+        // Make sure we don't warn on use of deprecated APIs (that cannot be redirected)
+        JSII_DEPRECATED: 'quiet',
       },
       options: ['--no-notices'],
     };


### PR DESCRIPTION
JSII doesn't respect the `CI=true` behavior (nor should it), prints to `stderr`, then the test fails.

Silence another source of jsii stderr output.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
