### PR TITLE
fix(integ-runner): inconsistent and unexpected CWD in test app execution

### DIFF
--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -78,6 +78,8 @@ export class MockCdkProvider {
     diagnostics: Diagnostic[];
     destructiveChanges: DestructiveChange[];
   }> {
+    const actualSnapshotLocation = actualSnapshot ? 'test/test-data/' + actualSnapshot : undefined;
+
     // WHEN
     const integTest = new IntegSnapshotRunner({
       cdk: this.cdk,
@@ -85,7 +87,7 @@ export class MockCdkProvider {
         fileName: 'test/test-data/' + integTestFile,
         discoveryRoot: 'test/test-data',
       }),
-      integOutDir: actualSnapshot ? 'test/test-data/' + actualSnapshot : undefined,
+      integOutDir: actualSnapshotLocation,
     });
 
     const results = await integTest.testSnapshot();
@@ -98,8 +100,8 @@ export class MockCdkProvider {
         CDK_INTEG_REGION: 'test-region',
       }),
       context: expect.any(Object),
-      execCmd: ['node', integTestFile],
-      output: actualSnapshot ?? `cdk-integ.out.${integTestFile}.snapshot`,
+      execCmd: ['node', 'test/test-data/' + integTestFile],
+      output: actualSnapshotLocation ?? `test/test-data/cdk-integ.out.${integTestFile}.snapshot`,
     });
 
     return results;

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -61,7 +61,7 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
-      app: 'xxxxx.test-with-snapshot.js.snapshot',
+      app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       requireApproval: 'never',
       pathMetadata: false,
       assetMetadata: false,
@@ -76,11 +76,11 @@ describe('IntegTest runIntegTests', () => {
       stacks: ['test-stack'],
     });
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
-      app: 'node xxxxx.test-with-snapshot.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot.js',
       requireApproval: 'never',
       pathMetadata: false,
       assetMetadata: false,
-      output: 'cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
       profile: undefined,
       context: expect.not.objectContaining({
         'vpc-provider:account=12345678:filter.isDefault=true:region=test-region:returnAsymmetricSubnets=true': expect.objectContaining({
@@ -92,7 +92,7 @@ describe('IntegTest runIntegTests', () => {
       stacks: ['test-stack', 'new-test-stack'],
     });
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith({
-      app: 'node xxxxx.test-with-snapshot.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot.js',
       pathMetadata: false,
       assetMetadata: false,
       context: expect.not.objectContaining({
@@ -104,7 +104,7 @@ describe('IntegTest runIntegTests', () => {
       profile: undefined,
       force: true,
       all: true,
-      output: 'cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
     });
   });
 
@@ -126,7 +126,7 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
-      app: 'node xxxxx.integ-test1.js',
+      app: 'node test/test-data/xxxxx.integ-test1.js',
       requireApproval: 'never',
       pathMetadata: false,
       assetMetadata: false,
@@ -137,17 +137,17 @@ describe('IntegTest runIntegTests', () => {
       }),
       lookups: false,
       stacks: ['stack1'],
-      output: 'cdk-integ.out.xxxxx.integ-test1.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
     });
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith({
-      app: 'node xxxxx.integ-test1.js',
+      app: 'node test/test-data/xxxxx.integ-test1.js',
       pathMetadata: false,
       assetMetadata: false,
       versionReporting: false,
       context: expect.any(Object),
       force: true,
       all: true,
-      output: 'cdk-integ.out.xxxxx.integ-test1.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
     });
   });
 
@@ -169,7 +169,7 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
-      app: 'node xxxxx.test-with-snapshot-assets-diff.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
       requireApproval: 'never',
       pathMetadata: false,
       assetMetadata: false,
@@ -181,11 +181,11 @@ describe('IntegTest runIntegTests', () => {
       versionReporting: false,
       lookups: true,
       stacks: ['test-stack'],
-      output: 'cdk-integ.out.xxxxx.test-with-snapshot-assets-diff.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot-assets-diff.js.snapshot',
       profile: undefined,
     });
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-      execCmd: ['node', 'xxxxx.test-with-snapshot-assets-diff.js'],
+      execCmd: ['node', 'test/test-data/xxxxx.test-with-snapshot-assets-diff.js'],
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',
         CDK_INTEG_REGION: 'test-region',
@@ -195,10 +195,10 @@ describe('IntegTest runIntegTests', () => {
           vpcId: 'vpc-60900905',
         }),
       }),
-      output: 'xxxxx.test-with-snapshot-assets-diff.js.snapshot',
+      output: 'test/test-data/xxxxx.test-with-snapshot-assets-diff.js.snapshot',
     });
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith({
-      app: 'node xxxxx.test-with-snapshot-assets-diff.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
       pathMetadata: false,
       assetMetadata: false,
       context: expect.not.objectContaining({
@@ -209,7 +209,7 @@ describe('IntegTest runIntegTests', () => {
       versionReporting: false,
       force: true,
       all: true,
-      output: 'cdk-integ.out.xxxxx.test-with-snapshot-assets-diff.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot-assets-diff.js.snapshot',
     });
   });
 
@@ -231,7 +231,7 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      app: 'xxxxx.test-with-snapshot.js.snapshot',
+      app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       context: expect.any(Object),
       stacks: ['test-stack'],
     }));
