### PR TITLE
fix(cli): update typescript to 5.9.x in init-templates

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -17,7 +17,7 @@
     "ts-jest": "^29.2.5",
     "aws-cdk": "%cdk-cli-version%",
     "ts-node": "^10.9.2",
-    "typescript": "~5.6.3"
+    "typescript": "~5.9.3"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -15,7 +15,7 @@
     "constructs": "%constructs-version%",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
-    "typescript": "~5.6.3"
+    "typescript": "~5.9.3"
   },
   "peerDependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -17,7 +17,7 @@
     "ts-jest": "^29.2.5",
     "aws-cdk": "%cdk-cli-version%",
     "ts-node": "^10.9.2",
-    "typescript": "~5.6.3"
+    "typescript": "~5.9.3"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/938

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
