### PR TITLE
feat(cli): add sts:TagSession permission to trusted accounts on bootstrap

### DIFF
--- a/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
+++ b/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
@@ -310,7 +310,9 @@ Resources:
                 Ref: AWS::AccountId
           - Fn::If:
               - HasTrustedAccounts
-              - Action: sts:AssumeRole
+              - Action:
+                  - sts:AssumeRole
+                  - sts:TagSession
                 Effect: Allow
                 Principal:
                   AWS:
@@ -340,7 +342,9 @@ Resources:
                 Ref: AWS::AccountId
           - Fn::If:
               - HasTrustedAccounts
-              - Action: sts:AssumeRole
+              - Action:
+                  - sts:AssumeRole
+                  - sts:TagSession
                 Effect: Allow
                 Principal:
                   AWS:
@@ -370,7 +374,9 @@ Resources:
                 Ref: AWS::AccountId
           - Fn::If:
               - HasTrustedAccountsForLookup
-              - Action: sts:AssumeRole
+              - Action:
+                  - sts:AssumeRole
+                  - sts:TagSession
                 Effect: Allow
                 Principal:
                   AWS:
@@ -378,7 +384,9 @@ Resources:
               - Ref: AWS::NoValue
           - Fn::If:
               - HasTrustedAccounts
-              - Action: sts:AssumeRole
+              - Action:
+                  - sts:AssumeRole
+                  - sts:TagSession
                 Effect: Allow
                 Principal:
                   AWS:
@@ -485,7 +493,9 @@ Resources:
                 Ref: AWS::AccountId
           - Fn::If:
               - HasTrustedAccounts
-              - Action: sts:AssumeRole
+              - Action:
+                  - sts:AssumeRole
+                  - sts:TagSession
                 Effect: Allow
                 Principal:
                   AWS:


### PR DESCRIPTION
## Description

Accounts bootstrapped with `--trust` or `--trust-for-lookup` need `sts:TagSession` permissions in AssumeRolePolicy. 

I got errors during `cdk deploy` run in CD pipelines executed on EKS cluster on the trusted account.

Error message:
Could not assume role in target account using current credentials (which are for account `<TRUSTED_ACCOUT>`) User: `arn:aws:sts::<TRUSTED_ACCOUT>:assumed-role/<eks-pod-role>` is not authorized to perform: `sts:TagSession` on resource: `arn:aws:iam::<TARGET_ACCOUNT>:role/cdk-hnb659fds-lookup-role-<TARGET_ACCOUNT>-us-east-1`

Troubleshooting revealed that DeploymentActionRole, FilePublishingRole, ImagePublishingRole, LookupRole don't have `sts:TagSession`. After updating AssumeRolePolicy `cdk deploy` worked normally.

Fixes https://github.com/aws/aws-cdk/issues/31557

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
