### PR TITLE
feat: add Git repository template support for cdk init

### DIFF
--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -395,6 +395,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'list': { type: 'boolean', desc: 'List the available templates' },
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
+          'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -396,6 +396,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
           'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
+          'from-git-url': { type: 'string', desc: 'Git repository URL containing templates', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -831,6 +831,16 @@
           "type": "string",
           "alias": "V",
           "desc": "The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built."
+        },
+        "from-path": {
+          "type": "string",
+          "desc": "Path to a local custom template directory",
+          "requiresArg": true
+        },
+        "from-git-url": {
+          "type": "string",
+          "desc": "Git repository URL containing templates",
+          "requiresArg": true
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -520,6 +520,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             canUseNetwork: undefined,
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
+            fromPath: args['from-path'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -521,6 +521,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
             fromPath: args['from-path'],
+            fromGitUrl: args['from-git-url'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -240,6 +240,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         generateOnly: args.generateOnly,
         libVersion: args.libVersion,
         fromPath: args.fromPath,
+        fromGitUrl: args.fromGitUrl,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -471,6 +472,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     generateOnly: config.init?.generateOnly,
     libVersion: config.init?.libVersion,
     fromPath: config.init?.fromPath,
+    fromGitUrl: config.init?.fromGitUrl,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -239,6 +239,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         list: args.list,
         generateOnly: args.generateOnly,
         libVersion: args.libVersion,
+        fromPath: args.fromPath,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -469,6 +470,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     list: config.init?.list,
     generateOnly: config.init?.generateOnly,
     libVersion: config.init?.libVersion,
+    fromPath: config.init?.fromPath,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -830,6 +830,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           desc: 'Path to a local custom template directory',
           requiresArg: true,
+        })
+        .option('from-git-url', {
+          default: undefined,
+          type: 'string',
+          desc: 'Git repository URL containing templates',
+          requiresArg: true,
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -824,6 +824,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           alias: 'V',
           desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.',
+        })
+        .option('from-path', {
+          default: undefined,
+          type: 'string',
+          desc: 'Path to a local custom template directory',
+          requiresArg: true,
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1327,6 +1327,20 @@ export interface InitOptions {
   readonly libVersion?: string;
 
   /**
+   * Path to a local custom template directory
+   *
+   * @default - undefined
+   */
+  readonly fromPath?: string;
+
+  /**
+   * Git repository URL containing templates
+   *
+   * @default - undefined
+   */
+  readonly fromGitUrl?: string;
+
+  /**
    * Positional argument for init
    */
   readonly TEMPLATE?: string;

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -319,6 +319,19 @@ describe('constructs version', () => {
     })).rejects.toThrow(/Template path does not exist/);
   });
 
+  cliTest('git template without network access throws error', async (workDir) => {
+    const projectDir = path.join(workDir, 'my-project');
+    await fs.mkdirp(projectDir);
+
+    await expect(cliInit({
+      ioHelper,
+      fromGitUrl: 'https://github.com/user/repo.git',
+      language: 'typescript',
+      canUseNetwork: false,
+      workDir: projectDir,
+    })).rejects.toThrow(/Cannot use Git URL without network access/);
+  });
+
   cliTest('CLI uses recommended feature flags from data file to initialize context', async (workDir) => {
     const recommendedFlagsFile = path.join(__dirname, '..', '..', 'lib', 'init-templates', '.recommended-feature-flags.json');
     await withReplacedFile(recommendedFlagsFile, JSON.stringify({ banana: 'yellow' }), () => cliInit({


### PR DESCRIPTION
Adds support for initializing CDK projects from Git repositories by introducing the `--from-git-url` option to the `cdk init` command. The implementation allows users to clone CDK templates directly from any Git repository, providing greater flexibility beyond the built-in templates.

The feature includes automatic template discovery that first checks for language directories at the repository root, and if not found, looks for a single subdirectory containing the template structure. Custom templates from Git repositories do not process placeholders like built-in templates do.All previously existing functionality remains unchanged so backward compatibility is ensured.

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
