### PR TITLE
feat(cli): introduce 'cdk resources' command for listing stack resources

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/index.ts
@@ -18,3 +18,4 @@ export * from './logs-monitor';
 export * from './hotswap';
 export * from './gc';
 export * from './import';
+export * from './resource-details';

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/resource-details.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/resource-details.ts
@@ -1,0 +1,60 @@
+/**
+ * Details about a CloudFormation resource
+ */
+export interface ResourceDetails {
+  /**
+   * The stack containing this resource
+   */
+  readonly stackId: string;
+
+  /**
+   * The CloudFormation logical ID
+   */
+  readonly logicalId: string;
+
+  /**
+   * The CloudFormation resource type (e.g., AWS::Lambda::Function)
+   */
+  readonly type: string;
+
+  /**
+   * The CDK construct path (from aws:cdk:path metadata)
+   * Will be '<unknown>' if metadata is not available
+   */
+  readonly constructPath: string;
+
+  /**
+   * Resources this resource depends on (from DependsOn)
+   */
+  readonly dependsOn: string[];
+
+  /**
+   * Cross-stack imports (from Fn::ImportValue)
+   */
+  readonly imports: string[];
+
+  /**
+   * The removal policy if specified
+   */
+  readonly removalPolicy?: 'retain' | 'destroy' | 'snapshot';
+}
+
+/**
+ * Extended details for --explain output
+ */
+export interface ResourceExplainDetails extends ResourceDetails {
+  /**
+   * The Condition attached to this resource, if any
+   */
+  readonly condition?: string;
+
+  /**
+   * Update policy if specified
+   */
+  readonly updatePolicy?: string;
+
+  /**
+   * Creation policy if specified
+   */
+  readonly creationPolicy?: string;
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/resource-details.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/resource-details.ts
@@ -1,4 +1,55 @@
 /**
+ * Details about a CloudFormation resource (without stackId, for use in nested output)
+ */
+export interface ResourceInfo {
+  /**
+   * The CloudFormation logical ID
+   */
+  readonly logicalId: string;
+
+  /**
+   * The CloudFormation resource type (e.g., AWS::Lambda::Function)
+   */
+  readonly type: string;
+
+  /**
+   * The CDK construct path (from aws:cdk:path metadata)
+   * Will be '<unknown>' if metadata is not available
+   */
+  readonly constructPath: string;
+
+  /**
+   * Resources this resource depends on (from DependsOn)
+   */
+  readonly dependsOn: string[];
+
+  /**
+   * Cross-stack imports (from Fn::ImportValue)
+   */
+  readonly imports: string[];
+
+  /**
+   * The removal policy if specified
+   */
+  readonly removalPolicy?: 'retain' | 'destroy' | 'snapshot';
+}
+
+/**
+ * Resources grouped by stack (for JSON output)
+ */
+export interface StackResources {
+  /**
+   * The stack ID
+   */
+  readonly stackId: string;
+
+  /**
+   * Resources in this stack
+   */
+  readonly resources: ResourceInfo[];
+}
+
+/**
  * Details about a CloudFormation resource
  */
 export interface ResourceDetails {

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -34,8 +34,8 @@ import type { Deployments, SuccessfulDeployStackResult } from '../api/deployment
 import { mappingsByEnvironment, parseMappingGroups } from '../api/refactor';
 import { type Tag } from '../api/tags';
 import { StackActivityProgress } from '../commands/deploy';
-import { listStacks } from '../commands/list-stacks';
 import { listResources, explainResource } from '../commands/list-resources';
+import { listStacks } from '../commands/list-stacks';
 import type { FromScan, GenerateTemplateOutput } from '../commands/migrate';
 import {
   appendWarningsToReadme,

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1082,7 +1082,20 @@ export class CdkToolkit {
     }
 
     if (options.json) {
-      await printSerializedObject(io, resources, true);
+      // Group resources by stack for cleaner JSON output
+      const byStack = new Map<string, typeof resources>();
+      for (const r of resources) {
+        const list = byStack.get(r.stackId) ?? [];
+        list.push(r);
+        byStack.set(r.stackId, list);
+      }
+
+      const groupedOutput = [...byStack.entries()].map(([stackId, stackResources]) => ({
+        stackId,
+        resources: stackResources.map(({ stackId: _, ...rest }) => rest),
+      }));
+
+      await printSerializedObject(io, groupedOutput, true);
       return 0;
     }
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1050,7 +1050,7 @@ export class CdkToolkit {
    */
   public async resources(
     selectors: string[],
-    options: { json?: boolean; long?: boolean; all?: boolean; type?: string; explain?: string } = {},
+    options: { json?: boolean; long?: boolean; all?: boolean; type?: string; explain?: string; ignoreCase?: boolean } = {},
   ): Promise<number> {
     const io = this.ioHost.asIoHelper();
 
@@ -1059,6 +1059,7 @@ export class CdkToolkit {
       const resource = await explainResource(this, {
         selectors,
         logicalId: options.explain,
+        ignoreCase: options.ignoreCase,
       });
 
       if (!resource) {
@@ -1070,7 +1071,7 @@ export class CdkToolkit {
     }
 
     // List all resources (with optional type filter)
-    const resources = await listResources(this, { selectors, type: options.type, all: options.all });
+    const resources = await listResources(this, { selectors, type: options.type, all: options.all, ignoreCase: options.ignoreCase });
 
     if (resources.length === 0) {
       if (options.type) {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -59,6 +59,38 @@ export async function makeConfig(): Promise<CliConfig> {
           'show-dependencies': { type: 'boolean', default: false, alias: 'd', desc: 'Display stack dependency information for each stack' },
         },
       },
+      'resources': {
+        arg: {
+          name: 'STACK',
+          variadic: false,
+        },
+        description: 'Lists all CloudFormation resources in a stack',
+        options: {
+          'long': {
+            type: 'boolean',
+            alias: 'l',
+            default: false,
+            desc: 'Display full resource list grouped by type (default shows summary counts)',
+          },
+          'all': {
+            type: 'boolean',
+            alias: 'a',
+            default: false,
+            desc: 'Include all resources (by default, noisy types like Lambda::Permission are hidden)',
+          },
+          'type': {
+            type: 'string',
+            alias: 't',
+            desc: 'Filter resources by type (case-insensitive partial match, e.g., "lambda" or "dynamodb")',
+            requiresArg: true,
+          },
+          'explain': {
+            type: 'string',
+            desc: 'Show detailed information for a specific resource by logical ID',
+            requiresArg: true,
+          },
+        },
+      },
       'synth': {
         arg: {
           name: 'STACKS',

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -89,6 +89,12 @@ export async function makeConfig(): Promise<CliConfig> {
             desc: 'Show detailed information for a specific resource by logical ID',
             requiresArg: true,
           },
+          'ignore-case': {
+            type: 'boolean',
+            alias: 'i',
+            default: false,
+            desc: 'Use case-insensitive matching for stack name patterns',
+          },
         },
       },
       'synth': {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -61,10 +61,10 @@ export async function makeConfig(): Promise<CliConfig> {
       },
       'resources': {
         arg: {
-          name: 'STACK',
-          variadic: false,
+          name: 'STACKS',
+          variadic: true,
         },
-        description: 'Lists all CloudFormation resources in a stack',
+        description: 'Lists all CloudFormation resources in the specified stack(s)',
         options: {
           'long': {
             type: 'boolean',

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -189,6 +189,12 @@
           "type": "string",
           "desc": "Show detailed information for a specific resource by logical ID",
           "requiresArg": true
+        },
+        "ignore-case": {
+          "type": "boolean",
+          "alias": "i",
+          "default": false,
+          "desc": "Use case-insensitive matching for stack name patterns"
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -160,6 +160,38 @@
         }
       }
     },
+    "resources": {
+      "arg": {
+        "name": "STACK",
+        "variadic": false
+      },
+      "description": "Lists all CloudFormation resources in a stack",
+      "options": {
+        "long": {
+          "type": "boolean",
+          "alias": "l",
+          "default": false,
+          "desc": "Display full resource list grouped by type (default shows summary counts)"
+        },
+        "all": {
+          "type": "boolean",
+          "alias": "a",
+          "default": false,
+          "desc": "Include all resources (by default, noisy types like Lambda::Permission are hidden)"
+        },
+        "type": {
+          "type": "string",
+          "alias": "t",
+          "desc": "Filter resources by type (case-insensitive partial match, e.g., \"lambda\" or \"dynamodb\")",
+          "requiresArg": true
+        },
+        "explain": {
+          "type": "string",
+          "desc": "Show detailed information for a specific resource by logical ID",
+          "requiresArg": true
+        }
+      }
+    },
     "synth": {
       "arg": {
         "name": "STACKS",

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -162,10 +162,10 @@
     },
     "resources": {
       "arg": {
-        "name": "STACK",
-        "variadic": false
+        "name": "STACKS",
+        "variadic": true
       },
-      "description": "Lists all CloudFormation resources in a stack",
+      "description": "Lists all CloudFormation resources in the specified stack(s)",
       "options": {
         "long": {
           "type": "boolean",

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -304,6 +304,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           all: args.all,
           type: args.type,
           explain: args.explain,
+          ignoreCase: args.ignoreCase,
         });
 
       case 'diff':

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -298,7 +298,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
       case 'resources':
         ioHost.currentAction = 'resources';
-        return cli.resources(args.STACK, {
+        return cli.resources(args.STACKS, {
           json: argv.json,
           long: args.long,
           all: args.all,

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -296,6 +296,16 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           showDeps: args.showDependencies,
         });
 
+      case 'resources':
+        ioHost.currentAction = 'resources';
+        return cli.resources(args.STACK, {
+          json: argv.json,
+          long: args.long,
+          all: args.all,
+          type: args.type,
+          explain: args.explain,
+        });
+
       case 'diff':
         ioHost.currentAction = 'diff';
         const enableDiffNoFail = isFeatureEnabled(configuration, cxapi.ENABLE_DIFF_NO_FAIL_CONTEXT);

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -54,6 +54,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         all: args.all,
         type: args.type,
         explain: args.explain,
+        ignoreCase: args.ignoreCase,
         STACKS: args.STACKS,
       };
       break;
@@ -366,6 +367,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     all: config.resources?.all,
     type: config.resources?.type,
     explain: config.resources?.explain,
+    ignoreCase: config.resources?.ignoreCase,
   };
   const synthOptions = {
     exclusively: config.synth?.exclusively,

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -54,7 +54,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         all: args.all,
         type: args.type,
         explain: args.explain,
-        STACK: args.STACK,
+        STACKS: args.STACKS,
       };
       break;
 

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -48,6 +48,16 @@ export function convertYargsToUserInput(args: any): UserInput {
       };
       break;
 
+    case 'resources':
+      commandOptions = {
+        long: args.long,
+        all: args.all,
+        type: args.type,
+        explain: args.explain,
+        STACK: args.STACK,
+      };
+      break;
+
     case 'synth':
     case 'synthesize':
       commandOptions = {
@@ -351,6 +361,12 @@ export function convertConfigToUserInput(config: any): UserInput {
     long: config.list?.long,
     showDependencies: config.list?.showDependencies,
   };
+  const resourcesOptions = {
+    long: config.resources?.long,
+    all: config.resources?.all,
+    type: config.resources?.type,
+    explain: config.resources?.explain,
+  };
   const synthOptions = {
     exclusively: config.synth?.exclusively,
     validation: config.synth?.validation,
@@ -530,6 +546,7 @@ export function convertConfigToUserInput(config: any): UserInput {
   const userInput: UserInput = {
     globalOptions,
     list: listOptions,
+    resources: resourcesOptions,
     synth: synthOptions,
     bootstrap: bootstrapOptions,
     gc: gcOptions,

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -27,6 +27,7 @@ type CliAction =
 | 'docs'
 | 'flags'
 | 'notices'
+| 'resources'
 | 'version'
 | 'cli-telemetry'
 | 'none';

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -208,6 +208,12 @@ export function parseCommandLineArguments(args: Array<string>): any {
           type: 'string',
           desc: 'Show detailed information for a specific resource by logical ID',
           requiresArg: true,
+        })
+        .option('ignore-case', {
+          default: false,
+          type: 'boolean',
+          alias: 'i',
+          desc: 'Use case-insensitive matching for stack name patterns',
         }),
     )
     .command(['synth [STACKS..]', 'synthesize [STACKS..]'], 'Synthesizes and prints the CloudFormation template for this stack', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -182,6 +182,34 @@ export function parseCommandLineArguments(args: Array<string>): any {
           desc: 'Display stack dependency information for each stack',
         }),
     )
+    .command('resources [STACK]', 'Lists all CloudFormation resources in a stack', (yargs: Argv) =>
+      yargs
+        .option('long', {
+          default: false,
+          type: 'boolean',
+          alias: 'l',
+          desc: 'Display full resource list grouped by type (default shows summary counts)',
+        })
+        .option('all', {
+          default: false,
+          type: 'boolean',
+          alias: 'a',
+          desc: 'Include all resources (by default, noisy types like Lambda::Permission are hidden)',
+        })
+        .option('type', {
+          default: undefined,
+          type: 'string',
+          alias: 't',
+          desc: 'Filter resources by type (case-insensitive partial match, e.g., "lambda" or "dynamodb")',
+          requiresArg: true,
+        })
+        .option('explain', {
+          default: undefined,
+          type: 'string',
+          desc: 'Show detailed information for a specific resource by logical ID',
+          requiresArg: true,
+        }),
+    )
     .command(['synth [STACKS..]', 'synthesize [STACKS..]'], 'Synthesizes and prints the CloudFormation template for this stack', (yargs: Argv) =>
       yargs
         .option('exclusively', {

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -182,7 +182,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           desc: 'Display stack dependency information for each stack',
         }),
     )
-    .command('resources [STACK]', 'Lists all CloudFormation resources in a stack', (yargs: Argv) =>
+    .command('resources [STACKS..]', 'Lists all CloudFormation resources in the specified stack(s)', (yargs: Argv) =>
       yargs
         .option('long', {
           default: false,

--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -15,6 +15,7 @@ const CONTEXT_KEY = 'context';
 export enum Command {
   LS = 'ls',
   LIST = 'list',
+  RESOURCES = 'resources',
   DIFF = 'diff',
   BOOTSTRAP = 'bootstrap',
   DEPLOY = 'deploy',

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -29,7 +29,7 @@ export interface UserInput {
   readonly list?: ListOptions;
 
   /**
-   * Lists all CloudFormation resources in a stack
+   * Lists all CloudFormation resources in the specified stack(s)
    */
   readonly resources?: ResourcesOptions;
 
@@ -374,7 +374,7 @@ export interface ListOptions {
 }
 
 /**
- * Lists all CloudFormation resources in a stack
+ * Lists all CloudFormation resources in the specified stack(s)
  *
  * @struct
  */
@@ -416,7 +416,7 @@ export interface ResourcesOptions {
   /**
    * Positional argument for resources
    */
-  readonly STACK?: string;
+  readonly STACKS?: Array<string>;
 }
 
 /**

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -414,6 +414,15 @@ export interface ResourcesOptions {
   readonly explain?: string;
 
   /**
+   * Use case-insensitive matching for stack name patterns
+   *
+   * aliases: i
+   *
+   * @default - false
+   */
+  readonly ignoreCase?: boolean;
+
+  /**
    * Positional argument for resources
    */
   readonly STACKS?: Array<string>;

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -29,6 +29,11 @@ export interface UserInput {
   readonly list?: ListOptions;
 
   /**
+   * Lists all CloudFormation resources in a stack
+   */
+  readonly resources?: ResourcesOptions;
+
+  /**
    * Synthesizes and prints the CloudFormation template for this stack
    *
    * aliases: synthesize
@@ -366,6 +371,52 @@ export interface ListOptions {
    * Positional argument for list
    */
   readonly STACKS?: Array<string>;
+}
+
+/**
+ * Lists all CloudFormation resources in a stack
+ *
+ * @struct
+ */
+export interface ResourcesOptions {
+  /**
+   * Display full resource list grouped by type (default shows summary counts)
+   *
+   * aliases: l
+   *
+   * @default - false
+   */
+  readonly long?: boolean;
+
+  /**
+   * Include all resources (by default, noisy types like Lambda::Permission are hidden)
+   *
+   * aliases: a
+   *
+   * @default - false
+   */
+  readonly all?: boolean;
+
+  /**
+   * Filter resources by type (case-insensitive partial match, e.g., "lambda" or "dynamodb")
+   *
+   * aliases: t
+   *
+   * @default - undefined
+   */
+  readonly type?: string;
+
+  /**
+   * Show detailed information for a specific resource by logical ID
+   *
+   * @default - undefined
+   */
+  readonly explain?: string;
+
+  /**
+   * Positional argument for resources
+   */
+  readonly STACK?: string;
 }
 
 /**

--- a/packages/aws-cdk/lib/commands/list-resources.ts
+++ b/packages/aws-cdk/lib/commands/list-resources.ts
@@ -16,9 +16,9 @@ const HIDDEN_RESOURCE_TYPES = [
  */
 export interface ListResourcesOptions {
   /**
-   * Stack selector (name or pattern)
+   * Stack selectors (names or patterns)
    */
-  readonly selector: string;
+  readonly selectors: string[];
 
   /**
    * Filter by resource type (e.g., AWS::Lambda::Function)
@@ -32,7 +32,7 @@ export interface ListResourcesOptions {
 }
 
 /**
- * List all resources in a stack
+ * List all resources in the specified stack(s)
  */
 export async function listResources(
   toolkit: CdkToolkit,
@@ -41,10 +41,10 @@ export async function listResources(
   const assembly = await toolkit.assembly();
 
   const stacks = await assembly.selectStacks(
-    { patterns: [options.selector] },
+    { patterns: options.selectors },
     {
       extend: ExtendedStackSelection.None,
-      defaultBehavior: DefaultSelection.OnlySingle,
+      defaultBehavior: DefaultSelection.AllStacks,
     },
   );
 
@@ -104,6 +104,7 @@ export async function listResources(
 
 /**
  * Get detailed information about a specific resource
+ * Note: --explain requires a single stack to be selected
  */
 export async function explainResource(
   toolkit: CdkToolkit,
@@ -112,7 +113,7 @@ export async function explainResource(
   const assembly = await toolkit.assembly();
 
   const stacks = await assembly.selectStacks(
-    { patterns: [options.selector] },
+    { patterns: options.selectors },
     {
       extend: ExtendedStackSelection.None,
       defaultBehavior: DefaultSelection.OnlySingle,

--- a/packages/aws-cdk/lib/commands/list-resources.ts
+++ b/packages/aws-cdk/lib/commands/list-resources.ts
@@ -1,0 +1,223 @@
+import type { ResourceDetails, ResourceExplainDetails } from '@aws-cdk/toolkit-lib';
+import type { CdkToolkit } from '../cli/cdk-toolkit';
+import { DefaultSelection, ExtendedStackSelection } from '../cxapp';
+
+const PATH_METADATA_KEY = 'aws:cdk:path';
+
+/**
+ * Resource types that are hidden by default (noisy/derivative resources)
+ */
+const HIDDEN_RESOURCE_TYPES = [
+  'AWS::Lambda::Permission',
+];
+
+/**
+ * Options for listing resources
+ */
+export interface ListResourcesOptions {
+  /**
+   * Stack selector (name or pattern)
+   */
+  readonly selector: string;
+
+  /**
+   * Filter by resource type (e.g., AWS::Lambda::Function)
+   */
+  readonly type?: string;
+
+  /**
+   * Include all resources (including hidden types like Lambda::Permission)
+   */
+  readonly all?: boolean;
+}
+
+/**
+ * List all resources in a stack
+ */
+export async function listResources(
+  toolkit: CdkToolkit,
+  options: ListResourcesOptions,
+): Promise<ResourceDetails[]> {
+  const assembly = await toolkit.assembly();
+
+  const stacks = await assembly.selectStacks(
+    { patterns: [options.selector] },
+    {
+      extend: ExtendedStackSelection.None,
+      defaultBehavior: DefaultSelection.OnlySingle,
+    },
+  );
+
+  if (stacks.stackCount === 0) {
+    return [];
+  }
+
+  const resources: ResourceDetails[] = [];
+
+  for (const stack of stacks.stackArtifacts) {
+    const template = stack.template;
+    const templateResources = template.Resources ?? {};
+
+    for (const [logicalId, resource] of Object.entries(templateResources)) {
+      const resourceObj = resource as any;
+      const resourceType = resourceObj.Type ?? '<unknown>';
+
+      // Filter by type if specified (case-insensitive partial match)
+      if (options.type && !resourceType.toLowerCase().includes(options.type.toLowerCase())) {
+        continue;
+      }
+
+      // Hide noisy resource types by default (unless --all or explicitly filtering for them)
+      if (!options.all && !options.type && HIDDEN_RESOURCE_TYPES.includes(resourceType)) {
+        continue;
+      }
+
+      // Strip stack name prefix from construct path
+      const fullPath = resourceObj.Metadata?.[PATH_METADATA_KEY] ?? '<unknown>';
+      const constructPath = stripStackPrefix(fullPath, stack.id);
+
+      resources.push({
+        stackId: stack.id,
+        logicalId,
+        type: resourceType,
+        constructPath,
+        dependsOn: Array.isArray(resourceObj.DependsOn)
+          ? resourceObj.DependsOn
+          : resourceObj.DependsOn
+            ? [resourceObj.DependsOn]
+            : [],
+        imports: extractImportValues(resourceObj),
+        removalPolicy: mapDeletionPolicy(resourceObj.DeletionPolicy),
+      });
+    }
+  }
+
+  // Sort by type first, then by logical ID
+  resources.sort((a, b) => {
+    const typeCompare = a.type.localeCompare(b.type);
+    if (typeCompare !== 0) return typeCompare;
+    return a.logicalId.localeCompare(b.logicalId);
+  });
+
+  return resources;
+}
+
+/**
+ * Get detailed information about a specific resource
+ */
+export async function explainResource(
+  toolkit: CdkToolkit,
+  options: ListResourcesOptions & { logicalId: string },
+): Promise<ResourceExplainDetails | undefined> {
+  const assembly = await toolkit.assembly();
+
+  const stacks = await assembly.selectStacks(
+    { patterns: [options.selector] },
+    {
+      extend: ExtendedStackSelection.None,
+      defaultBehavior: DefaultSelection.OnlySingle,
+    },
+  );
+
+  if (stacks.stackCount === 0) {
+    return undefined;
+  }
+
+  const stack = stacks.firstStack;
+  const template = stack.template;
+  const resource = template.Resources?.[options.logicalId] as any;
+
+  if (!resource) {
+    return undefined;
+  }
+
+  // Strip stack name prefix from construct path
+  const fullPath = resource.Metadata?.[PATH_METADATA_KEY] ?? '<unknown>';
+  const constructPath = stripStackPrefix(fullPath, stack.id);
+
+  return {
+    stackId: stack.id,
+    logicalId: options.logicalId,
+    type: resource.Type ?? '<unknown>',
+    constructPath,
+    dependsOn: Array.isArray(resource.DependsOn)
+      ? resource.DependsOn
+      : resource.DependsOn
+        ? [resource.DependsOn]
+        : [],
+    imports: extractImportValues(resource),
+    removalPolicy: mapDeletionPolicy(resource.DeletionPolicy),
+    condition: resource.Condition,
+    updatePolicy: resource.UpdatePolicy ? JSON.stringify(resource.UpdatePolicy) : undefined,
+    creationPolicy: resource.CreationPolicy ? JSON.stringify(resource.CreationPolicy) : undefined,
+  };
+}
+
+/**
+ * Extract Fn::ImportValue references from a resource
+ */
+function extractImportValues(resource: any): string[] {
+  const imports: string[] = [];
+
+  function walk(obj: any) {
+    if (obj === null || obj === undefined) return;
+
+    if (typeof obj === 'object') {
+      if ('Fn::ImportValue' in obj) {
+        const importRef = obj['Fn::ImportValue'];
+        if (typeof importRef === 'string') {
+          imports.push(importRef);
+        } else if (typeof importRef === 'object' && 'Fn::Sub' in importRef) {
+          imports.push(`\${${importRef['Fn::Sub']}}`);
+        }
+      }
+
+      for (const value of Object.values(obj)) {
+        walk(value);
+      }
+    } else if (Array.isArray(obj)) {
+      for (const item of obj) {
+        walk(item);
+      }
+    }
+  }
+
+  walk(resource.Properties);
+  return imports;
+}
+
+/**
+ * Map CloudFormation DeletionPolicy to removal policy
+ */
+function mapDeletionPolicy(policy?: string): 'retain' | 'destroy' | 'snapshot' | undefined {
+  switch (policy) {
+    case 'Retain': return 'retain';
+    case 'Delete': return 'destroy';
+    case 'Snapshot': return 'snapshot';
+    default: return undefined;
+  }
+}
+
+/**
+ * Strip the stack name prefix and /Resource suffix from a construct path
+ * e.g., "WebhookDeliveryStack/ReceiverApi/Account" -> "ReceiverApi/Account"
+ * e.g., "WebhookDeliveryStack/ApiLambda/Resource" -> "ApiLambda"
+ */
+function stripStackPrefix(path: string, stackId: string): string {
+  if (path === '<unknown>') return path;
+
+  let result = path;
+
+  // Strip stack prefix
+  const prefix = `${stackId}/`;
+  if (result.startsWith(prefix)) {
+    result = result.slice(prefix.length);
+  }
+
+  // Strip /Resource suffix (common CDK L2 pattern)
+  if (result.endsWith('/Resource')) {
+    result = result.slice(0, -9);
+  }
+
+  return result;
+}

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -271,8 +271,11 @@ describe('resources', () => {
     const jsonOutput = resultCalls[0][0].message;
     const parsed = JSON.parse(jsonOutput);
     expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed[0]).toHaveProperty('logicalId', 'MyBucket');
-    expect(parsed[0]).toHaveProperty('type', 'AWS::S3::Bucket');
+    expect(parsed[0]).toHaveProperty('stackId', 'ResourceStack');
+    expect(parsed[0].resources[0]).toHaveProperty('logicalId', 'MyBucket');
+    expect(parsed[0].resources[0]).toHaveProperty('type', 'AWS::S3::Bucket');
+    // stackId should not be on individual resources
+    expect(parsed[0].resources[0]).not.toHaveProperty('stackId');
   });
 
   test('lists resources in long mode', async () => {
@@ -485,7 +488,8 @@ describe('resources', () => {
     const jsonOutput = resultCalls[0][0].message;
     const parsed = JSON.parse(jsonOutput);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].type).toBe('AWS::Lambda::Function');
+    expect(parsed[0].resources).toHaveLength(1);
+    expect(parsed[0].resources[0].type).toBe('AWS::Lambda::Function');
   });
 
   test('hides Lambda::Permission by default', async () => {
@@ -526,7 +530,8 @@ describe('resources', () => {
     const jsonOutput = resultCalls[0][0].message;
     const parsed = JSON.parse(jsonOutput);
     expect(parsed).toHaveLength(1);
-    expect(parsed[0].type).toBe('AWS::Lambda::Function');
+    expect(parsed[0].resources).toHaveLength(1);
+    expect(parsed[0].resources[0].type).toBe('AWS::Lambda::Function');
   });
 
   test('shows Lambda::Permission with --all flag', async () => {
@@ -566,7 +571,8 @@ describe('resources', () => {
     const resultCalls = notifySpy.mock.calls.filter(([msg]: [any]) => msg.level === 'result');
     const jsonOutput = resultCalls[0][0].message;
     const parsed = JSON.parse(jsonOutput);
-    expect(parsed).toHaveLength(2);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].resources).toHaveLength(2);
   });
 });
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -224,7 +224,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack');
+    const result = await toolkit.resources(['ResourceStack']);
 
     // THEN
     expect(result).toEqual(0);
@@ -261,7 +261,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack', { json: true });
+    const result = await toolkit.resources(['ResourceStack'], { json: true });
 
     // THEN
     expect(result).toEqual(0);
@@ -308,7 +308,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack', { long: true });
+    const result = await toolkit.resources(['ResourceStack'], { long: true });
 
     // THEN
     expect(result).toEqual(0);
@@ -346,7 +346,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack', { explain: 'MyBucket' });
+    const result = await toolkit.resources(['ResourceStack'], { explain: 'MyBucket' });
 
     // THEN
     expect(result).toEqual(0);
@@ -382,7 +382,7 @@ describe('resources', () => {
     });
 
     // WHEN/THEN
-    await expect(toolkit.resources('ResourceStack', { explain: 'NonExistent' }))
+    await expect(toolkit.resources(['ResourceStack'], { explain: 'NonExistent' }))
       .rejects.toThrow("Resource 'NonExistent' not found");
   });
 
@@ -405,7 +405,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('EmptyStack');
+    const result = await toolkit.resources(['EmptyStack']);
 
     // THEN
     expect(result).toEqual(0);
@@ -440,7 +440,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack', { type: 'Lambda' });
+    const result = await toolkit.resources(['ResourceStack'], { type: 'Lambda' });
 
     // THEN
     expect(result).toEqual(0);
@@ -480,7 +480,7 @@ describe('resources', () => {
     });
 
     // WHEN
-    const result = await toolkit.resources('ResourceStack', { type: 'Lambda', json: true });
+    const result = await toolkit.resources(['ResourceStack'], { type: 'Lambda', json: true });
 
     // THEN
     expect(result).toEqual(0);
@@ -522,7 +522,7 @@ describe('resources', () => {
     });
 
     // WHEN - without --all
-    const result = await toolkit.resources('ResourceStack', { json: true });
+    const result = await toolkit.resources(['ResourceStack'], { json: true });
 
     // THEN - should only have 1 resource (Lambda::Permission hidden)
     expect(result).toEqual(0);
@@ -564,7 +564,7 @@ describe('resources', () => {
     });
 
     // WHEN - with --all
-    const result = await toolkit.resources('ResourceStack', { json: true, all: true });
+    const result = await toolkit.resources(['ResourceStack'], { json: true, all: true });
 
     // THEN - should have both resources
     expect(result).toEqual(0);

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -193,6 +193,383 @@ describe('list', () => {
   });
 });
 
+describe('resources', () => {
+  test('lists resources in summary mode by default', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyBucket/Resource' },
+            },
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyFunction/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack');
+
+    // THEN
+    expect(result).toEqual(0);
+    // Summary mode should show stack name and resource count
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'result',
+      message: expect.stringContaining('ResourceStack'),
+    }));
+  });
+
+  test('lists resources in JSON mode', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyBucket/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack', { json: true });
+
+    // THEN
+    expect(result).toEqual(0);
+    // JSON mode should output parseable JSON
+    const resultCalls = notifySpy.mock.calls.filter(([msg]: [any]) => msg.level === 'result');
+    expect(resultCalls.length).toBeGreaterThan(0);
+    const jsonOutput = resultCalls[0][0].message;
+    const parsed = JSON.parse(jsonOutput);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0]).toHaveProperty('logicalId', 'MyBucket');
+    expect(parsed[0]).toHaveProperty('type', 'AWS::S3::Bucket');
+  });
+
+  test('lists resources in long mode', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyBucket/Resource' },
+            },
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyFunction/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack', { long: true });
+
+    // THEN
+    expect(result).toEqual(0);
+    // Long mode should show resource count
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'result',
+      message: expect.stringContaining('resource(s) total'),
+    }));
+  });
+
+  test('explains a specific resource', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyBucket/Resource' },
+              DeletionPolicy: 'Retain',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack', { explain: 'MyBucket' });
+
+    // THEN
+    expect(result).toEqual(0);
+    // Should output the resource details
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'result',
+      message: expect.stringContaining('MyBucket'),
+    }));
+  });
+
+  test('throws error when explaining non-existent resource', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN/THEN
+    await expect(toolkit.resources('ResourceStack', { explain: 'NonExistent' }))
+      .rejects.toThrow("Resource 'NonExistent' not found");
+  });
+
+  test('shows info message when no resources found', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'EmptyStack',
+        template: { Resources: {} },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('EmptyStack');
+
+    // THEN
+    expect(result).toEqual(0);
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'info',
+      message: expect.stringContaining('No resources found'),
+    }));
+  });
+
+  test('shows info message when no resources match type filter', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack', { type: 'Lambda' });
+
+    // THEN
+    expect(result).toEqual(0);
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'info',
+      message: expect.stringContaining("No resources of type 'Lambda'"),
+    }));
+  });
+
+  test('filters resources by type', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyBucket/Resource' },
+            },
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyFunction/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN
+    const result = await toolkit.resources('ResourceStack', { type: 'Lambda', json: true });
+
+    // THEN
+    expect(result).toEqual(0);
+    const resultCalls = notifySpy.mock.calls.filter(([msg]: [any]) => msg.level === 'result');
+    const jsonOutput = resultCalls[0][0].message;
+    const parsed = JSON.parse(jsonOutput);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].type).toBe('AWS::Lambda::Function');
+  });
+
+  test('hides Lambda::Permission by default', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyFunction/Resource' },
+            },
+            MyPermission: {
+              Type: 'AWS::Lambda::Permission',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyPermission/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN - without --all
+    const result = await toolkit.resources('ResourceStack', { json: true });
+
+    // THEN - should only have 1 resource (Lambda::Permission hidden)
+    expect(result).toEqual(0);
+    const resultCalls = notifySpy.mock.calls.filter(([msg]: [any]) => msg.level === 'result');
+    const jsonOutput = resultCalls[0][0].message;
+    const parsed = JSON.parse(jsonOutput);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].type).toBe('AWS::Lambda::Function');
+  });
+
+  test('shows Lambda::Permission with --all flag', async () => {
+    // GIVEN
+    cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'ResourceStack',
+        template: {
+          Resources: {
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyFunction/Resource' },
+            },
+            MyPermission: {
+              Type: 'AWS::Lambda::Permission',
+              Metadata: { 'aws:cdk:path': 'ResourceStack/MyPermission/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      ioHost,
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: instanceMockFrom(Deployments),
+    });
+
+    // WHEN - with --all
+    const result = await toolkit.resources('ResourceStack', { json: true, all: true });
+
+    // THEN - should have both resources
+    expect(result).toEqual(0);
+    const resultCalls = notifySpy.mock.calls.filter(([msg]: [any]) => msg.level === 'result');
+    const jsonOutput = resultCalls[0][0].message;
+    const parsed = JSON.parse(jsonOutput);
+    expect(parsed).toHaveLength(2);
+  });
+});
+
 describe('deploy', () => {
   test('fails when no valid stack names are given', async () => {
     // GIVEN

--- a/packages/aws-cdk/test/cli/cli-arguments.test.ts
+++ b/packages/aws-cdk/test/cli/cli-arguments.test.ts
@@ -142,6 +142,7 @@ describe('config', () => {
       doctor: expect.anything(),
       docs: expect.anything(),
       refactor: expect.anything(),
+      resources: expect.anything(),
       cliTelemetry: expect.anything(),
     });
   });

--- a/packages/aws-cdk/test/commands/list-resources.test.ts
+++ b/packages/aws-cdk/test/commands/list-resources.test.ts
@@ -1,0 +1,600 @@
+import { Bootstrapper } from '../../lib/api/bootstrap';
+import { Deployments } from '../../lib/api/deployments';
+import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
+import { listResources, explainResource } from '../../lib/commands/list-resources';
+import { instanceMockFrom, MockCloudExecutable } from '../_helpers';
+
+describe('listResources', () => {
+  let cloudFormation: jest.Mocked<Deployments>;
+  let bootstrapper: jest.Mocked<Bootstrapper>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    cloudFormation = instanceMockFrom(Deployments);
+
+    bootstrapper = instanceMockFrom(Bootstrapper);
+    bootstrapper.bootstrapEnvironment.mockResolvedValue({ noOp: false, outputs: {} } as any);
+  });
+
+  test('lists resources from a single stack', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/MyBucket/Resource',
+              },
+            },
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/MyFunction/Resource',
+              },
+              DependsOn: ['MyBucket'],
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    expect(resources).toHaveLength(2);
+    expect(resources).toContainEqual(expect.objectContaining({
+      logicalId: 'MyBucket',
+      type: 'AWS::S3::Bucket',
+      constructPath: 'MyBucket',
+    }));
+    expect(resources).toContainEqual(expect.objectContaining({
+      logicalId: 'MyFunction',
+      type: 'AWS::Lambda::Function',
+      constructPath: 'MyFunction',
+      dependsOn: ['MyBucket'],
+    }));
+  });
+
+  test('returns empty array for stack with no resources', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'EmptyStack',
+        template: { Resources: {} },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'EmptyStack' });
+
+    expect(resources).toHaveLength(0);
+  });
+
+  test('handles missing metadata gracefully', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            NoMetadata: {
+              Type: 'AWS::S3::Bucket',
+              // No Metadata
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0].constructPath).toBe('<unknown>');
+  });
+
+  test('extracts Fn::ImportValue references', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyResource: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/MyResource/Resource',
+              },
+              Properties: {
+                Environment: {
+                  Variables: {
+                    BUCKET_ARN: { 'Fn::ImportValue': 'SharedBucketArn' },
+                  },
+                },
+              },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0].imports).toContain('SharedBucketArn');
+  });
+
+  test('maps DeletionPolicy to removalPolicy', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            RetainedBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/RetainedBucket/Resource',
+              },
+              DeletionPolicy: 'Retain',
+            },
+            DeletedBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/DeletedBucket/Resource',
+              },
+              DeletionPolicy: 'Delete',
+            },
+            SnapshotBucket: {
+              Type: 'AWS::RDS::DBInstance',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/SnapshotBucket/Resource',
+              },
+              DeletionPolicy: 'Snapshot',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    const retained = resources.find(r => r.logicalId === 'RetainedBucket');
+    const deleted = resources.find(r => r.logicalId === 'DeletedBucket');
+    const snapshot = resources.find(r => r.logicalId === 'SnapshotBucket');
+
+    expect(retained?.removalPolicy).toBe('retain');
+    expect(deleted?.removalPolicy).toBe('destroy');
+    expect(snapshot?.removalPolicy).toBe('snapshot');
+  });
+
+  test('sorts resources by type and logical ID', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            ZFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'TestStack/ZFunction/Resource' },
+            },
+            AFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'TestStack/AFunction/Resource' },
+            },
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyBucket/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    // Should be sorted: Lambda::Function (A then Z), then S3::Bucket
+    expect(resources[0].logicalId).toBe('AFunction');
+    expect(resources[1].logicalId).toBe('ZFunction');
+    expect(resources[2].logicalId).toBe('MyBucket');
+  });
+
+  test('filters by resource type (case-insensitive)', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyFunction/Resource' },
+            },
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyBucket/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    // Filter for lambda (lowercase)
+    const lambdaResources = await listResources(toolkit, { selector: 'TestStack', type: 'lambda' });
+    expect(lambdaResources).toHaveLength(1);
+    expect(lambdaResources[0].type).toBe('AWS::Lambda::Function');
+
+    // Filter for S3 (uppercase)
+    const s3Resources = await listResources(toolkit, { selector: 'TestStack', type: 'S3' });
+    expect(s3Resources).toHaveLength(1);
+    expect(s3Resources[0].type).toBe('AWS::S3::Bucket');
+  });
+
+  test('hides Lambda::Permission by default', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyFunction/Resource' },
+            },
+            MyPermission: {
+              Type: 'AWS::Lambda::Permission',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyPermission/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    // Without --all flag
+    const defaultResources = await listResources(toolkit, { selector: 'TestStack' });
+    expect(defaultResources).toHaveLength(1);
+    expect(defaultResources[0].type).toBe('AWS::Lambda::Function');
+
+    // With --all flag
+    const allResources = await listResources(toolkit, { selector: 'TestStack', all: true });
+    expect(allResources).toHaveLength(2);
+  });
+
+  test('shows Lambda::Permission when filtering by type', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyFunction/Resource' },
+            },
+            MyPermission: {
+              Type: 'AWS::Lambda::Permission',
+              Metadata: { 'aws:cdk:path': 'TestStack/MyPermission/Resource' },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    // When filtering by type, hidden types should be included
+    const permissionResources = await listResources(toolkit, { selector: 'TestStack', type: 'Permission' });
+    expect(permissionResources).toHaveLength(1);
+    expect(permissionResources[0].type).toBe('AWS::Lambda::Permission');
+  });
+
+  test('strips stack name prefix and /Resource suffix from construct paths', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'MyStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: {
+                'aws:cdk:path': 'MyStack/Api/Handler/Resource',
+              },
+            },
+            MyFunction: {
+              Type: 'AWS::Lambda::Function',
+              Metadata: {
+                'aws:cdk:path': 'MyStack/Api/Handler',
+              },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'MyStack' });
+
+    const bucket = resources.find(r => r.logicalId === 'MyBucket');
+    const fn = resources.find(r => r.logicalId === 'MyFunction');
+
+    // Should strip 'MyStack/' prefix and '/Resource' suffix
+    expect(bucket?.constructPath).toBe('Api/Handler');
+    // Should only strip 'MyStack/' prefix (no /Resource suffix)
+    expect(fn?.constructPath).toBe('Api/Handler');
+  });
+
+  test('handles DependsOn as string or array', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            ResourceA: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'TestStack/ResourceA/Resource' },
+            },
+            ResourceB: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'TestStack/ResourceB/Resource' },
+              DependsOn: 'ResourceA', // String form
+            },
+            ResourceC: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: { 'aws:cdk:path': 'TestStack/ResourceC/Resource' },
+              DependsOn: ['ResourceA', 'ResourceB'], // Array form
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resources = await listResources(toolkit, { selector: 'TestStack' });
+
+    const resourceA = resources.find(r => r.logicalId === 'ResourceA');
+    const resourceB = resources.find(r => r.logicalId === 'ResourceB');
+    const resourceC = resources.find(r => r.logicalId === 'ResourceC');
+
+    expect(resourceA?.dependsOn).toEqual([]);
+    expect(resourceB?.dependsOn).toEqual(['ResourceA']);
+    expect(resourceC?.dependsOn).toEqual(['ResourceA', 'ResourceB']);
+  });
+});
+
+describe('explainResource', () => {
+  let cloudFormation: jest.Mocked<Deployments>;
+  let bootstrapper: jest.Mocked<Bootstrapper>;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+
+    cloudFormation = instanceMockFrom(Deployments);
+
+    bootstrapper = instanceMockFrom(Bootstrapper);
+    bootstrapper.bootstrapEnvironment.mockResolvedValue({ noOp: false, outputs: {} } as any);
+  });
+
+  test('returns detailed info for existing resource', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/MyBucket/Resource',
+              },
+              Condition: 'CreateBucket',
+              DeletionPolicy: 'Retain',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resource = await explainResource(toolkit, {
+      selector: 'TestStack',
+      logicalId: 'MyBucket',
+    });
+
+    expect(resource).toBeDefined();
+    expect(resource?.logicalId).toBe('MyBucket');
+    expect(resource?.type).toBe('AWS::S3::Bucket');
+    expect(resource?.condition).toBe('CreateBucket');
+    expect(resource?.removalPolicy).toBe('retain');
+  });
+
+  test('returns undefined for non-existent resource', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: { Resources: {} },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resource = await explainResource(toolkit, {
+      selector: 'TestStack',
+      logicalId: 'NonExistent',
+    });
+
+    expect(resource).toBeUndefined();
+  });
+
+  test('includes update and creation policies', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyASG: {
+              Type: 'AWS::AutoScaling::AutoScalingGroup',
+              Metadata: {
+                'aws:cdk:path': 'TestStack/MyASG/Resource',
+              },
+              UpdatePolicy: {
+                AutoScalingRollingUpdate: {
+                  MinInstancesInService: 1,
+                },
+              },
+              CreationPolicy: {
+                ResourceSignal: {
+                  Count: 1,
+                  Timeout: 'PT5M',
+                },
+              },
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    const resource = await explainResource(toolkit, {
+      selector: 'TestStack',
+      logicalId: 'MyASG',
+    });
+
+    expect(resource).toBeDefined();
+    expect(resource?.updatePolicy).toBeDefined();
+    expect(resource?.creationPolicy).toBeDefined();
+    expect(JSON.parse(resource!.updatePolicy!)).toEqual({
+      AutoScalingRollingUpdate: { MinInstancesInService: 1 },
+    });
+    expect(JSON.parse(resource!.creationPolicy!)).toEqual({
+      ResourceSignal: { Count: 1, Timeout: 'PT5M' },
+    });
+  });
+
+  test('returns undefined for non-matching stack selector', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [{
+        stackName: 'TestStack',
+        template: {
+          Resources: {
+            MyBucket: {
+              Type: 'AWS::S3::Bucket',
+            },
+          },
+        },
+        env: 'aws://123456789012/us-east-1',
+      }],
+    });
+
+    const toolkit = new CdkToolkit({
+      cloudExecutable,
+      configuration: cloudExecutable.configuration,
+      sdkProvider: cloudExecutable.sdkProvider,
+      deployments: cloudFormation,
+    });
+
+    // When no stacks match the selector, explainResource returns undefined
+    // (The CdkToolkit.resources() method handles throwing the appropriate error)
+    const resource = await explainResource(toolkit, {
+      selector: 'NonExistentStack',
+      logicalId: 'MyBucket',
+    });
+
+    expect(resource).toBeUndefined();
+  });
+});