@@ -239,12 +239,12 @@ describe('IntegTest runIntegTests', () => {
       rollback: false,
     }));
     expect(cdkMock.mocks.deploy).toHaveBeenNthCalledWith(3, expect.objectContaining({
-      app: 'node xxxxx.test-with-snapshot.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot.js',
       stacks: ['Bundling/DefaultTest/DeployAssert'],
       rollback: false,
     }));
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith({
-      app: 'node xxxxx.test-with-snapshot.js',
+      app: 'node test/test-data/xxxxx.test-with-snapshot.js',
       pathMetadata: false,
       assetMetadata: false,
       context: expect.not.objectContaining({
@@ -255,7 +255,7 @@ describe('IntegTest runIntegTests', () => {
       versionReporting: false,
       force: true,
       all: true,
-      output: 'cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot',
     });
   });
 
@@ -313,8 +313,8 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-      execCmd: ['node', 'xxxxx.integ-test1.js'],
-      output: 'cdk-integ.out.xxxxx.integ-test1.js.snapshot',
+      execCmd: ['node', 'test/test-data/xxxxx.integ-test1.js'],
+      output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',
         CDK_INTEG_REGION: 'test-region',
@@ -342,7 +342,7 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
-      app: 'node xxxxx.integ-test1.js',
+      app: 'node test/test-data/xxxxx.integ-test1.js',
       requireApproval: 'never',
       pathMetadata: false,
       assetMetadata: false,
@@ -355,10 +355,10 @@ describe('IntegTest runIntegTests', () => {
       profile: 'test-profile',
       lookups: false,
       stacks: ['stack1'],
-      output: 'cdk-integ.out.xxxxx.integ-test1.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
     });
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith({
-      app: 'node xxxxx.integ-test1.js',
+      app: 'node test/test-data/xxxxx.integ-test1.js',
       pathMetadata: false,
       assetMetadata: false,
       versionReporting: false,
@@ -370,7 +370,7 @@ describe('IntegTest runIntegTests', () => {
       profile: 'test-profile',
       force: true,
       all: true,
-      output: 'cdk-integ.out.xxxxx.integ-test1.js.snapshot',
+      output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
     });
   });
 
@@ -625,13 +625,13 @@ describe('IntegTest runIntegTests', () => {
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith(expect.objectContaining({
-      app: 'node --no-warnings xxxxx.test-with-snapshot.js',
+      app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
     }));
     expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith(expect.objectContaining({
-      execCmd: ['node', '--no-warnings', 'xxxxx.test-with-snapshot.js'],
+      execCmd: ['node', '--no-warnings', 'test/test-data/xxxxx.test-with-snapshot.js'],
     }));
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith(expect.objectContaining({
-      app: 'node --no-warnings xxxxx.test-with-snapshot.js',
+      app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
     }));
   });
 });
@@ -655,7 +655,7 @@ describe('IntegTest watchIntegTest', () => {
 
     // THEN
     expect(cdkMock.mocks.watch).toHaveBeenCalledWith(expect.objectContaining({
-      app: 'node --no-warnings xxxxx.test-with-snapshot.js',
+      app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
       hotswap: HotswapMode.FALL_BACK,
       watch: true,
       traceLogs: false,
@@ -683,7 +683,7 @@ describe('IntegTest watchIntegTest', () => {
 
     // THEN
     expect(cdkMock.mocks.watch).toHaveBeenCalledWith(expect.objectContaining({
-      app: 'node --no-warnings xxxxx.test-with-snapshot.js',
+      app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
       hotswap: HotswapMode.FALL_BACK,
       watch: true,
       traceLogs: true,

--- a/packages/@aws-cdk/integ-runner/test/runner/integration-tests.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integration-tests.test.ts
@@ -138,4 +138,13 @@ describe('IntegrationTests Discovery', () => {
       expect(integTests[2].fileName).toEqual(expect.stringMatching(new RegExp('^.*test3\\.js$')));
     });
   });
+
+  describe('IntegTest directory is always cwd', () => {
+    test('directory is set to process.cwd()', async () => {
+      const integTests = await tests.fromCliOptions({ language: ['javascript'] });
+
+      expect(integTests.length).toBeGreaterThan(0);
+      expect(integTests[0].directory).toEqual(process.cwd());
+    });
+  });
 });

--- a/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
@@ -219,13 +219,13 @@ describe('IntegTest runSnapshotTests', () => {
       }));
       expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(1);
       expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-        execCmd: ['node', 'xxxxx.integ-test2.js'],
+        execCmd: ['node', 'test/test-data/xxxxx.integ-test2.js'],
         env: expect.objectContaining({
           CDK_INTEG_ACCOUNT: '12345678',
           CDK_INTEG_REGION: 'test-region',
         }),
         context: expect.any(Object),
-        output: '../../does/not/exist',
+        output: 'does/not/exist',
       });
     });
   });

--- a/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
@@ -102,7 +102,7 @@ describe('test runner', () => {
 
     expect(spawnSyncMock).toHaveBeenCalledWith(
       expect.stringMatching(/node/),
-      ['xxxxx.integ-test1.js'],
+      ['test/test-data/xxxxx.integ-test1.js'],
       expect.objectContaining({
         env: expect.objectContaining({
           CDK_INTEG_ACCOUNT: '12345678',


### PR DESCRIPTION
Fixes an issue with the working directory being inconsistent and unexpected during execution of the test app. Previously we had two different behaviors: For regular execution we would execute the app from the directory of the test file, but for watch we would run it in the actual user's CWD. This is inconsistent behavior making it difficult to write integ test cases than can be executed across all modes.

Additionally as reported in #638, languages likes python may rely on the working directory to import modules. The working directory changing compared to library code and modes, makes it very difficult to use integ-runner in these languages.

This change aligns the working directory for test app execution to always be the CWD integ-runner is executed from. Given the two existing choices, this is the less arbitrary one and aligns more with how running a test app directly (`node integ.app-under-test.test.js`) would work.

The practical implications of this are limited. Tests are already discovered and executed using relative paths. In case someone really dependent on this behavior, they can simply execute integ-runner from a different working dir.

Fixes #638

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license