### PR TITLE
fix(integ-runner): command to reproduce snapshot checkout does not always work

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -9,9 +9,9 @@ import * as workerpool from 'workerpool';
 import type { IntegRunnerOptions } from './runner-base';
 import { IntegRunner } from './runner-base';
 import * as logger from '../logger';
-import { chunks, exec, promiseWithResolvers } from '../utils';
+import { chunks, exec, execWithSubShell, promiseWithResolvers, renderCommand } from '../utils';
 import type { DestructiveChange, AssertionResults, AssertionResult } from '../workers/common';
-import { DiagnosticReason, formatAssertionResults } from '../workers/common';
+import { DiagnosticReason, formatAssertionResults, formatError } from '../workers/common';
 
 export interface CommonOptions {
   /**
@@ -114,15 +114,19 @@ export class IntegTestRunner extends IntegRunner {
    * all branches and we then search for one that starts with `HEAD branch: `
    */
   private checkoutSnapshot(): void {
-    const cwd = this.directory;
+    // We use the directory that contains the snapshot to run git commands in
+    // We don't change the cwd for executing git, but instead use the -C flag
+    // @see https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt
+    // This way we are guaranteed to operate under the correct git repo, even
+    // when executing integ-runner from outside the repo under test.
+    const gitCwd = path.dirname(this.snapshotDir);
+    const git = ['git', '-C', gitCwd];
 
     // https://git-scm.com/docs/git-merge-base
     let baseBranch: string | undefined = undefined;
     // try to find the base branch that the working branch was created from
     try {
-      const origin: string = exec(['git', 'remote', 'show', 'origin'], {
-        cwd,
-      });
+      const origin: string = exec([...git, 'remote', 'show', 'origin']);
       const originLines = origin.split('\n');
       for (const line of originLines) {
         if (line.trim().startsWith('HEAD branch: ')) {
@@ -141,22 +145,18 @@ export class IntegTestRunner extends IntegRunner {
     // if we found the base branch then get the merge-base (most recent common commit)
     // and checkout the snapshot using that commit
     if (baseBranch) {
-      const relativeSnapshotDir = path.relative(this.directory, this.snapshotDir);
+      const relativeSnapshotDir = path.relative(gitCwd, this.snapshotDir);
 
+      const checkoutCommand = [...git, 'checkout', [...git, 'merge-base', 'HEAD', baseBranch], '--', relativeSnapshotDir];
       try {
-        const base = exec(['git', 'merge-base', 'HEAD', baseBranch], {
-          cwd,
-        });
-        exec(['git', 'checkout', base, '--', relativeSnapshotDir], {
-          cwd,
-        });
+        execWithSubShell(checkoutCommand);
       } catch (e) {
         logger.warning('%s\n%s',
           `Could not checkout snapshot directory '${this.snapshotDir}'. Please verify the following command completes correctly:`,
-          `git checkout $(git merge-base HEAD ${baseBranch}) -- ${relativeSnapshotDir}`,
+          renderCommand(checkoutCommand),
           '',
         );
-        logger.warning('error: %s', e);
+        logger.warning('error: %s', formatError(e));
       }
     }
   }

--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -139,7 +139,7 @@ export class IntegTestRunner extends IntegRunner {
         `You need to manually checkout the snapshot directory ${this.snapshotDir}` +
         'from the merge-base (https://git-scm.com/docs/git-merge-base)',
       );
-      logger.warning('error: %s', e);
+      logger.warning('error: %s', formatError(e));
     }
 
     // if we found the base branch then get the merge-base (most recent common commit)

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -442,13 +442,13 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(spawnSyncMock.mock.calls).toEqual(expect.arrayContaining([
       expect.arrayContaining([
-        'git', ['remote', 'show', 'origin'],
+        'git', ['-C', expect.any(String), 'remote', 'show', 'origin'],
       ]),
       expect.arrayContaining([
-        'git', ['merge-base', 'HEAD', 'main'],
+        'git', ['-C', expect.any(String), 'merge-base', 'HEAD', 'main'],
       ]),
       expect.arrayContaining([
-        'git', ['checkout', 'abc', '--', 'xxxxx.test-with-snapshot.js.snapshot'],
+        'git', ['-C', expect.any(String), 'checkout', 'abc', '--', 'xxxxx.test-with-snapshot.js.snapshot'],
       ]),
     ]));
   });

--- a/packages/@aws-cdk/integ-runner/test/utils.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/utils.test.ts
@@ -1,0 +1,129 @@
+import * as child_process from 'child_process';
+import { execWithSubShell, renderCommand } from '../lib/utils';
+
+jest.mock('child_process');
+
+describe('execWithSubShell', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('executes simple command', () => {
+    // GIVEN
+    const mockSpawnSync = jest.spyOn(child_process, 'spawnSync').mockReturnValue({
+      status: 0,
+      stdout: Buffer.from('output'),
+      stderr: Buffer.from(''),
+    } as any);
+
+    // WHEN
+    const result = execWithSubShell(['echo', 'hello']);
+
+    // THEN
+    expect(mockSpawnSync).toHaveBeenCalledWith('echo', ['hello'], expect.anything());
+    expect(result).toBe('output');
+  });
+
+  test('executes command with subshell', () => {
+    // GIVEN
+    const mockSpawnSync = jest.spyOn(child_process, 'spawnSync')
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: Buffer.from('subcommand-output'),
+        stderr: Buffer.from(''),
+      } as any))
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: Buffer.from('main-output'),
+        stderr: Buffer.from(''),
+      } as any));
+
+    // WHEN
+    const result = execWithSubShell(['git', 'checkout', ['git', 'merge-base', 'HEAD'], '--', 'path/to/file']);
+
+    // THEN
+    // First call should be the subshell command
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(1, 'git', ['merge-base', 'HEAD'], expect.anything());
+    // Second call should be the main command with the subshell output substituted
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'git', ['checkout', 'subcommand-output', '--', 'path/to/file'], expect.anything());
+    expect(result).toBe('main-output');
+  });
+
+  test('executes command with nested subshells', () => {
+    // GIVEN
+    const mockSpawnSync = jest.spyOn(child_process, 'spawnSync')
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: Buffer.from('nested-output'),
+        stderr: Buffer.from(''),
+      } as any))
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: Buffer.from('subcommand-output'),
+        stderr: Buffer.from(''),
+      } as any))
+      .mockImplementationOnce(() => ({
+        status: 0,
+        stdout: Buffer.from('main-output'),
+        stderr: Buffer.from(''),
+      } as any));
+
+    // WHEN
+    const result = execWithSubShell(['command', ['subcommand', ['nested', 'command']]]);
+
+    // THEN
+    // First call should be the nested subshell command
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(1, 'nested', ['command'], expect.anything());
+    // Second call should be the subshell command with nested output substituted
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(2, 'subcommand', ['nested-output'], expect.anything());
+    // Third call should be the main command with the subshell output substituted
+    expect(mockSpawnSync).toHaveBeenNthCalledWith(3, 'command', ['subcommand-output'], expect.anything());
+    expect(result).toBe('main-output');
+  });
+
+  test('throws error when command fails', () => {
+    // GIVEN
+    jest.spyOn(child_process, 'spawnSync').mockReturnValue({
+      status: 1,
+      stdout: Buffer.from(''),
+      stderr: Buffer.from('error message'),
+    } as any);
+
+    // THEN
+    expect(() => execWithSubShell(['failing', 'command'])).toThrow('Command exited with status 1');
+  });
+});
+
+describe('renderCommand', () => {
+  test('renders simple command', () => {
+    // WHEN
+    const result = renderCommand(['echo', 'hello']);
+
+    // THEN
+    expect(result).toBe('echo hello');
+  });
+
+  test('renders command with subshell', () => {
+    // WHEN
+    const result = renderCommand(['git', 'checkout', ['git', 'merge-base', 'HEAD'], '--', 'path/to/file']);
+
+    // THEN
+    expect(result).toBe('git checkout $(git merge-base HEAD) -- path/to/file');
+  });
+
+  test('renders command with nested subshells', () => {
+    // WHEN
+    const result = renderCommand(['command', ['subcommand', ['nested', 'command']]]);
+
+    // THEN
+    expect(result).toBe('command $(subcommand $(nested command))');
+  });
+
+  test('handles empty arrays', () => {
+    // WHEN
+    const result = renderCommand([]);
+
+    // THEN
+    expect(result).toBe('');
+  });
+});

