### PR TITLE
fix(cli): flags commands do not forward context parameters to synth

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/context-app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/context-app/app.js
@@ -1,0 +1,21 @@
+const cdk = require('aws-cdk-lib');
+
+const app = new cdk.App();
+
+const contextValue = app.node.tryGetContext('myContextParam');
+
+if (!contextValue) {
+  throw new Error('Context parameter "myContextParam" is required');
+}
+
+const stack = new cdk.Stack(app, 'TestStack', {
+  description: `Stack created with context value: ${contextValue}`,
+});
+
+// Add a simple resource
+new cdk.CfnOutput(stack, 'ContextValue', {
+  value: contextValue,
+  description: 'The context value passed via CLI',
+});
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/context-app/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/context-app/cdk.json
@@ -1,0 +1,6 @@
+{
+  "app": "node app.js",
+  "context": {
+    "@aws-cdk/core:newStyleStackSynthesis": true
+  }
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/flags/cdk-flags-with-cli-context.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/flags/cdk-flags-with-cli-context.integtest.ts
@@ -1,0 +1,25 @@
+import { integTest, withAws, withSpecificCdkApp } from '../../../lib';
+
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
+integTest(
+  'flags command works with CLI context parameters',
+  withAws(
+    withSpecificCdkApp('context-app', async (fixture) => {
+      await fixture.cdk(['bootstrap', '-c', 'myContextParam=testValue']);
+
+      const output = await fixture.cdk([
+        'flags',
+        '--unstable=flags',
+        '--set',
+        '--recommended',
+        '--all',
+        '-c', 'myContextParam=testValue',
+        '--yes',
+      ]);
+
+      expect(output).toContain('Flag changes:');
+    }),
+    true,
+  ),
+);

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -498,7 +498,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           unstableFeatures: configuration.settings.get(['unstable']),
         });
         const flagsData = await toolkit.flags(cloudExecutable);
-        const handler = new FlagCommandHandler(flagsData, ioHelper, args, toolkit);
+        const handler = new FlagCommandHandler(flagsData, ioHelper, args, toolkit, configuration.context.all);
         return handler.processFlagsCommand();
 
       case 'synthesize':

--- a/packages/aws-cdk/lib/commands/flags/flags.ts
+++ b/packages/aws-cdk/lib/commands/flags/flags.ts
@@ -14,13 +14,19 @@ export class FlagCommandHandler {
   private readonly ioHelper: IoHelper;
 
   /** Main component that sets up all flag operation components */
-  constructor(flagData: FeatureFlag[], ioHelper: IoHelper, options: FlagOperationsParams, toolkit: Toolkit) {
+  constructor(
+    flagData: FeatureFlag[],
+    ioHelper: IoHelper,
+    options: FlagOperationsParams,
+    toolkit: Toolkit,
+    cliContextValues: Record<string, any> = {},
+  ) {
     this.flags = flagData.filter(flag => !OBSOLETE_FLAGS.includes(flag.name));
     this.options = { ...options, concurrency: options.concurrency ?? 4 };
     this.ioHelper = ioHelper;
 
     const validator = new FlagValidator(ioHelper);
-    const flagOperations = new FlagOperations(this.flags, toolkit, ioHelper);
+    const flagOperations = new FlagOperations(this.flags, toolkit, ioHelper, cliContextValues);
     const interactiveHandler = new InteractiveHandler(this.flags, flagOperations);
 
     this.router = new FlagOperationRouter(validator, interactiveHandler, flagOperations);

--- a/packages/aws-cdk/test/cli/cli.test.ts
+++ b/packages/aws-cdk/test/cli/cli.test.ts
@@ -1,10 +1,10 @@
+import { Toolkit } from '@aws-cdk/toolkit-lib';
 import { Notices } from '../../lib/api/notices';
 import * as cdkToolkitModule from '../../lib/cli/cdk-toolkit';
 import { exec } from '../../lib/cli/cli';
 import { CliIoHost } from '../../lib/cli/io-host';
 import { Configuration } from '../../lib/cli/user-configuration';
 import { TestIoHost } from '../_helpers/io-host';
-import { Toolkit } from '@aws-cdk/toolkit-lib';
 
 // Store original version module exports so we don't conflict with other tests
 const originalVersion = jest.requireActual('../../lib/cli/version');
@@ -110,7 +110,6 @@ jest.mock('../../lib/commands/flags/flags', () => {
     }),
   };
 });
