### PR TITLE
feat(cli): add --no-wait option to destroy command

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/destroy.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/destroy.ts
@@ -17,4 +17,12 @@ export interface DestroyOptions extends DefaultCdkOptions {
    * @default false
    */
   readonly exclusively?: boolean;
+
+  /**
+   * Whether or not to wait for the stack to finish deleting
+   * This functionality does not work for stacks which have dependent stacks
+   *
+   * @default false
+   */
+  readonly noWait?: boolean;
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/destroy.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/destroy.ts
@@ -19,10 +19,9 @@ export interface DestroyOptions extends DefaultCdkOptions {
   readonly exclusively?: boolean;
 
   /**
-   * Whether or not to wait for the stack to finish deleting
-   * This functionality does not work for stacks which have dependent stacks
+   * Skip waiting for the stack to finish deleting
    *
    * @default false
    */
-  readonly noWait?: boolean;
+  readonly skipAwaitDeletion?: boolean;
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
@@ -347,8 +347,8 @@
                     "default": false,
                     "type": "boolean"
                 },
-                "noWait": {
-                    "description": "Whether or not to wait for the stack to finish deleting\nThis functionality does not work for stacks which have dependent stacks",
+                "skipAwaitDeletion": {
+                    "description": "Skip waiting for the stack to finish deleting",
                     "default": false,
                     "type": "boolean"
                 },

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
@@ -347,6 +347,11 @@
                     "default": false,
                     "type": "boolean"
                 },
+                "noWait": {
+                    "description": "Whether or not to wait for the stack to finish deleting\nThis functionality does not work for stacks which have dependent stacks",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "stacks": {
                     "description": "List of stacks to deploy\n\nRequried if `all` is not set (Default - [])",
                     "type": "array",

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,5 +1,5 @@
 {
-  "schemaHash": "0807b42f8220bdafddeb4dad246a696721ed86e99ac6b13aa83359bab834d60d",
+  "schemaHash": "114ce6442af92b7cb7a22a956ab0ab4447c9de5380f14f96d1a494abdcab9157",
   "$comment": "Do not hold back the version on additions: jsonschema validation of the manifest by the consumer will trigger errors on unexpected fields.",
-  "revision": 48
+  "revision": 49
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,5 +1,5 @@
 {
   "schemaHash": "cbbd30e6b98ace323ee60dfc1f4d218342f1dde9a3250926a33acd5f025c4f8a",
   "$comment": "Do not hold back the version on additions: jsonschema validation of the manifest by the consumer will trigger errors on unexpected fields.",
-  "revision": 51
+  "revision": 49
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,5 +1,5 @@
 {
-  "schemaHash": "114ce6442af92b7cb7a22a956ab0ab4447c9de5380f14f96d1a494abdcab9157",
+  "schemaHash": "cbbd30e6b98ace323ee60dfc1f4d218342f1dde9a3250926a33acd5f025c4f8a",
   "$comment": "Do not hold back the version on additions: jsonschema validation of the manifest by the consumer will trigger errors on unexpected fields.",
-  "revision": 49
+  "revision": 51
 }

--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -191,6 +191,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
     await this.toolkit.destroy(cx, {
       roleArn: options.roleArn,
       stacks: this.stackSelector(options),
+      noWait: options.noWait,
     });
   }
 

--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -191,7 +191,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
     await this.toolkit.destroy(cx, {
       roleArn: options.roleArn,
       stacks: this.stackSelector(options),
-      noWait: options.noWait,
+      skipAwaitDeletion: options.skipAwaitDeletion,
     });
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -14,8 +14,7 @@ export interface DestroyOptions {
   readonly roleArn?: string;
 
   /**
-   * Whether or not to wait for the stack to finish deleting
-   * This functionality does not work for stacks which have dependent stacks
+   * Skip waiting for the stack to finish deleting
    */
-  readonly noWait?: boolean;
+  readonly skipAwaitDeletion?: boolean;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -12,4 +12,10 @@ export interface DestroyOptions {
    * The arn of the IAM role to use for the stack destroy operation
    */
   readonly roleArn?: string;
+
+  /**
+   * Whether or not to wait for the stack to finish deleting
+   * This functionality does not work for stacks which have dependent stacks
+   */
+  readonly noWait?: boolean;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-collection.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-collection.ts
@@ -37,24 +37,28 @@ export class StackCollection {
   public hasDependents(stack: cxapi.CloudFormationStackArtifact): boolean {
     const cache: { [key: string]: boolean } = {};
     const checkDependencies = (currentStack: cxapi.CloudFormationStackArtifact) => {
-      if (cache[currentStack.id]) // already checked dependencies for this stack
+      if (cache[currentStack.id]) { // already checked dependencies for this stack
         return false;
+      }
 
       cache[currentStack.id] = true;
       const dependencies = currentStack.dependencies.filter(dep => !dep.id.includes('.assets'));
-      if (dependencies.some(dep => dep.id === stack.id)) // currentStack depends on stack
+      if (dependencies.some(dep => dep.id === stack.id)) { // currentStack depends on stack
         return true;
+      }
 
       for (const dep of dependencies) {
-        if (checkDependencies(this.assembly.stackById(dep.id).firstStack))
+        if (checkDependencies(this.assembly.stackById(dep.id).firstStack)) {
           return true;
+        }
       }
       return false;
-    }
+    };
 
     for (const currentStack of this.stackArtifacts) {
-      if (currentStack.id === stack.id)
+      if (currentStack.id === stack.id) {
         continue;
+      }
 
       if (checkDependencies(currentStack)) {
         return true;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -723,8 +723,8 @@ export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHel
   } else {
     await ioHelper.defaults.info(
       chalk.bold(
-        format('Monitoring of stack deletion for %s will be skipped - subsequent actions may take place before the stack deletion is finished', deployName)
-      )
+        format('Monitoring of stack deletion for %s will be skipped - subsequent actions may take place before the stack deletion is finished', deployName),
+      ),
     );
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -721,7 +721,11 @@ export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHel
     });
     await monitor.start();
   } else {
-    await ioHelper.defaults.debug(chalk.bold(format('Monitoring of stack deletion for %s will be skipped - subsequent actions may take place before the stack deletion is finished', deployName)));
+    await ioHelper.defaults.info(
+      chalk.bold(
+        format('Monitoring of stack deletion for %s will be skipped - subsequent actions may take place before the stack deletion is finished', deployName)
+      )
+    );
   }
 
   try {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -277,7 +277,7 @@ export interface DestroyStackOptions {
   stack: cxapi.CloudFormationStackArtifact;
   deployName?: string;
   roleArn?: string;
-  noWait?: boolean;
+  skipAwaitDeletion?: boolean;
 }
 
 export interface StackExistsOptions {
@@ -587,7 +587,7 @@ export class Deployments {
       roleArn: executionRoleArn,
       stack: options.stack,
       deployName: options.deployName,
-      noWait: options.noWait,
+      skipAwaitDeletion: options.skipAwaitDeletion,
     }, this.ioHelper);
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -277,6 +277,7 @@ export interface DestroyStackOptions {
   stack: cxapi.CloudFormationStackArtifact;
   deployName?: string;
   roleArn?: string;
+  noWait?: boolean;
 }
 
 export interface StackExistsOptions {
@@ -586,6 +587,7 @@ export class Deployments {
       roleArn: executionRoleArn,
       stack: options.stack,
       deployName: options.deployName,
+      noWait: options.noWait,
     }, this.ioHelper);
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1195,6 +1195,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
             stack,
             deployName: stack.stackName,
             roleArn: options.roleArn,
+            // only allow noWait in cases where there are no dependent stacks
+            noWait: options.noWait && action === 'destroy' && stack.dependencies.some(dep => !dep.id.includes('.assets')),
           });
 
           ret.stacks.push({

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1195,8 +1195,9 @@ export class Toolkit extends CloudAssemblySourceBuilder {
             stack,
             deployName: stack.stackName,
             roleArn: options.roleArn,
-            // only allow noWait in cases where there are no dependent stacks
-            noWait: options.noWait && action === 'destroy' && stack.dependencies.some(dep => !dep.id.includes('.assets')),
+            skipAwaitDeletion: options.skipAwaitDeletion
+              // if the stack has dependent stacks, ignore skipAwaitDeletion
+              || (action === 'destroy' && stacks.hasDependents(stack)),
           });
 
           ret.stacks.push({

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -993,6 +993,8 @@ export class CdkToolkit {
           stack,
           deployName: stack.stackName,
           roleArn: options.roleArn,
+          // only allow noWait in cases where there are no dependent stacks
+          noWait: options.noWait && action === 'destroy' && stack.dependencies.some(dep => !dep.id.includes('.assets')),
         });
         await this.ioHost.asIoHelper().defaults.info(chalk.green(`\n ✅  %s: ${action}ed`), chalk.blue(stack.displayName));
       } catch (e) {
@@ -1871,6 +1873,11 @@ export interface DestroyOptions {
    * Whether the destroy request came from a deploy.
    */
   fromDeploy?: boolean;
+
+  /**
+   * Whether to wait for the stack to finish deleting.
+   */
+  noWait?: boolean;
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -993,8 +993,9 @@ export class CdkToolkit {
           stack,
           deployName: stack.stackName,
           roleArn: options.roleArn,
-          // only allow noWait in cases where there are no dependent stacks
-          noWait: options.noWait && action === 'destroy' && stack.dependencies.some(dep => !dep.id.includes('.assets')),
+          skipAwaitDeletion: options.skipAwaitDeletion
+            // if the stack has dependent stacks, ignore skipAwaitDeletion
+            || (action === 'destroy' && stacks.hasDependents(stack)),
         });
         await this.ioHost.asIoHelper().defaults.info(chalk.green(`\n ✅  %s: ${action}ed`), chalk.blue(stack.displayName));
       } catch (e) {
@@ -1875,9 +1876,9 @@ export interface DestroyOptions {
   fromDeploy?: boolean;
 
   /**
-   * Whether to wait for the stack to finish deleting.
+   * Skip waiting for the stack to finish deleting
    */
-  noWait?: boolean;
+  skipAwaitDeletion?: boolean;
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -336,7 +336,7 @@ export async function makeConfig(): Promise<CliConfig> {
         options: {
           'all': { type: 'boolean', default: false, desc: 'Destroy all available stacks' },
           'exclusively': { type: 'boolean', alias: 'e', desc: 'Only destroy requested stacks, don\'t include dependees' },
-          'no-wait': { type: 'boolean', desc: 'Whether or not to wait for the stack to finish deleting' },
+          'skip-await-deletion': { type: 'boolean', desc: 'Skip waiting for the stack to finish deleting' },
           'force': { type: 'boolean', alias: 'f', desc: 'Do not ask for confirmation before destroying the stacks' },
         },
       },

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -334,9 +334,10 @@ export async function makeConfig(): Promise<CliConfig> {
           variadic: true,
         },
         options: {
-          all: { type: 'boolean', default: false, desc: 'Destroy all available stacks' },
-          exclusively: { type: 'boolean', alias: 'e', desc: 'Only destroy requested stacks, don\'t include dependees' },
-          force: { type: 'boolean', alias: 'f', desc: 'Do not ask for confirmation before destroying the stacks' },
+          'all': { type: 'boolean', default: false, desc: 'Destroy all available stacks' },
+          'exclusively': { type: 'boolean', alias: 'e', desc: 'Only destroy requested stacks, don\'t include dependees' },
+          'no-wait': { type: 'boolean', desc: 'Whether or not to wait for the stack to finish deleting' },
+          'force': { type: 'boolean', alias: 'f', desc: 'Do not ask for confirmation before destroying the stacks' },
         },
       },
       'diff': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -718,9 +718,9 @@
           "alias": "e",
           "desc": "Only destroy requested stacks, don't include dependees"
         },
-        "no-wait": {
+        "skip-await-deletion": {
           "type": "boolean",
-          "desc": "Whether or not to wait for the stack to finish deleting"
+          "desc": "Skip waiting for the stack to finish deleting"
         },
         "force": {
           "type": "boolean",

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -718,6 +718,10 @@
           "alias": "e",
           "desc": "Only destroy requested stacks, don't include dependees"
         },
+        "no-wait": {
+          "type": "boolean",
+          "desc": "Whether or not to wait for the stack to finish deleting"
+        },
         "force": {
           "type": "boolean",
           "alias": "f",

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -436,6 +436,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           exclusively: args.exclusively,
           force: args.force,
           roleArn: args.roleArn,
+          noWait: args.noWait,
         });
 
       case 'gc':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -436,7 +436,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           exclusively: args.exclusively,
           force: args.force,
           roleArn: args.roleArn,
-          noWait: args.noWait,
+          skipAwaitDeletion: args.skipAwaitDeletion,
         });
 
       case 'gc':

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -191,6 +191,7 @@ export function convertYargsToUserInput(args: any): UserInput {
       commandOptions = {
         all: args.all,
         exclusively: args.exclusively,
+        noWait: args.noWait,
         force: args.force,
         STACKS: args.STACKS,
       };
@@ -453,6 +454,7 @@ export function convertConfigToUserInput(config: any): UserInput {
   const destroyOptions = {
     all: config.destroy?.all,
     exclusively: config.destroy?.exclusively,
+    noWait: config.destroy?.noWait,
     force: config.destroy?.force,
   };
   const diffOptions = {

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -191,7 +191,7 @@ export function convertYargsToUserInput(args: any): UserInput {
       commandOptions = {
         all: args.all,
         exclusively: args.exclusively,
-        noWait: args.noWait,
+        skipAwaitDeletion: args.skipAwaitDeletion,
         force: args.force,
         STACKS: args.STACKS,
       };
@@ -456,7 +456,7 @@ export function convertConfigToUserInput(config: any): UserInput {
   const destroyOptions = {
     all: config.destroy?.all,
     exclusively: config.destroy?.exclusively,
-    noWait: config.destroy?.noWait,
+    skipAwaitDeletion: config.destroy?.skipAwaitDeletion,
     force: config.destroy?.force,
   };
   const diffOptions = {

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -749,10 +749,10 @@ export function parseCommandLineArguments(args: Array<string>): any {
           alias: 'e',
           desc: "Only destroy requested stacks, don't include dependees",
         })
-        .option('no-wait', {
+        .option('skip-await-deletion', {
           default: undefined,
           type: 'boolean',
-          desc: 'Whether or not to wait for the stack to finish deleting',
+          desc: 'Skip waiting for the stack to finish deleting',
         })
         .option('force', {
           default: undefined,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -749,6 +749,11 @@ export function parseCommandLineArguments(args: Array<string>): any {
           alias: 'e',
           desc: "Only destroy requested stacks, don't include dependees",
         })
+        .option('no-wait', {
+          default: undefined,
+          type: 'boolean',
+          desc: 'Whether or not to wait for the stack to finish deleting',
+        })
         .option('force', {
           default: undefined,
           type: 'boolean',

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1163,6 +1163,13 @@ export interface DestroyOptions {
   readonly exclusively?: boolean;
 
   /**
+   * Whether or not to wait for the stack to finish deleting
+   *
+   * @default - undefined
+   */
+  readonly noWait?: boolean;
+
+  /**
    * Do not ask for confirmation before destroying the stacks
    *
    * aliases: f

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1163,11 +1163,11 @@ export interface DestroyOptions {
   readonly exclusively?: boolean;
 
   /**
-   * Whether or not to wait for the stack to finish deleting
+   * Skip waiting for the stack to finish deleting
    *
    * @default - undefined
    */
-  readonly noWait?: boolean;
+  readonly skipAwaitDeletion?: boolean;
 
   /**
    * Do not ask for confirmation before destroying the stacks


### PR DESCRIPTION
The motivation behind this option is to make deleting test stacks via the CI more efficient
In particular, stacks which contain lambdas attached to a VPC can take over 20 minutes to remove. This feature will improve CI run times significantly in those cases.
In cases where a stack has dependencies, this option will not be applied

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
