### PR TITLE
fix(aws-cdk): init template imports not following best practices to use `aws-cdk-lib/core`

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/javascript/bin/%name%.template.js
+++ b/packages/aws-cdk/lib/init-templates/app/javascript/bin/%name%.template.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const cdk = require('aws-cdk-lib');
+const cdk = require('aws-cdk-lib/core');
 const { %name.PascalCased%Stack } = require('../lib/%name%-stack');
 
 const app = new cdk.App();

--- a/packages/aws-cdk/lib/init-templates/app/javascript/lib/%name%-stack.template.js
+++ b/packages/aws-cdk/lib/init-templates/app/javascript/lib/%name%-stack.template.js
@@ -1,4 +1,4 @@
-const { Stack, Duration } = require('aws-cdk-lib');
+const { Stack, Duration } = require('aws-cdk-lib/core');
 // const sqs = require('aws-cdk-lib/aws-sqs');
 
 class %name.PascalCased%Stack extends Stack {

--- a/packages/aws-cdk/lib/init-templates/app/javascript/test/%name%.test.template.js
+++ b/packages/aws-cdk/lib/init-templates/app/javascript/test/%name%.test.template.js
@@ -1,4 +1,4 @@
-// const cdk = require('aws-cdk-lib');
+// const cdk = require('aws-cdk-lib/core');
 // const { Template } = require('aws-cdk-lib/assertions');
 // const %name.PascalCased% = require('../lib/%name%-stack');
 

--- a/packages/aws-cdk/lib/init-templates/app/typescript/bin/%name%.template.ts
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/bin/%name%.template.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib/core';
 import { %name.PascalCased%Stack } from '../lib/%name%-stack';
 
 const app = new cdk.App();

--- a/packages/aws-cdk/lib/init-templates/app/typescript/lib/%name%-stack.template.ts
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/lib/%name%-stack.template.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib/core';
 import { Construct } from 'constructs';
 // import * as sqs from 'aws-cdk-lib/aws-sqs';
 

--- a/packages/aws-cdk/lib/init-templates/app/typescript/test/%name%.test.template.ts
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/test/%name%.test.template.ts
@@ -1,4 +1,4 @@
-// import * as cdk from 'aws-cdk-lib';
+// import * as cdk from 'aws-cdk-lib/core';
 // import { Template } from 'aws-cdk-lib/assertions';
 // import * as %name.PascalCased% from '../lib/%name%-stack';
 

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/test/%name%.test.template.ts
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/test/%name%.test.template.ts
@@ -1,4 +1,4 @@
-// import * as cdk from 'aws-cdk-lib';
+// import * as cdk from 'aws-cdk-lib/core';
 // import { Template } from 'aws-cdk-lib/assertions';
 // import * as %name.PascalCased% from '../lib/index';
 

--- a/packages/aws-cdk/lib/init-templates/sample-app/javascript/bin/%name%.template.js
+++ b/packages/aws-cdk/lib/init-templates/sample-app/javascript/bin/%name%.template.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const cdk = require('aws-cdk-lib');
+const cdk = require('aws-cdk-lib/core');
 const { %name.PascalCased%Stack } = require('../lib/%name%-stack');
 
 const app = new cdk.App();

--- a/packages/aws-cdk/lib/init-templates/sample-app/javascript/lib/%name%-stack.template.js
+++ b/packages/aws-cdk/lib/init-templates/sample-app/javascript/lib/%name%-stack.template.js
@@ -1,4 +1,4 @@
-const cdk = require('aws-cdk-lib');
+const cdk = require('aws-cdk-lib/core');
 const sns = require('aws-cdk-lib/aws-sns');
 const subs = require('aws-cdk-lib/aws-sns-subscriptions');
 const sqs = require('aws-cdk-lib/aws-sqs');

--- a/packages/aws-cdk/lib/init-templates/sample-app/javascript/test/%name%.test.template.js
+++ b/packages/aws-cdk/lib/init-templates/sample-app/javascript/test/%name%.test.template.js
@@ -1,4 +1,4 @@
-const cdk = require('aws-cdk-lib');
+const cdk = require('aws-cdk-lib/core');
 const { Match, Template } = require('aws-cdk-lib/assertions');
 const %name.PascalCased% = require('../lib/%name%-stack');
 

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/bin/%name%.template.ts
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/bin/%name%.template.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import * as cdk from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib/core';
 import { %name.PascalCased%Stack } from '../lib/%name%-stack';
 
 const app = new cdk.App();

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/lib/%name%-stack.template.ts
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/lib/%name%-stack.template.ts
@@ -1,4 +1,4 @@
-import { Duration, Stack, StackProps } from 'aws-cdk-lib';
+import { Duration, Stack, StackProps } from 'aws-cdk-lib/core';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as sqs from 'aws-cdk-lib/aws-sqs';

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/test/%name%.test.template.ts
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/test/%name%.test.template.ts
@@ -1,4 +1,4 @@
-import * as cdk from 'aws-cdk-lib';
+import * as cdk from 'aws-cdk-lib/core';
 import { Template, Match } from 'aws-cdk-lib/assertions';
 import * as %name.PascalCased% from '../lib/%name%-stack';
 


### PR DESCRIPTION
Follows CDK best practices by using specific imports from `aws-cdk-lib/core` instead of importing the entire `aws-cdk-lib` package.

Affects all JavaScript and TypeScript templates across app, sample-app, and lib init types.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license