### PR TITLE
chore: telemetry-test run in wrong environment

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -60,7 +60,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: integ-approval
+    environment: run-tests
     env:
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -453,7 +453,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
     // Add a job for telemetry tests that runs before the main matrix
     const JOB_TELEMETRY = 'telemetry_tests';
     runTestsWorkflow.addJob(JOB_TELEMETRY, {
-      environment: props.approvalEnvironment,
+      environment: props.testEnvironment,
       runsOn: [props.testRunsOn],
       needs: [JOB_PREPARE],
       permissions: {


### PR DESCRIPTION
telemetry-test job should be run in the test environment not the approval environment.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
