### PR TITLE
chore: configure dependabot for all workspace packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,26 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    schedule:
+      interval: daily
     labels:
       - auto-approve
+    directories:
+      - /
+      - /packages/@aws-cdk-testing/cli-integ
+      - /packages/@aws-cdk/cdk-assets-lib
+      - /packages/@aws-cdk/cdk-cli-wrapper
+      - /packages/@aws-cdk/cli-plugin-contract
+      - /packages/@aws-cdk/cloud-assembly-api
+      - /packages/@aws-cdk/cloud-assembly-schema
+      - /packages/@aws-cdk/cloudformation-diff
+      - /packages/@aws-cdk/integ-runner
+      - /packages/@aws-cdk/toolkit-lib
+      - /packages/@aws-cdk/user-input-gen
+      - /packages/@aws-cdk/yarn-cling
+      - /packages/aws-cdk
+      - /packages/cdk
+      - /packages/cdk-assets
   - package-ecosystem: pip
     directory: /packages/aws-cdk/lib/init-templates
     schedule:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1656,7 +1656,12 @@ new pj.YamlFile(repo, '.github/dependabot.yml', {
     updates: [
       {
         'package-ecosystem': 'npm',
+        'schedule': { interval: 'daily' },
         'labels': ['auto-approve'],
+        'directories': ['/', ...repoProject.node.children
+          .filter(child => child instanceof TypeScriptWorkspace)
+          .map(ts => `/${path.relative(repoProject.outdir, ts.outdir)}`)
+          .sort()],
       },
       // init-templates
       ...['pip', 'maven', 'nuget'].map((pkgEco) => ({


### PR DESCRIPTION
The existing Dependabot configuration was invalid, missing the `directories` and `schedule` settings for npm packages. 

Unhelpfully, Dependabot only validates its configuration on `main` and not on a PR. This time I manually verified the config using `npx @bugron/validate-dependabot-yaml`. Yes, this is a 3P package, because there is also no official tool. 🙄 

This change dynamically generates the list of directories from all TypeScriptWorkspace projects in projen, ensuring new packages are automatically included in future Dependabot scans.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
