### PR TITLE
fix(cli): stack filter positional arg is not being respected

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring-multiple-envs/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring-multiple-envs/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "node refactoring.js",
+  "versionReporting": false,
+  "context": {
+    "aws-cdk:enableDiffNoFail": "true"
+  }
+}

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring-multiple-envs/refactoring.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/refactoring-multiple-envs/refactoring.js
@@ -1,0 +1,26 @@
+const cdk = require('aws-cdk-lib');
+const s3 = require('aws-cdk-lib/aws-s3');
+
+const BUCKET_ID = process.env.BUCKET_ID ?? 'OldName';
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+
+const app = new cdk.App();
+
+let gamma = {
+  region: 'eu-central-1',
+};
+let prod = {
+  region: 'us-east-1',
+};
+
+class MyStack extends cdk.Stack {
+  constructor(scope, id) {
+    super(scope, id);
+    new s3.Bucket(this, BUCKET_ID);
+  }
+}
+
+new MyStack(app, `${stackPrefix}-gamma-stack`, { env: gamma });
+new MyStack(app, `${stackPrefix}-prod-stack`, { env: prod });
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run.integtest.ts
@@ -49,6 +49,38 @@ integTest(
   }),
 );
 
+integTest(
+  'cdk refactor - filters stacks by pattern',
+  withSpecificFixture('refactoring-multiple-envs', async (fixture) => {
+    // First, deploy the stacks
+    await fixture.cdkDeploy('gamma-stack', {
+      modEnv: {
+        BUCKET_ID: 'OldName',
+      },
+    });
+    await fixture.cdkDeploy('prod-stack', {
+      modEnv: {
+        BUCKET_ID: 'OldName',
+      },
+    });
+
+    // Then see if the refactoring tool detects the change
+    const stdErr = await fixture.cdkRefactor({
+      options: ['*-gamma-stack', '--dry-run', '--unstable=refactor'],
+      allowErrExit: true,
+      captureStderr: true,
+      // Making sure the synthesized stack has a queue with
+      // the new name so that a refactor is detected
+      modEnv: {
+        BUCKET_ID: 'NewName',
+      },
+    });
+
+    const numberOfEnvironments = (stdErr.match(/Resource Type/g) || []).length;
+    expect(numberOfEnvironments).toEqual(1);
+  }),
+);
+
 function removeColor(str: string): string {
   return str.replace(/\x1B[[(?);]{0,2}(;?\d)*./g, '');
 }

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -493,6 +493,10 @@ export async function makeConfig(): Promise<CliConfig> {
             desc: 'Whether to do the refactor without asking for confirmation',
           },
         },
+        arg: {
+          name: 'STACKS',
+          variadic: true,
+        },
       },
       'cli-telemetry': {
         description: 'Enable or disable anonymous telemetry',

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -1015,6 +1015,10 @@
           "default": false,
           "desc": "Whether to do the refactor without asking for confirmation"
         }
+      },
+      "arg": {
+        "name": "STACKS",
+        "variadic": true
       }
     },
     "cli-telemetry": {

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -292,6 +292,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         overrideFile: args.overrideFile,
         revert: args.revert,
         force: args.force,
+        STACKS: args.STACKS,
       };
       break;
 

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -966,7 +966,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
       }),
     )
     .command('doctor', 'Check your set-up for potential problems')
-    .command('refactor', 'Moves resources between stacks or within the same stack', (yargs: Argv) =>
+    .command('refactor [STACKS..]', 'Moves resources between stacks or within the same stack', (yargs: Argv) =>
       yargs
         .option('additional-stack-name', {
           type: 'array',

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1569,6 +1569,11 @@ export interface RefactorOptions {
    * @default - false
    */
   readonly force?: boolean;
+
+  /**
+   * Positional argument for refactor
+   */
+  readonly STACKS?: Array<string>;
 }
 
 /**


### PR DESCRIPTION
At some point, the positional argument was lost, and there were no tests for it.

Add it to `cli-config.ts`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
