### PR TITLE
fix: CloudFormation timeout if $AWS_ENDPOINT_URL_S3 is set during `cdk deploy`

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/template-body-parameter.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/template-body-parameter.test.ts
@@ -1,0 +1,27 @@
+import { restUrlFromManifest } from '../../../lib/api/cloudformation/template-body-parameter';
+
+test('restUrlFromManifest ignores AWS_ENDPOINT_URL_S3', async () => {
+  process.env.AWS_ENDPOINT_URL_S3 = 'https://boop.com/';
+  try {
+    await expect(restUrlFromManifest('s3://my-bucket/object', {
+      account: '123456789012',
+      region: 'us-east-1',
+      name: 'env',
+    })).resolves.toEqual('https://s3.us-east-1.amazonaws.com/my-bucket/object');
+  } finally {
+    delete process.env.AWS_ENDPOINT_URL_S3;
+  }
+});
+
+test('restUrlFromManifest respects AWS_ENDPOINT_URL_S3_FOR_CLOUDFORMATION', async () => {
+  process.env.AWS_ENDPOINT_URL_S3_FOR_CLOUDFORMATION = 'https://boop.com/';
+  try {
+    await expect(restUrlFromManifest('s3://my-bucket/object', {
+      account: '123456789012',
+      region: 'us-east-1',
+      name: 'env',
+    })).resolves.toEqual('https://boop.com/my-bucket/object');
+  } finally {
+    delete process.env.AWS_ENDPOINT_URL_S3_FOR_CLOUDFORMATION;
+  }
+});


### PR DESCRIPTION
The CLI asks the SDK for the URL to an S3 bucket, in order to pass it to CloudFormation. CloudFormation will then attempt to contact S3 on that URL in order to download the template.

A feature of the the SDK is to respect the `$AWS_ENDPOINT_URL_S3` environment variable, which can be used to override the S3 endpoint that the SDK will hit; you might use this if you have private VPC endpoints for a number of AWS services.

The problem arises that `$AWS_ENDPOINT_URL_S3` also affects the URL that the CDK CLI passes to CloudFormation. This will most likely be an endpoint that is not routable for CloudFormation like `https://vpce-xxx.s3.us-east-1.vpce.amazonaws.com`, and CloudFormation will time out waiting for the template download.

To get around this, we will temporarily unset `$AWS_ENDPOINT_URL_S3` for the duration of calling the SDK to provide us with a URL.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
