### PR TITLE
chore(cli): legacy logging functions hide asynchronousity

### DIFF
--- a/packages/aws-cdk/test/logging.test.ts
+++ b/packages/aws-cdk/test/logging.test.ts
@@ -167,9 +167,9 @@ describe('logging', () => {
   describe('message codes', () => {
     test('validates message codes correctly', async () => {
       // Valid codes
-      expect(async () => await error({ message: 'test', code: 'CDK_TOOLKIT_E0001' })).not.toThrow();
-      expect(async () => await warning({ message: 'test', code: 'CDK_ASSETS_W4999' })).not.toThrow();
-      expect(async () => await info({ message: 'test', code: 'CDK_SDK_I0000' })).not.toThrow();
+      expect(async () => error({ message: 'test', code: 'CDK_TOOLKIT_E0001' })).not.toThrow();
+      expect(async () => warning({ message: 'test', code: 'CDK_ASSETS_W4999' })).not.toThrow();
+      expect(async () => info({ message: 'test', code: 'CDK_SDK_I0000' })).not.toThrow();
     });
 
     test('uses default codes when none provided', async () => {

--- a/packages/aws-cdk/test/logging.test.ts
+++ b/packages/aws-cdk/test/logging.test.ts
@@ -34,34 +34,34 @@ describe('logging', () => {
   });
 
   describe('stream selection', () => {
-    test('result() always writes to stdout with both styles', () => {
+    test('result() always writes to stdout with both styles', async () => {
       // String style
-      result('test message');
+      await result('test message');
       expect(mockStdout).toHaveBeenCalledWith('test message\n');
 
       expect(mockStderr).not.toHaveBeenCalled();
     });
 
-    test('error() always writes to stderr with both styles', () => {
+    test('error() always writes to stderr with both styles', async () => {
       // String style
-      error('test error');
+      await error('test error');
       expect(mockStderr).toHaveBeenCalledWith('test error\n');
 
       expect(mockStdout).not.toHaveBeenCalled();
     });
 
-    test('info() writes to stderr by default with both styles', () => {
+    test('info() writes to stderr by default with both styles', async () => {
       // String style
-      info('test print');
+      await info('test print');
       expect(mockStderr).toHaveBeenCalledWith('test print\n');
 
       expect(mockStdout).not.toHaveBeenCalled();
     });
 
-    test('info() writes to stdout in CI mode with both styles', () => {
+    test('info() writes to stdout in CI mode with both styles', async () => {
       ioHost.isCI = true;
       // String style
-      info('test print');
+      await info('test print');
       expect(mockStdout).toHaveBeenCalledWith('test print\n');
 
       expect(mockStderr).not.toHaveBeenCalled();
@@ -69,26 +69,26 @@ describe('logging', () => {
   });
 
   describe('log levels', () => {
-    test('respects log level settings with both styles', () => {
+    test('respects log level settings with both styles', async () => {
       ioHost.logLevel = 'error';
 
       // String style
-      error('error message');
-      warning('warning message');
-      info('print message');
+      await error('error message');
+      await warning('warning message');
+      await info('print message');
 
       expect(mockStderr).toHaveBeenCalledWith('error message\n');
       expect(mockStderr).not.toHaveBeenCalledWith('warning message\n');
       expect(mockStderr).not.toHaveBeenCalledWith('print message\n');
     });
 
-    test('debug messages only show at debug level with both styles', () => {
+    test('debug messages only show at debug level with both styles', async () => {
       ioHost.logLevel = 'info';
-      debug('debug message');
+      await debug('debug message');
       expect(mockStderr).not.toHaveBeenCalled();
 
       ioHost.logLevel = 'debug';
-      debug('debug message');
+      await debug('debug message');
       expect(mockStderr).toHaveBeenCalledWith(
         expect.stringMatching(/^\[\d{2}:\d{2}:\d{2}\] debug message\n$/),
       );
@@ -96,22 +96,22 @@ describe('logging', () => {
   });
 
   describe('formatted messages', () => {
-    test('handles format strings correctly with both styles', () => {
+    test('handles format strings correctly with both styles', async () => {
       // String style
-      info('Hello %s, you have %d messages', 'User', 5);
+      await info('Hello %s, you have %d messages', 'User', 5);
       expect(mockStderr).toHaveBeenCalledWith('Hello User, you have 5 messages\n');
     });
 
-    test('handles objects in format strings with both styles', () => {
+    test('handles objects in format strings with both styles', async () => {
       const obj = { name: 'test' };
       // String style
-      info('Object: %j', obj);
+      await info('Object: %j', obj);
       expect(mockStderr).toHaveBeenCalledWith('Object: {"name":"test"}\n');
     });
 
-    test('handles multiple style changes in single call', () => {
+    test('handles multiple style changes in single call', async () => {
       const obj = { id: 123 };
-      success('Processing %s: %j at %d%%', 'task', obj, 50);
+      await success('Processing %s: %j at %d%%', 'task', obj, 50);
       expect(mockStderr).toHaveBeenCalledWith(
         'Processing task: {"id":123} at 50%\n',
       );
@@ -119,81 +119,81 @@ describe('logging', () => {
   });
 
   describe('styled output', () => {
-    test('success() adds green color to output with both styles', () => {
+    test('success() adds green color to output with both styles', async () => {
       // String style
-      success('operation completed');
+      await success('operation completed');
       expect(mockStderr).toHaveBeenCalledWith('operation completed\n');
     });
 
-    test('highlight() adds bold formatting to output with both styles', () => {
+    test('highlight() adds bold formatting to output with both styles', async () => {
       // String style
-      highlight('important message');
+      await highlight('important message');
       expect(mockStderr).toHaveBeenCalledWith('important message\n');
     });
 
-    test('success handles format strings with styling', () => {
-      success('completed task %d of %d', 1, 3);
+    test('success handles format strings with styling', async () => {
+      await success('completed task %d of %d', 1, 3);
       expect(mockStderr).toHaveBeenCalledWith('completed task 1 of 3\n');
 
       // Remove the code from the test since it's an implementation detail
-      success('completed task %d of %d', 2, 3);
+      await success('completed task %d of %d', 2, 3);
       expect(mockStderr).toHaveBeenCalledWith('completed task 2 of 3\n');
     });
 
-    test('highlight handles complex objects with styling', () => {
+    test('highlight handles complex objects with styling', async () => {
       const complexObj = { status: 'active', count: 42 };
-      highlight('Status: %j', complexObj);
+      await highlight('Status: %j', complexObj);
       expect(mockStderr).toHaveBeenCalledWith('Status: {"status":"active","count":42}\n');
     });
   });
 
   describe('edge cases', () => {
-    test('handles null and undefined arguments with both styles', () => {
+    test('handles null and undefined arguments with both styles', async () => {
       // String style
-      info('Values: %s, %s', null, undefined);
+      await info('Values: %s, %s', null, undefined);
       expect(mockStderr).toHaveBeenCalledWith('Values: null, undefined\n');
     });
 
-    test('handles circular references in objects with both styles', () => {
+    test('handles circular references in objects with both styles', async () => {
       const obj: any = { name: 'test' };
       obj.self = obj;
 
       // String style
-      info('Object: %j', obj);
+      await info('Object: %j', obj);
       expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('[Circular'));
     });
   });
 
   describe('message codes', () => {
-    test('validates message codes correctly', () => {
+    test('validates message codes correctly', async () => {
       // Valid codes
-      expect(() => error({ message: 'test', code: 'CDK_TOOLKIT_E0001' })).not.toThrow();
-      expect(() => warning({ message: 'test', code: 'CDK_ASSETS_W4999' })).not.toThrow();
-      expect(() => info({ message: 'test', code: 'CDK_SDK_I0000' })).not.toThrow();
+      expect(async () => await error({ message: 'test', code: 'CDK_TOOLKIT_E0001' })).not.toThrow();
+      expect(async () => await warning({ message: 'test', code: 'CDK_ASSETS_W4999' })).not.toThrow();
+      expect(async () => await info({ message: 'test', code: 'CDK_SDK_I0000' })).not.toThrow();
     });
 
-    test('uses default codes when none provided', () => {
-      error('test error');
+    test('uses default codes when none provided', async () => {
+      await error('test error');
       expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('test error'));
       // Would need to modify the code to expose the actual message code for verification
     });
   });
 
   describe('CI mode behavior', () => {
-    test('correctly switches between stdout and stderr based on CI mode', () => {
+    test('correctly switches between stdout and stderr based on CI mode', async () => {
       ioHost.isCI = true;
-      warning('warning in CI');
-      success('success in CI');
-      error('error in CI');
+      await warning('warning in CI');
+      await success('success in CI');
+      await error('error in CI');
 
       expect(mockStdout).toHaveBeenCalledWith('warning in CI\n');
       expect(mockStdout).toHaveBeenCalledWith('success in CI\n');
       expect(mockStderr).toHaveBeenCalledWith('error in CI\n');
 
       ioHost.isCI = false;
-      warning('warning not in CI');
-      success('success not in CI');
-      error('error not in CI');
+      await warning('warning not in CI');
+      await success('success not in CI');
+      await error('error not in CI');
 
       expect(mockStderr).toHaveBeenCalledWith('warning not in CI\n');
       expect(mockStderr).toHaveBeenCalledWith('success not in CI\n');


### PR DESCRIPTION
Pulling apart from #631. These functions are legacy exports prior to `IoHost` being implemented, and everything `IoHost` related is `async`. To be backwards compatible, these functions do not wait for `IoHost` and its mostly okay because `CliIoHost` does not currently actually utilize any `awaits` despite being `async`. #631 introduces actual async functions to the `CliIoHost`, which break these tests. 

This is what these legacy exports end up calling, which is why they need to be `awaited`:

```ts
void helper.notify({
      data: undefined,
      time: new Date(),
      level,
      ...input,
    });
```



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
