### PR TITLE
fix(cli): deprecate "bootstrap-stack-name" in favor of "toolkit-stack-name" for gc command

### DIFF
--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -110,7 +110,8 @@ export async function makeConfig(): Promise<CliConfig> {
           'rollback-buffer-days': { type: 'number', desc: 'Delete assets that have been marked as isolated for this many days', default: 0 },
           'created-buffer-days': { type: 'number', desc: 'Never delete assets younger than this (in days)', default: 1 },
           'confirm': { type: 'boolean', desc: 'Confirm via manual prompt before deletion', default: true },
-          'toolkit-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"', requiresArg: true, alias: 'bootstrap-stack-name' },
+          'toolkit-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"', requiresArg: true, conflicts: 'bootstrap-stack-name' },
+          'bootstrap-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit" (deprecated, use --toolkit-stack-name)', deprecated: 'use --toolkit-stack-name', requiresArg: true, conflicts: 'toolkit-stack-name' }, // TODO: remove when garbage collection is GA
         },
       },
       'flags': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -110,7 +110,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'rollback-buffer-days': { type: 'number', desc: 'Delete assets that have been marked as isolated for this many days', default: 0 },
           'created-buffer-days': { type: 'number', desc: 'Never delete assets younger than this (in days)', default: 1 },
           'confirm': { type: 'boolean', desc: 'Confirm via manual prompt before deletion', default: true },
-          'bootstrap-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"', requiresArg: true },
+          'toolkit-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"', requiresArg: true, alias: 'bootstrap-stack-name' },
         },
       },
       'flags': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -326,7 +326,14 @@
           "type": "string",
           "desc": "The name of the CDK toolkit stack, if different from the default \"CDKToolkit\"",
           "requiresArg": true,
-          "alias": "bootstrap-stack-name"
+          "conflicts": "bootstrap-stack-name"
+        },
+        "bootstrap-stack-name": {
+          "type": "string",
+          "desc": "The name of the CDK toolkit stack, if different from the default \"CDKToolkit\" (deprecated, use --toolkit-stack-name)",
+          "deprecated": "use --toolkit-stack-name",
+          "requiresArg": true,
+          "conflicts": "toolkit-stack-name"
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -322,10 +322,11 @@
           "desc": "Confirm via manual prompt before deletion",
           "default": true
         },
-        "bootstrap-stack-name": {
+        "toolkit-stack-name": {
           "type": "string",
           "desc": "The name of the CDK toolkit stack, if different from the default \"CDKToolkit\"",
-          "requiresArg": true
+          "requiresArg": true,
+          "alias": "bootstrap-stack-name"
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -442,12 +442,15 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         if (!configuration.settings.get(['unstable']).includes('gc')) {
           throw new ToolkitError('Unstable feature use: \'gc\' is unstable. It must be opted in via \'--unstable\', e.g. \'cdk gc --unstable=gc\'');
         }
+        if (args.bootstrapStackName) {
+          await ioHost.defaults.warn('--bootstrap-stack-name is deprecated and will be removed when gc is GA. Use --toolkit-stack-name.');
+        }
         return cli.garbageCollect(args.ENVIRONMENTS, {
           action: args.action,
           type: args.type,
           rollbackBufferDays: args['rollback-buffer-days'],
           createdBufferDays: args['created-buffer-days'],
-          bootstrapStackName: args.bootstrapStackName,
+          bootstrapStackName: args.toolkitStackName ?? args.bootstrapStackName,
           confirm: args.confirm,
         });
 

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -89,7 +89,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         rollbackBufferDays: args.rollbackBufferDays,
         createdBufferDays: args.createdBufferDays,
         confirm: args.confirm,
-        bootstrapStackName: args.bootstrapStackName,
+        toolkitStackName: args.toolkitStackName,
         ENVIRONMENTS: args.ENVIRONMENTS,
       };
       break;
@@ -373,7 +373,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     rollbackBufferDays: config.gc?.rollbackBufferDays,
     createdBufferDays: config.gc?.createdBufferDays,
     confirm: config.gc?.confirm,
-    bootstrapStackName: config.gc?.bootstrapStackName,
+    toolkitStackName: config.gc?.toolkitStackName,
   };
   const flagsOptions = {
     value: config.flags?.value,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -90,6 +90,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         createdBufferDays: args.createdBufferDays,
         confirm: args.confirm,
         toolkitStackName: args.toolkitStackName,
+        bootstrapStackName: args.bootstrapStackName,
         ENVIRONMENTS: args.ENVIRONMENTS,
       };
       break;
@@ -374,6 +375,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     createdBufferDays: config.gc?.createdBufferDays,
     confirm: config.gc?.confirm,
     toolkitStackName: config.gc?.toolkitStackName,
+    bootstrapStackName: config.gc?.bootstrapStackName,
   };
   const flagsOptions = {
     value: config.flags?.value,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -345,11 +345,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
             type: 'boolean',
             desc: 'Confirm via manual prompt before deletion',
           })
-          .option('bootstrap-stack-name', {
+          .option('toolkit-stack-name', {
             default: undefined,
             type: 'string',
             desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"',
             requiresArg: true,
+            alias: 'bootstrap-stack-name',
           }),
     )
     .command('flags [FLAGNAME..]', 'View and toggle feature flags.', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -350,7 +350,15 @@ export function parseCommandLineArguments(args: Array<string>): any {
             type: 'string',
             desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit"',
             requiresArg: true,
-            alias: 'bootstrap-stack-name',
+            conflicts: 'bootstrap-stack-name',
+          })
+          .option('bootstrap-stack-name', {
+            default: undefined,
+            type: 'string',
+            desc: 'The name of the CDK toolkit stack, if different from the default "CDKToolkit" (deprecated, use --toolkit-stack-name)',
+            deprecated: 'use --toolkit-stack-name',
+            requiresArg: true,
+            conflicts: 'toolkit-stack-name',
           }),
     )
     .command('flags [FLAGNAME..]', 'View and toggle feature flags.', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -599,11 +599,17 @@ export interface GcOptions {
   /**
    * The name of the CDK toolkit stack, if different from the default "CDKToolkit"
    *
-   * aliases: bootstrap-stack-name
-   *
    * @default - undefined
    */
   readonly toolkitStackName?: string;
+
+  /**
+   * The name of the CDK toolkit stack, if different from the default "CDKToolkit" (deprecated, use --toolkit-stack-name)
+   *
+   * @deprecated use --toolkit-stack-name
+   * @default - undefined
+   */
+  readonly bootstrapStackName?: string;
 
   /**
    * Positional argument for gc

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -599,9 +599,11 @@ export interface GcOptions {
   /**
    * The name of the CDK toolkit stack, if different from the default "CDKToolkit"
    *
+   * aliases: bootstrap-stack-name
+   *
    * @default - undefined
    */
-  readonly bootstrapStackName?: string;
+  readonly toolkitStackName?: string;
 
   /**
    * Positional argument for gc


### PR DESCRIPTION
Fixes #385

Elsewhere we are consistently naming this property `toolkit-stack-name`, so this PR aligns `gc` with the rest of the CLI world. We may have better options here, like making `toolkit-stack-name` a global option, but this is an easy fix for now.

Does not break users by maintaining `bootstrap-stack-name` as an alias of `toolkit-stack-name` for `gc`. However `bootstrap-stack-name` is marked as deprecated and will be removed when we GA garbage collection.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
