### PR TITLE
chore: revert aws-actions/stale-issue-cleanup back to v6

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Stale issue job
     steps:
-    - uses: aws-actions/stale-issue-cleanup@v7.1.0
+    - uses: aws-actions/stale-issue-cleanup@v6
       with:
         # Setting messages to an empty string will cause the automation to skip
         # that category


### PR DESCRIPTION
There are some weird issues with the latest version. Let's just go back to the tried and tested on.

https://github.com/aws/aws-cdk-cli/actions/runs/17833245041/job/50705475999

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
