### PR TITLE
fix: cdk flags outputs empty table when recommended flags are already set

### DIFF
--- a/packages/aws-cdk/lib/commands/flag-operations.ts
+++ b/packages/aws-cdk/lib/commands/flag-operations.ts
@@ -477,6 +477,13 @@ export async function displayFlags(params: FlagOperationsParams): Promise<void> 
   }
 
   await displayFlagTable(flagsToDisplay, ioHelper);
+
+  // Add helpful message after empty table when not using --all
+  if (!all && flagsToDisplay.length === 0) {
+    await ioHelper.defaults.info('');
+    await ioHelper.defaults.info('✅ All feature flags are already set to their recommended values.');
+    await ioHelper.defaults.info('Use \'cdk flags --all --unstable=flags\' to see all flags and their current values.');
+  }
 }
 
 function isUserValueEqualToRecommended(flag: FeatureFlag): boolean {


### PR DESCRIPTION
Fixes #834 

### Description
DX improvement.

Previously, when the user ran `cdk flags` but already had all recommended flags configured, an empty table was displayed.
<img width="1177" height="160" alt="Screenshot 2025-09-03 at 12 01 43" src="https://github.com/user-attachments/assets/3b41df96-4256-49a3-88fc-1e405a04d8e8" />
*No context here, what does the table mean?*

In this change, we added a message to inform the user why they are seeing an empty table. We still print the table to maintain API consistency.
<img width="1102" height="542" alt="Screenshot 2025-09-05 at 21 16 11" src="https://github.com/user-attachments/assets/6c389d01-31b2-4c48-a609-fa545f5453f1" />
*Now the user knows why the table is empty, and is given guidance to display all flags*

### Testing
Added unit tests for positive and negative cases.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
