### PR TITLE
feat: add --template-path option for Git repository templates

### DIFF
--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -395,6 +395,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'list': { type: 'boolean', desc: 'List the available templates' },
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
+          'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -13,6 +13,8 @@ export const YARGS_HELPERS = new CliHelpers('./util/yargs-helpers');
  * - the `yargs` definition in `lib/parse-command-line-arguments.ts`.
  * - the `UserInput` type in `lib/user-input.ts`.
  * - the `convertXxxToUserInput` functions in `lib/convert-to-user-input.ts`.
+ *
+ * @returns Promise resolving to the complete CLI configuration object
  */
 export async function makeConfig(): Promise<CliConfig> {
   return {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -397,6 +397,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
           'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
           'from-git-url': { type: 'string', desc: 'Git repository URL containing templates', requiresArg: true },
+          'template-path': { type: 'string', desc: 'Path to a subdirectory within Git repositories', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -396,6 +396,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
           'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
+          'from-git-url': { type: 'string', desc: 'Git repository URL containing templates', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -520,6 +520,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             canUseNetwork: undefined,
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
+            fromPath: args['from-path'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -521,6 +521,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
             fromPath: args['from-path'],
+            fromGitUrl: args['from-git-url'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -550,7 +550,11 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 }
 
 /**
- * Determine which version of bootstrapping
+ * Determine which version of bootstrapping to use
+ *
+ * @param ioHost - CLI IO host for user interaction
+ * @param args - Arguments containing optional template path
+ * @returns Promise resolving to the bootstrap source configuration
  */
 async function determineBootstrapVersion(ioHost: CliIoHost, args: { template?: string }): Promise<BootstrapSource> {
   let source: BootstrapSource;
@@ -567,6 +571,13 @@ async function determineBootstrapVersion(ioHost: CliIoHost, args: { template?: s
   return source;
 }
 
+/**
+ * Check if a feature flag is enabled in the configuration
+ *
+ * @param configuration - CDK configuration object
+ * @param featureFlag - Feature flag name to check
+ * @returns true if the feature flag is enabled
+ */
 function isFeatureEnabled(configuration: Configuration, featureFlag: string) {
   return configuration.context.get(featureFlag) ?? cxapi.futureFlagDefault(featureFlag);
 }
@@ -579,6 +590,9 @@ function isFeatureEnabled(configuration: Configuration, featureFlag: string) {
  *   undefined.
  * - If the user passed a single empty string, they did something like `--array=`, which we'll
  *   take to mean they passed an empty array.
+ *
+ * @param xs - Input array from Yargs
+ * @returns Filtered array or undefined if no meaningful input
  */
 function arrayFromYargs(xs: string[]): string[] | undefined {
   if (xs.length === 0) {
@@ -587,6 +601,14 @@ function arrayFromYargs(xs: string[]): string[] | undefined {
   return xs.filter((x) => x !== '');
 }
 
+/**
+ * Determine the deployment method based on arguments and configuration
+ *
+ * @param args - Command line arguments
+ * @param configuration - CDK configuration object
+ * @param watch - Whether this is for watch mode
+ * @returns The determined deployment method
+ */
 function determineDeploymentMethod(args: any, configuration: Configuration, watch?: boolean): DeploymentMethod {
   let deploymentMethod: ChangeSetDeployment | DirectDeployment | undefined;
   switch (args.method) {
@@ -646,6 +668,14 @@ function determineDeploymentMethod(args: any, configuration: Configuration, watc
   }
 }
 
+/**
+ * Determine the hotswap mode based on provided flags
+ *
+ * @param hotswap - Whether hotswap-only mode is enabled
+ * @param hotswapFallback - Whether hotswap with fallback is enabled
+ * @param watch - Whether this is for watch mode
+ * @returns The determined hotswap mode
+ */
 function determineHotswapMode(hotswap?: boolean, hotswapFallback?: boolean, watch?: boolean): HotswapMode {
   if (hotswap && hotswapFallback) {
     throw new ToolkitError('Can not supply both --hotswap and --hotswap-fallback at the same time');

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -522,6 +522,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             libVersion: args.libVersion,
             fromPath: args['from-path'],
             fromGitUrl: args['from-git-url'],
+            templatePath: args['template-path'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -239,6 +239,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         list: args.list,
         generateOnly: args.generateOnly,
         libVersion: args.libVersion,
+        fromPath: args.fromPath,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -469,6 +470,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     list: config.init?.list,
     generateOnly: config.init?.generateOnly,
     libVersion: config.init?.libVersion,
+    fromPath: config.init?.fromPath,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -824,6 +824,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           alias: 'V',
           desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.',
+        })
+        .option('from-path', {
+          default: undefined,
+          type: 'string',
+          desc: 'Path to a local custom template directory',
+          requiresArg: true,
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -50,6 +50,8 @@ export interface CliInitOptions {
 
 /**
  * Initialize a CDK package in the current directory
+ *
+ * @param options - Configuration options for CDK initialization
  */
 export async function cliInit(options: CliInitOptions) {
   const ioHelper = options.ioHelper;
@@ -241,6 +243,9 @@ async function resolveLanguage(ioHelper: IoHelper, template: InitTemplate, reque
 
 /**
  * Validate Git URL format
+ *
+ * @param url - The Git URL to validate
+ * @returns true if the URL is a valid Git URL format
  */
 export function isValidGitUrl(url: string): boolean {
   try {
@@ -255,6 +260,9 @@ export function isValidGitUrl(url: string): boolean {
 
 /**
  * Get valid CDK language directories from a template path
+ *
+ * @param templatePath - Path to the template directory to scan
+ * @returns Array of supported language directory names found
  */
 async function getLanguageDirectories(templatePath: string): Promise<string[]> {
   const result: string[] = [];
@@ -281,6 +289,10 @@ async function getLanguageDirectories(templatePath: string): Promise<string[]> {
 
 /**
  * Check if a language directory contains valid template files
+ *
+ * @param langDir - Path to the language directory to check
+ * @param language - The programming language to validate files for
+ * @returns true if the directory contains valid template files for the language
  */
 async function hasValidLanguageFiles(langDir: string, language: string): Promise<boolean> {
   try {
@@ -309,6 +321,9 @@ async function hasValidLanguageFiles(langDir: string, language: string): Promise
 
 /**
  * Recursively get all files in a directory
+ *
+ * @param dir - Directory path to scan recursively
+ * @returns Array of all file names found in the directory tree
  */
 async function getAllFiles(dir: string): Promise<string[]> {
   const files: string[] = [];
@@ -366,10 +381,10 @@ export async function cloneGitRepository(gitUrl: string): Promise<string> {
 /**
  * Execute a command and return stdout
  *
- * @param cmd - command to execute
- * @param args - command arguments
- * @param options - execution options
- * @returns stdout if successful
+ * @param cmd - Command to execute (only 'git' is allowed for security)
+ * @param args - Command arguments array
+ * @param options - Execution options containing working directory
+ * @returns Promise resolving to stdout if successful
  */
 async function executeCommand(cmd: string, args: string[], { cwd }: { cwd: string }) {
   // Validate command

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -319,6 +319,19 @@ describe('constructs version', () => {
     })).rejects.toThrow(/Template path does not exist/);
   });
 
+  cliTest('git template without network access throws error', async (workDir) => {
+    const projectDir = path.join(workDir, 'my-project');
+    await fs.mkdirp(projectDir);
+
+    await expect(cliInit({
+      ioHelper,
+      fromGitUrl: 'https://github.com/user/repo.git',
+      language: 'typescript',
+      canUseNetwork: false,
+      workDir: projectDir,
+    })).rejects.toThrow(/Cannot use Git URL without network access/);
+  });
+
   cliTest('CLI uses recommended feature flags from data file to initialize context', async (workDir) => {
     const recommendedFlagsFile = path.join(__dirname, '..', '..', 'lib', 'init-templates', '.recommended-feature-flags.json');
     await withReplacedFile(recommendedFlagsFile, JSON.stringify({ banana: 'yellow' }), () => cliInit({


### PR DESCRIPTION
This enables users to specify which template to use from Git repositories containing multiple templates:
cdk init --from-git-url <url> --template-path <path> --language <lang>

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
