### PR TITLE
fix(cli): text not readable in light terminals

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/format.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format.ts
@@ -98,7 +98,7 @@ export class Formatter {
   }
 
   public print(fmt: string, ...args: any[]) {
-    this.stream.write(chalk.white(format(fmt, ...args)) + '\n');
+    this.stream.write(chalk.reset(format(fmt, ...args)) + '\n');
   }
 
   public warning(fmt: string, ...args: any[]) {
@@ -204,7 +204,7 @@ export class Formatter {
     if (diff.isRemoval) {
       return REMOVAL;
     }
-    return chalk.white('[?]');
+    return chalk.reset('[?]');
   }
 
   /**

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/non-interactive-io-host.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/non-interactive-io-host.ts
@@ -156,8 +156,8 @@ export class NonInteractiveIoHost implements IIoHost {
 const styleMap: Record<IoMessageLevel, (str: string) => string> = {
   error: chalk.red,
   warn: chalk.yellow,
-  result: chalk.white,
-  info: chalk.white,
+  result: chalk.reset,
+  info: chalk.reset,
   debug: chalk.gray,
   trace: chalk.gray,
 };

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -536,8 +536,8 @@ function extractPromptInfo(msg: IoRequest<any, any>): {
 const styleMap: Record<IoMessageLevel, (str: string) => string> = {
   error: chalk.red,
   warn: chalk.yellow,
-  result: chalk.white,
-  info: chalk.white,
+  result: chalk.reset,
+  info: chalk.reset,
   debug: chalk.gray,
   trace: chalk.gray,
 };

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -84,7 +84,7 @@ describe('CliIoHost', () => {
         message: 'test message',
       }));
 
-      expect(mockStderr).toHaveBeenCalledWith(chalk.white('test message') + '\n');
+      expect(mockStderr).toHaveBeenCalledWith(chalk.reset('test message') + '\n');
       expect(mockStdout).not.toHaveBeenCalled();
     });
 
@@ -112,7 +112,7 @@ describe('CliIoHost', () => {
         message: 'result message',
       }));
 
-      expect(mockStdout).toHaveBeenCalledWith(chalk.white('result message') + '\n');
+      expect(mockStdout).toHaveBeenCalledWith(chalk.reset('result message') + '\n');
       expect(mockStderr).not.toHaveBeenCalled();
     });
   });
@@ -184,7 +184,7 @@ describe('CliIoHost', () => {
     test.each([
       ['error', 'red', false],
       ['warn', 'yellow', false],
-      ['info', 'white', false],
+      ['info', 'reset', false],
       ['debug', 'gray', true],
       ['trace', 'gray', true],
     ] as Array<[IoMessageLevel, typeof chalk.ForegroundColor, boolean]>)('outputs %ss in %s color ', async (level, color, shouldAddTime) => {
@@ -229,7 +229,7 @@ describe('CliIoHost', () => {
         message: 'ci message',
       }));
 
-      expect(mockStdout).toHaveBeenCalledWith(chalk.white('ci message') + '\n');
+      expect(mockStdout).toHaveBeenCalledWith(chalk.reset('ci message') + '\n');
       expect(mockStderr).not.toHaveBeenCalled();
     });
 
@@ -275,7 +275,7 @@ describe('CliIoHost', () => {
         message: 'info message',
       }));
 
-      expect(mockStderr).toHaveBeenCalledWith(chalk.white('info message') + '\n');
+      expect(mockStderr).toHaveBeenCalledWith(chalk.reset('info message') + '\n');
     });
   });
 
@@ -505,7 +505,7 @@ describe('CliIoHost', () => {
           defaultResponse: [1, 2, 3],
         }));
 
-        expect(mockStderr).toHaveBeenCalledWith(chalk.white('test message') + '\n');
+        expect(mockStderr).toHaveBeenCalledWith(chalk.reset('test message') + '\n');
         expect(response).toEqual([1, 2, 3]);
       });
     });


### PR DESCRIPTION
With `chalk.white`, the text is hard to read on terminals with light backgrounds. `chalk.reset` works as expected in both dark and light background.

Fixes #751

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
