### PR TITLE
fix(cli): flags command shows unnecessary flags, not all table rows have vertical lines

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/format-table.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format-table.ts
@@ -7,12 +7,15 @@ import * as table from 'table';
  *
  * First row is considered the table header.
  */
-export function formatTable(cells: string[][], columns: number | undefined): string {
+export function formatTable(cells: string[][], columns: number | undefined, noHorizontalLines?: boolean): string {
   return table.table(cells, {
     border: TABLE_BORDER_CHARACTERS,
     columns: buildColumnConfig(columns !== undefined ? calculateColumnWidths(cells, columns) : undefined),
     drawHorizontalLine: (line) => {
       // Numbering like this: [line 0] [header = row[0]] [line 1] [row 1] [line 2] [content 2] [line 3]
+      if (noHorizontalLines) {
+        return line < 2 || line === cells.length;
+      }
       return (line < 2 || line === cells.length) || lineBetween(cells[line - 1], cells[line]);
     },
   }).trimRight();

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1276,29 +1276,46 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   /**
    * Retrieve feature flag information from the cloud assembly
    */
-
   public async flags(cx: ICloudAssemblySource): Promise<FeatureFlag[]> {
     this.requireUnstableFeature('flags');
 
     const ioHelper = asIoHelper(this.ioHost, 'flags');
     await using assembly = await assemblyFromSource(ioHelper, cx);
-    const artifacts = assembly.cloudAssembly.manifest.artifacts;
+    const artifacts = Object.values(assembly.cloudAssembly.manifest.artifacts!);
+    const featureFlagReports = artifacts.filter(a => a.type === ArtifactType.FEATURE_FLAG_REPORT);
 
-    return Object.values(artifacts!)
-      .filter(a => a.type === ArtifactType.FEATURE_FLAG_REPORT)
-      .flatMap(report => {
-        const properties = report.properties as FeatureFlagReportProperties;
-        const moduleName = properties.module;
+    const flags = featureFlagReports.flatMap(report => {
+      const properties = report.properties as FeatureFlagReportProperties;
+      const moduleName = properties.module;
 
-        return Object.entries(properties.flags).map(([flagName, flagInfo]) => ({
+      const flagsWithUnconfiguredBehavesLike = Object.entries(properties.flags)
+        .filter(([_, flagInfo]) => flagInfo.unconfiguredBehavesLike != undefined);
+
+      const shouldIncludeUnconfiguredBehavesLike = flagsWithUnconfiguredBehavesLike.length > 0;
+
+      return Object.entries(properties.flags).map(([flagName, flagInfo]) => {
+        const baseFlag = {
           module: moduleName,
           name: flagName,
           recommendedValue: flagInfo.recommendedValue,
           userValue: flagInfo.userValue ?? undefined,
           explanation: flagInfo.explanation ?? '',
-          unconfiguredBehavesLike: flagInfo.unconfiguredBehavesLike,
-        }));
+        };
+
+        if (shouldIncludeUnconfiguredBehavesLike) {
+          return {
+            ...baseFlag,
+            unconfiguredBehavesLike: {
+              v2: flagInfo.unconfiguredBehavesLike?.v2 === true ? true : false,
+            },
+          };
+        }
+
+        return baseFlag;
       });
+    });
+
+    return flags;
   }
 
   private requireUnstableFeature(requestedFeature: UnstableFeature) {

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1306,7 +1306,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
           return {
             ...baseFlag,
             unconfiguredBehavesLike: {
-              v2: flagInfo.unconfiguredBehavesLike?.v2 === true ? true : false,
+              v2: flagInfo.unconfiguredBehavesLike?.v2 ?? false,
             },
           };
         }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1281,7 +1281,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     const ioHelper = asIoHelper(this.ioHost, 'flags');
     await using assembly = await assemblyFromSource(ioHelper, cx);
-    const artifacts = Object.values(assembly.cloudAssembly.manifest.artifacts!);
+    const artifacts = Object.values(assembly.cloudAssembly.manifest.artifacts ?? {});
     const featureFlagReports = artifacts.filter(a => a.type === ArtifactType.FEATURE_FLAG_REPORT);
 
     const flags = featureFlagReports.flatMap(report => {

--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -87,7 +87,7 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
         default: true,
         unconfigured: true,
       };
-      await checkDefaultBehavior(params);
+      await setMultipleFlagsIfSupported(params);
     } else if (answer == FlagsMenuOptions.MODIFY_SPECIFIC_FLAG) {
       await setFlag(params, true);
     } else if (answer == FlagsMenuOptions.EXIT) {
@@ -167,7 +167,7 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
   }
 
   if (options.set && options.all && options.default) {
-    await checkDefaultBehavior(params);
+    await setMultipleFlagsIfSupported(params);
   }
 
   if (options.set && options.unconfigured && options.recommended) {
@@ -176,23 +176,20 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
   }
 
   if (options.set && options.unconfigured && options.default) {
-    await checkDefaultBehavior(params);
+    await setMultipleFlagsIfSupported(params);
   }
 }
 
 /**
- * Checks if the `unconfiguredBehavesLike` field is populated
- *
- * @returns true if --default options can be run
+ * Sets flag configurations to default values if `unconfiguredBehavesLike` is populated
  */
-async function checkDefaultBehavior(params: FlagOperationsParams) {
+async function setMultipleFlagsIfSupported(params: FlagOperationsParams) {
   const { flagData, ioHelper } = params;
   if (flagData[0].unconfiguredBehavesLike) {
     await setMultipleFlags(params);
     return;
   }
   await ioHelper.defaults.error('The --default options are not compatible with the AWS CDK library used by your application. Please upgrade to 2.212.0 or above.');
-  return;
 }
 
 async function setFlag(params: FlagOperationsParams, interactive?: boolean) {

--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -87,7 +87,7 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
         default: true,
         unconfigured: true,
       };
-      await setMultipleFlags(params);
+      await checkDefaultBehavior(params);
     } else if (answer == FlagsMenuOptions.MODIFY_SPECIFIC_FLAG) {
       await setFlag(params, true);
     } else if (answer == FlagsMenuOptions.EXIT) {
@@ -167,8 +167,7 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
   }
 
   if (options.set && options.all && options.default) {
-    await setMultipleFlags(params);
-    return;
+    await checkDefaultBehavior(params);
   }
 
   if (options.set && options.unconfigured && options.recommended) {
@@ -177,9 +176,23 @@ export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, o
   }
 
   if (options.set && options.unconfigured && options.default) {
+    await checkDefaultBehavior(params);
+  }
+}
+
+/**
+ * Checks if the `unconfiguredBehavesLike` field is populated
+ *
+ * @returns true if --default options can be run
+ */
+async function checkDefaultBehavior(params: FlagOperationsParams) {
+  const { flagData, ioHelper } = params;
+  if (flagData[0].unconfiguredBehavesLike) {
     await setMultipleFlags(params);
     return;
   }
+  await ioHelper.defaults.error('The --default options are not compatible with the AWS CDK library used by your application. Please upgrade to 2.212.0 or above.');
+  return;
 }
 
 async function setFlag(params: FlagOperationsParams, interactive?: boolean) {

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -42,6 +42,14 @@ const mockFlagsData: FeatureFlag[] = [
     userValue: 'true',
     explanation: 'Flag that matches recommendation',
   },
+  {
+    module: 'different-module',
+    name: '@aws-cdk/core:anotherMatchingFlag',
+    recommendedValue: 'true',
+    userValue: 'true',
+    explanation: 'Flag that matches recommendation',
+    unconfiguredBehavesLike: { v2: 'true' },
+  },
 ];
 
 function createMockToolkit(): jest.Mocked<Toolkit> {
@@ -121,8 +129,8 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
   });
 
   test('handles null user values correctly', async () => {
@@ -181,6 +189,19 @@ describe('displayFlags', () => {
     expect(plainTextOutput).toContain('different-module');
   });
 
+  test('does not display flag when unconfigured behavior is the same as recommended behavior', async () => {
+    const params = {
+      flagData: mockFlagsData,
+      toolkit: mockToolkit,
+      ioHelper,
+      all: true,
+    };
+    await displayFlags(params);
+
+    const plainTextOutput = output();
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anotherMatchingFlag');
+  });
+
   test('displays single flag details when only one substring match is found', async () => {
     const params = {
       flagData: mockFlagsData,
@@ -221,9 +242,10 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anothermatchingFlag');
   });
 
   test('returns all matching flags if user enters multiple substrings', async () => {
@@ -236,9 +258,10 @@ describe('displayFlags', () => {
     await displayFlags(params);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/core:matchingFlag');
-    expect(plainTextOutput).not.toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:anothermatchingFlag');
   });
 });
 
@@ -264,8 +287,8 @@ describe('handleFlags', () => {
     await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
   });
 
   test('displays only differing flags when no specific options are provided', async () => {
@@ -275,9 +298,9 @@ describe('handleFlags', () => {
     await handleFlags(mockFlagsData, ioHelper, options, mockToolkit);
 
     const plainTextOutput = output();
-    expect(plainTextOutput).toContain('@aws-cdk/core:testFlag');
-    expect(plainTextOutput).toContain('@aws-cdk/s3:anotherFlag');
-    expect(plainTextOutput).not.toContain('@aws-cdk/core:matchingFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/core:testFlag');
+    expect(plainTextOutput).toContain('  @aws-cdk/s3:anotherFlag');
+    expect(plainTextOutput).not.toContain('  @aws-cdk/core:matchingFlag');
   });
 
   test('handles flag not found for specific flag query', async () => {


### PR DESCRIPTION
When a user runs `cdk flags`, a table is displayed with information about their feature flags. This PR omits the intentionally unconfigured feature flags from the table and makes the table more visually appealing. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
