### PR TITLE
feat: add notice when users run `cdk flags` with an incompatible version of the CDK Library

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/format-table.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format-table.ts
@@ -7,12 +7,15 @@ import * as table from 'table';
  *
  * First row is considered the table header.
  */
-export function formatTable(cells: string[][], columns: number | undefined): string {
+export function formatTable(cells: string[][], columns: number | undefined, noHorizontalLines?: boolean): string {
   return table.table(cells, {
     border: TABLE_BORDER_CHARACTERS,
     columns: buildColumnConfig(columns !== undefined ? calculateColumnWidths(cells, columns) : undefined),
     drawHorizontalLine: (line) => {
       // Numbering like this: [line 0] [header = row[0]] [line 1] [row 1] [line 2] [content 2] [line 3]
+      if (noHorizontalLines) {
+        return line < 2 || line === cells.length;
+      }
       return (line < 2 || line === cells.length) || lineBetween(cells[line - 1], cells[line]);
     },
   }).trimRight();

--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -45,6 +45,12 @@ interface FlagOperationsParams {
 
 export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, options: FlagsOptions, toolkit: Toolkit) {
   flagData = flagData.filter(flag => !OBSOLETE_FLAGS.includes(flag.name));
+
+  if (flagData.length == 0) {
+    await ioHelper.defaults.error(`The 'cdk flags' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.`);
+    return;
+  }
+
   let params = {
     flagData,
     toolkit,
@@ -454,7 +460,6 @@ export async function displayFlags(params: FlagOperationsParams): Promise<void> 
       flag.userValue === undefined || !isUserValueEqualToRecommended(flag),
     );
   }
-
   await displayFlagTable(flagsToDisplay, ioHelper);
 }
 

--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -47,7 +47,7 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
   flagData = flagData.filter(flag => !OBSOLETE_FLAGS.includes(flag.name));
 
   if (flagData.length == 0) {
-    await ioHelper.defaults.error(`The 'cdk flags' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.`);
+    await ioHelper.defaults.error('The \'cdk flags\' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.');
     return;
   }
 

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -42,6 +42,14 @@ const mockFlagsData: FeatureFlag[] = [
     userValue: 'true',
     explanation: 'Flag that matches recommendation',
   },
+  {
+    module: 'different-module',
+    name: '@aws-cdk/core:anotherMatchingFlag',
+    recommendedValue: 'true',
+    userValue: 'true',
+    explanation: 'Flag that matches recommendation',
+    unconfiguredBehavesLike: { v2: 'true' },
+  },
 ];
 
 function createMockToolkit(): jest.Mocked<Toolkit> {
@@ -121,8 +129,8 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
   });
 
   test('handles null user values correctly', async () => {
@@ -181,6 +189,19 @@ describe('displayFlags', () => {
     expect(plainTextOutput).toContain('different-module');
   });
 
+  test('does not display flag when unconfigured behavior is the same as recommended behavior', async () => {
+    const params = {
+      flagData: mockFlagsData,
+      toolkit: mockToolkit,
+      ioHelper,
+      all: true,
+    };
+    await displayFlags(params);
+
+    const plainTextOutput = output();
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anotherMatchingFlag');
+  });
+
   test('displays single flag details when only one substring match is found', async () => {
     const params = {
       flagData: mockFlagsData,
@@ -221,9 +242,10 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anothermatchingFlag');
   });
 
   test('returns all matching flags if user enters multiple substrings', async () => {
@@ -236,9 +258,10 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/core:matchingFlag');
-    expect(plainTextOutput).not.toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anothermatchingFlag');
   });
 });
 
@@ -264,8 +287,8 @@ describe('handleFlags', () => {
     await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
   });
 
   test('displays only differing flags when no specific options are provided', async () => {
@@ -275,9 +298,9 @@ describe('handleFlags', () => {
     await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
-    expect(plainTextOutput).not.toContain('@aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:matchingFlag');
   });
 
   test('handles flag not found for specific flag query', async () => {

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -8,7 +8,6 @@ import { asIoHelper } from '../../lib/api-private';
 import { CliIoHost } from '../../lib/cli/io-host';
 import type { FlagsOptions } from '../../lib/cli/user-input';
 import { displayFlags, handleFlags } from '../../lib/commands/flag-operations';
-import { options } from 'yargs';
 
 jest.mock('enquirer', () => ({
   Select: jest.fn(),
@@ -483,15 +482,15 @@ describe('handleFlags', () => {
   });
 
   test('displays notice when user is on incompatible version', async () => {
-    const mockFlagsData: FeatureFlag[] = [];
+    const mockNoFlagsData: FeatureFlag[] = [];
 
     const options: FlagsOptions = {};
 
-    await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
+    await handleFlags(mockNoFlagsData, ioHelper, options, mockToolkit);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain(`The 'cdk flags' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.`);
-  })
+    expect(plainTextOutput).toContain('The \'cdk flags\' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.');
+  });
 });
 
 describe('modifyValues', () => {

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -8,6 +8,7 @@ import { asIoHelper } from '../../lib/api-private';
 import { CliIoHost } from '../../lib/cli/io-host';
 import type { FlagsOptions } from '../../lib/cli/user-input';
 import { displayFlags, handleFlags } from '../../lib/commands/flag-operations';
+import { options } from 'yargs';
 
 jest.mock('enquirer', () => ({
   Select: jest.fn(),
@@ -480,6 +481,17 @@ describe('handleFlags', () => {
     await cleanupCdkJsonFile(cdkJsonPath);
     requestResponseSpy.mockRestore();
   });
+
+  test('displays notice when user is on incompatible version', async () => {
+    const mockFlagsData: FeatureFlag[] = [];
+
+    const options: FlagsOptions = {};
+
+    await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
+
+    const plainTextOutput = output();
+    expect(plainTextOutput).toContain(`The 'cdk flags' command is not compatible with the AWS CDK library used by your application. Please upgrade to the latest version.`);
+  })
 });
 
 describe('modifyValues', () => {
@@ -759,3 +771,4 @@ describe('interactive prompts lead to the correct function calls', () => {
     await cleanupCdkJsonFile(cdkJsonPath);
   });
 });
+


### PR DESCRIPTION
Returns an error message for users if they run the `cdk flags` command with an incompatible version of `aws-cdk-lib`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
