### PR TITLE
chore: update toolkit-lib homepage to API Reference website

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -794,6 +794,7 @@ const toolkitLibTsCompilerOptions = {
 const toolkitLib = configureProject(
   new yarn.TypeScriptWorkspace({
     ...genericCdkProps(),
+    homepage: 'https://docs.aws.amazon.com/cdk/api/toolkit-lib',
     parent: repo,
     name: '@aws-cdk/toolkit-lib',
     description: 'AWS CDK Programmatic Toolkit Library',

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -132,7 +132,7 @@
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",
-  "homepage": "https://github.com/aws/aws-cdk",
+  "homepage": "https://docs.aws.amazon.com/cdk/api/toolkit-lib",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Fixes the following—changes it to https://docs.aws.amazon.com/cdk/api/toolkit-lib/:
<img width="1229" height="582" alt="Screenshot 2025-10-30 at 11 42 55" src="https://github.com/user-attachments/assets/8b6d26b0-676b-4bf2-8278-42fc9275d5d4" />
_The homepage should be the API reference, not the Construct Library repo._

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
