### PR TITLE
fix(integ-testing): ensure that `cdk-assets` can consume the lib output

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-can-read-lib-output.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-can-read-lib-output.integtest.ts
@@ -1,0 +1,14 @@
+import * as path from 'path';
+import { integTest } from '../../../lib/integ-test';
+import { withDefaultFixture } from '../../../lib/with-cdk-app';
+
+integTest('cdk-assets can read lib output', withDefaultFixture(async (fixture) => {
+  await fixture.cdkSynth();
+
+  await fixture.cdkAssets.makeCliAvailable();
+
+  const assetManifestFile = path.join(fixture.integTestDir, 'cdk.out', `${fixture.fullStackName('test-1')}.assets.json`);
+
+  // Should not fail
+  await fixture.shell(['cdk-assets', '--path', assetManifestFile, 'ls']);
+}));


### PR DESCRIPTION
Make sure to test that the version of `cdk-assets`-under-test can read the output of the `aws-cdk-lib`-under-test.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
