### PR TITLE
fix(integ-runner): snapshots involving AZs are different if `enableLookups: false`

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
@@ -326,11 +326,13 @@ export abstract class IntegRunner {
       fs.removeSync(this.snapshotDir);
     }
 
+    const actualTestSuite = await this.actualTestSuite();
+
     // if lookups are enabled then we need to synth again
     // using dummy context and save that as the snapshot
     await this.cdk.synthFast({
       execCmd: this.cdkApp.split(' '),
-      context: this.getContext(DEFAULT_SYNTH_OPTIONS.context),
+      context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
       output: path.relative(this.directory, this.snapshotDir),
     });


### PR DESCRIPTION
In https://github.com/aws/aws-cdk-cli/pull/666 we used `synthFast()` to always generate a snapshot in the same was as was used for validating (which was also using `synthFast()`).

The difference being, that the context we load depends on the `enableLookups: false|true` flag that's passed to `new IntegTest()` in the test case itself. So when writing the snapshot we have to take that same field into account.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
