### PR TITLE
fix(integ-runner): long-running tests warnings are displayed as errors

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/workers/common.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/common.ts
@@ -192,6 +192,11 @@ export enum DiagnosticReason {
   TEST_ERROR = 'TEST_ERROR',
 
   /**
+   * A non-failing warning from the integration test run
+   */
+  TEST_WARNING = 'TEST_WARNING',
+
+  /**
    * The snapshot test failed because the actual
    * snapshot was different than the expected snapshot
    */
@@ -293,6 +298,9 @@ export function printResults(diagnostic: Diagnostic): void {
       break;
     case DiagnosticReason.SNAPSHOT_FAILED:
       logger.error('  CHANGED    %s %s\n%s', diagnostic.testName, chalk.gray(`${diagnostic.duration}s`), indentLines(diagnostic.message, 6));
+      break;
+    case DiagnosticReason.TEST_WARNING:
+      logger.warning('  WARN       %s %s\n%s', diagnostic.testName, chalk.gray(`${diagnostic.duration}s`), indentLines(diagnostic.message, 6));
       break;
     case DiagnosticReason.SNAPSHOT_ERROR:
     case DiagnosticReason.TEST_ERROR:

--- a/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
@@ -132,7 +132,7 @@ export async function snapshotTestWorker(testInfo: IntegTestInfo, options: Snaps
 
   const timer = setTimeout(() => {
     workerpool.workerEmit({
-      reason: DiagnosticReason.SNAPSHOT_ERROR,
+      reason: DiagnosticReason.TEST_WARNING,
       testName: test.testName,
       message: 'Test is taking a very long time',
       duration: (Date.now() - start) / 1000,


### PR DESCRIPTION
This change introduces a new `TEST_WARNING` diagnostic reason to distinguish non-failing warnings from actual errors in the integration test runner. Previously, when a test took longer than 60 seconds, it would emit a `SNAPSHOT_ERROR` diagnostic, which was misleading since the test hadn't actually failed yet.

The new warning diagnostic allows the runner to inform users about long-running tests without treating them as errors. This provides better visibility into test performance while maintaining the distinction between warnings and actual failures. The warning is displayed with a `WARN` prefix in the output, making it clear that the test is still running but taking longer than expected.

### Before

<img width="611" height="137" alt="image" src="https://github.com/user-attachments/assets/20dda1c3-4bec-461f-bbed-8246dacdc38a" />


### After

```
@aws-cdk/aws-lambda-python-alpha:   WARN       integ.function.nodeps 60.003s
@aws-cdk/aws-lambda-python-alpha:       Test is taking a very long time
@aws-cdk/aws-lambda-python-alpha:   WARN       integ.function.sub 60.006s
@aws-cdk/aws-lambda-python-alpha:       Test is taking a very long time
@aws-cdk/aws-lambda-python-alpha:   WARN       integ.function.poetry 60.002s
@aws-cdk/aws-lambda-python-alpha:       Test is taking a very long time
@aws-cdk/aws-lambda-python-alpha:   WARN       integ.function.pipenv 60.002s
@aws-cdk/aws-lambda-python-alpha:       Test is taking a very long time
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
