### PR TITLE
feat(toolkit-lib): list action contains metadata

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-collection.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-collection.ts
@@ -42,6 +42,7 @@ export class StackCollection {
         id: stack.displayName ?? stack.id,
         name: stack.stackName,
         environment: stack.environment,
+        metadata: stack.manifest.metadata,
         dependencies: [],
       };
 

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/stack-details.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/stack-details.ts
@@ -1,3 +1,4 @@
+import type * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import type * as cxapi from '@aws-cdk/cx-api';
 
 /**
@@ -15,6 +16,7 @@ export interface StackDetails {
   id: string;
   name: string;
   environment: cxapi.Environment;
+  metadata?: { [path: string]: cxschema.MetadataEntry[] };
   dependencies: StackDependency[];
 }
 

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-custom-matchers.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-custom-matchers.ts
@@ -1,4 +1,4 @@
-import * as assert from 'assert';
+import { strict as assert } from 'node:assert';
 
 type TestableError = string | RegExp | Error;
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/list.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/list.test.ts
@@ -95,6 +95,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [],
     },
     {
@@ -105,6 +106,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_B.metadata,
       dependencies: [],
     }];
     expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
@@ -141,6 +143,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [],
     },
     {
@@ -151,6 +154,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_B.metadata,
       dependencies: [{
         id: 'Test-Stack-A',
         dependencies: [],
@@ -193,6 +197,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [],
     },
     {
@@ -203,6 +208,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_B.metadata,
       dependencies: [{
         id: 'Test-Stack-A',
         dependencies: [],
@@ -251,6 +257,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [],
     },
     {
@@ -261,6 +268,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_B.metadata,
       dependencies: [{
         id: 'Test-Stack-A',
         dependencies: [],
@@ -274,6 +282,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_C.metadata,
       dependencies: [{
         id: 'Test-Stack-A/Test-Stack-B',
         dependencies: [{
@@ -324,6 +333,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [],
     },
     {
@@ -334,6 +344,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_B.metadata,
       dependencies: [{
         id: 'Test-Stack-A',
         dependencies: [],
@@ -347,6 +358,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_C.metadata,
       dependencies: [{
         id: 'Test-Stack-B',
         dependencies: [{
@@ -411,6 +423,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_C.metadata,
       dependencies: [],
     },
     {
@@ -421,6 +434,7 @@ describe('list', () => {
         region: 'bermuda-triangle-1',
         name: 'aws://123456789012/bermuda-triangle-1',
       },
+      metadata: MOCK_STACK_A.metadata,
       dependencies: [{
         id: 'Test-Stack-C',
         dependencies: [],

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -988,29 +988,20 @@ export class CdkToolkit {
     }
 
     if (options.showDeps) {
-      const stackDeps = [];
-
-      for (const stack of stacks) {
-        stackDeps.push({
-          id: stack.id,
-          dependencies: stack.dependencies,
-        });
-      }
-
+      const stackDeps = stacks.map(stack => ({
+        id: stack.id,
+        dependencies: stack.dependencies,
+      }));
       await printSerializedObject(this.ioHost.asIoHelper(), stackDeps, options.json ?? false);
       return 0;
     }
 
     if (options.long) {
-      const long = [];
-
-      for (const stack of stacks) {
-        long.push({
-          id: stack.id,
-          name: stack.name,
-          environment: stack.environment,
-        });
-      }
+      const long = stacks.map(stack => ({
+        id: stack.id,
+        name: stack.name,
+        environment: stack.environment,
+      }));
       await printSerializedObject(this.ioHost.asIoHelper(), long, options.json ?? false);
       return 0;
     }
@@ -1019,7 +1010,6 @@ export class CdkToolkit {
     for (const stack of stacks) {
       await this.ioHost.asIoHelper().defaults.result(stack.id);
     }
-
     return 0; // exit-code
   }
 

--- a/packages/aws-cdk/lib/commands/list-stacks.ts
+++ b/packages/aws-cdk/lib/commands/list-stacks.ts
@@ -31,5 +31,11 @@ export async function listStacks(toolkit: CdkToolkit, options: ListStacksOptions
     defaultBehavior: DefaultSelection.AllStacks,
   });
 
-  return stacks.withDependencies();
+  // we only want to print a subset of information in `cdk list --json`
+  return stacks.withDependencies().map(stack => ({
+    id: stack.id,
+    name: stack.name,
+    environment: stack.environment,
+    dependencies: stack.dependencies,
+  }));
 }


### PR DESCRIPTION
Include stack metadata in the stack details returned from list. This allows implementing the equivalent of `cdk metadata` in custom tooling.

Resolves #501

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
