### PR TITLE
fix(cli): "cdk flags" nag message writes to stderr unconditionally

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -2113,11 +2113,29 @@ async function askUserConfirmation(
   });
 }
 
+/**
+ * Display a warning if there are flags that are different from the recommended value
+ *
+ * This happens if both of the following are true:
+ *
+ * - The user didn't configure the value
+ * - The default value for the flag (unconfiguredBehavesLike) is different from the recommended value
+ */
 export async function displayFlagsMessage(ioHost: IoHelper, toolkit: InternalToolkit, cloudExecutable: CloudExecutable): Promise<void> {
-  let numUnconfigured = (await toolkit.flags(cloudExecutable))
-    .filter(flag => !OBSOLETE_FLAGS.includes(flag.name))
-    .filter(flag => flag.userValue === undefined).length;
+  const flags = await toolkit.flags(cloudExecutable);
 
+  // The "unconfiguredBehavesLike" information got added later. If none of the flags have this information,
+  // we don't have enough information to reliably display this information without scaring users, so don't do anything.
+  if (flags.every(flag => flag.unconfiguredBehavesLike === undefined)) {
+    return;
+  }
+
+  const unconfiguredFlags = flags
+    .filter(flag => !OBSOLETE_FLAGS.includes(flag.name))
+    .filter(flag => (flag.unconfiguredBehavesLike?.v2 ?? false) !== flag.recommendedValue)
+    .filter(flag => flag.userValue === undefined);
+
+  const numUnconfigured = unconfiguredFlags.length;
   if (numUnconfigured > 0) {
     await ioHost.defaults.warn(`${numUnconfigured} feature flags are not configured. Run 'cdk --unstable=flags flags' to learn more.`);
   }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1065,7 +1065,7 @@ export class CdkToolkit {
         await printSerializedObject(this.ioHost.asIoHelper(), obscureTemplate(stacks.firstStack.template), json ?? false);
       }
 
-      await displayFlagsMessage(this.toolkit, this.props.cloudExecutable);
+      await displayFlagsMessage(this.ioHost.asIoHelper(), this.toolkit, this.props.cloudExecutable);
       return undefined;
     }
 
@@ -1075,7 +1075,7 @@ export class CdkToolkit {
       `Supply a stack id (${stacks.stackArtifacts.map((s) => chalk.green(s.hierarchicalId)).join(', ')}) to display its template.`,
     );
 
-    await displayFlagsMessage(this.toolkit, this.props.cloudExecutable);
+    await displayFlagsMessage(this.ioHost.asIoHelper(), this.toolkit, this.props.cloudExecutable);
     return undefined;
   }
 
@@ -2112,13 +2112,14 @@ async function askUserConfirmation(
     }
   });
 }
-export async function displayFlagsMessage(toolkit: InternalToolkit, cloudExecutable: CloudExecutable): Promise<void> {
+
+export async function displayFlagsMessage(ioHost: IoHelper, toolkit: InternalToolkit, cloudExecutable: CloudExecutable): Promise<void> {
   let numUnconfigured = (await toolkit.flags(cloudExecutable))
     .filter(flag => !OBSOLETE_FLAGS.includes(flag.name))
     .filter(flag => flag.userValue === undefined).length;
 
   if (numUnconfigured > 0) {
-    process.stderr.write(`You currently have ${numUnconfigured} unconfigured feature flag(s) that may require attention to keep your application up-to-date. Run 'cdk flags' to learn more.`);
+    await ioHost.defaults.warn(`${numUnconfigured} feature flags are not configured. Run 'cdk --unstable=flags flags' to learn more.`);
   }
 }
 


### PR DESCRIPTION
This ignores our rules for avoiding writing to `stderr` in CI environments. Use the IoHost instead.

* Also update the message to include the use of the unstable flag.
* The message is also too pessimistic, showing 18 unconfigured flags on a newly `cdk init`ed project. 

Part of that is the CDK library, fixed here: https://github.com/aws/aws-cdk/pull/35227

Part of that is we shouldn't alarm on unconfigured behavior being the same as default behavior. That's all just fine.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