### PR DESCRIPTION
This PR adds `cdk resources`, a new CLI command that lets users quickly see which resources their stacks define without digging through `cdk.out/` or deploying. It supports summary, detailed, and JSON modes, along with filtering and wildcard stack selection.

### Reason for this change

CDK users currently have no built-in way to inspect the synthesized CloudFormation resources in their stacks without:

* opening raw `cdk.out` templates
* deploying the stack
* writing custom tooling
* or depending on external CloudFormation inspection tools

A feature I, and I suspect others as well, have often wanted is a simple CLI command that answers:

> “What resources belong to this stack?”

This PR introduces a first-class solution: `cdk resources`.

---

### Description of changes

This PR adds a new CLI command, **`cdk resources`**, which lists CloudFormation resources from one or more synthesized stacks. It supports summary output, long-form detailed output, type filtering, wildcard stack selection, JSON mode, and resource explanation. This makes it significantly easier for developers to understand infrastructure generated by CDK apps.

---

### How it works

**Command Usage:**

```bash
cdk resources                         # All stacks (summary mode)
cdk resources --long                  # Long/detail mode
cdk resources --json                  # JSON output

cdk resources MyStack                 # Summary mode for stack MyStack
cdk resources --long Stack1 Stack2    # Long/detail mode for multiple stacks

cdk resources 'Prod*'                 # Wildcard pattern (quote recommended)
cdk resources '*'                     # Must be quoted — unquoted * will expand to local filenames
cdk resources --ignore-case 'prod*'   # Case-insensitive wildcard matching

cdk resources --type lambda           # Filter by resource type (case-insensitive)
cdk resources -t lambda               # Same as above
```

