### PR TITLE
fix(integ-runner): error when running the update workflow with toolkit-lib engine

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -4,6 +4,7 @@ import type { DefaultCdkOptions, DestroyOptions } from '@aws-cdk/cloud-assembly-
 import type { DeploymentMethod, ICloudAssemblySource, IIoHost, IoMessage, IoRequest, NonInteractiveIoHostProps, StackSelector } from '@aws-cdk/toolkit-lib';
 import { ExpandStackSelection, MemoryContext, NonInteractiveIoHost, StackSelectionStrategy, Toolkit } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
+import * as fs from 'fs-extra';
 
 export interface ToolkitLibEngineOptions {
   /**
@@ -199,6 +200,12 @@ export class ToolkitLibRunnerEngine implements ICdk {
   private async cx(options: DefaultCdkOptions): Promise<ICloudAssemblySource> {
     if (!options.app) {
       throw new Error('No app provided');
+    }
+
+    // check if the app is a path to existing snapshot and then use it as an assembly directory
+    const potentialCxPath = path.join(this.options.workingDirectory, options.app);
+    if (fs.pathExistsSync(potentialCxPath) && fs.statSync(potentialCxPath).isDirectory()) {
+      return this.toolkit.fromAssemblyDirectory(potentialCxPath);
     }
 
     let outdir;

--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -454,7 +454,7 @@ export class IntegTestRunner extends IntegRunner {
         });
       }
       // if the update workflow is not disabled, first
-      // perform a deployment with the exising snapshot
+      // perform a deployment with the existing snapshot
       // then perform a deployment (which will be a stack update)
       // with the current integration test
       // We also only want to run the update workflow if there is an existing

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib-snapshot-path.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib-snapshot-path.test.ts
@@ -1,0 +1,98 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import * as path from 'path';
+import { Toolkit } from '@aws-cdk/toolkit-lib';
+import * as fs from 'fs-extra';
+import { ToolkitLibRunnerEngine } from '../../lib/engines/toolkit-lib';
+
+jest.mock('@aws-cdk/toolkit-lib');
+jest.mock('fs-extra');
+
+const MockedToolkit = Toolkit as jest.MockedClass<typeof Toolkit>;
+const mockedFs = fs as jest.Mocked<typeof fs>;
+
+describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
+  let mockToolkit: jest.Mocked<Toolkit>;
+  let engine: ToolkitLibRunnerEngine;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockToolkit = {
+      fromCdkApp: jest.fn(),
+      fromAssemblyDirectory: jest.fn(),
+      synth: jest.fn(),
+    } as any;
+    MockedToolkit.mockImplementation(() => mockToolkit);
+
+    engine = new ToolkitLibRunnerEngine({
+      workingDirectory: '/test/dir',
+    });
+  });
+
+  it('should use fromAssemblyDirectory when app is a path to existing snapshot directory', async () => {
+    const snapshotPath = 'test.snapshot';
+    const fullSnapshotPath = path.join('/test/dir', snapshotPath);
+    const mockCx = { produce: jest.fn() };
+    const mockLock = { dispose: jest.fn() };
+
+    // Mock fs to indicate the snapshot directory exists
+    mockedFs.pathExistsSync.mockReturnValue(true);
+    mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as any);
+
+    mockToolkit.fromAssemblyDirectory.mockResolvedValue(mockCx as any);
+    mockToolkit.synth.mockResolvedValue(mockLock as any);
+
+    await engine.synth({
+      app: snapshotPath,
+      stacks: ['stack1'],
+    });
+
+    expect(mockedFs.pathExistsSync).toHaveBeenCalledWith(fullSnapshotPath);
+    expect(mockedFs.statSync).toHaveBeenCalledWith(fullSnapshotPath);
+    expect(mockToolkit.fromAssemblyDirectory).toHaveBeenCalledWith(fullSnapshotPath);
+    expect(mockToolkit.fromCdkApp).not.toHaveBeenCalled();
+  });
+
+  it('should use fromCdkApp when app is not a path to existing directory', async () => {
+    const appCommand = 'node bin/app.js';
+    const mockCx = { produce: jest.fn() };
+    const mockLock = { dispose: jest.fn() };
+
+    // Mock fs to indicate the path doesn't exist
+    mockedFs.pathExistsSync.mockReturnValue(false);
+
+    mockToolkit.fromCdkApp.mockResolvedValue(mockCx as any);
+    mockToolkit.synth.mockResolvedValue(mockLock as any);
+
+    await engine.synth({
+      app: appCommand,
+      stacks: ['stack1'],
+    });
+
+    expect(mockToolkit.fromCdkApp).toHaveBeenCalledWith(appCommand, expect.any(Object));
+    expect(mockToolkit.fromAssemblyDirectory).not.toHaveBeenCalled();
+  });
+
+  it('should use fromCdkApp when app path exists but is not a directory', async () => {
+    const appPath = 'app.js';
+    const fullAppPath = path.join('/test/dir', appPath);
+    const mockCx = { produce: jest.fn() };
+    const mockLock = { dispose: jest.fn() };
+
+    // Mock fs to indicate the path exists but is not a directory
+    mockedFs.pathExistsSync.mockReturnValue(true);
+    mockedFs.statSync.mockReturnValue({ isDirectory: () => false } as any);
+
+    mockToolkit.fromCdkApp.mockResolvedValue(mockCx as any);
+    mockToolkit.synth.mockResolvedValue(mockLock as any);
+
+    await engine.synth({
+      app: appPath,
+      stacks: ['stack1'],
+    });
+
+    expect(mockedFs.pathExistsSync).toHaveBeenCalledWith(fullAppPath);
+    expect(mockedFs.statSync).toHaveBeenCalledWith(fullAppPath);
+    expect(mockToolkit.fromCdkApp).toHaveBeenCalledWith(appPath, expect.any(Object));
+    expect(mockToolkit.fromAssemblyDirectory).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #715

The update workflow will deploy an existing snapshot from the main branch of the project before attempting to update the stack with incoming changes.

When the toolkit-lib engine was used, the snapshot directory was incorrectly treated as an CDK app command and failing. 

The fix is to check if the app value is a directory and if so, just use it as a cloud assembly directory.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
