### PR TITLE
fix(cli): error message when early validation failures cannot be retrieved is unclear

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
@@ -26,7 +26,8 @@ export class EarlyValidationReporter implements ValidationReporter {
 
       return `The template cannot be deployed because of early validation errors, but retrieving more details about those
 errors failed (${error}). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap
-your environment with the latest version of the CLI (need at least version 30, current version ${currentVersion ?? 'unknown'}).`;
+your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack.
+Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}).`;
     }
 
     let message = `ChangeSet '${changeSetName}' on stack '${stackName}' failed early validation`;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
@@ -27,7 +27,7 @@ export class EarlyValidationReporter implements ValidationReporter {
       return `The template cannot be deployed because of early validation errors, but retrieving more details about those
 errors failed (${error}). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap
 your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack.
-Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}).`;
+Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}.`;
     }
 
     let message = `ChangeSet '${changeSetName}' on stack '${stackName}' failed early validation`;

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -804,7 +804,8 @@ test('deployStack warns when it cannot get the events in case of early validatio
     }),
   ).rejects.toThrow(`The template cannot be deployed because of early validation errors, but retrieving more details about those
 errors failed (Error: AccessDenied). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap
-your environment with the latest version of the CLI (need at least version 30, current version 0).`);
+your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack.
+Bootstrap toolkit stack version 30 or later is needed; current version: 0.`);
 });
 
 test('deploy not skipped if template did not change but one tag removed', async () => {


### PR DESCRIPTION
Clarified error message for early validation failures in deployments.

The current error message is confusing: it can be taken to mean that the CLI version is outdated, which is not the case.

It also mentions the CDK Toolkit stack version without any explanation - it is not clear which version it is referring to.

I also believe that saying "with the latest version of the CLI" is redundant - the error message will only appear in a sufficiently up-to-date CLI.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
