### PR TITLE
fix(cli): displays a nag message for flags that don't need configuring

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/types.ts
@@ -123,5 +123,5 @@ export interface FeatureFlag {
   readonly recommendedValue: unknown;
   readonly userValue?: unknown;
   readonly explanation?: string;
-  readonly unconfiguredBehavesLike?: { [key: string]: any };
+  readonly unconfiguredBehavesLike?: { v2?: any };
 }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -2113,11 +2113,29 @@ async function askUserConfirmation(
   });
 }
 
+/**
+ * Display a warning if there are flags that are different from the recommended value
+ *
+ * This happens if both of the following are true:
+ *
+ * - The user didn't configure the value
+ * - The default value for the flag (unconfiguredBehavesLike) is different from the recommended value
+ */
 export async function displayFlagsMessage(ioHost: IoHelper, toolkit: InternalToolkit, cloudExecutable: CloudExecutable): Promise<void> {
-  let numUnconfigured = (await toolkit.flags(cloudExecutable))
-    .filter(flag => !OBSOLETE_FLAGS.includes(flag.name))
-    .filter(flag => flag.userValue === undefined).length;
+  const flags = await toolkit.flags(cloudExecutable);
 
+  // The "unconfiguredBehavesLike" information got added later. If none of the flags have this information,
+  // we don't have enough information to reliably display this information without scaring users, so don't do anything.
+  if (flags.every(flag => flag.unconfiguredBehavesLike === undefined)) {
+    return;
+  }
+
+  const unconfiguredFlags = flags
+    .filter(flag => !OBSOLETE_FLAGS.includes(flag.name))
+    .filter(flag => (flag.unconfiguredBehavesLike?.v2 ?? false) !== flag.recommendedValue)
+    .filter(flag => flag.userValue === undefined);
+
+  const numUnconfigured = unconfiguredFlags.length;
   if (numUnconfigured > 0) {
     await ioHost.defaults.warn(`${numUnconfigured} feature flags are not configured. Run 'cdk --unstable=flags flags' to learn more.`);
   }

--- a/packages/aws-cdk/test/cli/display-flags-message.test.ts
+++ b/packages/aws-cdk/test/cli/display-flags-message.test.ts
@@ -30,6 +30,7 @@ describe('displayFlagsMessage', () => {
         recommendedValue: 'true',
         explanation: 'Test flag',
         module: 'aws-cdk-lib',
+        unconfiguredBehavesLike: { v2: true },
       },
       {
         name: '@aws-cdk/s3:anotherFlag',
@@ -37,6 +38,7 @@ describe('displayFlagsMessage', () => {
         recommendedValue: 'false',
         explanation: 'Another test flag',
         module: 'aws-cdk-lib',
+        unconfiguredBehavesLike: { v2: true },
       },
       {
         name: '@aws-cdk/core:enableStackNameDuplicates',
@@ -44,6 +46,7 @@ describe('displayFlagsMessage', () => {
         recommendedValue: 'true',
         explanation: 'Obsolete flag',
         module: 'aws-cdk-lib',
+        unconfiguredBehavesLike: { v2: true },
       },
     ];
 
@@ -56,14 +59,16 @@ describe('displayFlagsMessage', () => {
       message: expect.stringContaining('1 feature flags are not configured'),
     }));
   });
+
   test('does not display a message when user has no unconfigured flags', async () => {
     const mockFlagsData = [
       {
         name: '@aws-cdk/s3:anotherFlag',
-        userValue: 'false',
-        recommendedValue: 'false',
+        userValue: false,
+        recommendedValue: false,
         explanation: 'Another test flag',
         module: 'aws-cdk-lib',
+        unconfiguredBehavesLike: { v2: true },
       },
     ];
     mockToolkit.flags.mockResolvedValue(mockFlagsData);
@@ -71,6 +76,24 @@ describe('displayFlagsMessage', () => {
     await displayFlagsMessage(ioHost.asHelper(), mockToolkit as any, mockCloudExecutable);
 
     expect(mockToolkit.flags).toHaveBeenCalledWith(mockCloudExecutable);
+    expect(ioHost.notifySpy).not.toHaveBeenCalled();
+  });
+
+  test('does not display a message when unconfigured behaviors is the same as recommended behavior', async () => {
+    const mockFlagsData = [
+      {
+        name: '@aws-cdk/s3:anotherFlag',
+        // userValue is undefined, meaning it is unconfigured
+        recommendedValue: false,
+        explanation: 'Another test flag',
+        module: 'aws-cdk-lib',
+        unconfiguredBehavesLike: { v2: false },
+      },
+    ];
+    mockToolkit.flags.mockResolvedValue(mockFlagsData);
+
+    await displayFlagsMessage(ioHost.asHelper(), mockToolkit as any, mockCloudExecutable);
+
     expect(ioHost.notifySpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
The flags nag message is too pessimistic, showing 18 unconfigured flags on a newly cdk inited project.

* Part of that is the CDK library emitting info for flags that don't exist anymore, fixed here: aws/aws-cdk#35227
* Part of that is we are alarming on unconfigured flags, even if the behavior of unconfigured flags is the same as recommended behavior.

We shouldn't alarm on the latter, so filter them out.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
