### PR TITLE
fix(integ-runner): snapshot errors don't provide meaningful information

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
@@ -176,7 +176,7 @@ export async function snapshotTestWorker(testInfo: IntegTestInfo, options: Snaps
   } catch (e: any) {
     failedTests.push(test.info);
     workerpool.workerEmit({
-      message: e.message,
+      message: formatError(e),
       testName: test.testName,
       reason: DiagnosticReason.SNAPSHOT_ERROR,
       duration: (Date.now() - start) / 1000,


### PR DESCRIPTION
Similar to #716, this adds context to errors when running snapshots. 

### Before

<img width="467" height="104" alt="image" src="https://github.com/user-attachments/assets/ab28ce62-b966-4916-8524-9a370c6fa032" />

No information, not actionable.

### After

<img width="933" height="171" alt="image" src="https://github.com/user-attachments/assets/d4ccf3eb-e0c8-4141-9a77-298cfcdabdc5" />

A clear error message that can be fixed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
