### PR TITLE
chore(cli): remove unused `registerIoHost`

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -135,7 +135,6 @@ export class CliIoHost implements IIoHost {
    */
   public noticesDestination: TargetStream = 'stderr';
 
-  private _internalIoHost?: IIoHost;
   private _progress: StackActivityProgress = StackActivityProgress.BAR;
 
   // Stack Activity Printer
@@ -153,15 +152,6 @@ export class CliIoHost implements IIoHost {
     this.requireDeployApproval = props.requireDeployApproval ?? RequireApproval.BROADENING;
 
     this.stackProgress = props.stackProgress ?? StackActivityProgress.BAR;
-  }
-
-  /**
-   * Returns the singleton instance
-   */
-  public registerIoHost(ioHost: IIoHost) {
-    if (ioHost !== this) {
-      this._internalIoHost = ioHost;
-    }
   }
 
   /**
@@ -245,10 +235,6 @@ export class CliIoHost implements IIoHost {
    * The caller waits until the notification completes.
    */
   public async notify(msg: IoMessage<unknown>): Promise<void> {
-    if (this._internalIoHost) {
-      return this._internalIoHost.notify(msg);
-    }
-
     if (this.isStackActivity(msg)) {
       if (!this.activityPrinter) {
         this.activityPrinter = this.makeActivityPrinter();
@@ -344,11 +330,6 @@ export class CliIoHost implements IIoHost {
    * default response from the input message will be used.
    */
   public async requestResponse<DataType, ResponseType>(msg: IoRequest<DataType, ResponseType>): Promise<ResponseType> {
-    // First call out to a registered instance if we have one
-    if (this._internalIoHost) {
-      return this._internalIoHost.requestResponse(msg);
-    }
-
     // If the request cannot be prompted for by the CliIoHost, we just accept the default
     if (!isPromptableRequest(msg)) {
       await this.notify(msg);


### PR DESCRIPTION
This was used during the transition period but is now unused. Remove it!

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
