### PR TITLE
feat(cli): change set review on deploy

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -82,13 +82,14 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_TOOLKIT_I5002` | Provides time for resource migration | `info` | {@link Duration} |
 | `CDK_TOOLKIT_W5021` | Empty non-existent stack, deployment is skipped | `warn` | n/a |
 | `CDK_TOOLKIT_W5022` | Empty existing stack, stack will be destroyed | `warn` | n/a |
+| `CDK_TOOLKIT_W5023` | No changes to existing stack, deployment is skipped | `warn` | n/a |
 | `CDK_TOOLKIT_I5031` | Informs about any log groups that are traced as part of the deployment | `info` | n/a |
 | `CDK_TOOLKIT_I5032` | Start monitoring log groups | `debug` | {@link CloudWatchLogMonitorControlEvent} |
 | `CDK_TOOLKIT_I5033` | A log event received from Cloud Watch | `info` | {@link CloudWatchLogEvent} |
 | `CDK_TOOLKIT_I5034` | Stop monitoring log groups | `debug` | {@link CloudWatchLogMonitorControlEvent} |
 | `CDK_TOOLKIT_E5035` | A log monitoring error | `error` | {@link ErrorPayload} |
 | `CDK_TOOLKIT_I5050` | Confirm rollback during deployment | `info` | {@link ConfirmationRequest} |
-| `CDK_TOOLKIT_I5060` | Confirm deploy security sensitive changes | `info` | {@link DeployConfirmationRequest} |
+| `CDK_TOOLKIT_I5060` | Confirm deploy changes | `info` | {@link DeployConfirmationRequest} |
 | `CDK_TOOLKIT_I5100` | Stack deploy progress | `info` | {@link StackDeployProgress} |
 | `CDK_TOOLKIT_I5210` | Started building a specific asset | `trace` | {@link BuildAsset} |
 | `CDK_TOOLKIT_I5211` | Building the asset has completed | `trace` | {@link Duration} |

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -35,6 +35,41 @@ export interface ChangeSetDeployment {
    * @default false
    */
   readonly importExistingResources?: boolean;
+
+  /**
+   * Whether to execute an existing change set instead of creating a new one.
+   * When true, the specified changeSetName must exist and will be executed directly.
+   * When false or undefined, a new change set will be created.
+   *
+   * This is useful for secure change set review workflows where:
+   * 1. A change set is created with `execute: false`
+   * 2. The change set is reviewed by authorized personnel
+   * 3. The same change set is executed using this option to ensure
+   *    the exact changes that were reviewed are deployed
+   *
+   * @example
+   * // Step 1: Create change set for review
+   * deployStack(\{
+   *   deploymentMethod: \{
+   *     method: 'change-set',
+   *     changeSetName: 'my-review-changeset',
+   *     execute: false
+   *   \}
+   * \});
+   *
+   * // Step 2: Execute the reviewed change set
+   * deployStack(\{
+   *   deploymentMethod: \{
+   *     method: 'change-set',
+   *     changeSetName: 'my-review-changeset',
+   *     executeExistingChangeSet: true,
+   *     execute: true
+   *   \}
+   * \});
+   *
+   * @default false
+   */
+  readonly executeExistingChangeSet?: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/index.ts
@@ -5,3 +5,4 @@ export * from './deployment-result';
 export * from './checks';
 export { addMetadataAssetsToManifest } from './assets';
 export { AssetManifestBuilder } from './asset-manifest-builder';
+export { changeSetHasNoChanges } from './cfn-api';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
@@ -43,6 +43,12 @@ interface FormatStackDiffOutput {
    * Complete formatted diff
    */
   readonly formattedDiff: string;
+
+  /**
+   * The type of permission changes in the stack diff.
+   * The IoHost will use this to decide whether or not to print.
+   */
+  readonly permissionChangeType: PermissionChangeType;
 }
 
 /**
@@ -323,6 +329,7 @@ export class DiffFormatter {
     return {
       numStacksWithChanges,
       formattedDiff,
+      permissionChangeType: this.permissionType(),
     };
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -152,6 +152,10 @@ export const IO = {
     code: 'CDK_TOOLKIT_W5022',
     description: 'Empty existing stack, stack will be destroyed',
   }),
+  CDK_TOOLKIT_W5023: make.warn({
+    code: 'CDK_TOOLKIT_W5023',
+    description: 'No changes to existing stack, deployment is skipped',
+  }),
   CDK_TOOLKIT_I5031: make.info({
     code: 'CDK_TOOLKIT_I5031',
     description: 'Informs about any log groups that are traced as part of the deployment',
@@ -183,7 +187,7 @@ export const IO = {
   }),
   CDK_TOOLKIT_I5060: make.confirm<DeployConfirmationRequest>({
     code: 'CDK_TOOLKIT_I5060',
-    description: 'Confirm deploy security sensitive changes',
+    description: 'Confirm deploy changes',
     interface: 'DeployConfirmationRequest',
   }),
   CDK_TOOLKIT_I5100: make.info<StackDeployProgress>({

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -4,6 +4,7 @@ import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import type { FeatureFlagReportProperties } from '@aws-cdk/cloud-assembly-schema';
 import { ArtifactType } from '@aws-cdk/cloud-assembly-schema';
 import type { TemplateDiff } from '@aws-cdk/cloudformation-diff';
+import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
@@ -35,7 +36,7 @@ import type {
   EnvironmentBootstrapResult,
 } from '../actions/bootstrap';
 import { BootstrapSource } from '../actions/bootstrap';
-import { AssetBuildTime, type DeployOptions } from '../actions/deploy';
+import { AssetBuildTime, type DeploymentMethod, type DeployOptions } from '../actions/deploy';
 import {
   buildParameterMap,
   type PrivateDeployOptions,
@@ -66,7 +67,7 @@ import type { StackAssembly } from '../api/cloud-assembly/private';
 import { ALL_STACKS } from '../api/cloud-assembly/private';
 import { CloudAssemblySourceBuilder } from '../api/cloud-assembly/source-builder';
 import type { StackCollection } from '../api/cloud-assembly/stack-collection';
-import { Deployments } from '../api/deployments';
+import { changeSetHasNoChanges, Deployments } from '../api/deployments';
 import { DiffFormatter } from '../api/diff';
 import { detectStackDrift } from '../api/drift';
 import { DriftFormatter } from '../api/drift/drift-formatter';
@@ -614,32 +615,6 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         return;
       }
 
-      const currentTemplate = await deployments.readCurrentTemplate(stack);
-
-      const formatter = new DiffFormatter({
-        templateInfo: {
-          oldTemplate: currentTemplate,
-          newTemplate: stack,
-        },
-      });
-
-      const securityDiff = formatter.formatSecurityDiff();
-
-      // Send a request response with the formatted security diff as part of the message,
-      // and the template diff as data
-      // (IoHost decides whether to print depending on permissionChangeType)
-      const deployMotivation = '"--require-approval" is enabled and stack includes security-sensitive updates.';
-      const deployQuestion = `${securityDiff.formattedDiff}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
-      const deployConfirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I5060.req(deployQuestion, {
-        motivation: deployMotivation,
-        concurrency,
-        permissionChangeType: securityDiff.permissionChangeType,
-        templateDiffs: formatter.diffs,
-      }));
-      if (!deployConfirmed) {
-        throw new ToolkitError('Aborted by user');
-      }
-
       // Following are the same semantics we apply with respect to Notification ARNs (dictated by the SDK)
       //
       //  - undefined  =>  cdk ignores it, as if it wasn't supported (allows external management).
