### PR TITLE
fix(aws-cdk): init templates use outdate node types

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.7.9",
+    "@types/node": "^24.10.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "aws-cdk": "%cdk-cli-version%",
@@ -22,5 +22,8 @@
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }

--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -22,8 +22,5 @@
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
-  },
-  "engines": {
-    "node": ">=24.0.0"
   }
 }

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -20,8 +20,5 @@
   "peerDependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
-  },
-  "engines": {
-    "node": ">=20.0.0"
   }
 }

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.7.9",
+    "@types/node": "^20.19.24",
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%",
     "jest": "^29.7.0",
@@ -20,5 +20,8 @@
   "peerDependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
+  },
+  "engines": {
+    "node": ">=20.0.0"
   }
 }

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/node": "22.7.9",
+    "@types/node": "^24.10.1",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "aws-cdk": "%cdk-cli-version%",
@@ -22,5 +22,8 @@
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
+  },
+  "engines": {
+    "node": ">=24.0.0"
   }
 }

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -22,8 +22,5 @@
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%"
-  },
-  "engines": {
-    "node": ">=24.0.0"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/935

The app needs to be on node@24, as we would like customers to run their applications on latest LTS of Node.js.
The lib needs to be node@20, as we would like customers to support minimum number of supported Node.js version.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
