### PR TITLE
refactor(cli): use IoHost for context, docs and doctor commands

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -218,6 +218,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
       case 'context':
         ioHost.currentAction = 'context';
         return context({
+          ioHelper,
           context: configuration.context,
           clear: argv.clear,
           json: argv.json,
@@ -228,11 +229,16 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
       case 'docs':
       case 'doc':
         ioHost.currentAction = 'docs';
-        return docs({ browser: configuration.settings.get(['browser']) });
+        return docs({
+          ioHelper,
+          browser: configuration.settings.get(['browser']),
+        });
 
       case 'doctor':
         ioHost.currentAction = 'doctor';
-        return doctor();
+        return doctor({
+          ioHelper,
+        });
 
       case 'ls':
       case 'list':

--- a/packages/aws-cdk/lib/commands/docs.ts
+++ b/packages/aws-cdk/lib/commands/docs.ts
@@ -1,6 +1,7 @@
 import * as childProcess from 'child_process';
+import { promisify } from 'node:util';
 import * as chalk from 'chalk';
-import { debug, info, warning } from '../../lib/logging';
+import type { IoHelper } from '../api-private';
 
 export const command = 'docs';
 export const describe = 'Opens the reference documentation in a browser';
@@ -13,27 +14,35 @@ export interface DocsOptions {
   /**
    * The command to use to open the browser
    */
-  browser: string;
+  readonly browser: string;
+
+  /**
+   * IoHelper for messaging
+   */
+  readonly ioHelper: IoHelper;
 }
 
 export async function docs(options: DocsOptions): Promise<number> {
+  const ioHelper = options.ioHelper;
   const url = 'https://docs.aws.amazon.com/cdk/api/v2/';
-  info(chalk.green(url));
+  await ioHelper.defaults.info(chalk.green(url));
   const browserCommand = (options.browser).replace(/%u/g, url);
-  debug(`Opening documentation ${chalk.green(browserCommand)}`);
-  return new Promise<number>((resolve, _reject) => {
-    childProcess.exec(browserCommand, (err, stdout, stderr) => {
-      if (err) {
-        debug(`An error occurred when trying to open a browser: ${err.stack || err.message}`);
-        return resolve(0);
-      }
-      if (stdout) {
-        debug(stdout);
-      }
-      if (stderr) {
-        warning(stderr);
-      }
-      resolve(0);
-    });
-  });
+  await ioHelper.defaults.debug(`Opening documentation ${chalk.green(browserCommand)}`);
+
+  const exec = promisify(childProcess.exec);
+
+  try {
+    const { stdout, stderr } = await exec(browserCommand);
+    if (stdout) {
+      await ioHelper.defaults.debug(stdout);
+    }
+    if (stderr) {
+      await ioHelper.defaults.warn(stderr);
+    }
+  } catch (err: unknown) {
+    const e = err as childProcess.ExecException;
+    await ioHelper.defaults.debug(`An error occurred when trying to open a browser: ${e.stack || e.message}`);
+  }
+
+  return 0;
 }

--- a/packages/aws-cdk/test/cli/cli-commands.test.ts
+++ b/packages/aws-cdk/test/cli/cli-commands.test.ts
@@ -1,14 +1,7 @@
 import { exec } from '../../lib/cli/cli';
-import * as logging from '../../lib/logging';
+import { CliIoHost } from '../../lib/cli/io-host';
 
-// Mock the dependencies
-jest.mock('../../lib/logging', () => ({
-  info: jest.fn(),
-  debug: jest.fn(),
-  error: jest.fn(),
-  print: jest.fn(),
-  result: jest.fn(),
-}));
+const notifySpy = jest.spyOn(CliIoHost.prototype, 'notify');
 
 jest.mock('@aws-cdk/cx-api');
 jest.mock('../../lib/cli/platform-warnings', () => ({
@@ -27,21 +20,21 @@ jest.mock('../../lib/api/notices', () => ({
 describe('doctor', () => {
   test('prints CDK version', async () => {
     await exec(['doctor']);
-    expect(logging.info).toHaveBeenCalledWith(expect.stringContaining('CDK Version:'));
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({ level: 'info', message: expect.stringContaining('CDK Version:') }));
   });
 });
 
 describe('docs', () => {
   test('prints docs url version', async () => {
     await exec(['docs', '-b "echo %u"']);
-    expect(logging.info).toHaveBeenCalledWith(expect.stringContaining('https://docs.aws.amazon.com/cdk/api/v2/'));
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({ level: 'info', message: expect.stringContaining('https://docs.aws.amazon.com/cdk/api/v2/') }));
   });
 });
 
 describe('context', () => {
   test('prints note about empty context', async () => {
     await exec(['context']);
-    expect(logging.info).toHaveBeenCalledWith(expect.stringContaining('This CDK application does not have any saved context values yet.'));
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({ level: 'info', message: expect.stringContaining('This CDK application does not have any saved context values yet.') }));
   });
 });
 

--- a/packages/aws-cdk/test/commands/cdk-docs.test.ts
+++ b/packages/aws-cdk/test/commands/cdk-docs.test.ts
@@ -1,9 +1,11 @@
 import * as child_process from 'child_process';
 import { mocked } from 'jest-mock';
 import { docs } from '../../lib/commands/docs';
+import { TestIoHost } from '../_helpers/io-host';
 
-// eslint-disable-next-line no-console
-console.log = jest.fn();
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('docs');
+
 jest.mock('child_process');
 
 describe('`cdk docs`', () => {
@@ -11,7 +13,10 @@ describe('`cdk docs`', () => {
     const mockChildProcessExec: any = (_: string, cb: (err?: Error, stdout?: string, stderr?: string) => void) => cb();
     mocked(child_process.exec).mockImplementation(mockChildProcessExec);
 
-    const result = await docs({ browser: 'echo %u' });
+    const result = await docs({
+      ioHelper,
+      browser: 'echo %u',
+    });
     expect(result).toBe(0);
   });
 
@@ -19,7 +24,10 @@ describe('`cdk docs`', () => {
     const mockChildProcessExec: any = (_: string, cb: (err: Error, stdout?: string, stderr?: string) => void) => cb(new Error('TEST'));
     mocked(child_process.exec).mockImplementation(mockChildProcessExec);
 
-    const result = await docs({ browser: 'echo %u' });
+    const result = await docs({
+      ioHelper,
+      browser: 'echo %u',
+    });
     expect(result).toBe(0);
   });
 });

--- a/packages/aws-cdk/test/commands/cdk-doctor.test.ts
+++ b/packages/aws-cdk/test/commands/cdk-doctor.test.ts
@@ -1,11 +1,12 @@
 import { doctor } from '../../lib/commands/doctor';
+import { TestIoHost } from '../_helpers/io-host';
 
-// eslint-disable-next-line no-console
-console.log = jest.fn();
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('doctor');
 
 describe('`cdk doctor`', () => {
   test('exits with 0 when everything is OK', async () => {
-    const result = await doctor();
+    const result = await doctor({ ioHelper });
     expect(result).toBe(0);
   });
 });

--- a/packages/aws-cdk/test/commands/context-command.test.ts
+++ b/packages/aws-cdk/test/commands/context-command.test.ts
@@ -3,9 +3,13 @@ import { contextHandler } from '../../lib/commands/context';
 import { Settings } from '../../lib/api/settings';
 import { Context } from '../../lib/api/context';
 import { Configuration } from '../../lib/cli/user-configuration';
+import { TestIoHost } from '../_helpers/io-host';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('context');
 
 describe('context --list', () => {
-  test('runs', async() => {
+  test('runs', async () => {
     // GIVEN
     const configuration = new Configuration();
     configuration.context.set('foo', 'bar');
@@ -16,6 +20,7 @@ describe('context --list', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
     });
   });
@@ -35,6 +40,7 @@ describe('context --reset', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'foo',
     });
@@ -58,6 +64,7 @@ describe('context --reset', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: '1',
     });
@@ -83,6 +90,7 @@ describe('context --reset', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'match-*',
     });
@@ -106,6 +114,7 @@ describe('context --reset', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'fo*',
     });
@@ -128,6 +137,7 @@ describe('context --reset', () => {
 
     // When
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'match-*',
     }));
@@ -150,6 +160,7 @@ describe('context --reset', () => {
 
     // THEN
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'baz',
     })).rejects.toThrow(/No context value matching key/);
@@ -166,6 +177,7 @@ describe('context --reset', () => {
 
     // THEN
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'baz',
       force: true,
@@ -183,6 +195,7 @@ describe('context --reset', () => {
 
     // THEN
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: '2',
     })).rejects.toThrow(/No context key with number/);
@@ -202,6 +215,7 @@ describe('context --reset', () => {
 
     // THEN
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'foo',
     })).rejects.toThrow(/Cannot reset readonly context value with key/);
@@ -225,6 +239,7 @@ describe('context --reset', () => {
 
     // THEN
     await expect(contextHandler({
+      ioHelper,
       context: configuration.context,
       reset: 'match-*',
     })).rejects.toThrow(/None of the matched context values could be reset/);
@@ -245,6 +260,7 @@ describe('context --clear', () => {
 
     // WHEN
     await contextHandler({
+      ioHelper,
       context: configuration.context,
       clear: true,
     });


### PR DESCRIPTION
Replace old indirect logging calls with direct IoHost calls.

Pulled out from https://github.com/aws/aws-cdk-cli/pull/695 for review-ability.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
