### PR TITLE
chore(toolkit-lib): consider developer builds as supporting context overflow

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/tree.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/tree.ts
@@ -36,7 +36,7 @@ export function some(node: ConstructTreeNode | undefined, predicate: (n: Constru
   }
 }
 
-export async function loadTree(assembly: CloudAssembly, trace: (msg: string) => Promise<void>): Promise<ConstructTreeNode | undefined > {
+export async function loadTree(assembly: CloudAssembly, trace: (msg: string) => Promise<void>): Promise<ConstructTreeNode | undefined> {
   try {
     const outdir = assembly.directory;
     const fileName = assembly.tree()?.file;

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/prepare-source.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/prepare-source.test.ts
@@ -1,0 +1,198 @@
+import { frameworkSupportsContextOverflow } from '../../../lib/api/cloud-assembly/private/prepare-source';
+import type { ConstructTreeNode } from '../../../lib/api/tree';
+
+describe('frameworkSupportsContextOverflow', () => {
+  test('returns true for undefined tree', () => {
+    expect(frameworkSupportsContextOverflow(undefined)).toBe(true);
+  });
+
+  test('returns true for empty tree', () => {
+    expect(frameworkSupportsContextOverflow({} as any)).toBe(true);
+  });
+
+  test('returns true for tree with non-App constructs', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        stack1: {
+          id: 'stack1',
+          path: 'stack1',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.Stack',
+            version: '2.50.0',
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(true);
+  });
+
+  test('returns false for v1 App', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        app: {
+          id: 'app',
+          path: 'app',
+          constructInfo: {
+            fqn: '@aws-cdk/core.App',
+            version: '1.180.0',
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(false);
+  });
+
+  test('returns false for v2 App with version <= 2.38.0', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        app: {
+          id: 'app',
+          path: 'app',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.App',
+            version: '2.38.0',
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(false);
+  });
+
+  test('returns true for v2 App with version > 2.38.0', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        app: {
+          id: 'app',
+          path: 'app',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.App',
+            version: '2.38.1',
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(true);
+  });
+
+  test('returns true for v2 App with developer version (0.0.0)', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        app: {
+          id: 'app',
+          path: 'app',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.App',
+            version: '0.0.0',
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(true);
+  });
+
+  test('returns false if any node in the tree is a v1 App', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        stack1: {
+          id: 'stack1',
+          path: 'stack1',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.Stack',
+            version: '2.50.0',
+          },
+        },
+        nested: {
+          id: 'nested',
+          path: 'nested',
+          children: {
+            app: {
+              id: 'app',
+              path: 'nested/app',
+              constructInfo: {
+                fqn: '@aws-cdk/core.App',
+                version: '1.180.0',
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(false);
+  });
+
+  test('returns false if any node in the tree is a v2 App with version <= 2.38.0', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        stack1: {
+          id: 'stack1',
+          path: 'stack1',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.Stack',
+            version: '2.50.0',
+          },
+        },
+        nested: {
+          id: 'nested',
+          path: 'nested',
+          children: {
+            app: {
+              id: 'app',
+              path: 'nested/app',
+              constructInfo: {
+                fqn: 'aws-cdk-lib.App',
+                version: '2.38.0',
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(false);
+  });
+
+  test('returns true if all v2 Apps in the tree have version > 2.38.0', () => {
+    const tree: ConstructTreeNode = {
+      id: 'root',
+      path: '',
+      children: {
+        app1: {
+          id: 'app1',
+          path: 'app1',
+          constructInfo: {
+            fqn: 'aws-cdk-lib.App',
+            version: '2.38.1',
+          },
+        },
+        nested: {
+          id: 'nested',
+          path: 'nested',
+          children: {
+            app2: {
+              id: 'app2',
+              path: 'nested/app2',
+              constructInfo: {
+                fqn: 'aws-cdk-lib.App',
+                version: '2.50.0',
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(frameworkSupportsContextOverflow(tree)).toBe(true);
+  });
+});


### PR DESCRIPTION
Updates the context overflow support detection logic to consider developer builds (with version `0.0.0`) as supported. This has no customer facing impact but prevents an incorrect debug message from being emitted when using a dev build of the framework, e.g. when running integ tests in the `aws/aws-cdk` repo.

Also extracts the context overflow detection logic into a separate function to improve testability and maintainability. Added unit tests to ensure the function works correctly with different CDK versions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license