### PR TITLE
chore: npm trusted publishing for jsii packages is ignored

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -292,7 +292,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   aws-cdk-cloud-assembly-schema_release_maven:
     name: "@aws-cdk/cloud-assembly-schema: Publish to Maven Central"
@@ -861,7 +861,7 @@ jobs:
           NPM_DIST_TAG: latest
           NPM_REGISTRY: registry.npmjs.org
           NPM_CONFIG_PROVENANCE: "true"
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TRUSTED_PUBLISHER: "true"
         run: npx -p publib@latest publib-npm
   aws-cdk-cli-lib-alpha_release_maven:
     name: "@aws-cdk/cli-lib-alpha: Publish to Maven Central"

--- a/projenrc/jsii.ts
+++ b/projenrc/jsii.ts
@@ -270,6 +270,7 @@ export class JsiiBuild extends pj.Component {
       registry: tsProject.package.npmRegistry,
       npmTokenSecret: tsProject.package.npmTokenSecret,
       npmProvenance: tsProject.package.npmProvenance,
+      trustedPublishing: true,
       // No support for CodeArtifact here
       // codeArtifactOptions: tsProject.codeArtifactOptions,
     };
@@ -477,10 +478,10 @@ export class JsiiBuild extends pj.Component {
     target: JsiiPacmakTarget,
     packTask: pj.Task,
   ): {
-      publishTools: Tools;
-      bootstrapSteps: Array<Step>;
-      packagingSteps: Array<Step>;
-    } {
+    publishTools: Tools;
+    bootstrapSteps: Array<Step>;
+    packagingSteps: Array<Step>;
+  } {
     const bootstrapSteps: Array<Step> = [];
     const packagingSteps: Array<Step> = [];
 

--- a/projenrc/jsii.ts
+++ b/projenrc/jsii.ts
@@ -478,10 +478,10 @@ export class JsiiBuild extends pj.Component {
     target: JsiiPacmakTarget,
     packTask: pj.Task,
   ): {
-    publishTools: Tools;
-    bootstrapSteps: Array<Step>;
-    packagingSteps: Array<Step>;
-  } {
+      publishTools: Tools;
+      bootstrapSteps: Array<Step>;
+      packagingSteps: Array<Step>;
+    } {
     const bootstrapSteps: Array<Step> = [];
     const packagingSteps: Array<Step> = [];
 


### PR DESCRIPTION
For jsii packages, the NPM publishing takes a different code path.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
