### PR TITLE
feat(toolkit-lib): `BootstrapTemplate` helper provides access to bootstrap templates from source

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
@@ -254,15 +254,21 @@ export class BootstrapSource {
       templateFile,
     };
   }
+}
+
+/**
+ * Represents a bootstrap template that can be serialized to YAML or JSON
+ */
+export class BootstrapTemplate {
+  private constructor(private readonly template: any) {}
 
   /**
-   * Get the bootstrap template as a string
+   * Load a bootstrap template from a source
    *
    * @param source - The bootstrap template source configuration
-   * @param json - Whether to return JSON format (default: YAML)
-   * @returns The bootstrap template as a string
+   * @returns A BootstrapTemplate instance
    */
-  static async showTemplate(source: BootstrapOptions['source'] = { source: 'default' }, json: boolean = false): Promise<string> {
+  static async fromSource(source: BootstrapOptions['source'] = { source: 'default' }): Promise<BootstrapTemplate> {
     let template: any;
 
     switch (source.source) {
@@ -274,6 +280,24 @@ export class BootstrapSource {
         break;
     }
 
-    return serializeStructure(template, json);
+    return new BootstrapTemplate(template);
+  }
+
+  /**
+   * Serialize the template as YAML
+   *
+   * @returns The template as a YAML string
+   */
+  public asYAML(): string {
+    return serializeStructure(this.template, false);
+  }
+
+  /**
+   * Serialize the template as JSON
+   *
+   * @returns The template as a JSON string
+   */
+  public asJSON(): string {
+    return serializeStructure(this.template, true);
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
@@ -281,7 +281,8 @@ export class BootstrapTemplate {
     return new BootstrapTemplate(template);
   }
 
-  private constructor(private readonly template: any) {}
+  private constructor(private readonly template: any) {
+  }
 
   /**
    * Serialize the template as YAML

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
@@ -260,8 +260,6 @@ export class BootstrapSource {
  * Represents a bootstrap template that can be serialized to YAML or JSON
  */
 export class BootstrapTemplate {
-  private constructor(private readonly template: any) {}
-
   /**
    * Load a bootstrap template from a source
    *
@@ -282,6 +280,8 @@ export class BootstrapTemplate {
 
     return new BootstrapTemplate(template);
   }
+
+  private constructor(private readonly template: any) {}
 
   /**
    * Serialize the template as YAML

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
@@ -1,3 +1,4 @@
+import * as path from 'path';
 import type * as cxapi from '@aws-cdk/cx-api';
 import { environmentsFromDescriptors } from './private';
 import type { ICloudAssemblySource } from '../../api/cloud-assembly';
@@ -6,6 +7,7 @@ import type { IIoHost } from '../../api/io';
 import { asIoHelper } from '../../api/io/private';
 import type { Tag } from '../../api/tags';
 import { assemblyFromSource } from '../../toolkit/private';
+import { bundledPackageRootDir, loadStructuredFile, serializeStructure } from '../../util';
 
 /**
  * Create manage bootstrap environments
@@ -251,5 +253,27 @@ export class BootstrapSource {
       source: 'custom',
       templateFile,
     };
+  }
+
+  /**
+   * Get the bootstrap template as a string
+   *
+   * @param source - The bootstrap template source configuration
+   * @param json - Whether to return JSON format (default: YAML)
+   * @returns The bootstrap template as a string
+   */
+  static async showTemplate(source: BootstrapOptions['source'] = { source: 'default' }, json: boolean = false): Promise<string> {
+    let template: any;
+
+    switch (source.source) {
+      case 'custom':
+        template = await loadStructuredFile(source.templateFile);
+        break;
+      case 'default':
+        template = await loadStructuredFile(path.join(bundledPackageRootDir(__dirname), 'lib', 'api', 'bootstrap', 'bootstrap-template.yaml'));
+        break;
+    }
+
+    return serializeStructure(template, json);
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
@@ -627,4 +627,44 @@ describe('bootstrap', () => {
       }));
     });
   });
+
+  describe('BootstrapSource.showTemplate', () => {
+    test('can retrieve default bootstrap template as YAML', async () => {
+      // WHEN
+      const template = await BootstrapSource.showTemplate();
+
+      // THEN
+      expect(template).toContain('Description:');
+      expect(template).toContain('Parameters:');
+      expect(template).toContain('Resources:');
+      expect(template).toContain('StagingBucket:');
+      // Should be YAML format (not valid JSON)
+      expect(() => JSON.parse(template)).toThrow();
+    });
+
+    test('can retrieve default bootstrap template as JSON', async () => {
+      // WHEN
+      const template = await BootstrapSource.showTemplate(BootstrapSource.default(), true);
+
+      // THEN
+      const parsed = JSON.parse(template);
+      expect(parsed.Description).toBeDefined();
+      expect(parsed.Parameters).toBeDefined();
+      expect(parsed.Resources).toBeDefined();
+      expect(parsed.Resources.StagingBucket).toBeDefined();
+    });
+
+    test('can retrieve custom bootstrap template', async () => {
+      // GIVEN
+      const customTemplatePath = path.join(__dirname, '_fixtures/custom-bootstrap-template.yaml');
+
+      // WHEN
+      const template = await BootstrapSource.showTemplate(
+        BootstrapSource.customTemplate(customTemplatePath),
+      );
+
+      // THEN
+      expect(template).toContain('Description: Custom CDK Bootstrap Template');
+    });
+  });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/bootstrap.test.ts
@@ -11,7 +11,7 @@ import {
 import { bold } from 'chalk';
 
 import type { BootstrapOptions } from '../../lib/actions/bootstrap';
-import { BootstrapEnvironments, BootstrapSource, BootstrapStackParameters } from '../../lib/actions/bootstrap';
+import { BootstrapEnvironments, BootstrapSource, BootstrapStackParameters, BootstrapTemplate } from '../../lib/actions/bootstrap';
 import { SdkProvider } from '../../lib/api/aws-auth/private';
 import { Toolkit } from '../../lib/toolkit/toolkit';
 import { TestIoHost, builderFixture, disposableCloudAssemblySource } from '../_helpers';
@@ -628,10 +628,11 @@ describe('bootstrap', () => {
     });
   });
 
-  describe('BootstrapSource.showTemplate', () => {
+  describe('BootstrapTemplate.fromSource', () => {
     test('can retrieve default bootstrap template as YAML', async () => {
       // WHEN
-      const template = await BootstrapSource.showTemplate();
+      const bootstrapTemplate = await BootstrapTemplate.fromSource();
+      const template = bootstrapTemplate.asYAML();
 
       // THEN
       expect(template).toContain('Description:');
@@ -644,7 +645,8 @@ describe('bootstrap', () => {
 
     test('can retrieve default bootstrap template as JSON', async () => {
       // WHEN
-      const template = await BootstrapSource.showTemplate(BootstrapSource.default(), true);
+      const bootstrapTemplate = await BootstrapTemplate.fromSource();
+      const template = bootstrapTemplate.asJSON();
 
       // THEN
       const parsed = JSON.parse(template);
@@ -659,9 +661,10 @@ describe('bootstrap', () => {
       const customTemplatePath = path.join(__dirname, '_fixtures/custom-bootstrap-template.yaml');
 
       // WHEN
-      const template = await BootstrapSource.showTemplate(
+      const bootstrapTemplate = await BootstrapTemplate.fromSource(
         BootstrapSource.customTemplate(customTemplatePath),
       );
+      const template = bootstrapTemplate.asYAML();
 
       // THEN
       expect(template).toContain('Description: Custom CDK Bootstrap Template');


### PR DESCRIPTION
Fixes #1010 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
