### PR TITLE
fix: skipLibCheck is not turned on for all init templates

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
@@ -20,6 +20,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
     ]

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/tsconfig.json
@@ -20,6 +20,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
     ]

--- a/packages/aws-cdk/lib/init-templates/sample-app/javascript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/javascript/tsconfig.json
@@ -22,6 +22,7 @@
     "allowJs": true,
     "checkJs": true,
     "noEmit": true,
+    "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
     ]

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
@@ -20,6 +20,7 @@
     "inlineSources": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
+    "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
     ]


### PR DESCRIPTION
This makes TypeScript check whether all provided type files are coherent, which is taking more and more time as the CDK is growing.

Turning this off greatly decreases type checking and compilation times.

See: https://devblogs.microsoft.com/typescript/announcing-typescript-5-9/#minimal-and-updated-tsc---init

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
