### PR TITLE
fix(integ-runner): return explicit failure when assertion results are missing

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -177,6 +177,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
       traceLogs: options.traceLogs,
       stacks: this.stackSelector(options),
       deploymentMethod: this.deploymentMethod(options),
+      outputsFile: options.outputsFile ? path.join(this.options.workingDirectory, options.outputsFile) : undefined,
     });
   }
 


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/1007

When running integration tests with assertions, the `processAssertionResults` method would silently return `undefined` if the assertion results file didn't exist or if the assertion stack name wasn't found in the outputs. This made debugging failed integration tests difficult because there was no indication of what went wrong.

This change makes the method return explicit failure results with descriptive error messages in these scenarios, making it much easier to understand why an integration test with assertions didn't produce the expected results.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license