### PR TITLE
feat: refactor options can be provided via the config file

### DIFF
--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -1189,6 +1189,33 @@ locations for a given environment. Resource locations are in the format
 resource currently deployed, while the destination must refer to a location
 that is not already occupied by any resource.
 
+All command line options that are also available in the configuration file
+(`cdk.json`) in the `refactor` section. For example, you can specify the 
+`--dry-run` option in `cdk.json` as follows:
+
+```json
+{
+  "app": "node bin/main.js",
+  "refactor": {
+    "dryRun": true
+  }
+}
+```
+
+The same naming pattern applies to all other options, except for 
+`--additional-stack-name`, which becomes `additionalStackNames`:
+
+```json
+{
+  "app": "node bin/main.js",
+  "refactor": {
+    "additionalStackNames": [
+      "Foo",
+      "Bar"
+    ]
+  }
+}
+```
 
 ### `cdk drift`
 

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -279,13 +279,19 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           throw new ToolkitError('Unstable feature use: \'refactor\' is unstable. It must be opted in via \'--unstable\', e.g. \'cdk refactor --unstable=refactor\'');
         }
 
+        const getOptionValue = (name: string) => args[name] ?? configuration.settings.get(['refactor', name]);
+
+        const additionalStackNames = args.additionalStackName != null
+          ? arrayFromYargs(args.additionalStackName ?? [])
+          : configuration.settings.get(['refactor', 'additionalStackNames']) ?? [];
+
         ioHost.currentAction = 'refactor';
         return cli.refactor({
-          dryRun: args.dryRun,
-          overrideFile: args.overrideFile,
-          revert: args.revert,
+          dryRun: getOptionValue('dryRun'),
+          overrideFile: getOptionValue('overrideFile'),
+          revert: getOptionValue('revert'),
           stacks: selector,
-          additionalStackNames: arrayFromYargs(args.additionalStackName ?? []),
+          additionalStackNames,
         });
 
       case 'bootstrap':


### PR DESCRIPTION
Allow the user to pass options via the config file:

```json
{
  "app": "node bin/main.js",
  "refactor": {
    "dryRun": true
  }
}
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
