### PR TITLE
feat(toolkit-lib): network detector

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
@@ -4,6 +4,7 @@ import * as https from 'node:https';
 import type { Notice, NoticeDataSource } from './types';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage, humanHttpStatusError, humanNetworkError } from '../../util';
+import { NetworkDetector } from '../../util/network-detector';
 import type { IoHelper } from '../io/private';
 
 /**
@@ -44,6 +45,12 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
   }
 
   async fetch(): Promise<Notice[]> {
+    // Check connectivity before attempting network request
+    const hasConnectivity = await NetworkDetector.hasConnectivity(this.agent);
+    if (!hasConnectivity) {
+      throw new ToolkitError('No internet connectivity detected');
+    }
+
     // We are observing lots of timeouts when running in a massively parallel
     // integration test environment, so wait for a longer timeout there.
     //

--- a/packages/@aws-cdk/toolkit-lib/lib/util/network-detector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/network-detector.ts
@@ -5,18 +5,12 @@ import { request } from 'https';
  * Detects internet connectivity by making a lightweight request to the notices endpoint
  */
 export class NetworkDetector {
-  private static readonly CACHE_DURATION_MS = 30_000; // 30 seconds
-  private static readonly TIMEOUT_MS = 500;
-  
-  private static cachedResult: boolean | undefined;
-  private static cacheExpiry: number = 0;
-
   /**
    * Check if internet connectivity is available
    */
   public static async hasConnectivity(agent?: Agent): Promise<boolean> {
     const now = Date.now();
-    
+
     // Return cached result if still valid
     if (this.cachedResult !== undefined && now < this.cacheExpiry) {
       return this.cachedResult;
@@ -33,6 +27,12 @@ export class NetworkDetector {
       return false;
     }
   }
+
+  private static readonly CACHE_DURATION_MS = 30_000; // 30 seconds
+  private static readonly TIMEOUT_MS = 500;
+
+  private static cachedResult: boolean | undefined;
+  private static cacheExpiry: number = 0;
 
   private static ping(agent?: Agent): Promise<boolean> {
     return new Promise((resolve) => {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/network-detector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/network-detector.ts
@@ -1,0 +1,58 @@
+import type { Agent } from 'https';
+import { request } from 'https';
+
+/**
+ * Detects internet connectivity by making a lightweight request to the notices endpoint
+ */
+export class NetworkDetector {
+  private static readonly CACHE_DURATION_MS = 30_000; // 30 seconds
+  private static readonly TIMEOUT_MS = 500;
+  
+  private static cachedResult: boolean | undefined;
+  private static cacheExpiry: number = 0;
+
+  /**
+   * Check if internet connectivity is available
+   */
+  public static async hasConnectivity(agent?: Agent): Promise<boolean> {
+    const now = Date.now();
+    
+    // Return cached result if still valid
+    if (this.cachedResult !== undefined && now < this.cacheExpiry) {
+      return this.cachedResult;
+    }
+
+    try {
+      const connected = await this.ping(agent);
+      this.cachedResult = connected;
+      this.cacheExpiry = now + this.CACHE_DURATION_MS;
+      return connected;
+    } catch {
+      this.cachedResult = false;
+      this.cacheExpiry = now + this.CACHE_DURATION_MS;
+      return false;
+    }
+  }
+
+  private static ping(agent?: Agent): Promise<boolean> {
+    return new Promise((resolve) => {
+      const req = request({
+        hostname: 'cli.cdk.dev-tools.aws.dev',
+        path: '/notices.json',
+        method: 'HEAD',
+        agent,
+        timeout: this.TIMEOUT_MS,
+      }, (res) => {
+        resolve(res.statusCode !== undefined && res.statusCode < 500);
+      });
+
+      req.on('error', () => resolve(false));
+      req.on('timeout', () => {
+        req.destroy();
+        resolve(false);
+      });
+
+      req.end();
+    });
+  }
+}

--- a/packages/@aws-cdk/toolkit-lib/test/util/network-detector.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/util/network-detector.test.ts
@@ -25,7 +25,7 @@ describe('NetworkDetector', () => {
       destroy: jest.fn(),
     };
 
-    mockRequest.mockImplementation((_, callback) => {
+    mockRequest.mockImplementation((_options, callback) => {
       callback({ statusCode: 200 });
       return mockReq;
     });
@@ -41,7 +41,7 @@ describe('NetworkDetector', () => {
       destroy: jest.fn(),
     };
 
-    mockRequest.mockImplementation((_, callback) => {
+    mockRequest.mockImplementation((_options, callback) => {
       callback({ statusCode: 500 });
       return mockReq;
     });
@@ -91,7 +91,7 @@ describe('NetworkDetector', () => {
       destroy: jest.fn(),
     };
 
-    mockRequest.mockImplementation((_, callback) => {
+    mockRequest.mockImplementation((_options, callback) => {
       callback({ statusCode: 200 });
       return mockReq;
     });

--- a/packages/@aws-cdk/toolkit-lib/test/util/network-detector.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/util/network-detector.test.ts
@@ -1,0 +1,104 @@
+import * as https from 'https';
+import { NetworkDetector } from '../../lib/util/network-detector';
+
+// Mock the https module
+jest.mock('https');
+const mockHttps = https as jest.Mocked<typeof https>;
+
+describe('NetworkDetector', () => {
+  let mockRequest: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequest = jest.fn();
+    mockHttps.request.mockImplementation(mockRequest);
+
+    // Clear static cache between tests
+    (NetworkDetector as any).cachedResult = undefined;
+    (NetworkDetector as any).cacheExpiry = 0;
+  });
+
+  test('returns true when server responds with success status', async () => {
+    const mockReq = {
+      on: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    mockRequest.mockImplementation((_, callback) => {
+      callback({ statusCode: 200 });
+      return mockReq;
+    });
+
+    const result = await NetworkDetector.hasConnectivity();
+    expect(result).toBe(true);
+  });
+
+  test('returns false when server responds with server error', async () => {
+    const mockReq = {
+      on: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    mockRequest.mockImplementation((_, callback) => {
+      callback({ statusCode: 500 });
+      return mockReq;
+    });
+
+    const result = await NetworkDetector.hasConnectivity();
+    expect(result).toBe(false);
+  });
+
+  test('returns false on network error', async () => {
+    const mockReq = {
+      on: jest.fn((event, handler) => {
+        if (event === 'error') {
+          setTimeout(() => handler(new Error('Network error')), 0);
+        }
+      }),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    mockRequest.mockReturnValue(mockReq);
+
+    const result = await NetworkDetector.hasConnectivity();
+    expect(result).toBe(false);
+  });
+
+  test('returns false on timeout', async () => {
+    const mockReq = {
+      on: jest.fn((event, handler) => {
+        if (event === 'timeout') {
+          setTimeout(() => handler(), 0);
+        }
+      }),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    mockRequest.mockReturnValue(mockReq);
+
+    const result = await NetworkDetector.hasConnectivity();
+    expect(result).toBe(false);
+  });
+
+  test('caches result for subsequent calls', async () => {
+    const mockReq = {
+      on: jest.fn(),
+      end: jest.fn(),
+      destroy: jest.fn(),
+    };
+
+    mockRequest.mockImplementation((_, callback) => {
+      callback({ statusCode: 200 });
+      return mockReq;
+    });
+
+    await NetworkDetector.hasConnectivity();
+    await NetworkDetector.hasConnectivity();
+
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/aws-cdk/lib/cli/telemetry/sink/endpoint-sink.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/sink/endpoint-sink.ts
@@ -2,7 +2,7 @@ import type { IncomingMessage } from 'http';
 import type { Agent } from 'https';
 import { request } from 'https';
 import { parse, type UrlWithStringQuery } from 'url';
-import { ToolkitError } from '@aws-cdk/toolkit-lib';
+import { ToolkitError, NetworkDetector } from '@aws-cdk/toolkit-lib';
 import { IoHelper } from '../../../api-private';
 import type { IIoHost } from '../../io-host';
 import type { TelemetrySchema } from '../schema';
@@ -94,6 +94,13 @@ export class EndpointTelemetrySink implements ITelemetrySink {
     url: UrlWithStringQuery,
     body: { events: TelemetrySchema[] },
   ): Promise<boolean> {
+    // Check connectivity before attempting network request
+    const hasConnectivity = await NetworkDetector.hasConnectivity(this.agent);
+    if (!hasConnectivity) {
+      await this.ioHelper.defaults.trace('No internet connectivity detected, skipping telemetry');
+      return false;
+    }
+
     try {
       const res = await doRequest(url, body, this.agent);
 


### PR DESCRIPTION
this PR implements a connectivity detector that performs a HEAD request to the notices endpoint, with a timeout of 30 seconds. before making any subsequent network calls, (including GET notices and PUT telemetry) we check to see if we have already determined the network to be disconnected. in those cases, we skip subsequent calls.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
