### PR TITLE
refactor(cli): split version functions into those that display and those that do not

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -30,7 +30,7 @@ import { getMigrateScanType } from '../commands/migrate';
 import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
 import { ProxyAgentProvider } from './proxy-agent';
-import { isDeveloperBuildVersion, version, versionNumber } from './version';
+import { isDeveloperBuildVersion, versionWithBuild, versionNumber } from './version';
 
 if (!process.stdout.isTTY) {
   // Disable chalk color highlighting
@@ -79,7 +79,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     await ioHost.defaults.debug(`Error while checking for platform warnings: ${e}`);
   }
 
-  await ioHost.defaults.debug('CDK Toolkit CLI version:', version());
+  await ioHost.defaults.debug('CDK Toolkit CLI version:', versionWithBuild());
   await ioHost.defaults.debug('Command line arguments:', argv);
 
   const configuration = await Configuration.fromArgsAndFiles(ioHelper,
@@ -500,7 +500,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         });
       case 'version':
         ioHost.currentAction = 'version';
-        return ioHost.defaults.result(version());
+        return ioHost.defaults.result(versionWithBuild());
 
       default:
         throw new ToolkitError('Unknown command: ' + command);

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -12,7 +12,6 @@ import { prettyPrintError } from './pretty-print-error';
 import { GLOBAL_PLUGIN_HOST } from './singleton-plugin-host';
 import type { Command } from './user-configuration';
 import { Configuration } from './user-configuration';
-import * as version from './version';
 import { asIoHelper } from '../../lib/api-private';
 import type { IReadLock } from '../api';
 import { ToolkitInfo, Notices } from '../api';
@@ -30,6 +29,8 @@ import { getMigrateScanType } from '../commands/migrate';
 import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
 import { ProxyAgentProvider } from './proxy-agent';
+import { isDeveloperBuildVersion, version, versionNumber } from './version';
+import { displayVersionMessage } from './display-version';
 
 if (!process.stdout.isTTY) {
   // Disable chalk color highlighting
@@ -78,7 +79,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     await ioHost.defaults.debug(`Error while checking for platform warnings: ${e}`);
   }
 
