### PR TITLE
chore: add `deps-dev` as valid commit scope for dependabot PRs

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -44,6 +44,7 @@ jobs:
             cloud-assembly-schema
             cloudformation-diff
             deps
+            deps-dev
             dev-deps
             docs
             integ-runner

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1749,7 +1749,8 @@ repoProject.github?.tryFindWorkflow('pull-request-lint')?.file?.patch(
   pj.JsonPatch.replace('/jobs/validate/steps/0/with/scopes', [
     'cli',
     'deps',
-    'dev-deps',
+    'dev-deps', // projen
+    'deps-dev', // dependabot
     'docs',
     'bootstrap',
     'integ-testing',


### PR DESCRIPTION
Dependabot uses `deps-dev` as the conventional commit scope for dev dependency updates, while projen uses `dev-deps`. This adds `deps-dev` as a valid scope to the PR linter so dependabot PRs pass validation.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
