### PR TITLE
fix(cli): running `--telemetry-file` without the `--unstable` option creates a telemetry file

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli-telemetry/cdk-cli-telemetry-send-to-file-unstable.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cli-telemetry/cdk-cli-telemetry-send-to-file-unstable.integtest.ts
@@ -1,0 +1,19 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
+integTest(
+  'sending cli telemetry to file fails if not invoked with --unstable',
+  withDefaultFixture(async (fixture) => {
+    const telemetryFile = path.join(fixture.integTestDir, `telemetry-${Date.now()}.json`);
+    try {
+      await fixture.cdk(['list', `--telemetry-file=${telemetryFile}`]);
+      throw new Error('Expected command to fail');
+    } catch (error) {
+      expect(fs.existsSync(telemetryFile)).toBeFalsy();
+      expect(fixture.output.toString()).toContain('Unstable feature use');
+    }
+  }),
+);

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -99,6 +99,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     caBundlePath: configuration.settings.get(['caBundlePath']),
   });
 
+  if (argv['telemetry-file'] && !configuration.settings.get(['unstable']).includes('telemetry')) {
+    throw new ToolkitError('Unstable feature use: \'telemetry-file\' is unstable. It must be opted in via \'--unstable\', e.g. \'cdk deploy --unstable=telemetry --telemetry-file=my/file/path\'');
+  }
+
   try {
     await ioHost.startTelemetry(argv, configuration.context);
   } catch (e: any) {
@@ -207,10 +211,6 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
     if (args.all && args.STACKS) {
       throw new ToolkitError('You must either specify a list of Stacks or the `--all` argument');
-    }
-
-    if (args['telemetry-file'] && !configuration.settings.get(['unstable']).includes('telemetry')) {
-      throw new ToolkitError('Unstable feature use: \'telemetry-file\' is unstable. It must be opted in via \'--unstable\', e.g. \'cdk deploy --unstable=telemetry --telemetry-file=my/file/path\'');
     }
 
     args.STACKS = args.STACKS ?? (args.STACK ? [args.STACK] : []);


### PR DESCRIPTION
This feature is currently unstable, so it shouldn't apply at all if invoked without the `--unstable` flag. 

Right now, it creates a telemetry file with an event indicating the aforementioned failure.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
