### PR TITLE
fix: checking `CdkBootstrapVersion` when the SSM parameter is encrypted

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-resources.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/environment/environment-resources.ts
@@ -142,7 +142,14 @@ export class EnvironmentResources {
     const ssm = this.sdk.ssm();
 
     try {
-      const result = await ssm.getParameter({ Name: parameterName });
+      const result = await ssm.getParameter({
+        Name: parameterName,
+        // A custom template might use a SecureString for this, so we request the decrypted parameter.
+        // The flag is safe to set, since it will be ignored for unencrypted parameters.
+        // It is still up to user to ensure that all roles have sufficient permissions,
+        // however when using AWS Managed Keys, SSM is granted decryption permissions by default.
+        WithDecryption: true,
+      });
 
       const asNumber = parseInt(`${result.Parameter?.Value}`, 10);
       if (isNaN(asNumber)) {

--- a/packages/@aws-cdk/toolkit-lib/lib/context-providers/ssm-parameters.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/context-providers/ssm-parameters.ts
@@ -36,7 +36,7 @@ export class SSMContextProviderPlugin implements ContextProviderPlugin {
   }
 
   /**
-   * Gets the value of an SSM Parameter, while not throwin if the parameter does not exist.
+   * Gets the value of an SSM Parameter, while not thrown if the parameter does not exist.
    * @param account       - the account in which the SSM Parameter is expected to be.
    * @param region        - the region in which the SSM Parameter is expected to be.
    * @param parameterName - the name of the SSM Parameter

--- a/packages/@aws-cdk/toolkit-lib/test/api/environment/environment-resources.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/environment/environment-resources.test.ts
@@ -80,7 +80,7 @@ test('failure to read SSM parameter results in exception passthrough for existin
   await expect(envResources().validateVersion(99, '/abc')).rejects.toThrow(/Computer says no/);
 });
 
-describe('validateversion without bootstrap stack', () => {
+describe('validate version without bootstrap stack', () => {
   beforeEach(() => {
     mockToolkitInfo(ToolkitInfo.bootstrapStackNotFoundInfo('TestBootstrapStack'));
   });
@@ -155,5 +155,21 @@ describe('validateversion without bootstrap stack', () => {
 
     // WHEN
     await expect(envResources().validateVersion(8, '/abc')).rejects.toThrow(/Has the environment been bootstrapped?/);
+  });
+
+  test('SSM parameter is requested with decryption enabled', async () => {
+    // GIVEN
+    mockSSMClient.on(GetParameterCommand).resolves({
+      Parameter: { Value: '10' },
+    });
+
+    // WHEN
+    await envResources().versionFromSsmParameter('/abc');
+
+    // THEN
+    expect(mockSSMClient.commandCalls(GetParameterCommand)[0].args[0].input).toEqual({
+      Name: '/abc',
+      WithDecryption: true,
+    });
   });
 });


### PR DESCRIPTION
When using a custom bootstrap template, users may choose to store the bootstrap version in a `SecureString` SSM parameter instead the default `String` type. The CDK CLI currently doesn't request decryption, causing it to fail when reading such parameters. While the parameter contains no sensitive data, overly aggressively configured checkers might flag the parameter.

This PR resolves #955, at least in most cases. It should now be possible to use a custom bootstrap template and encrypt the CDK Bootstrap version parameter. 

The change adds `WithDecryption: true` to the SSM `getParameter` call. The flag is safe to always set because it's ignored for unencrypted parameters. When using AWS Managed Keys, SSM already has the necessary decryption permissions by default via Key policy. Otherwise it is up to the user to ensure sufficient decryption permissions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
