### PR TITLE
fix(cli): requests get throttled when there is a large number of stacks

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/index.ts
@@ -15,6 +15,7 @@ import { ResourceLocation, ResourceMapping } from './cloudformation';
 import { hashObject } from './digest';
 import type { MappingGroup } from '../../actions';
 import { ToolkitError } from '../../toolkit/toolkit-error';
+import { pLimit } from '../../util/concurrency';
 
 export * from './exclude';
 export * from './context';
@@ -144,8 +145,10 @@ export async function getDeployedStacks(
     };
   };
 
+  const limit = pLimit(20);
+
   // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
-  return Promise.all(summaries.map(normalize));
+  return Promise.all(summaries.map(s => limit(() => normalize(s))));
 }
 
 export function formatEnvironmentSectionHeader(environment: cxapi.Environment) {

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -1136,7 +1136,7 @@ command to consider only a subset of them, you can specify the stacks you
 want, both local and deployed:
 
 ```shell
-$ cdk refactor --local-stack Foo --local-stack Bar --deployed-stack Foo --unstable=refactor --dry-run 
+$ cdk refactor Test* ProdStack --unstable=refactor --dry-run 
 ```
 
 This is useful if, for example, you have more than one CDK application deployed


### PR DESCRIPTION
The CLI is making an unlimited number of concurrent `GetTemplate` requests. When there is a large number of stacks, CloudFormation may throttle the requests.

Limit concurrency to 20.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
