### PR TITLE
feat(cli): update Go init templates to v1.23.0 and add post-install tidy

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-go/init-go.integtest.ts
@@ -20,9 +20,9 @@ import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '..
       }
 
       await shell.shell(['go', 'mod', 'edit', '-replace', `github.com/aws/aws-cdk-go/awscdk/v2=${dir}/go/awscdk`]);
+      await shell.shell(['go', 'mod', 'tidy']);
     }
 
-    await shell.shell(['go', 'mod', 'tidy']);
     await shell.shell(['go', 'test']);
     await shell.shell(['cdk', 'synth']);
   })));

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -390,6 +390,8 @@ async function postInstall(ioHelper: IoHelper, language: string, canUseNetwork: 
       return postInstallJava(ioHelper, canUseNetwork, workDir);
     case 'python':
       return postInstallPython(ioHelper, workDir);
+    case 'go':
+      return postInstallGo(ioHelper, canUseNetwork, workDir);
   }
 }
 
@@ -438,6 +440,20 @@ async function postInstallPython(ioHelper: IoHelper, cwd: string) {
   } catch {
     await ioHelper.defaults.warn('Unable to create virtualenv automatically');
     await ioHelper.defaults.warn(`Please run '${python} -m venv .venv'!`);
+  }
+}
+
+async function postInstallGo(ioHelper: IoHelper, canUseNetwork: boolean, cwd: string) {
+  if (!canUseNetwork) {
+    await ioHelper.defaults.warn('Please run \'go mod tidy\'!');
+    return;
+  }
+
+  await ioHelper.defaults.info(`Executing ${chalk.green('go mod tidy')}...`);
+  try {
+    await execute(ioHelper, 'go', ['mod', 'tidy'], { cwd });
+  } catch (e: any) {
+    await ioHelper.defaults.warn('\'go mod tidy\' failed: ' + formatErrorMessage(e));
   }
 }
 

--- a/packages/aws-cdk/lib/init-templates/app/go/go.template.mod
+++ b/packages/aws-cdk/lib/init-templates/app/go/go.template.mod
@@ -1,9 +1,9 @@
 module %name%
 
-go 1.18
+go 1.23.0
 
 require (
   github.com/aws/aws-cdk-go/awscdk/v2 v%cdk-version%
   github.com/aws/constructs-go/constructs/v10 v10.0.5
-  github.com/aws/jsii-runtime-go v1.29.0
+  github.com/aws/jsii-runtime-go v1.112.0
 )

--- a/packages/aws-cdk/lib/init-templates/sample-app/go/go.template.mod
+++ b/packages/aws-cdk/lib/init-templates/sample-app/go/go.template.mod
@@ -1,9 +1,9 @@
 module %name%
 
-go 1.18
+go 1.23.0
 
 require (
   github.com/aws/aws-cdk-go/awscdk/v2 v%cdk-version%
   github.com/aws/constructs-go/constructs/v10 v10.0.5
-  github.com/aws/jsii-runtime-go v1.29.0
+  github.com/aws/jsii-runtime-go v1.112.0
 )


### PR DESCRIPTION
This PR updates the Go init templates and adds automatic dependency management:

## Changes
- **Go version**: Updated from 1.18 to 1.23.0 in both app and sample-app templates
- **jsii-runtime-go**: Updated from v1.29.0 to v1.112.0 for latest compatibility
- **Post-install automation**: Added `postInstallGo` function that automatically runs `go mod tidy` after project initialization
- **Integration test**: Updated to run `go mod tidy` after module replacement for proper dependency resolution

## Benefits
- Users get the latest stable Go version (1.23.0) 
- Latest jsii runtime with bug fixes and improvements
- Automatic dependency management eliminates manual `go mod tidy` step
- Better developer experience for Go CDK projects

## Testing
- Integration tests updated and should pass with the new flow
- Post-install step gracefully handles network unavailability

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license