### PR TITLE
fix(cli): improve language selection logic in cliInit function

### DIFF
--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -22,6 +22,18 @@ describe('constructs version', () => {
     expect(await fs.pathExists(path.join(workDir, 'lib'))).toBeTruthy();
   });
 
+  cliTest("when type is 'lib' and language is not specified, it default language to TypeScript", async (workDir) => {
+    await cliInit({
+      ioHelper,
+      type: 'lib',
+      workDir,
+    });
+
+    // Check that tsconfig.json and lib/ got created in the current directory
+    expect(await fs.pathExists(path.join(workDir, 'tsconfig.json'))).toBeTruthy();
+    expect(await fs.pathExists(path.join(workDir, 'lib'))).toBeTruthy();
+  })
+
   cliTest('can override requested version with environment variable', async (workDir) => {
     await cliInit({
       ioHelper,

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -32,7 +32,7 @@ describe('constructs version', () => {
     // Check that tsconfig.json and lib/ got created in the current directory
     expect(await fs.pathExists(path.join(workDir, 'tsconfig.json'))).toBeTruthy();
     expect(await fs.pathExists(path.join(workDir, 'lib'))).toBeTruthy();
-  })
+  });
 
   cliTest('can override requested version with environment variable', async (workDir) => {
     await cliInit({


### PR DESCRIPTION
Fixes #660 

### Description Changes

When running `cdk init`, if the specified command type can only be executed in a single language, allow the command to be executed without selecting a language.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
