### PR TITLE
fix(cloud-assembly-schema): bump the version number

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,4 +1,4 @@
 {
   "schemaHash": "4709e40bc5dd6ad7d2bb6c6bd0315c622b7f4aa07ee3af66ff07f9bc77fdf783",
-  "revision": 44
+  "revision": 45
 }


### PR DESCRIPTION
I did not want to bump the version number previously because the CLI did not yet *act* on the new definitions found inside the schema, and users would get the error message:

```
This CDK CLI is not compatible with the CDK library used by your application. Please upgrade the CLI to the latest version.
```

For no benefit.

This was a mistake, because we use `jsonschema` to validate the contents of the manifest file and now old versions of the CLI try and validate new files using the old schema, and instead they get the error:

```
Invalid assembly manifest:
instance.artifacts.aws-cdk-lib/feature-flag-report.type is not one of enum values: none,aws:cloudformation:stack,cdk:tree,cdk:asset-manifest,cdk:cloud-assembly
instance.artifacts.aws-cdk-lib/feature-flag-report.properties requires property "templateFile"
instance.artifacts.aws-cdk-lib/feature-flag-report.properties requires property "file"
```

We will need another mechanism to achieve the goal of not requiring people to upgrade their CLI unnecessarily; holding back the version number is just exchanging one error message for a worse one.

Belatedly bump the version number here, so that we can release this and reapply this change: https://github.com/aws/aws-cdk/pull/34880


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