-
 
 describe('exec verbose flag tests', () => {
   beforeEach(() => {
@@ -554,7 +553,7 @@ describe('flags command tests', () => {
       },
       context: {
         all: {
-          'myContextParam': 'testValue',
+          myContextParam: 'testValue',
         },
         get: jest.fn().mockReturnValue([]),
       },

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -1227,9 +1227,6 @@ describe('CLI context parameters', () => {
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit, cliContextValues);
     await flagOperations.processFlagsCommand();
 
-    // Verify that fromCdkApp was called
-    expect(mockToolkit.fromCdkApp).toHaveBeenCalledTimes(2);
-
     // Get the first call's context store and verify it contains merged context
     // fromCdkApp(app, { contextStore: ..., outdir: ... }) was called
     const firstCallArgs = mockToolkit.fromCdkApp.mock.calls[0]; // Get first call arguments
@@ -1239,12 +1236,11 @@ describe('CLI context parameters', () => {
     // contextStore is defined as we've verified above
     const contextData = await contextStore!.read();
 
-    // Verify both file context and CLI context are present
     expect(contextData).toEqual({
-      '@aws-cdk/core:existingFlag': true, // from cdk.json
-      '@aws-cdk/core:testFlag': true,      // set by the operation
-      foo: 'bar',                          // from CLI
-      myContextParam: 'myValue',           // from CLI
+      '@aws-cdk/core:existingFlag': true,
+      '@aws-cdk/core:testFlag': true,
+      foo: 'bar',
+      myContextParam: 'myValue',
     });
 
     await cleanupCdkJsonFile(cdkJsonPath);
@@ -1276,9 +1272,6 @@ describe('CLI context parameters', () => {
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit, cliContextValues);
     await flagOperations.processFlagsCommand();
 
-    // Verify that fromCdkApp was called during safe flag checking
-    expect(mockToolkit.fromCdkApp).toHaveBeenCalled();
-
     // Get the first call's context store and verify it contains merged context
     // fromCdkApp(app, { contextStore: ..., outdir: ... }) was called
     const firstCallArgs = mockToolkit.fromCdkApp.mock.calls[0]; // Get first call arguments
@@ -1288,11 +1281,10 @@ describe('CLI context parameters', () => {
     // contextStore is defined as we've verified above
     const contextData = await contextStore!.read();
 
-    // Verify both file context and CLI context are merged
     expect(contextData).toEqual({
-      '@aws-cdk/core:fileFlag': false,  // from cdk.json
-      myCliParam: 'cliValue',            // from CLI
-      anotherParam: 'anotherValue',      // from CLI
+      '@aws-cdk/core:fileFlag': false,
+      myCliParam: 'cliValue',
+      anotherParam: 'anotherValue',
     });
 
     await cleanupCdkJsonFile(cdkJsonPath);

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -1249,7 +1249,7 @@ describe('CLI context parameters', () => {
 
   test('CLI context values are passed to synthesis during safe flag checking', async () => {
     const cdkJsonPath = await createCdkJsonFile({
-      '@aws-cdk/core:fileFlag': false,
+      '@aws-cdk/core:existingFlag': true,
     });
 
     mockToolkit.diff.mockResolvedValue({
@@ -1260,8 +1260,8 @@ describe('CLI context parameters', () => {
     requestResponseSpy.mockResolvedValue(false);
 
     const cliContextValues = {
-      myCliParam: 'cliValue',
-      anotherParam: 'anotherValue',
+      foo: 'bar',
+      myContextParam: 'myValue',
     };
 
     const options: FlagsOptions = {
@@ -1282,9 +1282,9 @@ describe('CLI context parameters', () => {
     const contextData = await contextStore!.read();
 
     expect(contextData).toEqual({
-      '@aws-cdk/core:fileFlag': false,
-      'myCliParam': 'cliValue',
-      'anotherParam': 'anotherValue',
+      '@aws-cdk/core:existingFlag': true,
+      'foo': 'bar',
+      'myContextParam': 'myValue',
     });
 
     await cleanupCdkJsonFile(cdkJsonPath);

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -1239,8 +1239,8 @@ describe('CLI context parameters', () => {
     expect(contextData).toEqual({
       '@aws-cdk/core:existingFlag': true,
       '@aws-cdk/core:testFlag': true,
-      foo: 'bar',
-      myContextParam: 'myValue',
+      'foo': 'bar',
+      'myContextParam': 'myValue',
     });
 
     await cleanupCdkJsonFile(cdkJsonPath);
@@ -1283,8 +1283,8 @@ describe('CLI context parameters', () => {
 
     expect(contextData).toEqual({
       '@aws-cdk/core:fileFlag': false,
-      myCliParam: 'cliValue',
-      anotherParam: 'anotherValue',
+      'myCliParam': 'cliValue',
+      'anotherParam': 'anotherValue',
     });
 
     await cleanupCdkJsonFile(cdkJsonPath);


### PR DESCRIPTION
Fixes #918

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
