### PR TITLE
chore(cli): add cdk flags to readme command list

### DIFF
--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -32,6 +32,7 @@ The AWS CDK Toolkit provides the `cdk` command-line interface that can be used t
 | [`cdk refactor`](#cdk-refactor)           | Moves resources between stacks or within the same stack                           |
 | [`cdk drift`](#cdk-drift)                 | Detect drifts in the given CloudFormation stack(s)                                |
 | [`cdk cli-telemetry`](#cdk-cli-telemetry) | Enable or disable cli telemetry collection                                        |
+| [`cdk flags`](#cdk-flags)                 | View and modify your feature flag configurations                                  |
 
 ## Common topics
 


### PR DESCRIPTION
the docs are already in the readme, just don't show up in the list

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