@@ -655,6 +630,63 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         }
       }
 
+      const tags = (options.tags && options.tags.length > 0) ? options.tags : tagsForStack(stack);
+
+      let deploymentMethod: DeploymentMethod | undefined;
+      let changeSet: DescribeChangeSetCommandOutput | undefined;
+      if (options.deploymentMethod?.method === 'change-set') {
+        // Create a CloudFormation change set
+        const changeSetName = options.deploymentMethod?.changeSetName || `cdk-deploy-change-set-${Date.now()}`;
+        await deployments.deployStack({
+          stack,
+          deployName: stack.stackName,
+          roleArn: options.roleArn,
+          toolkitStackName: this.toolkitStackName,
+          reuseAssets: options.reuseAssets,
+          notificationArns,
+          tags,
+          deploymentMethod: { method: 'change-set' as const, changeSetName, execute: false },
+          forceDeployment: options.forceDeployment,
+          parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
+          usePreviousParameters: options.parameters?.keepExistingParameters,
+          extraUserAgent: options.extraUserAgent,
+          assetParallelism: options.assetParallelism,
+        });
+
+        // Describe the change set to be presented to the user
+        changeSet = await deployments.describeChangeSet(stack, changeSetName);
+
+        // Don't continue deploying the stack if there are no changes (unless forced)
+        if (!options.forceDeployment && changeSetHasNoChanges(changeSet)) {
+          await deployments.deleteChangeSet(stack, changeSet.ChangeSetName!);
+          return ioHelper.notify(IO.CDK_TOOLKIT_W5023.msg(`${chalk.bold(stack.displayName)}: stack has no changes, skipping deployment.`));
+        }
+
+        // Adjust the deployment method for the subsequent deployment to execute the existing change set
+        deploymentMethod = { ...options.deploymentMethod, changeSetName, executeExistingChangeSet: true };
+      }
+      // Present the diff to the user
+      const oldTemplate = await deployments.readCurrentTemplate(stack);
+      const formatter = new DiffFormatter({ templateInfo: { oldTemplate, newTemplate: stack, changeSet } });
+      const diff = formatter.formatStackDiff();
+
+      // Send a request response with the formatted diff as part of the message, and the template diff as data
+      // (IoHost decides whether to print depending on permissionChangeType)
+      const deployMotivation = 'Approval required for stack deployment.';
+      const deployQuestion = `${diff.formattedDiff}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
+      const deployConfirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I5060.req(deployQuestion, {
+        motivation: deployMotivation,
+        concurrency,
+        permissionChangeType: diff.permissionChangeType,
+        templateDiffs: formatter.diffs,
+      }));
+      if (!deployConfirmed) {
+        if (changeSet?.ChangeSetName) {
+          await deployments.deleteChangeSet(stack, changeSet.ChangeSetName);
+        }
+        throw new ToolkitError('Aborted by user');
+      }
+
       const stackIndex = stacks.indexOf(stack) + 1;
       const deploySpan = await ioHelper.span(SPAN.DEPLOY_STACK)
         .begin(`${chalk.bold(stack.displayName)}: deploying... [${stackIndex}/${stackCollection.stackCount}]`, {
@@ -662,11 +694,6 @@ export class Toolkit extends CloudAssemblySourceBuilder {
           current: stackIndex,
           stack,
         });
-
-      let tags = options.tags;
-      if (!tags || tags.length === 0) {
-        tags = tagsForStack(stack);
-      }
 
       let deployDuration;
       try {
@@ -687,7 +714,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
             reuseAssets: options.reuseAssets,
             notificationArns,
             tags,
-            deploymentMethod: options.deploymentMethod,
+            deploymentMethod: deploymentMethod ?? options.deploymentMethod,
             forceDeployment: options.forceDeployment,
             parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
             usePreviousParameters: options.parameters?.keepExistingParameters,

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
@@ -19,6 +19,12 @@ jest.mock('../../lib/api/deployments', () => {
       resolveEnvironment: jest.fn().mockResolvedValue({}),
       isSingleAssetPublished: jest.fn().mockResolvedValue(true),
       readCurrentTemplate: jest.fn().mockResolvedValue({ Resources: {} }),
+      describeChangeSet: jest.fn().mockResolvedValue({
+        ChangeSetName: 'test-changeset',
+        Changes: [],
+        Status: 'CREATE_COMPLETE',
+      }),
+      deleteChangeSet: jest.fn().mockResolvedValue({}),
     })),
   };
 });

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -29,6 +29,22 @@ beforeEach(() => {
   jest.spyOn(deployments.Deployments.prototype, 'readCurrentTemplate').mockResolvedValue({ Resources: {} });
   jest.spyOn(deployments.Deployments.prototype, 'buildSingleAsset').mockImplementation();
   jest.spyOn(deployments.Deployments.prototype, 'publishSingleAsset').mockImplementation();
+  jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet').mockResolvedValue({
+    ChangeSetName: 'test-changeset',
+    Changes: [
+      {
+        Type: 'Resource',
+        ResourceChange: {
+          Action: 'Add',
+          LogicalResourceId: 'TestResource',
+          ResourceType: 'AWS::S3::Bucket',
+        },
+      },
+    ],
+    Status: 'CREATE_COMPLETE',
+    $metadata: {},
+  });
+  jest.spyOn(deployments.Deployments.prototype, 'deleteChangeSet').mockResolvedValue();
 });
 
 describe('deploy', () => {
@@ -65,7 +81,7 @@ IAM Statement Changes
       code: 'CDK_TOOLKIT_I5060',
       message: expect.stringContaining('Do you wish to deploy these changes'),
       data: expect.objectContaining({
-        motivation: expect.stringContaining('stack includes security-sensitive updates.'),
+        motivation: expect.stringContaining('Approval required for stack'),
         permissionChangeType: 'broadening',
         templateDiffs: expect.objectContaining({
           Stack1: expect.objectContaining({
@@ -161,6 +177,158 @@ IAM Statement Changes
         forcePublish: true,
       }));
     });
+
+    test('change-set method creates and describes changeset before deployment', async () => {
+      const describeChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet');
+
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'change-set',
+          changeSetName: 'my-test-changeset',
+        },
+      });
+
+      // THEN
+      // First call should create changeset with execute: false
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        deploymentMethod: expect.objectContaining({
+          method: 'change-set',
+          changeSetName: 'my-test-changeset',
+          execute: false,
+        }),
+      }));
+
+      // Should describe the changeset
+      expect(describeChangeSetSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'my-test-changeset',
+      );
+
+      // Second call should execute the existing changeset
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        deploymentMethod: expect.objectContaining({
+          method: 'change-set',
+          changeSetName: 'my-test-changeset',
+          executeExistingChangeSet: true,
+        }),
+      }));
+
+      expect(mockDeployStack).toHaveBeenCalledTimes(2);
+    });
+
+    test('change-set with auto-generated changeSetName when not provided', async () => {
+      const describeChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet');
+
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'change-set',
+        },
+      });
+
+      // THEN
+      // Should use auto-generated name
+      const expectedChangeSetPattern = /^cdk-deploy-change-set-\d+$/;
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        deploymentMethod: expect.objectContaining({
+          method: 'change-set',
+          changeSetName: expect.stringMatching(expectedChangeSetPattern),
+          execute: false,
+        }),
+      }));
+      expect(describeChangeSetSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringMatching(expectedChangeSetPattern),
+      );
+    });
+
+    test('change-set with no changes deletes changeset and skips deployment', async () => {
+      const deleteChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'deleteChangeSet');
+      jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet').mockResolvedValue({
+        ChangeSetName: 'empty-changeset',
+        Status: 'FAILED',
+        StatusReason: "The submitted information didn't contain changes. Submit different information to create a change set.",
+        $metadata: {},
+      });
+
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'change-set',
+          changeSetName: 'empty-changeset',
+        },
+      });
+
+      // THEN
+      expect(deleteChangeSetSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        'empty-changeset',
+      );
+
+      // Should only be called once (for changeset creation, not execution)
+      expect(mockDeployStack).toHaveBeenCalledTimes(1);
+
+      // Should show skip message
+      expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('stack has no changes, skipping deployment'),
+      }));
+    });
+
+    test('change-set method preserves other deployment options', async () => {
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'change-set',
+          changeSetName: 'test-changeset',
+        },
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+        reuseAssets: ['asset1'],
+        notificationArns: ['arn:aws:sns:us-east-1:111111111111:topic'],
+        forceDeployment: true,
+        parameters: StackParameters.exactly({
+          'my-param': 'my-value',
+        }),
+        assetParallelism: false,
+      });
+
+      // THEN - Both calls should preserve all options
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+        reuseAssets: ['asset1'],
+        notificationArns: ['arn:aws:sns:us-east-1:111111111111:topic'],
+        forceDeployment: true,
+        parameters: { 'my-param': 'my-value' },
+        assetParallelism: false,
+      }));
+
+      expect(mockDeployStack).toHaveBeenCalledTimes(2);
+    });
+
+    test('non-change-set deployment uses original flow', async () => {
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'direct',
+        },
+      });
+
+      // THEN
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        deploymentMethod: { method: 'direct' },
+      }));
+
+      // Should only be called once (no changeset creation)
+      expect(mockDeployStack).toHaveBeenCalledTimes(1);
+
+      // describeChangeSet should not be called
+      expect(deployments.Deployments.prototype.describeChangeSet).not.toHaveBeenCalled();
+    });
   });
 
   describe('deployment results', () => {
@@ -227,6 +395,44 @@ IAM Statement Changes
 
       // THEN
       successfulDeployment();
+    });
+
+    test('change-set information included in diff formatter', async () => {
+      const changeSetData = {
+        ChangeSetName: 'test-changeset',
+        Changes: [
+          {
+            Type: 'Resource' as const,
+            ResourceChange: {
+              Action: 'Add' as const,
+              LogicalResourceId: 'TestResource',
+              ResourceType: 'AWS::S3::Bucket',
+            },
+          },
+        ],
+        Status: 'CREATE_COMPLETE' as const,
+      };
+
+      jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet').mockResolvedValue({
+        ...changeSetData,
+        $metadata: {},
+      });
+
+      // WHEN
+      const cx = await builderFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: {
+          method: 'change-set',
+          changeSetName: 'test-changeset',
+        },
+      });
+
+      // THEN
+      // The changeset data should be available for diff formatting
+      // This is verified through the successful execution and user approval flow
+      expect(ioHost.requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+        message: expect.stringContaining('Do you wish to deploy these changes'),
+      }));
     });
   });
 
@@ -320,6 +526,156 @@ IAM Statement Changes
     // THEN
     expect(mockDispose).toHaveBeenCalled();
     await realDispose();
+  });
+
+  test('user rejection of change-set deployment deletes changeset', async () => {
+    const deleteChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'deleteChangeSet');
+
+    // Mock describeChangeSet to return the specific changeset name
+    jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet').mockResolvedValue({
+      ChangeSetName: 'rejected-changeset',
+      Changes: [
+        {
+          Type: 'Resource',
+          ResourceChange: {
+            Action: 'Add',
+            LogicalResourceId: 'TestResource',
+            ResourceType: 'AWS::S3::Bucket',
+          },
+        },
+      ],
+      Status: 'CREATE_COMPLETE',
+      $metadata: {},
+    });
+
+    // Mock user rejection
+    ioHost.requestSpy.mockResolvedValue(false);
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const result = toolkit.deploy(cx, {
+      deploymentMethod: {
+        method: 'change-set',
+        changeSetName: 'rejected-changeset',
+      },
+    });
+
+    // THEN
+    await expect(result).rejects.toThrow('Aborted by user');
+
+    // Should delete the changeset before throwing
+    expect(deleteChangeSetSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      'rejected-changeset',
+    );
+
+    // Should only be called once (for changeset creation, not execution)
+    expect(mockDeployStack).toHaveBeenCalledTimes(1);
+  });
+
+  test('user rejection of non-change-set deployment does not call deleteChangeSet', async () => {
+    const deleteChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'deleteChangeSet');
+
+    // Mock user rejection
+    ioHost.requestSpy.mockResolvedValue(false);
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const result = toolkit.deploy(cx, {
+      deploymentMethod: {
+        method: 'direct',
+      },
+    });
+
+    // THEN
+    await expect(result).rejects.toThrow('Aborted by user');
+
+    // Should NOT delete changeset for non-changeset deployment
+    expect(deleteChangeSetSpy).not.toHaveBeenCalled();
+  });
+
+  test('motivation message format contains stack display name', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.deploy(cx);
+
+    // THEN
+    expect(ioHost.requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        motivation: 'Approval required for stack deployment.',
+      }),
+    }));
+  });
+
+  test('describeChangeSet failure is propagated', async () => {
+    jest.spyOn(deployments.Deployments.prototype, 'describeChangeSet').mockRejectedValue(
+      new Error('Failed to describe changeset'),
+    );
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const result = toolkit.deploy(cx, {
+      deploymentMethod: {
+        method: 'change-set',
+        changeSetName: 'failing-describe-changeset',
+      },
+    });
+
+    // THEN
+    await expect(result).rejects.toThrow('Failed to describe changeset');
+  });
+
+  test('deleteChangeSet failure during user rejection throws deleteChangeSet error', async () => {
+    const deleteChangeSetSpy = jest.spyOn(deployments.Deployments.prototype, 'deleteChangeSet')
+      .mockRejectedValue(new Error('Failed to delete changeset'));
+
+    // Mock user rejection
+    ioHost.requestSpy.mockResolvedValue(false);
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const result = toolkit.deploy(cx, {
+      deploymentMethod: {
+        method: 'change-set',
+        changeSetName: 'delete-fail-changeset',
+      },
+    });
+
+    // THEN
+    await expect(result).rejects.toThrow('Failed to delete changeset');
+
+    // deleteChangeSet should have been attempted
+    expect(deleteChangeSetSpy).toHaveBeenCalled();
+  });
+
+  test('deploymentMethod variable overrides options.deploymentMethod for changeset execution', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.deploy(cx, {
+      deploymentMethod: {
+        method: 'change-set',
+        changeSetName: 'override-test',
+      },
+    });
+
+    // THEN
+    // First call: changeset creation
+    expect(mockDeployStack).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      deploymentMethod: expect.objectContaining({
+        method: 'change-set',
+        changeSetName: 'override-test',
+        execute: false,
+      }),
+    }));
+
+    // Second call: changeset execution with modified deployment method
+    expect(mockDeployStack).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      deploymentMethod: expect.objectContaining({
+        method: 'change-set',
+        changeSetName: 'override-test',
+        executeExistingChangeSet: true,
+      }),
+    }));
   });
 });
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -4,6 +4,7 @@ import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { ConfirmationRequest, DeploymentMethod, ToolkitAction, ToolkitOptions } from '@aws-cdk/toolkit-lib';
 import { PermissionChangeType, Toolkit, ToolkitError } from '@aws-cdk/toolkit-lib';
+import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
@@ -32,6 +33,7 @@ import type { BootstrapEnvironmentOptions } from '../api/bootstrap';
 import { Bootstrapper } from '../api/bootstrap';
 import { ExtendedStackSelection, StackCollection } from '../api/cloud-assembly';
 import type { Deployments, SuccessfulDeployStackResult } from '../api/deployments';
+import { changeSetHasNoChanges } from '../api/deployments';
 import { mappingsByEnvironment, parseMappingGroups } from '../api/refactor';
 import { type Tag } from '../api/tags';
 import { StackActivityProgress } from '../commands/deploy';
@@ -492,30 +494,6 @@ export class CdkToolkit {
         return;
       }
 
-      if (requireApproval !== RequireApproval.NEVER) {
-        const currentTemplate = await this.props.deployments.readCurrentTemplate(stack);
-        const formatter = new DiffFormatter({
-          templateInfo: {
-            oldTemplate: currentTemplate,
-            newTemplate: stack,
-          },
-        });
-        const securityDiff = formatter.formatSecurityDiff();
-        if (requiresApproval(requireApproval, securityDiff.permissionChangeType)) {
-          const motivation = '"--require-approval" is enabled and stack includes security-sensitive updates';
-          await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
-          await askUserConfirmation(
-            this.ioHost,
-            IO.CDK_TOOLKIT_I5060.req(`${motivation}: 'Do you wish to deploy these changes'`, {
-              motivation,
-              concurrency,
-              permissionChangeType: securityDiff.permissionChangeType,
-              templateDiffs: formatter.diffs,
-            }),
-          );
-        }
-      }
-
       // Following are the same semantics we apply with respect to Notification ARNs (dictated by the SDK)
       //
       //  - undefined  =>  cdk ignores it, as if it wasn't supported (allows external management).
@@ -531,13 +509,106 @@ export class CdkToolkit {
         }
       }
 
-      const stackIndex = stacks.indexOf(stack) + 1;
-      await this.ioHost.asIoHelper().defaults.info(`${chalk.bold(stack.displayName)}: deploying... [${stackIndex}/${stackCollection.stackCount}]`);
-      const startDeployTime = new Date().getTime();
       let tags = options.tags;
       if (!tags || tags.length === 0) {
         tags = tagsForStack(stack);
       }
+
+      let deploymentMethod: DeploymentMethod | undefined;
+
+      switch (requireApproval) {
+        case RequireApproval.BROADENING: {
+          const currentTemplate = await this.props.deployments.readCurrentTemplate(stack);
+          const formatter = new DiffFormatter({
+            templateInfo: {
+              oldTemplate: currentTemplate,
+              newTemplate: stack,
+            },
+          });
+          const securityDiff = formatter.formatSecurityDiff();
+          if (requiresApproval(requireApproval, securityDiff.permissionChangeType)) {
+            const motivation = '"--require-approval" is enabled and stack includes security-sensitive updates';
+            await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
+            await askUserConfirmation(
+              this.ioHost,
+              IO.CDK_TOOLKIT_I5060.req(`${motivation}: 'Do you wish to deploy these changes'`, {
+                motivation,
+                concurrency,
+                permissionChangeType: securityDiff.permissionChangeType,
+                templateDiffs: formatter.diffs,
+              }),
+            );
+          }
+          break;
+        }
+
+        case RequireApproval.ANYCHANGE: {
+          let changeSet: DescribeChangeSetCommandOutput | undefined;
+          if (options.deploymentMethod?.method === 'change-set') {
+            // Create a CloudFormation change set
+            const changeSetName = options.deploymentMethod?.changeSetName || `cdk-deploy-change-set-${Date.now()}`;
+            await this.props.deployments.deployStack({
+              stack,
+              deployName: stack.stackName,
+              roleArn: options.roleArn,
+              toolkitStackName: options.toolkitStackName,
+              reuseAssets: options.reuseAssets,
+              notificationArns,
+              tags,
+              deploymentMethod: { method: 'change-set' as const, changeSetName, execute: false },
+              forceDeployment: options.force,
+              parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
+              usePreviousParameters: options.usePreviousParameters,
+              extraUserAgent: options.extraUserAgent,
+              assetParallelism: options.assetParallelism,
+              ignoreNoStacks: options.ignoreNoStacks,
+            });
+
+            // Describe the change set to be presented to the user
+            changeSet = await this.props.deployments.describeChangeSet(stack, changeSetName);
+
+            // Don't continue deploying the stack if there are no changes (unless forced)
+            if (!options.force && changeSetHasNoChanges(changeSet)) {
+              await this.ioHost.asIoHelper().defaults.info('No changes');
+              await this.deleteChangeSet(stack, changeSet.ChangeSetName!);
+              return;
+            }
+
+            // Adjust the deployment method for the subsequent deployment to execute the existing change set
+            deploymentMethod = { ...options.deploymentMethod, changeSetName, executeExistingChangeSet: true };
+          }
+
+          // Present the diff to the user
+          const oldTemplate = await this.props.deployments.readCurrentTemplate(stack);
+          const formatter = new DiffFormatter({ templateInfo: { oldTemplate, newTemplate: stack, changeSet } });
+          const diff = formatter.formatStackDiff();
+          await this.ioHost.asIoHelper().defaults.info(diff.formattedDiff);
+
+          // Prompt the user to confirm deployment
+          try {
+            const motivation = 'Approval required for stack deployment.';
+            await askUserConfirmation(
+              this.ioHost,
+              IO.CDK_TOOLKIT_I5060.req(`${motivation}: 'Do you wish to deploy these changes'`, {
+                motivation,
+                concurrency,
+                permissionChangeType: diff.permissionChangeType,
+                templateDiffs: formatter.diffs,
+              }),
+            );
+          } catch (e: unknown) {
+            if (changeSet?.ChangeSetName) {
+              await this.deleteChangeSet(stack, changeSet.ChangeSetName);
+            }
+            throw e;
+          }
+          break;
+        }
+      }
+
+      const stackIndex = stacks.indexOf(stack) + 1;
+      await this.ioHost.asIoHelper().defaults.info(`${chalk.bold(stack.displayName)}: deploying... [${stackIndex}/${stackCollection.stackCount}]`);
+      const startDeployTime = new Date().getTime();
 
       // There is already a startDeployTime constant, but that does not work with telemetry.
       // We should integrate the two in the future
@@ -564,7 +635,7 @@ export class CdkToolkit {
             tags,
             execute: options.execute,
             changeSetName: options.changeSetName,
-            deploymentMethod: options.deploymentMethod,
+            deploymentMethod: deploymentMethod ?? options.deploymentMethod,
             forceDeployment: options.force,
             parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
             usePreviousParameters: options.usePreviousParameters,
@@ -1500,6 +1571,18 @@ export class CdkToolkit {
       roleArn: options.roleArn,
       stackName: assetNode.parentStack.stackName,
     }));
+  }
+
+  /**
+   * Delete a change set (with CLI-appropriate error handling)
+   */
+  private async deleteChangeSet(stack: cxapi.CloudFormationStackArtifact, changeSetName: string): Promise<void> {
+    try {
+      await this.props.deployments.deleteChangeSet(stack, changeSetName);
+    } catch (error) {
+      // Log but don't throw - change set cleanup failure shouldn't break deployment
+      await this.ioHost.asIoHelper().defaults.debug(`Failed to cleanup change set ${changeSetName} for stack ${stack.displayName}: ${error}`);
+    }
   }
 }
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -61,7 +61,7 @@ import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import { Manifest, RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
 import type { DestroyStackResult } from '@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
-import { DescribeStacksCommand, GetTemplateCommand, StackStatus } from '@aws-sdk/client-cloudformation';
+import { ChangeSetStatus, DescribeStacksCommand, GetTemplateCommand, StackStatus } from '@aws-sdk/client-cloudformation';
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import * as fs from 'fs-extra';
 import type { Template, SdkProvider } from '../../lib/api';
@@ -643,6 +643,492 @@ describe('deploy', () => {
 
     expect(cloudExecutable.hasApp).toEqual(false);
     expect(mockSynthesize).not.toHaveBeenCalled();
+  });
+
+  describe('RequireApproval.ANYCHANGE', () => {
+    let toolkit: CdkToolkit;
+    let mockDeployments: Deployments;
+
+    beforeEach(() => {
+      mockDeployments = new FakeCloudFormation({
+        'Test-Stack-A': { Foo: 'Bar' },
+        'Test-Stack-B': { Baz: 'Zinga!' },
+        'Test-Stack-C': { Baz: 'Zinga!' },
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+    });
+
+    test('creates change set, shows diff, prompts for approval, and deploys changes', async () => {
+      const mockDeployStack = jest.spyOn(mockDeployments, 'deployStack');
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set', changeSetName: 'test-change-set' },
+      });
+
+      // THEN
+      expect(mockDeployStack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentMethod: { method: 'change-set', changeSetName: 'test-change-set', execute: false },
+        }),
+      );
+      expect(requestSpy).toHaveBeenCalled();
+      expect(mockDeployStack).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deploymentMethod: { method: 'change-set', changeSetName: 'test-change-set', executeExistingChangeSet: true },
+        }),
+      );
+      expect(mockDeployStack).toHaveBeenCalledTimes(2);
+    });
+
+    test('deletes change set when there are no changes', async () => {
+      // GIVEN
+      const mockDeployStack = jest.spyOn(mockDeployments, 'deployStack');
+      const mockDeleteChangeSet = jest.spyOn(mockDeployments, 'deleteChangeSet');
+      jest.spyOn(mockDeployments, 'describeChangeSet').mockResolvedValue({
+        ChangeSetId: 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/cdk-change-set/12345',
+        ChangeSetName: 'cdk-change-set',
+        StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/Test-Stack-A-Display-Name/12345',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: "The submitted information didn't contain changes. Submit different information to create a change set.",
+        $metadata: {},
+      });
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set' } as DeploymentMethod,
+      });
+
+      // THEN
+      expect(mockDeleteChangeSet).toHaveBeenCalled();
+      expect(mockDeployStack).toHaveBeenCalledTimes(1);
+    });
+
+    test('deletes change set when user rejects', async () => {
+      // GIVEN
+      const mockDeleteChangeSet = jest.spyOn(mockDeployments, 'deleteChangeSet');
+      requestSpy.mockRejectedValue(new Error('Aborted by user'));
+
+      // WHEN
+      const result = toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set' } as DeploymentMethod,
+      });
+
+      // THEN
+      await expect(result).rejects.toThrow('Aborted by user');
+      expect(mockDeleteChangeSet).toHaveBeenCalled();
+    });
+
+    // Test that verifies the behavior when deleteChangeSet fails during a no-changes scenario.
+    // The deleteChangeSet method in cdk-toolkit.ts catches errors and logs them as debug messages
+    // rather than propagating them, ensuring that change set cleanup failures don't break deployments.
+    test('continues deployment when change set deletion fails (no changes scenario)', async () => {
+      // GIVEN
+      const mockDeleteChangeSet = jest.spyOn(mockDeployments, 'deleteChangeSet').mockRejectedValue(new Error('Failed to delete change set'));
+      jest.spyOn(mockDeployments, 'describeChangeSet').mockResolvedValue({
+        ChangeSetId: 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/cdk-change-set/12345',
+        ChangeSetName: 'cdk-change-set',
+        StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/Test-Stack-A-Display-Name/12345',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: "The submitted information didn't contain changes. Submit different information to create a change set.",
+        $metadata: {},
+      });
+
+      // WHEN - deployment should complete successfully despite change set deletion failure
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set' } as DeploymentMethod,
+      });
+
+      // THEN - verify deleteChangeSet was called but error was caught and didn't break deployment
+      expect(mockDeleteChangeSet).toHaveBeenCalled();
+      expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        level: 'debug',
+        message: expect.stringContaining('Failed to cleanup change set'),
+      }));
+      expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        level: 'debug',
+        message: expect.stringContaining('cdk-change-set'),
+      }));
+    });
+
+    // Test that verifies the behavior when deleteChangeSet fails after user rejects the deployment.
+    // Even if the change set cleanup fails, the original user rejection error should be propagated,
+    // not the deletion failure. This ensures proper error handling and user feedback.
+    test('continues with user rejection when change set deletion fails', async () => {
+      // GIVEN
+      const mockDeleteChangeSet = jest.spyOn(mockDeployments, 'deleteChangeSet').mockRejectedValue(new Error('Failed to delete change set'));
+      requestSpy.mockRejectedValue(new Error('Aborted by user'));
+
+      // WHEN
+      const result = toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set' } as DeploymentMethod,
+      });
+
+      // THEN - deployment should still be rejected by user (not by change set deletion failure)
+      await expect(result).rejects.toThrow('Aborted by user');
+      expect(mockDeleteChangeSet).toHaveBeenCalled();
+      expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        level: 'debug',
+        message: expect.stringContaining('Failed to cleanup change set'),
+      }));
+    });
+  });
+
+  // Tests for RequireApproval.BROADENING mode, which prompts for approval only when
+  // security-sensitive changes broaden permissions. This is the default approval mode.
+  // It checks if IAM or security group changes expand permissions and requires user confirmation
+  // only for those broadening changes, while allowing non-broadening changes to proceed automatically.
+  describe('RequireApproval.BROADENING', () => {
+    let toolkit: CdkToolkit;
+    let mockDeployments: Deployments;
+
+    beforeEach(() => {
+      mockDeployments = new FakeCloudFormation({
+        'Test-Stack-A': { Foo: 'Bar' },
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+    });
+
+    test('prompts for approval when security changes broaden permissions', async () => {
+      // GIVEN - mock readCurrentTemplate to return a template without IAM resources
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {},
+      });
+
+      // Mock the stack to have IAM resources (broadening change)
+      const stackWithIAM = {
+        ...MockStack.MOCK_STACK_A,
+        template: {
+          Resources: {
+            MyRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 'lambda.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+                ManagedPolicyArns: ['arn:aws:iam::aws:policy/AdministratorAccess'],
+              },
+            },
+          },
+        },
+      };
+
+      cloudExecutable = await MockCloudExecutable.create({
+        stacks: [stackWithIAM],
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - verify that user was prompted for approval
+      expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+        code: 'CDK_TOOLKIT_I5060',
+        data: expect.objectContaining({
+          permissionChangeType: 'broadening',
+        }),
+      }));
+    });
+
+    // Verifies that when IAM permissions are reduced (narrowing change), no approval is required
+    test('does not prompt for approval when changes are non-broadening', async () => {
+      // GIVEN - mock readCurrentTemplate to return a template with existing IAM resources
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {
+          MyRole: {
+            Type: 'AWS::IAM::Role',
+            Properties: {
+              AssumeRolePolicyDocument: {
+                Version: '2012-10-17',
+                Statement: [
+                  {
+                    Effect: 'Allow',
+                    Principal: { Service: 'lambda.amazonaws.com' },
+                    Action: 'sts:AssumeRole',
+                  },
+                ],
+              },
+              ManagedPolicyArns: ['arn:aws:iam::aws:policy/AdministratorAccess'],
+            },
+          },
+        },
+      });
+
+      // New template removes the managed policy (narrowing, not broadening)
+      const stackWithReducedPermissions = {
+        ...MockStack.MOCK_STACK_A,
+        template: {
+          Resources: {
+            MyRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 'lambda.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      cloudExecutable = await MockCloudExecutable.create({
+        stacks: [stackWithReducedPermissions],
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - verify that user was NOT prompted (no broadening changes)
+      expect(requestSpy).not.toHaveBeenCalled();
+    });
+
+    // Verifies that when there are no IAM or security changes, no approval is required
+    test('does not prompt for approval when there are no IAM changes', async () => {
+      // GIVEN - mock readCurrentTemplate to return empty template
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {},
+      });
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - verify that user was NOT prompted (no security changes)
+      expect(requestSpy).not.toHaveBeenCalled();
+    });
+
+    // Verifies the complete flow: prompt for approval → user accepts → deployment proceeds
+    test('deploys successfully when user approves broadening changes', async () => {
+      // GIVEN
+      const mockDeployStack = jest.spyOn(mockDeployments, 'deployStack');
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {},
+      });
+
+      const stackWithIAM = {
+        ...MockStack.MOCK_STACK_A,
+        template: {
+          Resources: {
+            MyRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 's3.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      cloudExecutable = await MockCloudExecutable.create({
+        stacks: [stackWithIAM],
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+
+      // WHEN - user approves the deployment
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - deployment should proceed
+      expect(requestSpy).toHaveBeenCalled();
+      expect(mockDeployStack).toHaveBeenCalledTimes(1);
+    });
+
+    // Verifies the complete flow: prompt for approval → user rejects → deployment is cancelled
+    test('rejects deployment when user denies broadening changes', async () => {
+      // GIVEN
+      const mockDeployStack = jest.spyOn(mockDeployments, 'deployStack');
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {},
+      });
+      requestSpy.mockRejectedValue(new Error('User rejected'));
+
+      const stackWithIAM = {
+        ...MockStack.MOCK_STACK_A,
+        template: {
+          Resources: {
+            MyRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 's3.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      cloudExecutable = await MockCloudExecutable.create({
+        stacks: [stackWithIAM],
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+
+      // WHEN
+      const result = toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - deployment should be rejected
+      await expect(result).rejects.toThrow('User rejected');
+      expect(requestSpy).toHaveBeenCalled();
+      expect(mockDeployStack).not.toHaveBeenCalled();
+    });
+
+    // Verifies that the security diff is displayed to the user before requesting approval,
+    // allowing them to review the specific IAM changes that are broadening permissions
+    test('displays security diff when prompting for broadening changes', async () => {
+      // GIVEN
+      jest.spyOn(mockDeployments, 'readCurrentTemplate').mockResolvedValue({
+        Resources: {},
+      });
+
+      const stackWithIAM = {
+        ...MockStack.MOCK_STACK_A,
+        template: {
+          Resources: {
+            MyRole: {
+              Type: 'AWS::IAM::Role',
+              Properties: {
+                AssumeRolePolicyDocument: {
+                  Version: '2012-10-17',
+                  Statement: [
+                    {
+                      Effect: 'Allow',
+                      Principal: { Service: 'lambda.amazonaws.com' },
+                      Action: 'sts:AssumeRole',
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        },
+      };
+
+      cloudExecutable = await MockCloudExecutable.create({
+        stacks: [stackWithIAM],
+      });
+
+      toolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockDeployments,
+      });
+
+      // WHEN
+      await toolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.BROADENING,
+      });
+
+      // THEN - verify security diff was displayed
+      expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        level: 'info',
+        message: expect.stringContaining('MyRole'),
+      }));
+      expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          motivation: expect.stringContaining('--require-approval'),
+          permissionChangeType: 'broadening',
+        }),
+      }));
+    });
   });
 
   describe('readCurrentTemplate', () => {
@@ -1933,6 +2419,29 @@ class FakeCloudFormation extends Deployments {
       default:
         throw new Error(`not an expected mock stack: ${stack.stackName}`);
     }
+  }
+
+  public describeChangeSet(stack: cxapi.CloudFormationStackArtifact, changeSetName: string): Promise<any> {
+    return Promise.resolve({
+      ChangeSetId: `arn:aws:cloudformation:us-east-1:123456789012:changeSet/${changeSetName}/12345`,
+      ChangeSetName: changeSetName,
+      StackId: `arn:aws:cloudformation:us-east-1:123456789012:stack/${stack.stackName}/12345`,
+      Status: 'CREATE_COMPLETE',
+      Changes: [
+        {
+          Type: 'Resource',
+          ResourceChange: {
+            Action: 'Modify',
+            LogicalResourceId: 'TestResource',
+            ResourceType: 'AWS::S3::Bucket',
+          },
+        },
+      ],
+    });
+  }
+
+  public deleteChangeSet(_stack: cxapi.CloudFormationStackArtifact, _changeSetName: string): Promise<void> {
+    return Promise.resolve();
   }
 }
 


### PR DESCRIPTION
Implementation of #801 and [RFC 370: CLI deploy with change set review confirmation](https://github.com/aws/aws-cdk-rfcs/pull/802).


> This feature enhances the existing `--require-approval=any-change` option to show all stack changes (not just security changes) and integrates CloudFormation change set creation and review to provide users with an accurate preview of what will be applied before deployment execution.
>
> Modern cloud infrastructure contains critical stateful resources—databases, persistent storage, message queues, and other systems that hold valuable data and maintain complex state. Engineers deploying changes to these environments carry significant responsibility: a single misunderstood deployment can lead to data loss, service outages, or security vulnerabilities that affect customers and business operations. While Infrastructure as Code provides repeatability and version control, it doesn't eliminate the fundamental need for engineers to understand precisely what changes will be applied before execution. Tooling must bridge this gap by providing clear, accurate previews of deployment impact—especially for stateful resources where "undo" isn't always possible. This enhancement ensures that engineers have the complete information they need to make informed decisions about infrastructure changes.




---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_
