### PR TITLE
fix(toolkit-lib): "refactor" never releases reader lock or cleans up temp dir

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1062,8 +1062,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     this.requireUnstableFeature('refactor');
 
     const ioHelper = asIoHelper(this.ioHost, 'refactor');
-    const assembly = await assemblyFromSource(ioHelper, cx);
-    return this._refactor(assembly, ioHelper, options);
+    await using assembly = await assemblyFromSource(ioHelper, cx);
+    return await this._refactor(assembly, ioHelper, options);
   }
 
   private async _refactor(assembly: StackAssembly, ioHelper: IoHelper, options: RefactorOptions = {}): Promise<void> {


### PR DESCRIPTION
The refactor operation was not using `await using` on the assembly that it got from `assemblyFromSource`, causing it to never be cleaned up.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
