### PR TITLE
fix: plugin load errors are missing information

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/plugin/plugin.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/plugin/plugin.ts
@@ -36,12 +36,19 @@ export class PluginHost implements IPluginHost {
    * @param ioHost - the I/O host to use for printing progress information
    */
   public async load(moduleSpec: string, ioHost?: IIoHost) {
+    const resolved = this._doResolve(moduleSpec);
+    if (ioHost) {
+      await IoHelper.fromIoHost(ioHost, 'init').defaults.debug(`Loading plug-in: ${resolved} from ${moduleSpec}`);
+    }
+    return this._doLoad(resolved);
+  }
+
+  /**
+   * Do the resolving of a module string to an actual path
+   */
+  private _doResolve(moduleSpec: string) {
     try {
-      const resolved = require.resolve(moduleSpec);
-      if (ioHost) {
-        await IoHelper.fromIoHost(ioHost, 'init').defaults.debug(`Loading plug-in: ${resolved} from ${moduleSpec}`);
-      }
-      return this._doLoad(resolved);
+      return require.resolve(moduleSpec);
     } catch (e: any) {
       // according to Node.js docs `MODULE_NOT_FOUND` is the only possible error here
       // @see https://nodejs.org/api/modules.html#requireresolverequest-options


### PR DESCRIPTION
Currently errors during plugin loading are not exposed to the user, making it impossible to debug.

### Before

<img width="1367" height="35" alt="image" src="https://github.com/user-attachments/assets/f3e26138-1978-4e13-b2ed-8d42d11da961" />

### After

<img width="1029" height="82" alt="image" src="https://github.com/user-attachments/assets/727c2605-0ece-4d66-8ae8-fe01f7171cff" />



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license