**Key behaviors:**

* Supports wildcard stack name selection (via `minimatch`)
* Summary mode shows resource counts grouped by type
* Long/detail mode (`--long` or `-l`) shows full logical IDs under each type
* JSON mode (`--json` or `-j`) returns machine-readable `ResourceDetails[]`
* `--type <pattern>` (or `-t <pattern>`) filters resources by type (case-insensitive)
* `--all` shows normally hidden resource types (e.g., `Lambda::Permission`)
* `--explain <LogicalId>` produces deep, structured resource detail (single-stack only)
* Automatically handles:

  * normalized `DependsOn` arrays
  * import extraction (`Fn::ImportValue`)
  * construct path derivation from metadata
  * DeletionPolicy → removalPolicy mapping
  * missing metadata gracefully
* Case-insensitive matching supported with `--ignore-case` (or `-i`)

---

### Files changed

**Implementation:**

* `cli-config.ts` — command definition and option parsing
* `cli.ts` — dispatch to toolkit
* `cdk-toolkit.ts` — new `CdkToolkit.resources()` method
* `commands/list-resources.ts` — core logic (`listResources`, `explainResource`)
* `@aws-cdk/toolkit-lib/.../resource-details.ts` — shared type definitions

**Auto-generated (via `yarn pre-compile`):**

