### PR TITLE
feat(integ-runner): use toolkit-lib as default engine

### DIFF
--- a/packages/@aws-cdk/integ-runner/test/cli.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/cli.test.ts
@@ -23,8 +23,9 @@ afterAll(() => {
 });
 
 describe.each([
-  ['cli-wrapper', []],
+  ['cli-wrapper', ['--unstable', 'deprecated-cli-engine']],
   ['toolkit-lib', ['--unstable', 'toolkit-lib-engine']],
+  ['toolkit-lib', []], // default
 ])('Test discovery with engine %s', (_engine: string, engineArgs: string[]) => {
   const currentCwd = process.cwd();
   beforeAll(() => {


### PR DESCRIPTION
This PR makes the toolkit-lib engine the default for integ-runner, replacing the previous cli-wrapper engine.

## Changes

- **Default engine switch**:  is now the default engine instead of 
- **Deprecation path**: Added  unstable flag to temporarily revert to the old engine
- **User guidance**: Added helpful error messages and deprecation warnings to guide users through the transition
- **Test updates**: Updated test suite to reflect the new default engine

## Migration Path

Users experiencing issues with the new default engine can temporarily revert using:
```
--unstable=deprecated-cli-engine
```

The old engine is scheduled for removal in January 2026.

## Error Handling

When errors occur with the new engine, users receive guidance on how to report issues and temporarily revert if needed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license