### PR TITLE
fix(cli): metadata path in generated templates is invalid for migrate command

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1202,7 +1202,7 @@ export class CdkToolkit {
         const templateBody = readFromPath(options.fromPath!);
 
         const parsedTemplate = deserializeStructure(templateBody);
-        const templateId = parsedTemplate.Metadata?.TemplateId?.toString();
+        const templateId = parsedTemplate.Metadata?.AWSToolsMetrics?.IaC_Generator?.toString();
         if (templateId) {
           // if we have a template id, we can call describe generated template to get the resource identifiers
           // resource metadata, and template source to generate the template


### PR DESCRIPTION
Fixes #902 

The path to the template Id had been changed by CloudFormation so migrate.json was not being generated correctly.

Old format:
```
Metadata:
  TemplateId: <arn>
```
New format:
```
Metadata:
  AWSToolsMetrics:
    IaC_Generator: <arn>
```
We do not have a test that would have caught this because the resource scan can take such a long time that it was causing errors in our tests when it did exist.

Adding a new test for this is something we should look into but it will likely require a new test account that is empty except for test resources so that the test will run fast enough.

I tested this change manually and we now have all the data we need in migrate.json again (edited to remove all actual identifying information):
```
{
  "//": "This file is generated by cdk migrate. It will be automatically deleted after the first successful deployment of this app to the environment of the original resources.",
  "Source": "arn:aws:cloudformation:ap-southeast-1:xxxxxxxxx:generatedTemplate/xxxxxxxx",
  "Resources": [
    {
      "ResourceType": "AWS::SQS::Queue",
      "LogicalResourceId": "SQSQueueSimpleStackBarapsoutheast1b",
      "ResourceIdentifier": {
        "QueueUrl": "https://sqs.ap-southeast-1.amazonaws.com/xxxxxxxx/SimpleStack-Bar-ap-southeast-1b"
      }
    },
    {
      "ResourceType": "AWS::SQS::Queue",
      "LogicalResourceId": "SQSQueueCdkfromcfne2etestSimpleStackgolangBarapsoutheast1b",
      "ResourceIdentifier": {
        "QueueUrl": "https://sqs.ap-southeast-1.amazonaws.com/xxxxxxxxx/cdk-from-cfn-e2e-test-SimpleStack-golang-Bar-ap-southeast-1b"
      }
    }
  ]
}
```

and the diff shows:
```
new-app-test % cdk diff
Stack new-app-test
Parameters and rules created during migration do not affect resource configuration.
Parameters
[+] Parameter BootstrapVersion BootstrapVersion: {"Type":"AWS::SSM::Parameter::Value<String>","Default":"/cdk-bootstrap/hnb659fds/version","Description":"Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]"}

Resources
[←] AWS::SQS::Queue SQSQueueCdkfromcfne2etestSimpleStackgolangBarapsoutheast1b SQSQueueCdkfromcfne2etestSimpleStackgolangBarapsoutheast1b import
[←] AWS::SQS::Queue SQSQueueSimpleStackBarapsoutheast1b SQSQueueSimpleStackBarapsoutheast1b import



✨  Number of stacks with differences: 1
```
with the deployment logs:
```
new-app-test % cdk deploy

✨  Synthesis time: 4.3s

new-app-test: creating stack for resource migration...
new-app-test: importing resources into stack...
new-app-test: creating CloudFormation changeset...

 ✅  new-app-test
'
✨  Resource migration time: 53.54s
'
new-app-test: applying CDKMetadata and Outputs to stack (if applicable)...
new-app-test: start: Building new-app-test Template
new-app-test: success: Built new-app-test Template
new-app-test: start: Publishing new-app-test Template (current_account-ap-southeast-1-dcf01c72)
new-app-test: success: Published new-app-test Template (current_account-ap-southeast-1-dcf01c72)
new-app-test: deploying... [1/1]

 ✅  new-app-test (no changes)

✨  Deployment time: 1.41s

Stack ARN:
arn:aws:cloudformation:ap-southeast-1:xxxxxxxxx:stack/new-app-test/xxxxxxxx
```
---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
