### PR TITLE
refactor(cli): use IoHost in `cdk init`

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1168,6 +1168,7 @@ export class CdkToolkit {
           fromScan: options.fromScan,
           sdkProvider: this.props.sdkProvider,
           environment: environment,
+          ioHelper: this.ioHost.asIoHelper(),
         });
         templateToDelete = generateTemplateOutput.templateId;
       } else if (scanType == TemplateSourceOptions.PATH) {
@@ -1210,7 +1211,7 @@ export class CdkToolkit {
       }
       const stack = generateStack(generateTemplateOutput.migrateJson.templateBody, options.stackName, language);
       await this.ioHost.asIoHelper().defaults.info(chalk.green(' ⏳  Generating CDK app for %s...'), chalk.blue(options.stackName));
-      await generateCdkApp(options.stackName, stack!, language, options.outputPath, options.compress);
+      await generateCdkApp(this.ioHost.asIoHelper(), options.stackName, stack!, language, options.outputPath, options.compress);
       if (generateTemplateOutput) {
         writeMigrateJsonFile(options.outputPath, options.stackName, generateTemplateOutput.migrateJson);
       }

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -474,9 +474,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         ioHost.currentAction = 'init';
         const language = configuration.settings.get(['language']);
         if (args.list) {
-          return printAvailableTemplates(language);
+          return printAvailableTemplates(ioHelper, language);
         } else {
           return cliInit({
+            ioHelper,
             type: args.TEMPLATE,
             language,
             canUseNetwork: undefined,

--- a/packages/aws-cdk/lib/commands/init/os.ts
+++ b/packages/aws-cdk/lib/commands/init/os.ts
@@ -1,7 +1,7 @@
 import * as child_process from 'child_process';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
-import { debug } from '../../logging';
+import type { IoHelper } from '../../api-private';
 
 /**
  * OS helpers
@@ -9,9 +9,9 @@ import { debug } from '../../logging';
  * Shell function which both prints to stdout and collects the output into a
  * string.
  */
-export async function shell(command: string[]): Promise<string> {
+export async function shell(ioHelper: IoHelper, command: string[]): Promise<string> {
   const commandLine = renderCommandLine(command);
-  debug(`Executing ${chalk.blue(commandLine)}`);
+  await ioHelper.defaults.debug(`Executing ${chalk.blue(commandLine)}`);
   const child = child_process.spawn(command[0], renderArguments(command.slice(1)), {
     // Need this for Windows where we want .cmd and .bat to be found as well.
     shell: true,

--- a/packages/aws-cdk/lib/commands/migrate.ts
+++ b/packages/aws-cdk/lib/commands/migrate.ts
@@ -24,6 +24,7 @@ import { info } from '../../lib/logging';
 import type { ICloudFormationClient, SdkProvider } from '../api/aws-auth';
 import { CloudFormationStack } from '../api/cloudformation';
 import { Mode } from '../api/plugin';
+import type { IoHelper } from '../api-private';
 import { zipDirectory } from '../util';
 const camelCase = require('camelcase');
 const decamelize = require('decamelize');
@@ -39,6 +40,7 @@ const MIGRATE_SUPPORTED_LANGUAGES: readonly string[] = cdk_from_cfn.supported_la
  * @param outputPath - The path at which to generate the CDK app
  */
 export async function generateCdkApp(
+  ioHelper: IoHelper,
   stackName: string,
   stack: string,
   language: string,
@@ -53,6 +55,7 @@ export async function generateCdkApp(
     fs.mkdirSync(resolvedOutputPath, { recursive: true });
     const generateOnly = compress;
     await cliInit({
+      ioHelper,
       type: 'app',
       language,
       canUseNetwork: true,
@@ -933,6 +936,7 @@ export interface GenerateTemplateOptions {
   fromScan?: FromScan;
   sdkProvider: SdkProvider;
   environment: Environment;
+  ioHelper: IoHelper;
 }
 
 /**

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -3,10 +3,15 @@ import * as path from 'path';
 import * as cxapi from '@aws-cdk/cx-api';
 import * as fs from 'fs-extra';
 import { availableInitLanguages, availableInitTemplates, cliInit, currentlyRecommendedAwsCdkLibFlags, expandPlaceholders, printAvailableTemplates } from '../../lib/commands/init';
+import { TestIoHost } from '../_helpers/io-host';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('init');
 
 describe('constructs version', () => {
   cliTest('create a TypeScript library project', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'lib',
       language: 'typescript',
       workDir,
@@ -19,6 +24,7 @@ describe('constructs version', () => {
 
   cliTest('can override requested version with environment variable', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'lib',
       language: 'typescript',
       workDir,
@@ -32,6 +38,7 @@ describe('constructs version', () => {
 
   cliTest('asking for a nonexistent template fails', async (workDir) => {
     await expect(cliInit({
+      ioHelper,
       type: 'banana',
       language: 'typescript',
       workDir,
@@ -40,6 +47,7 @@ describe('constructs version', () => {
 
   cliTest('asking for a template but no language prints and throws', async (workDir) => {
     await expect(cliInit({
+      ioHelper,
       type: 'app',
       workDir,
     })).rejects.toThrow(/No language/);
@@ -47,6 +55,7 @@ describe('constructs version', () => {
 
   cliTest('create a TypeScript app project', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'typescript',
       workDir,
@@ -59,6 +68,7 @@ describe('constructs version', () => {
 
   cliTest('create a JavaScript app project', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'javascript',
       workDir,
@@ -72,6 +82,7 @@ describe('constructs version', () => {
 
   cliTest('create a Java app project', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'java',
       canUseNetwork: false,
@@ -94,6 +105,7 @@ describe('constructs version', () => {
 
   cliTest('create a .NET app project in csharp', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'csharp',
       canUseNetwork: false,
@@ -116,6 +128,7 @@ describe('constructs version', () => {
 
   cliTest('create a .NET app project in fsharp', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'fsharp',
       canUseNetwork: false,
@@ -138,6 +151,7 @@ describe('constructs version', () => {
 
   cliTestWithDirSpaces('csharp app with spaces', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'csharp',
       canUseNetwork: false,
@@ -156,6 +170,7 @@ describe('constructs version', () => {
 
   cliTestWithDirSpaces('fsharp app with spaces', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'fsharp',
       canUseNetwork: false,
@@ -174,6 +189,7 @@ describe('constructs version', () => {
 
   cliTest('create a Python app project', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'python',
       canUseNetwork: false,
@@ -196,6 +212,7 @@ describe('constructs version', () => {
 
   cliTest('--generate-only should skip git init', async (workDir) => {
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'javascript',
       canUseNetwork: false,
@@ -213,6 +230,7 @@ describe('constructs version', () => {
     fs.mkdirSync(path.join(workDir, '.git'));
 
     await cliInit({
+      ioHelper,
       type: 'app',
       language: 'typescript',
       canUseNetwork: false,
@@ -227,6 +245,7 @@ describe('constructs version', () => {
   cliTest('CLI uses recommended feature flags from data file to initialize context', async (workDir) => {
     const recommendedFlagsFile = path.join(__dirname, '..', '..', 'lib', 'init-templates', '.recommended-feature-flags.json');
     await withReplacedFile(recommendedFlagsFile, JSON.stringify({ banana: 'yellow' }), () => cliInit({
+      ioHelper,
       type: 'app',
       language: 'typescript',
       canUseNetwork: false,
@@ -241,6 +260,7 @@ describe('constructs version', () => {
   cliTest('CLI uses init versions file to initialize template', async (workDir) => {
     const recommendedFlagsFile = path.join(__dirname, '..', '..', 'lib', 'init-templates', '.init-version.json');
     await withReplacedFile(recommendedFlagsFile, JSON.stringify({ 'aws-cdk-lib': '100.1.1', 'constructs': '^200.2.2' }), () => cliInit({
+      ioHelper,
       type: 'app',
       language: 'typescript',
       canUseNetwork: false,
@@ -258,6 +278,7 @@ describe('constructs version', () => {
       for (const lang of templ.languages) {
         await withTempDir(async tmpDir => {
           await cliInit({
+            ioHelper,
             type: templ.name,
             language: lang,
             canUseNetwork: false,
@@ -301,7 +322,7 @@ test('check available init languages', async () => {
 });
 
 test('exercise printing available templates', async () => {
-  await printAvailableTemplates();
+  await printAvailableTemplates(ioHelper);
 });
 
 describe('expandPlaceholders', () => {

--- a/packages/aws-cdk/test/commands/migrate.test.ts
+++ b/packages/aws-cdk/test/commands/migrate.test.ts
@@ -29,11 +29,14 @@ import {
   TemplateSourceOptions,
   FromScan,
 } from '../../lib/commands/migrate';
+import { TestIoHost } from '../_helpers/io-host';
 import { MockSdkProvider, mockCloudFormationClient, restoreSdkMocksToDefault } from '../_helpers/mock-sdk';
 
 jest.setTimeout(120_000);
 
 const exec = promisify(_exec);
+
+const ioHelper = new TestIoHost().asHelper('migrate');
 
 describe('Migrate Function Tests', () => {
   let sdkProvider: MockSdkProvider;
@@ -205,7 +208,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generateCdkApp generates the expected cdk app when called for typescript', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodTypeScript', 'typescript');
-    await generateCdkApp('GoodTypeScript', stack, 'typescript', workDir);
+    await generateCdkApp(ioHelper, 'GoodTypeScript', stack, 'typescript', workDir);
 
     // Packages exist in the correct spot
     expect(fs.pathExistsSync(path.join(workDir, 'GoodTypeScript', 'package.json'))).toBeTruthy();
@@ -234,7 +237,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generateCdkApp adds cdk-migrate key in context', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodTypeScript', 'typescript');
-    await generateCdkApp('GoodTypeScript', stack, 'typescript', workDir);
+    await generateCdkApp(ioHelper, 'GoodTypeScript', stack, 'typescript', workDir);
 
     // cdk.json exist in the correct spot
     expect(fs.pathExistsSync(path.join(workDir, 'GoodTypeScript', 'cdk.json'))).toBeTruthy();
@@ -246,7 +249,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generateCdkApp generates the expected cdk app when called for python', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodPython', 'python');
-    await generateCdkApp('GoodPython', stack, 'python', workDir);
+    await generateCdkApp(ioHelper, 'GoodPython', stack, 'python', workDir);
 
     // Packages exist in the correct spot
     expect(fs.pathExistsSync(path.join(workDir, 'GoodPython', 'requirements.txt'))).toBeTruthy();
@@ -273,7 +276,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generateCdkApp generates the expected cdk app when called for java', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodJava', 'java');
-    await generateCdkApp('GoodJava', stack, 'java', workDir);
+    await generateCdkApp(ioHelper, 'GoodJava', stack, 'java', workDir);
 
     // Packages exist in the correct spot
     expect(fs.pathExistsSync(path.join(workDir, 'GoodJava', 'pom.xml'))).toBeTruthy();
@@ -305,7 +308,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generateCdkApp generates the expected cdk app when called for csharp', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodCSharp', 'csharp');
-    await generateCdkApp('GoodCSharp', stack, 'csharp', workDir);
+    await generateCdkApp(ioHelper, 'GoodCSharp', stack, 'csharp', workDir);
 
     // Packages exist in the correct spot
     expect(fs.pathExistsSync(path.join(workDir, 'GoodCSharp', 'src', 'GoodCSharp.sln'))).toBeTruthy();
@@ -333,7 +336,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generatedCdkApp generates the expected cdk app when called for go', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodGo', 'go');
-    await generateCdkApp('GoodGo', stack, 'go', workDir);
+    await generateCdkApp(ioHelper, 'GoodGo', stack, 'go', workDir);
 
     expect(fs.pathExists(path.join(workDir, 's3.go'))).toBeTruthy();
     const app = fs.readFileSync(path.join(workDir, 'GoodGo', 'good_go.go'), 'utf8').split('\n');
@@ -351,7 +354,7 @@ describe('Migrate Function Tests', () => {
 
   cliTest('generatedCdkApp generates a zip file when --compress is used', async (workDir) => {
     const stack = generateStack(validTemplate, 'GoodTypeScript', 'typescript');
-    await generateCdkApp('GoodTypeScript', stack, 'typescript', workDir, true);
+    await generateCdkApp(ioHelper, 'GoodTypeScript', stack, 'typescript', workDir, true);
 
     // Packages not in outDir
     expect(fs.pathExistsSync(path.join(workDir, 'GoodTypeScript', 'package.json'))).toBeFalsy();
@@ -487,6 +490,7 @@ describe('generateTemplate', () => {
 
   test('generateTemplate successfully generates template with a new scan', async () => {
     const opts: GenerateTemplateOptions = {
+      ioHelper,
       stackName: stackName,
       filters: [],
       fromScan: FromScan.NEW,
@@ -511,6 +515,7 @@ describe('generateTemplate', () => {
       });
 
     const opts = {
+      ioHelper,
       stackName: stackName,
       filters: [],
       newScan: true,
@@ -528,6 +533,7 @@ describe('generateTemplate', () => {
       });
 
     const opts: GenerateTemplateOptions = {
+      ioHelper,
       stackName: stackName,
       filters: [],
       fromScan: FromScan.MOST_RECENT,
@@ -541,6 +547,7 @@ describe('generateTemplate', () => {
 
   test('generateTemplate throws an error when an invalid key is passed in the filters', async () => {
     const opts: GenerateTemplateOptions = {
+      ioHelper,
       stackName: stackName,
       filters: ['invalid-key=invalid-value'],
       fromScan: FromScan.MOST_RECENT,
@@ -560,6 +567,7 @@ describe('generateTemplate', () => {
       });
 
     const opts: GenerateTemplateOptions = {
+      ioHelper,
       stackName: stackName,
       sdkProvider: sdkProvider,
       environment: environment,
@@ -571,6 +579,7 @@ describe('generateTemplate', () => {
 
   test('generateTemplate successfully generates templates with valid filter options', async () => {
     const opts: GenerateTemplateOptions = {
+      ioHelper,
       stackName: stackName,
       filters: ['type=AWS::S3::Bucket,identifier={"my-key":"my-bucket"}', 'type=AWS::EC2::Instance'],
       sdkProvider: sdkProvider,


### PR DESCRIPTION
Replace old indirect logging calls with direct IoHost calls.
Includes some changes for `cdk migrate` since that calls init internally.

Pulled out from https://github.com/aws/aws-cdk-cli/pull/695 for review-ability.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
