### PR TITLE
feat: take all neighbors into account when computing resource digests

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
@@ -1,6 +1,7 @@
 import type { Environment } from '@aws-cdk/cx-api';
 import type { CloudFormationStack } from './cloudformation';
 import { ResourceLocation, ResourceMapping } from './cloudformation';
+import type { GraphDirection } from './digest';
 import { computeResourceDigests } from './digest';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import { equalSets } from '../../util/sets';
@@ -29,9 +30,12 @@ export class RefactoringContext {
 
   constructor(props: RefactorManagerOptions) {
     this.environment = props.environment;
-    const moves = resourceMoves(props.deployedStacks, props.localStacks);
-    const [nonAmbiguousMoves, ambiguousMoves] = partitionByAmbiguity(props.overrides ?? [], moves);
+    const moves = resourceMoves(props.deployedStacks, props.localStacks, 'direct');
+    const additionalOverrides = structuralOverrides(props.deployedStacks, props.localStacks);
+    const overrides = (props.overrides ?? []).concat(additionalOverrides);
+    const [nonAmbiguousMoves, ambiguousMoves] = partitionByAmbiguity(overrides, moves);
     this.ambiguousMoves = ambiguousMoves;
+
     this._mappings = resourceMappings(nonAmbiguousMoves);
   }
 
@@ -48,9 +52,32 @@ export class RefactoringContext {
   }
 }
 
-function resourceMoves(before: CloudFormationStack[], after: CloudFormationStack[]): ResourceMove[] {
-  const digestsBefore = resourceDigests(before);
-  const digestsAfter = resourceDigests(after);
+/**
+ * Generates an automatic list of overrides that can be deduced from the structure of the opposite resource graph.
+ * Suppose we have the following resource graph:
+ *
+ *     A --> B
+ *     C --> D
+ *
+ * such that B and D are identical, but A is different from C. Then digest(B) = digest(D). If both resources are moved,
+ * we have an ambiguity. But if we reverse the arrows:
+ *
+ *     A <-- B
+ *     C <-- D
+ *
+ * then digest(B) ≠ digest(D), because they now have different dependencies. If we compute the mappings from this
+ * opposite graph, we can use them as a set of overrides to disambiguate the original moves.
+ *
+ */
+function structuralOverrides(deployedStacks: CloudFormationStack[], localStacks: CloudFormationStack[]): ResourceMapping[] {
+  const moves = resourceMoves(deployedStacks, localStacks, 'opposite');
+  const [nonAmbiguousMoves] = partitionByAmbiguity([], moves);
+  return resourceMappings(nonAmbiguousMoves);
+}
+
+function resourceMoves(before: CloudFormationStack[], after: CloudFormationStack[], direction: GraphDirection): ResourceMove[] {
+  const digestsBefore = resourceDigests(before, direction);
+  const digestsAfter = resourceDigests(after, direction);
 
   const stackNames = (stacks: CloudFormationStack[]) => stacks.map((s) => s.stackName).sort().join(', ');
   if (!isomorphic(digestsBefore, digestsAfter)) {
@@ -119,14 +146,14 @@ function zip(
 /**
  * Computes a list of pairs [digest, location] for each resource in the stack.
  */
-function resourceDigests(stacks: CloudFormationStack[]): Record<string, ResourceLocation[]> {
+function resourceDigests(stacks: CloudFormationStack[], direction: GraphDirection): Record<string, ResourceLocation[]> {
   // index stacks by name
   const stacksByName = new Map<string, CloudFormationStack>();
   for (const stack of stacks) {
     stacksByName.set(stack.stackName, stack);
   }
 
-  const digests = computeResourceDigests(stacks);
+  const digests = computeResourceDigests(stacks, direction);
 
   return groupByKey(
     Object.entries(digests).map(([loc, digest]) => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -530,43 +530,6 @@ describe(computeResourceDigests, () => {
     expect(result['Stack2.AnotherBucket']).toBeDefined();
     expect(result['Stack1.Bucket']).not.toEqual(result['Stack2.AnotherBucket']);
   });
-
-  test('identical resources up to dependers', () => {
-    {
-      const template = {
-        Resources: {
-          Bucket1: {
-            Type: 'AWS::S3::Bucket',
-            Properties: {},
-          },
-          Bucket2: {
-            Type: 'AWS::S3::Bucket',
-            Properties: {},
-          },
-          Foo: {
-            Type: 'AWS::Foo::Foo',
-            Properties: {
-              SomeProp: { Ref: 'Bucket1' },
-            },
-          },
-          Bar: {
-            Type: 'AWS::Foo::Bar',
-            Properties: {
-              SomeProp: { Ref: 'Bucket2' },
-            },
-          },
-        },
-      };
-
-      const stacks = makeStacks([template]);
-      const result = computeResourceDigests(stacks);
-      expect(result['Stack1.Bucket1']).toBeDefined();
-      expect(result['Stack1.Bucket2']).toBeDefined();
-      // Not the same digest even though the properties are the same
-      // The structure of the graph tells us that these are different resources
-      expect(result['Stack1.Bucket1']).not.toEqual(result['Stack1.Bucket2']);
-    }
-  });
 });
 
 describe(usePrescribedMappings, () => {


### PR DESCRIPTION
The current definition of the digest of a resource computes a hash of its properties plus the hashes of its dependencies. 

But if we have a graph like:

        A --> B
        C --> D

where `B` and `D` are identical, the current algorithm will compute the same digest for them, even if `A` is different from `C` (and therefore have different digests). This is undesirable, as some cases are considered ambiguous, even if we could very well tell them apart. Real world example:

<img width="326" height="182" alt="non-ambiguous" src="https://github.com/user-attachments/assets/32e442c6-9605-43b4-bdd5-a745f1a0426f" />

`Role1` and `Role2` tend to be identical, but they can nevertheless be told apart because at least the functions will have different properties. So, even if both roles are renamed, for example,  we can still provide a valid mapping.

This change improves the algorithm by also taking into account all neighbors of a resource for digest computation. It does this by doing a two pass over the graph: first navigating in topological order and computing the digests, then navigating in the opposite order and doing the same. So each resource has two digests, that are in turn, used to compute the final digest.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
