### PR TITLE
chore: remove obsolete `MappingSource` class

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/refactor/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/refactor/index.ts
@@ -1,69 +1,8 @@
 import type * as cxapi from '@aws-cdk/cx-api';
 import type { StackSelector } from '../../api';
 import type { SdkProvider } from '../../api/aws-auth/sdk-provider';
-import type { ExcludeList } from '../../api/refactoring';
-import { groupStacks, InMemoryExcludeList, NeverExclude, RefactoringContext } from '../../api/refactoring';
+import { groupStacks, RefactoringContext } from '../../api/refactoring';
 import { ToolkitError } from '../../toolkit/toolkit-error';
-
-type MappingType = 'auto' | 'explicit';
-
-/**
- * The source of the resource mappings to be used for refactoring.
- */
-export class MappingSource {
-  /**
-   * The mapping will be automatically generated based on a comparison of
-   * the deployed stacks and the local stacks.
-   *
-   * @param exclude - A list of resource locations to exclude from the mapping.
-   */
-  public static auto(exclude: string[] = []): MappingSource {
-    const excludeList = new InMemoryExcludeList(exclude);
-    return new MappingSource('auto', [], excludeList);
-  }
-
-  /**
-   * An explicitly provided list of mappings, which will be used for refactoring.
-   */
-  public static explicit(groups: MappingGroup[]): MappingSource {
-    return new MappingSource('explicit', groups, new NeverExclude());
-  }
-
-  /**
-   * An explicitly provided list of mappings, which will be used for refactoring,
-   * but in reverse, that is, the source locations will become the destination
-   * locations and vice versa.
-   */
-  public static reverse(groups: MappingGroup[]): MappingSource {
-    const reverseGroups = groups.map((group) => ({
-      ...group,
-      resources: Object.fromEntries(Object.entries(group.resources).map(([src, dst]) => [dst, src])),
-    }));
-
-    return MappingSource.explicit(reverseGroups);
-  }
-
-  /**
-   * @internal
-   */
-  public readonly source: MappingType;
-
-  /**
-   * @internal
-   */
-  public readonly groups: MappingGroup[];
-
-  /**
-   * @internal
-   */
-  public readonly exclude: ExcludeList;
-
-  private constructor(source: MappingType, groups: MappingGroup[], exclude: ExcludeList) {
-    this.source = source;
-    this.groups = groups;
-    this.exclude = exclude;
-  }
-}
 
 export interface RefactorOptions {
   /**


### PR DESCRIPTION
It was used when we were giving users the option to provide an explicit mapping file and exclusion list.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
