### PR TITLE
chore: auto-approve dependabot and aws-cdk-lib upgrade PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,9 @@
 
 version: 2
 updates:
+  - package-ecosystem: npm
+    labels:
+      - auto-approve
   - package-ecosystem: pip
     directory: /packages/aws-cdk/lib/init-templates
     schedule:

--- a/.github/workflows/upgrade-aws-cdk-lib_aws-cdk.yml
+++ b/.github/workflows/upgrade-aws-cdk-lib_aws-cdk.yml
@@ -77,6 +77,7 @@ jobs:
             *Automatically created by projen via the "upgrade-aws-cdk-lib_aws-cdk" workflow*
           branch: github-actions/upgrade-aws-cdk-lib_aws-cdk
           title: "feat(deps): upgrade aws-cdk-lib"
+          labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1252,6 +1252,7 @@ new pj.javascript.UpgradeDependencies(cli, {
   workflow: true,
   workflowOptions: {
     schedule: pj.javascript.UpgradeDependenciesSchedule.WEEKDAY,
+    labels: ['auto-approve'],
   },
 });
 
@@ -1652,13 +1653,20 @@ cliInteg.gitignore.addPatterns('npm-shrinkwrap.json');
 new pj.YamlFile(repo, '.github/dependabot.yml', {
   obj: {
     version: 2,
-    updates: ['pip', 'maven', 'nuget'].map((pkgEco) => ({
-      'package-ecosystem': pkgEco,
-      'directory': '/packages/aws-cdk/lib/init-templates',
-      'schedule': { interval: 'weekly' },
-      'labels': ['auto-approve'],
-      'open-pull-requests-limit': 5,
-    })),
+    updates: [
+      {
+        'package-ecosystem': 'npm',
+        'labels': ['auto-approve'],
+      },
+      // init-templates
+      ...['pip', 'maven', 'nuget'].map((pkgEco) => ({
+        'package-ecosystem': pkgEco,
+        'directory': '/packages/aws-cdk/lib/init-templates',
+        'schedule': { interval: 'weekly' },
+        'labels': ['auto-approve'],
+        'open-pull-requests-limit': 5,
+      })),
+    ],
   },
   committed: true,
 });


### PR DESCRIPTION
These currently need manual approval, which is not our SOP.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
