### PR TITLE
fix(cli): upgrade jest in init-templates to remove one deprecation warning

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/javascript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/javascript/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "aws-cdk": "%cdk-cli-version%",
-    "jest": "^29.7.0"
+    "jest": "^30"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -11,10 +11,10 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
+    "@types/jest": "^30",
     "@types/node": "^24.10.1",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "jest": "^30",
+    "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.3"

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -13,8 +13,8 @@
     "@types/node": "^20.19.24",
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%",
-    "jest": "^29",
-    "ts-jest": "^30",
+    "jest": "^30",
+    "ts-jest": "^29",
     "typescript": "~5.9.3"
   },
   "peerDependencies": {

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -9,12 +9,12 @@
     "test": "jest"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
+    "@types/jest": "^30",
     "@types/node": "^20.19.24",
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "jest": "^29",
+    "ts-jest": "^30",
     "typescript": "~5.9.3"
   },
   "peerDependencies": {

--- a/packages/aws-cdk/lib/init-templates/sample-app/javascript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/javascript/package.json
@@ -11,7 +11,7 @@
   },
   "devDependencies": {
     "aws-cdk": "%cdk-cli-version%",
-    "jest": "^29.7.0"
+    "jest": "^30"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -11,10 +11,10 @@
     "cdk": "cdk"
   },
   "devDependencies": {
-    "@types/jest": "^29.5.14",
+    "@types/jest": "^30",
     "@types/node": "^24.10.1",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.2.5",
+    "jest": "^30",
+    "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.3"


### PR DESCRIPTION
Via a long transitive dependency chain, jest 29 depends on a package called `inflight` that throws up a warning on install:

```
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
```

Upgrade the package.json we generate upon `cdk init` to jest 30 so that customers don't see this warning. Even though everything works fine and this module is being used for testing so even if it leaked it wouldn't matter, it still gives them bad vibes.

We still have the following installation warning:

```
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
```

This dependency comes via:

```
jest 30.2 -> @jest/transform 30.2 -> babel-plugin-instanbul 7.0.1 -> test-exclude 6.0 -> glob 7.2.3
```

So still present in the latest jest, and there's nothing we can do about it.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
