### PR TITLE
fix(integ-runner): assertion failures are incorrectly passing tests

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -177,6 +177,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
       traceLogs: options.traceLogs,
       stacks: this.stackSelector(options),
       deploymentMethod: this.deploymentMethod(options),
+      outputsFile: options.outputsFile ? path.join(this.options.workingDirectory, options.outputsFile) : undefined,
     });
   }
 

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
@@ -144,6 +144,30 @@ describe('ToolkitLibRunnerEngine', () => {
           method: 'hotswap',
           fallback: { method: 'change-set' },
         },
+        outputsFile: undefined,
+      });
+    });
+
+    it('should pass outputsFile with absolute path when provided', async () => {
+      const mockCx = {};
+      mockToolkit.fromCdkApp.mockResolvedValue(mockCx as any);
+
+      await engine.deploy({
+        app: 'test-app',
+        stacks: ['stack1'],
+        outputsFile: 'assertion-results.json',
+      });
+
+      expect(mockToolkit.deploy).toHaveBeenCalledWith(mockCx, {
+        stacks: {
+          strategy: 'pattern-must-match',
+          patterns: ['stack1'],
+          expand: 'upstream',
+        },
+        deploymentMethod: {
+          method: 'change-set',
+        },
+        outputsFile: '/test/dir/assertion-results.json',
       });
     });
 

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -634,6 +634,44 @@ describe('IntegTest runIntegTests', () => {
       app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
     }));
   });
+
+  test('with failed assertions', async () => {
+    // GIVEN
+    const outputsFile = 'cdk-integ.out.xxxxx.test-with-snapshot.js.snapshot/assertion-results.json';
+    const fullOutputsPath = `test/test-data/${outputsFile}`;
+    jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+    jest.spyOn(fs, 'readJSONSync').mockReturnValue({
+      BundlingDefaultTestDeployAssertAACA0CAF: {
+        AssertionResultsTest123: '{"status":"fail","message":"Expected 2 but received 1"}',
+      },
+    });
+    jest.spyOn(fs, 'unlinkSync').mockImplementation();
+
+    const integTest = new IntegTestRunner({
+      cdk: cdkMock.cdk,
+      region: 'eu-west-1',
+      test: new IntegTest({
+        fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
+        discoveryRoot: 'test/test-data',
+      }),
+    });
+
+    // WHEN
+    const results = await integTest.runIntegTestCase({
+      testCaseName: 'xxxxx.test-with-snapshot',
+    });
+
+    // THEN
+    expect(results).toBeDefined();
+    expect(results?.AssertionResultsTest123).toEqual({
+      status: 'fail',
+      message: 'Expected 2 but received 1',
+    });
+    expect(cdkMock.mocks.deploy).toHaveBeenCalledWith(expect.objectContaining({
+      outputsFile: fullOutputsPath,
+    }));
+    expect(fs.readJSONSync).toHaveBeenCalledWith(fullOutputsPath);
+  });
 });
 
 describe('IntegTest watchIntegTest', () => {


### PR DESCRIPTION
Fixes #1007

Integration tests were incorrectly reporting success even when assertions failed. The test output would show assertion failures in the CloudFormation stack outputs (with `"status":"fail"` messages), but the integ-runner would still report the test as passed.

This happened because the integ-runner wasn't passing the `outputsFile` option through to the toolkit-lib deploy method. Without this, assertion results were never written to disk and couldn't be evaluated by the test runner. The fix ensures the `outputsFile` path is properly resolved to an absolute path and passed through to the deploy method, allowing the runner to correctly detect and report assertion failures.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
