### PR TITLE
fix(integ-runner): disable update workflow by default

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/cli.ts
+++ b/packages/@aws-cdk/integ-runner/lib/cli.ts
@@ -40,7 +40,7 @@ export function parseCliArgs(args: string[] = []) {
     .option('strict', { type: 'boolean', default: false, desc: 'Fail if any specified tests are not found' })
     .options('from-file', { type: 'string', desc: 'Read TEST names from a file (one TEST per line)' })
     .option('inspect-failures', { type: 'boolean', desc: 'Keep the integ test cloud assembly if a failure occurs for inspection', default: false })
-    .option('disable-update-workflow', { type: 'boolean', default: false, desc: 'If this is "true" then the stack update workflow will be disabled' })
+    .option('disable-update-workflow', { type: 'boolean', default: true, desc: 'DEPRECATED. Update workflow has been temporarily disabled until we can make it work correctly.' })
     .option('language', {
       alias: 'l',
       default: ['javascript', 'typescript', 'python', 'go'],
@@ -100,7 +100,7 @@ export function parseCliArgs(args: string[] = []) {
     clean: argv.clean as boolean,
     force: argv.force as boolean,
     dryRun: argv['dry-run'] as boolean,
-    disableUpdateWorkflow: argv['disable-update-workflow'] as boolean,
+    disableUpdateWorkflow: true,
     language: arrayFromYargs(argv.language),
     watch: argv.watch as boolean,
     strict: argv.strict as boolean,
@@ -186,7 +186,7 @@ async function run(options: ReturnType<typeof parseCliArgs>, { engine }: EngineO
         clean: options.clean,
         dryRun: options.dryRun,
         verbosity: options.verbosity,
-        updateWorkflow: !options.disableUpdateWorkflow,
+        updateWorkflow: false,
         watch: options.watch,
       });
       testsSucceeded = success;


### PR DESCRIPTION
I've lost 2 hours
debugging why my deployment was failing trying to deploy to nonexistent and non-requested accounts and regions, and the
answer was: the checked-in snapshot was nonsensical, and the update workflow will first deploy the checked-in snapshot and only then deploy the current snapshot.

Good idea, bad execution: if existing
snapshots are not region-agnostic they are guaranteed to fail. We should probably resynthesize them from the previous git commit instead.

Whatever it is, what we do right now doesn't work so I'm disabling the default.

Turn `--disable-update-workflow` into `--[no-]update-workflow`, with the default being `false`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
