### PR TITLE
fix(integ-runner): `--profile` not working with toolkit-lib engine

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -33,6 +33,13 @@ export interface ToolkitLibEngineOptions {
    * The region the CDK app should synthesize itself for
    */
   readonly region: string;
+
+  /**
+   * The AWS profile to use when authenticating
+   *
+   * @default - no profile is passed, the default profile is used
+   */
+  readonly profile?: string;
 }
 
 /**
@@ -56,6 +63,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
       ioHost: this.showOutput ? this.ioHost : new NoopIoHost(),
       sdkConfig: {
         baseCredentials: BaseCredentials.awsCliCompatible({
+          profile: options.profile,
           defaultRegion: options.region,
         }),
       },

--- a/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
@@ -20,6 +20,7 @@ export function makeEngine(options: IntegRunnerOptions): ICdk {
         showOutput: options.showOutput,
         env: options.env,
         region: options.region,
+        profile: options.profile,
       });
     case 'cli-wrapper':
     default:

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { HotswapMode } from '@aws-cdk/cdk-cli-wrapper';
-import { Toolkit } from '@aws-cdk/toolkit-lib';
+import { Toolkit, BaseCredentials } from '@aws-cdk/toolkit-lib';
 import { ToolkitLibRunnerEngine } from '../../lib/engines/toolkit-lib';
 
 jest.mock('@aws-cdk/toolkit-lib');
 
 const MockedToolkit = Toolkit as jest.MockedClass<typeof Toolkit>;
+const MockedBaseCredentials = BaseCredentials as jest.Mocked<typeof BaseCredentials>;
 
 describe('ToolkitLibRunnerEngine', () => {
   let mockToolkit: jest.Mocked<Toolkit>;
@@ -228,6 +229,21 @@ describe('ToolkitLibRunnerEngine', () => {
       expect(MockedToolkit).toHaveBeenCalledWith(expect.objectContaining({
         ioHost: expect.any(Object),
       }));
+    });
+
+    it('should pass profile to BaseCredentials', () => {
+      MockedBaseCredentials.awsCliCompatible = jest.fn();
+
+      new ToolkitLibRunnerEngine({
+        workingDirectory: '/test',
+        region: 'us-dummy-1',
+        profile: 'test-profile',
+      });
+
+      expect(MockedBaseCredentials.awsCliCompatible).toHaveBeenCalledWith({
+        profile: 'test-profile',
+        defaultRegion: 'us-dummy-1',
+      });
     });
 
     it('should throw error when no app is provided', async () => {


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/993

This change adds `profile` support to the toolkit-lib engine in the integ-runner package. The profile option is now passed through from the IntegRunnerOptions to the ToolkitLibEngineOptions and ultimately to the BaseCredentials configuration. This allows users to specify which AWS profile to use when running integration tests with the toolkit-lib engine, providing consistency with other authentication options already available in the integ-runner.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
