### PR TITLE
chore: fix codeowner team name

### DIFF
--- a/packages/cdk-assets/.github/CODEOWNERS
+++ b/packages/cdk-assets/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-/.github/ @aws-cdk-core-team
-/bin/ @aws-cdk-core-team
-/lib/ @aws-cdk-core-team
-/test/ @aws-cdk-core-team
+/.github/ @aws/aws-cdk-core-team
+/bin/ @aws/aws-cdk-core-team
+/lib/ @aws/aws-cdk-core-team
+/test/ @aws/aws-cdk-core-team

--- a/packages/cdk-assets/.github/CODEOWNERS
+++ b/packages/cdk-assets/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-/.github/ @cdk-core-team
-/bin/ @cdk-core-team
-/lib/ @cdk-core-team
-/test/ @cdk-core-team
+/.github/ @aws-cdk-core-team
+/bin/ @aws-cdk-core-team
+/lib/ @aws-cdk-core-team
+/test/ @aws-cdk-core-team


### PR DESCRIPTION
This was using an incorrect name. The correct name is @aws/aws-cdk-core-team.

## Was

<img width="720" height="517" alt="image" src="https://github.com/user-attachments/assets/8b329077-8d96-40e6-bcf2-2c14526b1b35" />

## Now

<img width="458" height="339" alt="image" src="https://github.com/user-attachments/assets/ab854646-4086-4e53-8e68-64520dcf12d0" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
