### PR TITLE
fix(cli-integ): add retry for iam eventual consistency issue and  migration tests for java

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
@@ -84,7 +84,7 @@ async function testDockerCredential(fixture: TestFixture, credSource: DockerDoma
 
   await fixture.cdkAssets.makeCliAvailable();
   let output: string = '';
-  
+
   await retry(process.stdout, 'Getting docker credentials', retry.forSeconds(60), async () => {
     output = await fixture.shell(['docker-credential-cdk-assets', 'get'], {
       modEnv: {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
@@ -84,6 +84,7 @@ async function testDockerCredential(fixture: TestFixture, credSource: DockerDoma
 
   await fixture.cdkAssets.makeCliAvailable();
   let output: string = '';
+  
   await retry(process.stdout, 'Getting docker credentials', retry.forSeconds(60), async () => {
     output = await fixture.shell(['docker-credential-cdk-assets', 'get'], {
       modEnv: {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
@@ -5,7 +5,7 @@ import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 // eslint-disable-next-line import/no-relative-packages
 import type { DockerDomainCredentialSource } from '../../../../../@aws-cdk/cdk-assets-lib/lib/private/docker-credentials';
 import type { TestFixture } from '../../../lib';
-import { integTest, withDefaultFixture, withRetry } from '../../../lib';
+import { integTest, withDefaultFixture, withRetry, retry } from '../../../lib';
 
 jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
 
@@ -83,13 +83,16 @@ async function testDockerCredential(fixture: TestFixture, credSource: DockerDoma
   fs.writeFileSync(input, `${domain}\n`);
 
   await fixture.cdkAssets.makeCliAvailable();
-  const output = await fixture.shell(['docker-credential-cdk-assets', 'get'], {
-    modEnv: {
-      ...fixture.cdkShellEnv(),
-      CDK_DOCKER_CREDS_FILE: credsFilePath,
-    },
-    stdio: [fs.openSync(input, 'r')],
-    captureStderr: false,
+  let output: string = '';
+  await retry(process.stdout, 'Getting docker credentials', retry.forSeconds(60), async () => {
+    output = await fixture.shell(['docker-credential-cdk-assets', 'get'], {
+      modEnv: {
+        ...fixture.cdkShellEnv(),
+        CDK_DOCKER_CREDS_FILE: credsFilePath,
+      },
+      stdio: [fs.openSync(input, 'r')],
+      captureStderr: false,
+    });
   });
 
   const response = JSON.parse(output);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-java.integtest.ts
@@ -1,5 +1,5 @@
 import { deploysSuccessfully } from './testcase';
-import { integTest, withCDKMigrateFixture } from '../../../lib';
+import { integTest, withCDKMigrateFixture, withRetry } from '../../../lib';
 
 const language = 'java';
 
@@ -7,7 +7,7 @@ jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-c
 
 integTest(
   `cdk migrate ${language} deploys successfully`,
-  withCDKMigrateFixture(language, async (fixture) => {
+  withRetry(withCDKMigrateFixture(language, async (fixture) => {
     await deploysSuccessfully(fixture, language);
-  }),
+  })),
 );

--- a/packages/cdk-assets/bin/docker-credential-cdk-assets.ts
+++ b/packages/cdk-assets/bin/docker-credential-cdk-assets.ts
@@ -39,32 +39,9 @@ async function main() {
 
   // Read the domain to fetch from stdin
   let endpoint = fs.readFileSync(0, { encoding: 'utf-8' }).trim();
-
-  const deadline = Date.now() + 60_000; // 60 seconds timeout
-  let lastError: Error | undefined;
-
-  while (Date.now() < deadline) {
-    try {
-      const credentials = await fetchDockerLoginCredentials(new DefaultAwsClient(), config, endpoint);
-      // Write the credentials back to stdout
-      fs.writeFileSync(1, JSON.stringify(credentials));
-      return;
-    } catch (e: any) {
-      lastError = e;
-      
-      // Retry on AccessDenied errors due to eventual consistency in AWS IAM.
-      // Newly created roles and policies may take time to propagate across regions.
-      if (e.name === 'AccessDenied') {
-        await new Promise(resolve => setTimeout(resolve, 5000)); // Wait 5 seconds
-        continue;
-      }
-      
-      // For other errors, throw immediately
-      throw e;
-    }
-  }
-
-  throw lastError;
+  const credentials = await fetchDockerLoginCredentials(new DefaultAwsClient(), config, endpoint);
+  // Write the credentials back to stdout
+  fs.writeFileSync(1, JSON.stringify(credentials));
 }
 
 main().catch((e) => {

--- a/packages/cdk-assets/bin/docker-credential-cdk-assets.ts
+++ b/packages/cdk-assets/bin/docker-credential-cdk-assets.ts
@@ -39,9 +39,32 @@ async function main() {
 
   // Read the domain to fetch from stdin
   let endpoint = fs.readFileSync(0, { encoding: 'utf-8' }).trim();
-  const credentials = await fetchDockerLoginCredentials(new DefaultAwsClient(), config, endpoint);
-  // Write the credentials back to stdout
-  fs.writeFileSync(1, JSON.stringify(credentials));
+
+  const deadline = Date.now() + 60_000; // 60 seconds timeout
+  let lastError: Error | undefined;
+
+  while (Date.now() < deadline) {
+    try {
+      const credentials = await fetchDockerLoginCredentials(new DefaultAwsClient(), config, endpoint);
+      // Write the credentials back to stdout
+      fs.writeFileSync(1, JSON.stringify(credentials));
+      return;
+    } catch (e: any) {
+      lastError = e;
+      
+      // Retry on AccessDenied errors due to eventual consistency in AWS IAM.
+      // Newly created roles and policies may take time to propagate across regions.
+      if (e.name === 'AccessDenied') {
+        await new Promise(resolve => setTimeout(resolve, 5000)); // Wait 5 seconds
+        continue;
+      }
+      
+      // For other errors, throw immediately
+      throw e;
+    }
+  }
+
+  throw lastError;
 }
 
 main().catch((e) => {


### PR DESCRIPTION
### Background
The CDK pipelines have been experiencing intermittent failures due to flaky tests that typically pass on retry. This pull request addresses the investigation of the two most frequent failing tests.

<img width="1307" height="530" alt="image (1)" src="https://github.com/user-attachments/assets/c03da25a-6921-4358-8a12-81db8722d437" />


### AWS IAM Eventual Consistency Issue
Test: `docker-credential-cdk-assets can assume role and fetch ECR credentials`

Issue: Docker credential fetching fails with AccessDenied errors because newly created IAM roles and policies require time to propagate across AWS regions.

Fix: Implemented a 60-second retry mechanism for `fetchDockerLoginCredentials()` when encountering AccessDenied errors.

### CDK Migration Test Instability
Test: `cdk migrate java deploys successfully`

Issue: Java CDK migration tests fail sporadically due to Maven Central repository rate limiting errors & dependency resolution failure

Fix: Implemented full test retry logic as these transient network-related issues could not be reproduced in local environments.

### Impact
These changes should improve pipeline stability and reduce the need for manual intervention.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

