### PR TITLE
refactor(cli): use IoHost in version and platform-warnings

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -62,6 +62,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     currentAction: cmd,
     stackProgress: argv.progress,
   }, true);
+  const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
 
   // Debug should always imply tracing
   if (argv.debug || argv.verbose > 2) {
@@ -72,7 +73,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   }
 
   try {
-    await checkForPlatformWarnings();
+    await checkForPlatformWarnings(ioHelper);
   } catch (e) {
     await ioHost.defaults.debug(`Error while checking for platform warnings: ${e}`);
   }
@@ -87,8 +88,6 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     },
   });
   await configuration.load();
-
-  const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
 
   // Always create and use ProxyAgent to support configuration via env vars
   const proxyAgent = await new ProxyAgentProvider(ioHelper).create({
@@ -165,7 +164,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     await outDirLock?.release();
 
     // Do PSAs here
-    await version.displayVersionMessage();
+    await version.displayVersionMessage(ioHelper);
 
     await refreshNotices;
     if (cmd === 'notices') {

--- a/packages/aws-cdk/lib/cli/platform-warnings.ts
+++ b/packages/aws-cdk/lib/cli/platform-warnings.ts
@@ -1,10 +1,10 @@
 import * as os from 'os';
 import * as fs from 'fs-extra';
-import * as logging from '../logging';
+import type { IoHelper } from '../api-private';
 
-export async function checkForPlatformWarnings() {
+export async function checkForPlatformWarnings(ioHelper: IoHelper) {
   if (await hasDockerCopyBug()) {
-    logging.warning('`cdk synth` may hang in Docker on Linux 5.6-5.10. See https://github.com/aws/aws-cdk/issues/21379 for workarounds.');
+    await ioHelper.defaults.warn('`cdk synth` may hang in Docker on Linux 5.6-5.10. See https://github.com/aws/aws-cdk/issues/21379 for workarounds.');
   }
 }
 

--- a/packages/aws-cdk/lib/cli/version.ts
+++ b/packages/aws-cdk/lib/cli/version.ts
@@ -4,9 +4,9 @@ import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
-import { debug, info } from '../logging';
 import { cdkCacheDir } from '../util';
 import { cliRootDir } from './root-dir';
+import type { IoHelper } from '../api-private';
 import { formatAsBanner } from './util/console-formatters';
 import { execNpmView } from './util/npm';
 
@@ -115,16 +115,22 @@ function getMajorVersionUpgradeMessage(currentVersion: string): string | void {
   }
 }
 
-export async function displayVersionMessage(currentVersion = versionNumber(), versionCheckCache?: VersionCheckTTL): Promise<void> {
+export async function displayVersionMessage(
+  ioHelper: IoHelper,
+  currentVersion = versionNumber(),
+  versionCheckCache?: VersionCheckTTL,
+): Promise<void> {
   if (!process.stdout.isTTY || process.env.CDK_DISABLE_VERSION_CHECK) {
     return;
   }
 
   try {
     const versionMessages = await getVersionMessages(currentVersion, versionCheckCache ?? new VersionCheckTTL());
-    formatAsBanner(versionMessages).forEach(e => info(e));
+    for (const e of formatAsBanner(versionMessages)) {
+      await ioHelper.defaults.info(e);
+    }
   } catch (err: any) {
-    debug(`Could not run version check - ${err.message}`);
+    await ioHelper.defaults.debug(`Could not run version check - ${err.message}`);
   }
 }
 /* c8 ignore stop */

--- a/packages/aws-cdk/lib/commands/context.ts
+++ b/packages/aws-cdk/lib/commands/context.ts
@@ -71,7 +71,7 @@ export async function contextHandler(options: ContextOptions): Promise<number> {
       await listContext(ioHelper, options.context);
     }
   }
-  await version.displayVersionMessage();
+  await version.displayVersionMessage(options.ioHelper);
 
   return 0;
 }

--- a/packages/aws-cdk/lib/commands/doctor.ts
+++ b/packages/aws-cdk/lib/commands/doctor.ts
@@ -11,7 +11,7 @@ export async function doctor({ ioHelper }: { ioHelper: IoHelper }): Promise<numb
       exitStatus = -1;
     }
   }
-  await version.displayVersionMessage();
+  await version.displayVersionMessage(ioHelper);
   return exitStatus;
 }
 

--- a/packages/aws-cdk/test/cli/version.test.ts
+++ b/packages/aws-cdk/test/cli/version.test.ts
@@ -7,7 +7,7 @@ import { setTimeout as _setTimeout } from 'timers';
 import { promisify } from 'util';
 import * as npm from '../../lib/cli/util/npm';
 import { displayVersionMessage, getVersionMessages, isDeveloperBuild, VersionCheckTTL } from '../../lib/cli/version';
-import * as logging from '../../lib/logging';
+import { TestIoHost } from '../_helpers/io-host';
 
 jest.setTimeout(10_000);
 
@@ -16,6 +16,9 @@ const setTimeout = promisify(_setTimeout);
 function tmpfile(): string {
   return `/tmp/version-${Math.floor(Math.random() * 10000)}`;
 }
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper();
 
 beforeEach(() => {
   process.chdir(os.tmpdir()); // Need a chdir because in the workspace 'npm view' will take a long time
@@ -70,9 +73,8 @@ test('No Version specified for storage in the TTL file', async () => {
 test('Skip version check if environment variable is set', async () => {
   sinon.stub(process, 'stdout').value({ ...process.stdout, isTTY: true });
   sinon.stub(process, 'env').value({ ...process.env, CDK_DISABLE_VERSION_CHECK: '1' });
-  const printStub = sinon.stub(logging, 'info');
-  await displayVersionMessage();
-  expect(printStub.called).toEqual(false);
+  await displayVersionMessage(ioHelper);
+  expect(ioHost.notifySpy).not.toHaveBeenCalled();
 });
 
 describe('version message', () => {


### PR DESCRIPTION
Replace old indirect logging calls with direct IoHost calls.

Pulled out from https://github.com/aws/aws-cdk-cli/pull/695 for review-ability.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