-  await ioHost.defaults.debug('CDK Toolkit CLI version:', version.displayVersion());
+  await ioHost.defaults.debug('CDK Toolkit CLI version:', version());
   await ioHost.defaults.debug('Command line arguments:', argv);
 
   const configuration = await Configuration.fromArgsAndFiles(ioHelper,
@@ -103,7 +104,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     context: configuration.context,
     output: configuration.settings.get(['outdir']),
     httpOptions: { agent: proxyAgent },
-    cliVersion: version.versionNumber(),
+    cliVersion: versionNumber(),
   });
   const refreshNotices = (async () => {
     // the cdk notices command has it's own refresh
@@ -164,7 +165,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     await outDirLock?.release();
 
     // Do PSAs here
-    await version.displayVersionMessage(ioHelper);
+    await displayVersionMessage(ioHelper);
 
     await refreshNotices;
     if (cmd === 'notices') {
@@ -499,7 +500,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         });
       case 'version':
         ioHost.currentAction = 'version';
-        return ioHost.defaults.result(version.displayVersion());
+        return ioHost.defaults.result(version());
 
       default:
         throw new ToolkitError('Unknown command: ' + command);
@@ -637,7 +638,7 @@ export function cli(args: string[] = process.argv.slice(2)) {
     .catch((err) => {
       // Log the stack trace if we're on a developer workstation. Otherwise this will be into a minified
       // file and the printed code line and stack trace are huge and useless.
-      prettyPrintError(err, version.isDeveloperBuild());
+      prettyPrintError(err, isDeveloperBuildVersion());
       process.exitCode = 1;
     });
 }

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -4,6 +4,7 @@ import type { ChangeSetDeployment, DeploymentMethod, DirectDeployment } from '@a
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import { CdkToolkit, AssetBuildTime } from './cdk-toolkit';
+import { displayVersionMessage } from './display-version';
 import type { IoMessageLevel } from './io-host';
 import { CliIoHost } from './io-host';
 import { parseCommandLineArguments } from './parse-command-line-arguments';
@@ -30,7 +31,6 @@ import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
 import { ProxyAgentProvider } from './proxy-agent';
 import { isDeveloperBuildVersion, version, versionNumber } from './version';
-import { displayVersionMessage } from './display-version';
 
 if (!process.stdout.isTTY) {
   // Disable chalk color highlighting

--- a/packages/aws-cdk/lib/cli/display-version.ts
+++ b/packages/aws-cdk/lib/cli/display-version.ts
@@ -1,0 +1,115 @@
+import { ToolkitError } from '@aws-cdk/toolkit-lib';
+import * as chalk from 'chalk';
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import * as semver from 'semver';
+import { IoHelper } from '../api-private';
+import { formatAsBanner } from '../legacy';
+import { cdkCacheDir, versionNumber } from '../util';
+import { execNpmView } from './util/npm';
+
+const ONE_DAY_IN_SECONDS = 1 * 24 * 60 * 60;
+
+const UPGRADE_DOCUMENTATION_LINKS: Record<number, string> = {
+  1: 'https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html',
+};
+
+export class VersionCheckTTL {
+  public static timestampFilePath(): string {
+    // Using the same path from account-cache.ts
+    return path.join(cdkCacheDir(), 'repo-version-ttl');
+  }
+
+  private readonly file: string;
+
+  // File modify times are accurate only to the second
+  private readonly ttlSecs: number;
+
+  constructor(file?: string, ttlSecs?: number) {
+    this.file = file || VersionCheckTTL.timestampFilePath();
+    try {
+      fs.mkdirsSync(path.dirname(this.file));
+      fs.accessSync(path.dirname(this.file), fs.constants.W_OK);
+    } catch {
+      throw new ToolkitError(`Directory (${path.dirname(this.file)}) is not writable.`);
+    }
+    this.ttlSecs = ttlSecs || ONE_DAY_IN_SECONDS;
+  }
+
+  public async hasExpired(): Promise<boolean> {
+    try {
+      const lastCheckTime = (await fs.stat(this.file)).mtimeMs;
+      const today = new Date().getTime();
+
+      if ((today - lastCheckTime) / 1000 > this.ttlSecs) { // convert ms to sec
+        return true;
+      }
+      return false;
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        return true;
+      } else {
+        throw err;
+      }
+    }
+  }
+
+  public async update(latestVersion?: string): Promise<void> {
+    if (!latestVersion) {
+      latestVersion = '';
+    }
+    await fs.writeFile(this.file, latestVersion);
+  }
+}
+
+// Export for unit testing only.
+// Don't use directly, use displayVersionMessage() instead.
+export async function getVersionMessages(currentVersion: string, cacheFile: VersionCheckTTL): Promise<string[]> {
+  if (!(await cacheFile.hasExpired())) {
+    return [];
+  }
+
+  const packageInfo = await execNpmView(currentVersion);
+  const latestVersion = packageInfo.latestVersion;
+  await cacheFile.update(JSON.stringify(packageInfo));
+
+  // If the latest version is the same as the current version, there is no need to display a message
+  if (semver.eq(latestVersion, currentVersion)) {
+    return [];
+  }
+
+  const versionMessage = [
+    packageInfo.deprecated ? `${chalk.red(packageInfo.deprecated as string)}` : undefined,
+    `Newer version of CDK is available [${chalk.green(latestVersion as string)}]`,
+    getMajorVersionUpgradeMessage(currentVersion),
+    'Upgrade recommended (npm install -g aws-cdk)',
+  ].filter(Boolean) as string[];
+
+  return versionMessage;
+}
+
+function getMajorVersionUpgradeMessage(currentVersion: string): string | void {
+  const currentMajorVersion = semver.major(currentVersion);
+  if (UPGRADE_DOCUMENTATION_LINKS[currentMajorVersion]) {
+    return `Information about upgrading from version ${currentMajorVersion}.x to version ${currentMajorVersion + 1}.x is available here: ${UPGRADE_DOCUMENTATION_LINKS[currentMajorVersion]}`;
+  }
+}
+
+export async function displayVersionMessage(
+  ioHelper: IoHelper,
+  currentVersion = versionNumber(),
+  versionCheckCache?: VersionCheckTTL,
+): Promise<void> {
+  if (!process.stdout.isTTY || process.env.CDK_DISABLE_VERSION_CHECK) {
+    return;
+  }
+
+  try {
+    const versionMessages = await getVersionMessages(currentVersion, versionCheckCache ?? new VersionCheckTTL());
+    for (const e of formatAsBanner(versionMessages)) {
+      await ioHelper.defaults.info(e);
+    }
+  } catch (err: any) {
+    await ioHelper.defaults.debug(`Could not run version check - ${err.message}`);
+  }
+}

--- a/packages/aws-cdk/lib/cli/display-version.ts
+++ b/packages/aws-cdk/lib/cli/display-version.ts
@@ -1,11 +1,11 @@
+import * as path from 'path';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
-import * as path from 'path';
 import * as fs from 'fs-extra';
 import * as semver from 'semver';
-import { IoHelper } from '../api-private';
-import { formatAsBanner } from '../legacy';
+import type { IoHelper } from '../api-private';
 import { cdkCacheDir, versionNumber } from '../util';
+import { formatAsBanner } from './util/console-formatters';
 import { execNpmView } from './util/npm';
 
 const ONE_DAY_IN_SECONDS = 1 * 24 * 60 * 60;

--- a/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
+++ b/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
@@ -1,6 +1,6 @@
 import { ciSystemIsStdErrSafe } from '../ci-systems';
 import { isCI } from '../io-host';
-import * as version from '../version';
+import { version } from '../version';
 
 export { isCI } from '../io-host';
 
@@ -31,7 +31,7 @@ export function yargsNegativeAlias<T extends { [x in S | L]: boolean | undefined
  * @returns the current version of the CLI
  */
 export function cliVersion(): string {
-  return version.version();
+  return version();
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
+++ b/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
@@ -31,7 +31,7 @@ export function yargsNegativeAlias<T extends { [x in S | L]: boolean | undefined
  * @returns the current version of the CLI
  */
 export function cliVersion(): string {
-  return version.displayVersion();
+  return version.version();
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
+++ b/packages/aws-cdk/lib/cli/util/yargs-helpers.ts
@@ -1,6 +1,6 @@
 import { ciSystemIsStdErrSafe } from '../ci-systems';
 import { isCI } from '../io-host';
-import { version } from '../version';
+import { versionWithBuild } from '../version';
 
 export { isCI } from '../io-host';
 
@@ -31,7 +31,7 @@ export function yargsNegativeAlias<T extends { [x in S | L]: boolean | undefined
  * @returns the current version of the CLI
  */
 export function cliVersion(): string {
-  return version();
+  return versionWithBuild();
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/version.ts
+++ b/packages/aws-cdk/lib/cli/version.ts
@@ -2,7 +2,7 @@
 import * as path from 'path';
 import { cliRootDir } from './root-dir';
 
-export function version() {
+export function versionWithBuild() {
   return `${versionNumber()} (build ${commit()})`;
 }
 

--- a/packages/aws-cdk/lib/cli/version.ts
+++ b/packages/aws-cdk/lib/cli/version.ts
@@ -1,26 +1,12 @@
 /* c8 ignore start */
 import * as path from 'path';
-import { ToolkitError } from '@aws-cdk/toolkit-lib';
-import * as chalk from 'chalk';
-import * as fs from 'fs-extra';
-import * as semver from 'semver';
-import { cdkCacheDir } from '../util';
 import { cliRootDir } from './root-dir';
-import type { IoHelper } from '../api-private';
-import { formatAsBanner } from './util/console-formatters';
-import { execNpmView } from './util/npm';
 
-const ONE_DAY_IN_SECONDS = 1 * 24 * 60 * 60;
-
-const UPGRADE_DOCUMENTATION_LINKS: Record<number, string> = {
-  1: 'https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html',
-};
-
-export function displayVersion() {
+export function version() {
   return `${versionNumber()} (build ${commit()})`;
 }
 
-export function isDeveloperBuild(): boolean {
+export function isDeveloperBuildVersion(): boolean {
   return versionNumber() === '0.0.0';
 }
 
@@ -33,104 +19,3 @@ function commit(): string {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   return require(path.join(cliRootDir(), 'build-info.json')).commit;
 }
-
-export class VersionCheckTTL {
-  public static timestampFilePath(): string {
-    // Using the same path from account-cache.ts
-    return path.join(cdkCacheDir(), 'repo-version-ttl');
-  }
-
-  private readonly file: string;
-
-  // File modify times are accurate only to the second
-  private readonly ttlSecs: number;
-
-  constructor(file?: string, ttlSecs?: number) {
-    this.file = file || VersionCheckTTL.timestampFilePath();
-    try {
-      fs.mkdirsSync(path.dirname(this.file));
-      fs.accessSync(path.dirname(this.file), fs.constants.W_OK);
-    } catch {
-      throw new ToolkitError(`Directory (${path.dirname(this.file)}) is not writable.`);
-    }
-    this.ttlSecs = ttlSecs || ONE_DAY_IN_SECONDS;
-  }
-
-  public async hasExpired(): Promise<boolean> {
-    try {
-      const lastCheckTime = (await fs.stat(this.file)).mtimeMs;
-      const today = new Date().getTime();
-
-      if ((today - lastCheckTime) / 1000 > this.ttlSecs) { // convert ms to sec
-        return true;
-      }
-      return false;
-    } catch (err: any) {
-      if (err.code === 'ENOENT') {
-        return true;
-      } else {
-        throw err;
-      }
-    }
-  }
-
-  public async update(latestVersion?: string): Promise<void> {
-    if (!latestVersion) {
-      latestVersion = '';
-    }
-    await fs.writeFile(this.file, latestVersion);
-  }
-}
-
-// Export for unit testing only.
-// Don't use directly, use displayVersionMessage() instead.
-export async function getVersionMessages(currentVersion: string, cacheFile: VersionCheckTTL): Promise<string[]> {
-  if (!(await cacheFile.hasExpired())) {
-    return [];
-  }
-
-  const packageInfo = await execNpmView(currentVersion);
-  const latestVersion = packageInfo.latestVersion;
-  await cacheFile.update(JSON.stringify(packageInfo));
-
-  // If the latest version is the same as the current version, there is no need to display a message
-  if (semver.eq(latestVersion, currentVersion)) {
-    return [];
-  }
-
-  const versionMessage = [
-    packageInfo.deprecated ? `${chalk.red(packageInfo.deprecated as string)}` : undefined,
-    `Newer version of CDK is available [${chalk.green(latestVersion as string)}]`,
-    getMajorVersionUpgradeMessage(currentVersion),
-    'Upgrade recommended (npm install -g aws-cdk)',
-  ].filter(Boolean) as string[];
-
-  return versionMessage;
-}
-
-function getMajorVersionUpgradeMessage(currentVersion: string): string | void {
-  const currentMajorVersion = semver.major(currentVersion);
-  if (UPGRADE_DOCUMENTATION_LINKS[currentMajorVersion]) {
-    return `Information about upgrading from version ${currentMajorVersion}.x to version ${currentMajorVersion + 1}.x is available here: ${UPGRADE_DOCUMENTATION_LINKS[currentMajorVersion]}`;
-  }
-}
-
-export async function displayVersionMessage(
-  ioHelper: IoHelper,
-  currentVersion = versionNumber(),
-  versionCheckCache?: VersionCheckTTL,
-): Promise<void> {
-  if (!process.stdout.isTTY || process.env.CDK_DISABLE_VERSION_CHECK) {
-    return;
-  }
-
-  try {
-    const versionMessages = await getVersionMessages(currentVersion, versionCheckCache ?? new VersionCheckTTL());
-    for (const e of formatAsBanner(versionMessages)) {
-      await ioHelper.defaults.info(e);
-    }
-  } catch (err: any) {
-    await ioHelper.defaults.debug(`Could not run version check - ${err.message}`);
-  }
-}
-/* c8 ignore stop */

--- a/packages/aws-cdk/lib/commands/context.ts
+++ b/packages/aws-cdk/lib/commands/context.ts
@@ -5,7 +5,7 @@ import type { Context } from '../api/context';
 import type { IoHelper } from '../api-private';
 import { renderTable } from '../cli/tables';
 import { PROJECT_CONFIG, PROJECT_CONTEXT, USER_DEFAULTS } from '../cli/user-configuration';
-import * as version from '../cli/version';
+import { displayVersionMessage } from '../cli/display-version';
 
 /**
  * Options for the context command
@@ -71,7 +71,7 @@ export async function contextHandler(options: ContextOptions): Promise<number> {
       await listContext(ioHelper, options.context);
     }
   }
-  await version.displayVersionMessage(ioHelper);
+  await displayVersionMessage(ioHelper);
 
   return 0;
 }

--- a/packages/aws-cdk/lib/commands/context.ts
+++ b/packages/aws-cdk/lib/commands/context.ts
@@ -3,9 +3,9 @@ import * as chalk from 'chalk';
 import { minimatch } from 'minimatch';
 import type { Context } from '../api/context';
 import type { IoHelper } from '../api-private';
+import { displayVersionMessage } from '../cli/display-version';
 import { renderTable } from '../cli/tables';
 import { PROJECT_CONFIG, PROJECT_CONTEXT, USER_DEFAULTS } from '../cli/user-configuration';
-import { displayVersionMessage } from '../cli/display-version';
 
 /**
  * Options for the context command

--- a/packages/aws-cdk/lib/commands/doctor.ts
+++ b/packages/aws-cdk/lib/commands/doctor.ts
@@ -2,7 +2,8 @@ import * as process from 'process';
 import * as cxapi from '@aws-cdk/cx-api';
 import * as chalk from 'chalk';
 import type { IoHelper } from '../api-private';
-import * as version from '../cli/version';
+import { displayVersionMessage } from '../cli/display-version';
+import { version } from '../cli/version';
 
 export async function doctor({ ioHelper }: { ioHelper: IoHelper }): Promise<number> {
   let exitStatus: number = 0;
@@ -11,7 +12,7 @@ export async function doctor({ ioHelper }: { ioHelper: IoHelper }): Promise<numb
       exitStatus = -1;
     }
   }
-  await version.displayVersionMessage(ioHelper);
+  await displayVersionMessage(ioHelper);
   return exitStatus;
 }
 
@@ -24,7 +25,7 @@ const verifications: Array<(ioHelper: IoHelper) => boolean | Promise<boolean>> =
 // ### Verifications ###
 
 async function displayVersionInformation(ioHelper: IoHelper) {
-  await ioHelper.defaults.info(`ℹ️ CDK Version: ${chalk.green(version.displayVersion())}`);
+  await ioHelper.defaults.info(`ℹ️ CDK Version: ${chalk.green(version())}`);
   return true;
 }
 

--- a/packages/aws-cdk/lib/commands/doctor.ts
+++ b/packages/aws-cdk/lib/commands/doctor.ts
@@ -3,7 +3,7 @@ import * as cxapi from '@aws-cdk/cx-api';
 import * as chalk from 'chalk';
 import type { IoHelper } from '../api-private';
 import { displayVersionMessage } from '../cli/display-version';
-import { version } from '../cli/version';
+import { versionWithBuild } from '../cli/version';
 
 export async function doctor({ ioHelper }: { ioHelper: IoHelper }): Promise<number> {
   let exitStatus: number = 0;
@@ -25,7 +25,7 @@ const verifications: Array<(ioHelper: IoHelper) => boolean | Promise<boolean>> =
 // ### Verifications ###
 
 async function displayVersionInformation(ioHelper: IoHelper) {
-  await ioHelper.defaults.info(`ℹ️ CDK Version: ${chalk.green(version())}`);
+  await ioHelper.defaults.info(`ℹ️ CDK Version: ${chalk.green(versionWithBuild())}`);
   return true;
 }
 

--- a/packages/aws-cdk/test/cli/version.test.ts
+++ b/packages/aws-cdk/test/cli/version.test.ts
@@ -6,8 +6,9 @@ import * as sinon from 'sinon';
 import { setTimeout as _setTimeout } from 'timers';
 import { promisify } from 'util';
 import * as npm from '../../lib/cli/util/npm';
-import { displayVersionMessage, getVersionMessages, isDeveloperBuild, VersionCheckTTL } from '../../lib/cli/version';
+import { isDeveloperBuildVersion } from '../../lib/cli/version';
 import { TestIoHost } from '../_helpers/io-host';
+import { displayVersionMessage, getVersionMessages, VersionCheckTTL } from '../../lib/cli/display-version';
 
 jest.setTimeout(10_000);
 
@@ -150,7 +151,7 @@ test('isDeveloperBuild call does not throw an error', () => {
   // that the value is `true` when running tests, because I won't want to make too
   // many assumptions for no good reason.
 
-  isDeveloperBuild();
+  isDeveloperBuildVersion();
 
   // THEN: should not explode
 });


### PR DESCRIPTION
Pulled out of #631. Needed so that we can access version functions within the IoHost without offending the circular dependency checker (which checks file imports)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
