### PR TITLE
test(cli-integ): output go version in init-go integration tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
@@ -8,6 +8,7 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
     const shell = ShellHelper.fromContext(context);
     await context.cli.makeCliAvailable();
 
+    await shell.shell(['go', 'version']);
     await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'go', template]);
 
     // Canaries will use the generated go.mod as is


### PR DESCRIPTION
This change adds a `go version` check to the init-go integration test to ensure Go is available and allow checking the version before running the CDK init command.

This helps provide better debugging information if the test fails due to Go not being available in the test environment.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license