### PR TITLE
fix(toolkit-lib): make default environment resolution optional

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -84,6 +84,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
       outdir: options.output ? path.join(this.options.workingDirectory, options.output) : undefined,
       contextStore: new MemoryContext(options.context),
       lookups: false,
+      resolveDefaultEnvironment: false,
       env: {
         ...this.options.env,
         ...options.env,
@@ -209,6 +210,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
       workingDirectory: this.options.workingDirectory,
       outdir,
       lookups: options.lookups,
+      resolveDefaultEnvironment: false, // not part of the integ-runner contract
       contextStore: new MemoryContext(options.context),
       env: this.options.env,
       synthOptions: {

--- a/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
@@ -326,11 +326,13 @@ export abstract class IntegRunner {
       fs.removeSync(this.snapshotDir);
     }
 
+    const actualTestSuite = await this.actualTestSuite();
+
     // if lookups are enabled then we need to synth again
     // using dummy context and save that as the snapshot
     await this.cdk.synthFast({
       execCmd: this.cdkApp.split(' '),
-      context: this.getContext(DEFAULT_SYNTH_OPTIONS.context),
+      context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
       output: path.relative(this.directory, this.snapshotDir),
     });

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
@@ -73,6 +73,7 @@ describe('ToolkitLibRunnerEngine', () => {
         contextStore: expect.any(Object),
         lookups: false,
         env: { TEST: 'true' },
+        resolveDefaultEnvironment: false,
         synthOptions: {
           versionReporting: false,
           pathMetadata: false,


### PR DESCRIPTION
This PR makes the default environment resolution optional in the toolkit-lib. It allows avoiding unnecessary STS calls when the environment is explicitly specified or when local actions are performed without internet access.

Then uses the new feature in `integ-runner` to disable the default env lookup in the toolkit-lib engine. The existing engine doesn't provide the env variables either, so it's clearly not needed. We don't want to add to this contract at this time and also resolving the account adds an unnecessary delay.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license