### PR TITLE
chore: use a private package name in build-standalone-zip task

### DIFF
--- a/projenrc/build-standalone-zip.task.ts
+++ b/projenrc/build-standalone-zip.task.ts
@@ -20,7 +20,7 @@ async function main() {
 
     // Write a package.json with the top-level dependency
     await fs.writeFile(path.join(outdir, 'package.json'), JSON.stringify({
-      name: 'test',
+      name: '@aws-cdk/build-standalone-zip',
       private: true,
       version: '1.0.0',
       dependencies,


### PR DESCRIPTION
Updates the package name in the build-standalone-zip task from 'test' to '@aws-cdk/build-standalone-zip' to prevent the following warning:
<img width="531" height="184" alt="image" src="https://github.com/user-attachments/assets/fc30e85d-4c03-453c-a629-e3af64807dfb" />


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license