### PR TITLE
feat(cli): `--yes` option to accept all questions

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth-telemetry-with-errors.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth-telemetry-with-errors.integtest.ts
@@ -36,6 +36,7 @@ integTest(
               ci: expect.anything(), // changes based on where this is called
               validation: true,
               quiet: false,
+              yes: false,
             },
             config: {
               context: {},
@@ -84,6 +85,7 @@ integTest(
               ci: expect.anything(), // changes based on where this is called
               validation: true,
               quiet: false,
+              yes: false,
             },
             config: {
               context: {},

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth-telemetry.integtest.ts
@@ -28,6 +28,7 @@ integTest(
               ci: expect.anything(), // changes based on where this is called
               validation: true,
               quiet: false,
+              yes: false,
             },
             config: {
               context: {},
@@ -77,6 +78,7 @@ integTest(
               ci: expect.anything(), // changes based on where this is called
               validation: true,
               quiet: false,
+              yes: false,
             },
             config: {
               context: {},

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -44,7 +44,7 @@ export async function makeConfig(): Promise<CliConfig> {
       'ci': { type: 'boolean', desc: 'Force CI detection. If CI=true then logs will be sent to stdout instead of stderr', default: YARGS_HELPERS.isCI() },
       'unstable': { type: 'array', desc: 'Opt in to unstable features. The flag indicates that the scope and API of a feature might still change. Otherwise the feature is generally production ready and fully supported. Can be specified multiple times.', default: [] },
       'telemetry-file': { type: 'string', desc: 'Send telemetry data to a local file.', default: undefined },
-      'yes': { type: 'boolean', alias: 'y', desc: 'Skip interactive prompts. If yes=true then the operation will proceed without confirmation.', default: false },
+      'yes': { type: 'boolean', alias: 'y', desc: 'Automatically answer interactive prompts with the recommended response. This includes confirming actions.', default: false },
     },
     commands: {
       'list': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -44,6 +44,7 @@ export async function makeConfig(): Promise<CliConfig> {
       'ci': { type: 'boolean', desc: 'Force CI detection. If CI=true then logs will be sent to stdout instead of stderr', default: YARGS_HELPERS.isCI() },
       'unstable': { type: 'array', desc: 'Opt in to unstable features. The flag indicates that the scope and API of a feature might still change. Otherwise the feature is generally production ready and fully supported. Can be specified multiple times.', default: [] },
       'telemetry-file': { type: 'string', desc: 'Send telemetry data to a local file.', default: undefined },
+      'yes': { type: 'boolean', alias: 'y', desc: 'Skip interactive prompts. If yes=true then the operation will proceed without confirmation.', default: false },
     },
     commands: {
       'list': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -131,7 +131,7 @@
     "yes": {
       "type": "boolean",
       "alias": "y",
-      "desc": "Skip interactive prompts. If yes=true then the operation will proceed without confirmation.",
+      "desc": "Automatically answer interactive prompts with the recommended response. This includes confirming actions.",
       "default": false
     }
   },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -127,6 +127,12 @@
     "telemetry-file": {
       "type": "string",
       "desc": "Send telemetry data to a local file."
+    },
+    "yes": {
+      "type": "boolean",
+      "alias": "y",
+      "desc": "Skip interactive prompts. If yes=true then the operation will proceed without confirmation.",
+      "default": false
     }
   },
   "commands": {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -70,7 +70,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     isCI: Boolean(argv.ci),
     currentAction: cmd,
     stackProgress: argv.progress,
-    nonInteractive: argv.yes,
+    autoRespond: argv.yes,
   }, true);
   const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
 

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -70,6 +70,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
     isCI: Boolean(argv.ci),
     currentAction: cmd,
     stackProgress: argv.progress,
+    nonInteractive: argv.yes,
   }, true);
   const ioHelper = asIoHelper(ioHost, ioHost.currentAction as any);
 

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -35,6 +35,7 @@ export function convertYargsToUserInput(args: any): UserInput {
     ci: args.ci,
     unstable: args.unstable,
     telemetryFile: args.telemetryFile,
+    yes: args.yes,
   };
   let commandOptions;
   switch (args._[0] as Command) {
@@ -344,6 +345,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     ci: config.ci,
     unstable: config.unstable,
     telemetryFile: config.telemetryFile,
+    yes: config.yes,
   };
   const listOptions = {
     long: config.list?.long,

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -438,13 +438,19 @@ export class CliIoHost implements IIoHost {
       if (this.autoRespond) {
         // respond with yes to all confirmations
         if (isConfirmationPrompt(msg)) {
-          // @TODO print message and confirmation
+          await this.notify({
+            ...msg,
+            message: `${chalk.cyan(msg.message)} (auto-confirmed)`,
+          });
           return true;
         }
 
         // respond with the default for all other messages
         if (msg.defaultResponse) {
-          // @TODO print message and response
+          await this.notify({
+            ...msg,
+            message: `${chalk.cyan(msg.message)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,
+          });
           return msg.defaultResponse;
         }
       }

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -161,6 +161,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
       type: 'string',
       desc: 'Send telemetry data to a local file.',
     })
+    .option('yes', {
+      default: false,
+      type: 'boolean',
+      alias: 'y',
+      desc: 'Skip interactive prompts. If yes=true then the operation will proceed without confirmation.',
+    })
     .command(['list [STACKS..]', 'ls [STACKS..]'], 'Lists all stacks in the app', (yargs: Argv) =>
       yargs
         .option('long', {

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -165,7 +165,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
       default: false,
       type: 'boolean',
       alias: 'y',
-      desc: 'Skip interactive prompts. If yes=true then the operation will proceed without confirmation.',
+      desc: 'Automatically answer interactive prompts with the recommended response. This includes confirming actions.',
     })
     .command(['list [STACKS..]', 'ls [STACKS..]'], 'Lists all stacks in the app', (yargs: Argv) =>
       yargs

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -329,7 +329,7 @@ export interface GlobalOptions {
   readonly telemetryFile?: string;
 
   /**
-   * Skip interactive prompts. If yes=true then the operation will proceed without confirmation.
+   * Automatically answer interactive prompts with the recommended response. This includes confirming actions.
    *
    * @default - false
    */

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -327,6 +327,13 @@ export interface GlobalOptions {
    * @default - undefined
    */
   readonly telemetryFile?: string;
+
+  /**
+   * Skip interactive prompts. If yes=true then the operation will proceed without confirmation.
+   *
+   * @default - false
+   */
+  readonly yes?: boolean;
 }
 
 /**

--- a/packages/aws-cdk/test/cli/cli-arguments.test.ts
+++ b/packages/aws-cdk/test/cli/cli-arguments.test.ts
@@ -35,6 +35,7 @@ describe('yargs', () => {
         unstable: [],
         notices: undefined,
         output: undefined,
+        yes: false,
       },
       deploy: {
         STACKS: undefined,

--- a/packages/aws-cdk/test/cli/cli.test.ts
+++ b/packages/aws-cdk/test/cli/cli.test.ts
@@ -59,6 +59,12 @@ jest.mock('../../lib/cli/parse-command-line-arguments', () => ({
       if (args.includes('--role-arn')) {
         result = { ...result, roleArn: 'arn:aws:iam::123456789012:role/TestRole' };
       }
+    } else if (args.includes('deploy')) {
+      result = {
+        ...result,
+        _: ['deploy'],
+        parameters: [],
+      };
     }
 
     // Handle notices flags
@@ -486,22 +492,24 @@ describe('gc command tests', () => {
   });
 });
 
-test('when --yes option is provided, CliIoHost is in non-interactive mode', async () => {
-  // GIVEN
-  const migrateSpy = jest.spyOn(cdkToolkitModule.CdkToolkit.prototype, 'deploy').mockResolvedValue();
-  const execSpy = jest.spyOn(CliIoHost, 'instance');
+describe('--yes', () => {
+  test('when --yes option is provided, CliIoHost is using autoRespond', async () => {
+    // GIVEN
+    const migrateSpy = jest.spyOn(cdkToolkitModule.CdkToolkit.prototype, 'deploy').mockResolvedValue();
+    const execSpy = jest.spyOn(CliIoHost, 'instance');
 
-  // WHEN
-  await exec(['deploy', '--yes']);
+    // WHEN
+    await exec(['deploy', '--yes']);
 
-  // THEN
-  expect(execSpy).toHaveBeenCalledWith(
-    expect.objectContaining({
-      nonInteractive: true,
-    }),
-    true,
-  );
+    // THEN
+    expect(execSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        autoRespond: true,
+      }),
+      true,
+    );
 
-  migrateSpy.mockRestore();
-  execSpy.mockRestore();
+    migrateSpy.mockRestore();
+    execSpy.mockRestore();
+  });
 });

--- a/packages/aws-cdk/test/cli/cli.test.ts
+++ b/packages/aws-cdk/test/cli/cli.test.ts
@@ -79,6 +79,10 @@ jest.mock('../../lib/cli/parse-command-line-arguments', () => ({
       result = { ...result, verbose: parseInt(args[verboseIndex + 1], 10) };
     }
 
+    if (args.includes('--yes')) {
+      result = { ...result, yes: true };
+    }
+
     return Promise.resolve(result);
   }),
 }));
@@ -480,4 +484,24 @@ describe('gc command tests', () => {
     );
     expect(gcSpy).toHaveBeenCalled();
   });
+});
+
+test('when --yes option is provided, CliIoHost is in non-interactive mode', async () => {
+  // GIVEN
+  const migrateSpy = jest.spyOn(cdkToolkitModule.CdkToolkit.prototype, 'deploy').mockResolvedValue();
+  const execSpy = jest.spyOn(CliIoHost, 'instance');
+
+  // WHEN
+  await exec(['deploy', '--yes']);
+
+  // THEN
+  expect(execSpy).toHaveBeenCalledWith(
+    expect.objectContaining({
+      nonInteractive: true,
+    }),
+    true,
+  );
+
+  migrateSpy.mockRestore();
+  execSpy.mockRestore();
 });

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -494,6 +494,47 @@ describe('CliIoHost', () => {
       });
     });
 
+    describe('non-interactive mode', () => {
+      const nonInteractiveIoHost = CliIoHost.instance({
+        logLevel: 'trace',
+        nonInteractive: true,
+        isCI: false,
+        isTTY: true,
+      }, true);
+
+      test('it does not prompt the user and return true', async () => {
+        // WHEN
+        const response = await nonInteractiveIoHost.requestResponse(plainMessage({
+          time: new Date(),
+          level: 'info',
+          action: 'synth',
+          code: 'CDK_TOOLKIT_I0001',
+          message: 'test message',
+          defaultResponse: true,
+        }));
+
+        // THEN
+        expect(mockStdout).not.toHaveBeenCalledWith(chalk.cyan('test message') + ' (y/n) ');
+        expect(response).toBe(true);
+      });
+
+      test('approvalToolkitCodes also skip', async () => {
+        // WHEN
+        const response = await nonInteractiveIoHost.requestResponse(plainMessage({
+          time: new Date(),
+          level: 'info',
+          action: 'synth',
+          code: 'CDK_TOOLKIT_I5060',
+          message: 'test message',
+          defaultResponse: true,
+        }));
+
+        // THEN
+        expect(mockStdout).not.toHaveBeenCalledWith(chalk.cyan('test message') + ' (y/n) ');
+        expect(response).toBe(true);
+      });
+    });
+
     describe('non-promptable data', () => {
       test('logs messages and returns default unchanged', async () => {
         const response = await ioHost.requestResponse(plainMessage({

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -503,6 +503,8 @@ describe('CliIoHost', () => {
       }, true);
 
       test('it does not prompt the user and return true', async () => {
+        const notifySpy = jest.spyOn(autoRespondingIoHost, 'notify');
+
         // WHEN
         const response = await autoRespondingIoHost.requestResponse(plainMessage({
           time: new Date(),
@@ -515,10 +517,15 @@ describe('CliIoHost', () => {
 
         // THEN
         expect(mockStdout).not.toHaveBeenCalledWith(chalk.cyan('test message') + ' (y/n) ');
+        expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+          message: chalk.cyan('test message') + ' (auto-confirmed)',
+        }));
         expect(response).toBe(true);
       });
 
       test('messages with default are skipped', async () => {
+        const notifySpy = jest.spyOn(autoRespondingIoHost, 'notify');
+
         // WHEN
         const response = await autoRespondingIoHost.requestResponse(plainMessage({
           time: new Date(),
@@ -531,6 +538,9 @@ describe('CliIoHost', () => {
 
         // THEN
         expect(mockStdout).not.toHaveBeenCalledWith(chalk.cyan('test message') + ' (y/n) ');
+        expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+          message: chalk.cyan('test message') + ' (auto-responded with default: foobar)',
+        }));
         expect(response).toBe('foobar');
       });
     });

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -494,17 +494,17 @@ describe('CliIoHost', () => {
       });
     });
 
-    describe('non-interactive mode', () => {
-      const nonInteractiveIoHost = CliIoHost.instance({
+    describe('--yes mode', () => {
+      const autoRespondingIoHost = CliIoHost.instance({
         logLevel: 'trace',
-        nonInteractive: true,
+        autoRespond: true,
         isCI: false,
         isTTY: true,
       }, true);
 
       test('it does not prompt the user and return true', async () => {
         // WHEN
-        const response = await nonInteractiveIoHost.requestResponse(plainMessage({
+        const response = await autoRespondingIoHost.requestResponse(plainMessage({
           time: new Date(),
           level: 'info',
           action: 'synth',
@@ -518,20 +518,20 @@ describe('CliIoHost', () => {
         expect(response).toBe(true);
       });
 
-      test('approvalToolkitCodes also skip', async () => {
+      test('messages with default are skipped', async () => {
         // WHEN
-        const response = await nonInteractiveIoHost.requestResponse(plainMessage({
+        const response = await autoRespondingIoHost.requestResponse(plainMessage({
           time: new Date(),
           level: 'info',
           action: 'synth',
           code: 'CDK_TOOLKIT_I5060',
           message: 'test message',
-          defaultResponse: true,
+          defaultResponse: 'foobar',
         }));
 
         // THEN
         expect(mockStdout).not.toHaveBeenCalledWith(chalk.cyan('test message') + ' (y/n) ');
-        expect(response).toBe(true);
+        expect(response).toBe('foobar');
       });
     });
 


### PR DESCRIPTION
Adds a new `--yes` cli option so that when provided, commands can continue without confirmation. Any confirmation prompts will be accepted. Other user input will use a default value if available. The CLI might still prompt for input in situations where there is no default answer.

Fixes #732 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