* `cli-type-registry.json`
* `parse-command-line-arguments.ts`
* `convert-to-user-input.ts`
* `user-input.ts`

**Tests:**

* `test/commands/list-resources.test.ts` — 17 unit tests
* `test/cli/cdk-toolkit.test.ts` — 10 integration tests

---

### Describe any new or updated permissions being added

N/A — No new AWS permissions required.
This command operates purely on synthesized CloudFormation templates already present in the local Cloud Assembly.

---

### Description of how you validated changes

* **17 unit tests** covering resource extraction, filtering, metadata handling, hidden resources, import detection, removalPolicy mapping, sorting, explain mode, and wildcard matching
* **10 integration tests** covering summary mode, long/detail mode, JSON output, explain mode, filtering, and CLI behavior
* Manual testing against real CDK apps to validate:

  * wildcard stack selection
  * JSON correctness
  * resource hiding behavior
  * explain mode
  * case-insensitive matching
* Verified parser regeneration with `yarn pre-compile`
* CI: `yarn build` and full Jest suite pass

---

### Usage Example

**Summary (default):**

```
WebhookDeliveryStack: 110 resources

ApiGateway::Method ...................... 46
ApiGateway::Resource .................... 23
Lambda::Function ........................ 5
...
```

**Long mode:**

```
WebhookDeliveryStack: 110 resources

Lambda::Function (5)
  ApiLambda                       ApiLambda
  WorkerLambda                    WorkerLambda
```

**JSON mode:**

```json
[
  {
    "stackId": "WebhookDeliveryStack",
    "resources": [
      {
        "logicalId": "ApiLambda",
        "type": "AWS::Lambda::Function",
        "constructPath": "ApiLambda",
        "dependsOn": [],
        "imports": [],
        "removalPolicy": "destroy"
      }
    ]
  }
]
```

**Explain mode:**

```bash
cdk resources MyStack --explain MyBucket
```

```json
{
  "stackId": "MyStack",
  "logicalId": "MyBucket",
  "type": "AWS::S3::Bucket",
  "constructPath": "MyBucket",
  "dependsOn": [],
  "imports": [],
  "removalPolicy": "retain",
  "condition": "CreateBucket"
}
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
