### PR TITLE
fix(cli): when CDK library is too old, an empty flags table is displayed

### DIFF
--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -44,6 +44,12 @@ interface FlagOperationsParams {
 
 export async function handleFlags(flagData: FeatureFlag[], ioHelper: IoHelper, options: FlagsOptions, toolkit: Toolkit) {
   flagData = flagData.filter(flag => !OBSOLETE_FLAGS.includes(flag.name));
+
+  if (flagData.length == 0) {
+    await ioHelper.defaults.error('The \'cdk flags\' command is not compatible with the AWS CDK library used by your application. Please upgrade to 2.212.0 or above.');
+    return;
+  }
+
   let params = {
     flagData,
     toolkit,

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -457,6 +457,17 @@ describe('handleFlags', () => {
     await cleanupCdkJsonFile(cdkJsonPath);
     requestResponseSpy.mockRestore();
   });
+
+  test('displays notice when user is on incompatible version', async () => {
+    const mockNoFlagsData: FeatureFlag[] = [];
+
+    const options: FlagsOptions = {};
+
+    await handleFlags(mockNoFlagsData, ioHelper, options, mockToolkit);
+
+    const plainTextOutput = output();
+    expect(plainTextOutput).toContain('The \'cdk flags\' command is not compatible with the AWS CDK library used by your application. Please upgrade to 2.212.0 or above.');
+  });
 });
 
 describe('modifyValues', () => {


### PR DESCRIPTION
Returns an error message for users if they run the `cdk flags` command with an incompatible version of `aws-cdk-lib`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
