### PR TITLE
feat(cli): add basic Git repository support for cdk init

### DIFF
--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -395,6 +395,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'list': { type: 'boolean', desc: 'List the available templates' },
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
+          'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -394,7 +394,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'language': { type: 'string', alias: 'l', desc: 'The language to be used for the new project (default can be configured in ~/.cdk.json)', choices: await availableInitLanguages() },
           'list': { type: 'boolean', desc: 'List the available templates' },
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
-          'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
+          'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize built-in templates with. Defaults to the version that was current when this CLI was built.' },
           'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true, conflicts: ['lib-version'] },
         },
       },

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -396,6 +396,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize built-in templates with. Defaults to the version that was current when this CLI was built.' },
           'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true, conflicts: ['lib-version'] },
+          'from-git-url': { type: 'string', desc: 'Git repository URL containing templates', requiresArg: true, conflicts: ['lib-version', 'from-path'] },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -395,7 +395,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'list': { type: 'boolean', desc: 'List the available templates' },
           'generate-only': { type: 'boolean', default: false, desc: 'If true, only generates project files, without executing additional operations such as setting up a git repo, installing dependencies or compiling the project' },
           'lib-version': { type: 'string', alias: 'V', default: undefined, desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.' },
-          'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true },
+          'from-path': { type: 'string', desc: 'Path to a local custom template directory', requiresArg: true, conflicts: ['lib-version'] },
         },
       },
       'migrate': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -835,7 +835,10 @@
         "from-path": {
           "type": "string",
           "desc": "Path to a local custom template directory",
-          "requiresArg": true
+          "requiresArg": true,
+          "conflicts": [
+            "lib-version"
+          ]
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -831,6 +831,11 @@
           "type": "string",
           "alias": "V",
           "desc": "The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built."
+        },
+        "from-path": {
+          "type": "string",
+          "desc": "Path to a local custom template directory",
+          "requiresArg": true
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -830,7 +830,7 @@
         "lib-version": {
           "type": "string",
           "alias": "V",
-          "desc": "The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built."
+          "desc": "The version of the CDK library (aws-cdk-lib) to initialize built-in templates with. Defaults to the version that was current when this CLI was built."
         },
         "from-path": {
           "type": "string",
@@ -838,6 +838,15 @@
           "requiresArg": true,
           "conflicts": [
             "lib-version"
+          ]
+        },
+        "from-git-url": {
+          "type": "string",
+          "desc": "Git repository URL containing templates",
+          "requiresArg": true,
+          "conflicts": [
+            "lib-version",
+            "from-path"
           ]
         }
       }

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -514,9 +514,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           return printAvailableTemplates(ioHelper, language);
         } else {
           // Gate custom template support with unstable flag
-          if (args['from-path'] && !configuration.settings.get(['unstable']).includes('init')) {
+          if ((args['from-path'] || args['from-git-url']) && !configuration.settings.get(['unstable']).includes('init')) {
             throw new ToolkitError('Unstable feature use: \'init\' with custom templates is unstable. It must be opted in via \'--unstable\', e.g. \'cdk init --from-path=./my-template --unstable=init\'');
           }
+
           return cliInit({
             ioHelper,
             type: args.TEMPLATE,
@@ -525,6 +526,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
             fromPath: args['from-path'],
+            fromGitUrl: args['from-git-url'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -520,6 +520,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             canUseNetwork: undefined,
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
+            fromPath: args['from-path'],
           });
         }
       case 'migrate':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -513,6 +513,10 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         if (args.list) {
           return printAvailableTemplates(ioHelper, language);
         } else {
+          // Gate custom template support with unstable flag
+          if (args['from-path'] && !configuration.settings.get(['unstable']).includes('init')) {
+            throw new ToolkitError('Unstable feature use: \'init\' with custom templates is unstable. It must be opted in via \'--unstable\', e.g. \'cdk init --from-path=./my-template --unstable=init\'');
+          }
           return cliInit({
             ioHelper,
             type: args.TEMPLATE,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -240,6 +240,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         generateOnly: args.generateOnly,
         libVersion: args.libVersion,
         fromPath: args.fromPath,
+        fromGitUrl: args.fromGitUrl,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -471,6 +472,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     generateOnly: config.init?.generateOnly,
     libVersion: config.init?.libVersion,
     fromPath: config.init?.fromPath,
+    fromGitUrl: config.init?.fromGitUrl,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -239,6 +239,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         list: args.list,
         generateOnly: args.generateOnly,
         libVersion: args.libVersion,
+        fromPath: args.fromPath,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -469,6 +470,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     list: config.init?.list,
     generateOnly: config.init?.generateOnly,
     libVersion: config.init?.libVersion,
+    fromPath: config.init?.fromPath,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -823,7 +823,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           default: undefined,
           type: 'string',
           alias: 'V',
-          desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.',
+          desc: 'The version of the CDK library (aws-cdk-lib) to initialize built-in templates with. Defaults to the version that was current when this CLI was built.',
         })
         .option('from-path', {
           default: undefined,
@@ -831,6 +831,13 @@ export function parseCommandLineArguments(args: Array<string>): any {
           desc: 'Path to a local custom template directory',
           requiresArg: true,
           conflicts: ['lib-version'],
+        })
+        .option('from-git-url', {
+          default: undefined,
+          type: 'string',
+          desc: 'Git repository URL containing templates',
+          requiresArg: true,
+          conflicts: ['lib-version', 'from-path'],
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -830,6 +830,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           desc: 'Path to a local custom template directory',
           requiresArg: true,
+          conflicts: ['lib-version'],
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -824,6 +824,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           alias: 'V',
           desc: 'The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.',
+        })
+        .option('from-path', {
+          default: undefined,
+          type: 'string',
+          desc: 'Path to a local custom template directory',
+          requiresArg: true,
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1318,7 +1318,7 @@ export interface InitOptions {
   readonly generateOnly?: boolean;
 
   /**
-   * The version of the CDK library (aws-cdk-lib) to initialize the project with. Defaults to the version that was current when this CLI was built.
+   * The version of the CDK library (aws-cdk-lib) to initialize built-in templates with. Defaults to the version that was current when this CLI was built.
    *
    * aliases: V
    *
@@ -1332,6 +1332,13 @@ export interface InitOptions {
    * @default - undefined
    */
   readonly fromPath?: string;
+
+  /**
+   * Git repository URL containing templates
+   *
+   * @default - undefined
+   */
+  readonly fromGitUrl?: string;
 
   /**
    * Positional argument for init

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1327,6 +1327,13 @@ export interface InitOptions {
   readonly libVersion?: string;
 
   /**
+   * Path to a local custom template directory
+   *
+   * @default - undefined
+   */
+  readonly fromPath?: string;
+
+  /**
    * Positional argument for init
    */
   readonly TEMPLATE?: string;

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -315,12 +315,10 @@ export class InitTemplate {
    *
    * @param language - the language to instantiate this template with
    * @param targetDirectory - the directory where the template is to be instantiated into
-   * /* eslint-disable jsdoc/require-param-description */
-   * @param stackName
+   * @param stackName - the name of the stack to create
    * @default undefined
-   * @param libVersion
+   * @param libVersion - the version of the CDK library to use
    * @default undefined
-   * /* eslint-enable jsdoc/require-param-description */
    */
   public async install(ioHelper: IoHelper, language: string, targetDirectory: string, stackName?: string, libVersion?: string) {
     if (this.languages.indexOf(language) === -1) {

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -538,7 +538,7 @@ async function listDirectory(dirPath: string) {
  * Print available templates to the user
  * @param ioHelper - IO helper for user interaction
  * @param language - Programming language filter
- * @default - Shows all available templates
+ * @default undefined
  */
 export async function printAvailableTemplates(ioHelper: IoHelper, language?: string) {
   await ioHelper.defaults.info('Available templates:');
@@ -569,7 +569,7 @@ export async function printAvailableTemplates(ioHelper: IoHelper, language?: str
  * @param migrate - Whether this is a migration project
  * @default undefined
  * @param cdkVersion - Version of the CDK to use
- * @default - Uses built-in CDK version
+ * @default undefined
  */
 async function initializeProject(
   ioHelper: IoHelper,

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -802,11 +802,9 @@ async function loadInitVersions(): Promise<Versions> {
     'aws-cdk': versionNumber(),
   };
   for (const [key, value] of Object.entries(ret)) {
-    /* c8 ignore start */
     if (!value) {
       throw new ToolkitError(`Missing init version from ${initVersionFile}: ${key}`);
     }
-    /* c8 ignore stop */
   }
 
   return ret;

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -315,10 +315,12 @@ export class InitTemplate {
    *
    * @param language - the language to instantiate this template with
    * @param targetDirectory - the directory where the template is to be instantiated into
+   * /* eslint-disable jsdoc/require-param-description */
    * @param stackName
    * @default undefined
    * @param libVersion
    * @default undefined
+   * /* eslint-enable jsdoc/require-param-description */
    */
   public async install(ioHelper: IoHelper, language: string, targetDirectory: string, stackName?: string, libVersion?: string) {
     if (this.languages.indexOf(language) === -1) {

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -291,6 +291,7 @@ describe('constructs version', () => {
     await fs.mkdirp(tsDir);
 
     await fs.writeFile(path.join(tsDir, 'package.json'), JSON.stringify({ name: '%name%' }, null, 2));
+    await fs.writeFile(path.join(tsDir, 'app.ts'), 'console.log("Hello!");');
 
     const projectDir = path.join(workDir, 'my-project');
     await fs.mkdirp(projectDir);
@@ -305,6 +306,7 @@ describe('constructs version', () => {
     });
 
     expect(await fs.pathExists(path.join(projectDir, 'package.json'))).toBeTruthy();
+    expect(await fs.pathExists(path.join(projectDir, 'app.ts'))).toBeTruthy();
   });
 
   cliTest('custom template path does not exist throws error', async (workDir) => {

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -309,6 +309,30 @@ describe('constructs version', () => {
     expect(await fs.pathExists(path.join(projectDir, 'app.ts'))).toBeTruthy();
   });
 
+  cliTest('custom template with multiple languages fails if language not provided', async (workDir) => {
+    // Create a custom template with both TypeScript and Python
+    const templateDir = path.join(workDir, 'custom-template');
+    const tsDir = path.join(templateDir, 'typescript');
+    const pyDir = path.join(templateDir, 'python');
+    await fs.mkdirp(tsDir);
+    await fs.mkdirp(pyDir);
+
+    await fs.writeFile(path.join(tsDir, 'app.ts'), 'console.log("Hello TS!");');
+    await fs.writeFile(path.join(pyDir, 'app.py'), 'print("Hello Python!")');
+
+    const projectDir = path.join(workDir, 'my-project');
+    await fs.mkdirp(projectDir);
+
+    // Don't specify language - should fail since multiple languages are available
+    await expect(cliInit({
+      ioHelper,
+      fromPath: templateDir,
+      canUseNetwork: false,
+      generateOnly: true,
+      workDir: projectDir,
+    })).rejects.toThrow(/No language was selected/);
+  });
+
   cliTest('custom template path does not exist throws error', async (workDir) => {
     const projectDir = path.join(workDir, 'my-project');
     await fs.mkdirp(projectDir);

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -345,6 +345,33 @@ describe('constructs version', () => {
     })).rejects.toThrow(/Template path does not exist/);
   });
 
+  cliTest('Git URL without network access throws error', async (workDir) => {
+    const projectDir = path.join(workDir, 'my-project');
+    await fs.mkdirp(projectDir);
+
+    await expect(cliInit({
+      ioHelper,
+      fromGitUrl: 'https://github.com/user/repo',
+      language: 'typescript',
+      canUseNetwork: false,
+      workDir: projectDir,
+    })).rejects.toThrow(/Cannot clone Git repository: network access is disabled/);
+  });
+
+  cliTest('Git URL with invalid URL throws error', async (workDir) => {
+    const projectDir = path.join(workDir, 'my-project');
+    await fs.mkdirp(projectDir);
+
+    await expect(cliInit({
+      ioHelper,
+      fromGitUrl: 'https://nonexistent-git-repo-12345.com/user/repo',
+      language: 'typescript',
+      canUseNetwork: true,
+      generateOnly: true,
+      workDir: projectDir,
+    })).rejects.toThrow(/Failed to load template from Git URL/);
+  });
+
   cliTest('CLI uses recommended feature flags from data file to initialize context', async (workDir) => {
     const recommendedFlagsFile = path.join(__dirname, '..', '..', 'lib', 'init-templates', '.recommended-feature-flags.json');
     await withReplacedFile(recommendedFlagsFile, JSON.stringify({ banana: 'yellow' }), () => cliInit({


### PR DESCRIPTION
Added `--from-git-url` option to pull a custom template from a Git repository. This option supports scenarios where repository contains a single template which is represented by language directories for it at the repository root. The option auto-detects language for single-language template (one language directory at repo root) and requires `--language` flag for a multi-language template (multiple CDK supported language directories at repo root). This new option is gated with `--unstable=init` flag. Wrote tests for this functionality.

Fixes #

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
