### PR TITLE
feat(cli): git repository support for custom init templates

### DIFF
--- a/packages/@aws-cdk/user-input-gen/lib/yargs-gen.ts
+++ b/packages/@aws-cdk/user-input-gen/lib/yargs-gen.ts
@@ -105,15 +105,20 @@ function makeYargs(config: CliConfig, helpers: CliHelpers): Statement {
     }
     commandCallArgs.push(lit(commandFacts.description));
 
-    if (commandFacts.options) {
-      commandCallArgs.push(optionsExpr);
-    }
-
     // Add implies calls if present
     if (commandFacts.implies) {
       for (const [key, value] of Object.entries(commandFacts.implies)) {
         optionsExpr = optionsExpr.callMethod('implies', lit(key), lit(value));
       }
+    }
+
+    // Add check function if present
+    if (commandFacts.check) {
+      optionsExpr = optionsExpr.callMethod('check', code.expr.directCode(commandFacts.check.toString()));
+    }
+
+    if (commandFacts.options || commandFacts.check) {
+      commandCallArgs.push(optionsExpr);
     }
 
     yargsExpr = yargsExpr.callMethod('command', ...commandCallArgs);

--- a/packages/@aws-cdk/user-input-gen/lib/yargs-types.ts
+++ b/packages/@aws-cdk/user-input-gen/lib/yargs-types.ts
@@ -8,6 +8,7 @@ interface YargsCommand {
 export interface CliAction extends YargsCommand {
   options?: { [optionName: string]: CliOption };
   implies?: { [key: string]: string };
+  check?: (argv: any) => boolean | undefined;
 }
 
 interface YargsArg {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -897,10 +897,16 @@
           "type": "string",
           "desc": "Path to a specific template within a multi-template repository",
           "requiresArg": true
+        },
+        "from-git-url": {
+          "type": "string",
+          "desc": "Git repository URL to clone custom template from",
+          "requiresArg": true,
+          "conflicts": [
+            "lib-version",
+            "from-path"
+          ]
         }
-      },
-      "implies": {
-        "template-path": "from-path"
       }
     },
     "migrate": {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -547,7 +547,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           return printAvailableTemplates(ioHelper, language);
         } else {
           // Gate custom template support with unstable flag
-          if (args['from-path'] && !configuration.settings.get(['unstable']).includes('init')) {
+          if ((args['from-path'] || args['from-git-url']) && !configuration.settings.get(['unstable']).includes('init')) {
             throw new ToolkitError('Unstable feature use: \'init\' with custom templates is unstable. It must be opted in via \'--unstable\', e.g. \'cdk init --from-path=./my-template --unstable=init\'');
           }
           return cliInit({
@@ -558,6 +558,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
             generateOnly: args.generateOnly,
             libVersion: args.libVersion,
             fromPath: args['from-path'],
+            fromGitUrl: args['from-git-url'],
             templatePath: args['template-path'],
           });
         }

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -249,6 +249,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         libVersion: args.libVersion,
         fromPath: args.fromPath,
         templatePath: args.templatePath,
+        fromGitUrl: args.fromGitUrl,
         TEMPLATE: args.TEMPLATE,
       };
       break;
@@ -491,6 +492,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     libVersion: config.init?.libVersion,
     fromPath: config.init?.fromPath,
     templatePath: config.init?.templatePath,
+    fromGitUrl: config.init?.fromGitUrl,
   };
   const migrateOptions = {
     stackName: config.migrate?.stackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -888,6 +888,23 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           desc: 'Path to a specific template within a multi-template repository',
           requiresArg: true,
+        })
+        .option('from-git-url', {
+          default: undefined,
+          type: 'string',
+          desc: 'Git repository URL to clone custom template from',
+          requiresArg: true,
+          conflicts: ['lib-version', 'from-path'],
+        })
+        .check((argv) => {
+          const hasTemplatePath = Boolean(argv['template-path']);
+          const hasValidSource = Boolean(argv['from-path'] || argv['from-git-url']);
+          if (hasTemplatePath && !hasValidSource) {
+            const e = new Error('--template-path can only be used with --from-path or --from-git-url');
+            e.name = 'ValidationError';
+            throw e;
+          }
+          return true;
         }),
     )
     .command('migrate', 'Migrate existing AWS resources into a CDK app', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1402,6 +1402,13 @@ export interface InitOptions {
   readonly templatePath?: string;
 
   /**
+   * Git repository URL to clone custom template from
+   *
+   * @default - undefined
+   */
+  readonly fromGitUrl?: string;
+
+  /**
    * Positional argument for init
    */
   readonly TEMPLATE?: string;


### PR DESCRIPTION
Rohan:
> Updated code for `cdk init` command to handle custom templates from Git repository sources. This is compatible with the existing `--language` and `--template-path` flags. The `--from-git-url` flag was added to clone a Git URL that is passed in by the user, clones the repository, extracts the specified template files and initializes new project with them. The `cdk init` functionality of creating new local Git repo to track changes, making initial commit, and installing project dependencies is maintained.

Added additional tests and implemented changes I had requested. There were 40 commits before, and many merge conflicts from https://github.com/aws/aws-cdk-cli/pull/819.

Unit test coverage for `init.ts` is now 97.65%. Tested by hand for many cases as well.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
