### PR TITLE
chore: improve stability of tests by copying SSM Parameter Value

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap-template.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap-template.test.ts
@@ -2,25 +2,25 @@ import { Bootstrapper } from '../../../lib/api/bootstrap';
 import type { IIoHost } from '../../../lib/api/io';
 import { asIoHelper } from '../../../lib/api/io/private';
 
-describe('ExternalId Protection Integration Test', () => {
-  let ioHost: IIoHost;
-  let ioHelper: any;
+let ioHost: IIoHost;
+let ioHelper: any;
+let template: any;
 
-  beforeEach(() => {
-    ioHost = {
-      notify: jest.fn(),
-      requestResponse: jest.fn(),
-    };
-    ioHelper = asIoHelper(ioHost, 'bootstrap');
-  });
+beforeEach(async () => {
+  ioHost = {
+    notify: jest.fn(),
+    requestResponse: jest.fn(),
+  };
+  ioHelper = asIoHelper(ioHost, 'bootstrap');
 
-  test('bootstrap template denies AssumeRole with ExternalId by default', async () => {
-    // GIVEN
-    const bootstrapper = new Bootstrapper({ source: 'default' }, ioHelper);
+  // GIVEN
+  const bootstrapper = new Bootstrapper({ source: 'default' }, ioHelper);
+  // WHEN
+  template = await (bootstrapper as any).loadTemplate();
+});
 
-    // WHEN
-    const template = await (bootstrapper as any).loadTemplate();
-
+describe('bootstrap template', () => {
+  test('denies AssumeRole with ExternalId by default', async () => {
     // THEN
     // Verify the parameter exists
     expect(template.Parameters.DenyExternalId).toMatchObject({
@@ -69,5 +69,9 @@ describe('ExternalId Protection Integration Test', () => {
     for (const stmt of cfnStatements) {
       expect(stmt.Condition).toBeUndefined();
     }
+  });
+
+  test('has the same values for BootstrapVersion Parameter and Output', async () => {
+    expect(template.Outputs.BootstrapVersion.Value).toEqual(template.Resources.CdkBootstrapVersion.Properties.Value);
   });
 });

--- a/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
+++ b/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
@@ -844,5 +844,8 @@ Outputs:
   BootstrapVersion:
     Description: The version of the bootstrap resources that are currently mastered
       in this stack
-    Value:
-      Fn::GetAtt: [CdkBootstrapVersion, Value]
+    # This value is purposely duplicated here from the AWS::SSM::Parameter value we define above.
+    # {Fn::GetAtt} on an SSM Parameter is eventually consistent, and can fail with "parameter
+    # doesn't exist" even after just having been created. To reduce our deploy failure rate, we
+    # duplicate the value here and use a build-time test to ensure the two values are the same.
+    Value: '29'

--- a/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
+++ b/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
@@ -813,6 +813,7 @@ Resources:
       Type: String
       Name:
         Fn::Sub: '/cdk-bootstrap/${Qualifier}/version'
+      # Also update this value below (see comment there)
       Value: '29'
 Outputs:
   BucketName:

--- a/packages/aws-cdk/test/commands/bootstrap.test.ts
+++ b/packages/aws-cdk/test/commands/bootstrap.test.ts
@@ -1,5 +1,8 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { Bootstrapper } from '../../lib/api/bootstrap';
 import { exec } from '../../lib/cli/cli';
+import { deserializeStructure } from '@aws-cdk/toolkit-lib/lib/util';
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/packages/aws-cdk/test/commands/bootstrap.test.ts
+++ b/packages/aws-cdk/test/commands/bootstrap.test.ts
@@ -1,8 +1,5 @@
-import * as fs from 'fs/promises';
-import * as path from 'path';
 import { Bootstrapper } from '../../lib/api/bootstrap';
 import { exec } from '../../lib/cli/cli';
-import { deserializeStructure } from '@aws-cdk/toolkit-lib/lib/util';
 
 beforeEach(() => {
   jest.clearAllMocks();


### PR DESCRIPTION
`{Fn::GetAtt}` on an `AWS::SSM::Parameter` is eventually consistent. If an SSM Parameter was just created in a stack deployment, the `{Fn::GetAtt}` may sometimes fail with a "Parameter not found" error.

This causes ~2 canary failures per week (about 1% failure rate).

We don't actually need to `{Fn::GetAtt}` the value as we know what it is (it is static, after all). Copy the same literal value into both places to reduce the canary failure rate by a little bit, and add a test to make sure the values don't accidentally drift apart.

Internal reference D259904064.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