--- a/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
@@ -155,24 +155,15 @@ describe('test runner', () => {
     expect(spawnSyncMock.mock.calls).toEqual(expect.arrayContaining([
       expect.arrayContaining([
         expect.stringMatching(/git/),
-        ['remote', 'show', 'origin'],
-        expect.objectContaining({
-          cwd: 'test/test-data',
-        }),
+        ['-C', 'test/test-data', 'remote', 'show', 'origin'],
       ]),
       expect.arrayContaining([
         expect.stringMatching(/git/),
-        ['merge-base', 'HEAD', 'master'],
-        expect.objectContaining({
-          cwd: 'test/test-data',
-        }),
+        ['-C', 'test/test-data', 'merge-base', 'HEAD', 'master'],
       ]),
       expect.arrayContaining([
         expect.stringMatching(/git/),
-        ['checkout', 'abc', '--', 'xxxxx.test-with-snapshot.js.snapshot'],
-        expect.objectContaining({
-          cwd: 'test/test-data',
-        }),
+        ['-C', 'test/test-data', 'checkout', 'abc', '--', 'xxxxx.test-with-snapshot.js.snapshot'],
       ]),
     ]));
 


### PR DESCRIPTION
During the update workflow, when checking out the previous snapshot failed, we print a git command to allow the user to reproduce potential issues. This command doesn't work as printed, as it assumes it is run from the same directory the test case file is in. However in most situations a users will have run `integ-runner` from a parent directory.

It would print something like this, assuming you are in the same directory as the test file:
```console
git checkout $(git merge-base HEAD main) -- integ.bucket-deployment-deployed-bucket.js.snapshot
```

The change in this PR updates `git` operations to use the `-C` flag to specify the correct directory instead of changing the working directory for the shell execution. Also changes the base the directory the snapshot is in, instead of `this.directory`. This results in the same dir, but is more localized to the feature and does not rely on the fact that `this.directory` and `this.snapshotDir` happen to share the same parent.

So now, we print a working command, where ever you are:
```console
git -C path/to/tests checkout $(git -C path/to/tests merge-base HEAD main) -- integ.bucket-deployment-deployed-bucket.js.snapshot
```

I could have just changed the printed command, but decided that consistency between what we run and what we show is important. This also simplifies the code because we don't have to manually maintain the logger output anymore.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license