### PR TITLE
feat(cli-integ): release @aws-cdk-testing/cli-integ

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/README.md
+++ b/packages/@aws-cdk-testing/cli-integ/README.md
@@ -78,7 +78,8 @@ bin/run-suite -a cli-integ-tests -t 'load old assemblies'
 
 ### Running a test suite against binaries
 
-The test suites that run the "init tests" require actual packages staged in CodeArtifact repositories to run. This requires you to do a full build, then create a CodeArtifact repository in your own account, uploading the packages there, and then running the tests in a shell configured to have NPM, Pip, Maven etc look for those packages in CodeArtifact.
+The test suites that run the "init tests" require actual packages staged in CodeArtifact repositories to run.
+This requires you to do a full build, then create a CodeArtifact repository in your own account, uploading the packages there, and then running the tests in a shell configured to have NPM, Pip, Maven etc look for those packages in CodeArtifact.
 
 ```shell
 # Build and pack all of CDK (in the `aws-cdk` repo, will take ~an hour)


### PR DESCRIPTION
#905 intended to trigger a release for `@aws-cdk-testing/cli-integ`, where it did not rely on the deprecated `cli-lib-alpha` module. because it was marked as a chore, the release was skipped and the latest version still runs the tests that were removed in #905. These tests are now failing because they cannot find the right version of `cli-lib-alpha`.  By releasing a version of `@aws-cdk-testing/cli-integ`, we won't have to worry about this anymore.

this PR is intended to trigger a release and nothing else.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
