### PR TITLE
refactor(cli): property bag for refreshStacks function

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
@@ -219,7 +219,12 @@ export class GarbageCollector {
     const activeAssets = new ActiveAssetCache();
 
     // Grab stack templates first
-    await refreshStacks(cfn, this.ioHelper, activeAssets, qualifier);
+    await refreshStacks({
+      cfn,
+      ioHelper: this.ioHelper,
+      activeAssets,
+      qualifier,
+    });
     // Start the background refresh
     const backgroundStackRefresh = new BackgroundStackRefresh({
       cfn,


### PR DESCRIPTION
The refreshStacks function currently takes 4 individual parameters, making it difficult to maintain as new parameters are added. 

This change:
- Introduces a `RefreshStacksProps` interface to group function parameters
- Refactors the `refreshStacks` function signature to accept a single props object

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
