### PR TITLE
fix: CDK app fails to launch if paths contain spaces

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
@@ -107,58 +107,121 @@ export function spaceAvailableForContext(env: Env, limit: number) {
 /**
  * Guess the executable from the command-line argument
  *
- * Only do this if the file is NOT marked as executable. If it is,
- * we'll defer to the shebang inside the file itself.
+ * Input is the "app" string the user gave us. Output is the command line we are going to execute.
  *
- * If we're on Windows, we ALWAYS take the handler, since it's hard to
- * verify if registry associations have or have not been set up for this
- * file type, so we'll assume the worst and take control.
+ * - On Windows: it's hard to verify if registry associations have or have not
+ *   been set up for this file type (i.e., ShellExec'ing the file will work or not),
+ *   so we'll assume the worst and take control ourselves.
+ *
+ * - On POSIX: if the file is NOT marked as executable, guess the interpreter. If it is executable,
+ *   the correct interpreter should be in the file's shebang and we just execute it directly.
+ *
+ * The behavior of only guessing the interpreter if the command line is a single file name
+ * is a bit limited: we can't put a `.js` file with arguments in the command line and have
+ * it work properly. Nevertheless, this is the behavior we have had for a long time and nobody
+ * has really complained about it, so we'll keep it for now.
  */
-export async function guessExecutable(app: string, debugFn: (msg: string) => Promise<void>) {
-  const commandLine = appToArray(app);
-  if (commandLine.length === 1) {
-    let fstat;
-
-    try {
-      fstat = await fs.stat(commandLine[0]);
-    } catch {
-      await debugFn(`Not a file: '${commandLine[0]}'. Using '${commandLine}' as command-line`);
-      return commandLine;
-    }
-
-    // eslint-disable-next-line no-bitwise
-    const isExecutable = (fstat.mode & fs.constants.X_OK) !== 0;
-    const isWindows = process.platform === 'win32';
-
-    const handler = EXTENSION_MAP.get(path.extname(commandLine[0]));
-    if (handler && (!isExecutable || isWindows)) {
-      return handler(commandLine[0]);
-    }
+export async function guessExecutable(commandLine: string, debugFn: (msg: string) => Promise<void>): Promise<string> {
+  // The command line with spaces in it could reference a file on disk. If true,
+  // we quote it and return that, optionally by prefixing an interpreter.
+  const fullFile = await checkFile(commandLine);
+  if (fullFile) {
+    return guessInterpreter(fullFile);
   }
+
+  // Otherwise, the first word on the command line could reference a file on
+  // disk (quoted or non-quoted). If true, we optionally prefix an interpreter.
+  const [first, rest] = splitFirstShellWord(commandLine);
+  const firstFile = await checkFile(first);
+  if (firstFile) {
+    return `${guessInterpreter(firstFile)} ${rest}`.trim();
+  }
+
+  // We couldn't parse it, so just use the given command line.
+  await debugFn(`Not a file: '${commandLine}'. Using '${commandLine} as command-line`);
   return commandLine;
+}
+
+/**
+ * Guess the right interpreter to use to execute the given file and return a (partial) command line to execute it.
+ *
+ * This may entail:
+ *
+ * - Prefixing an interpreter if necessary
+ * - Quoting the file name if necessary
+ */
+function guessInterpreter(file: FileInfo): string {
+  const isWindows = process.platform === 'win32';
+
+  const handler = EXTENSION_MAP[path.extname(file.fileName)];
+  if (handler && (!file.isExecutable || isWindows)) {
+    return handler(file.fileName);
+  }
+
+  return quoteSpaces(file.fileName);
 }
 
 /**
  * Mapping of extensions to command-line generators
  */
-const EXTENSION_MAP = new Map<string, CommandGenerator>([
-  ['.js', executeNode],
-]);
+const EXTENSION_MAP: Record<string, CommandGenerator> = {
+  '.js': executeNode,
+};
 
-type CommandGenerator = (file: string) => string[];
+type CommandGenerator = (file: string) => string;
 
 /**
  * Execute the given file with the same 'node' process as is running the current process
  */
-function executeNode(scriptFile: string): string[] {
-  return [process.execPath, scriptFile];
+function executeNode(scriptFile: string): string {
+  return `${quoteSpaces(process.execPath)} ${quoteSpaces(scriptFile)}`;
 }
 
 /**
- * Make sure the 'app' is an array
- *
- * If it's a string, split on spaces as a trivial way of tokenizing the command line.
+ * Parse off the first quoted or unquoted shell word.
  */
-function appToArray(app: any) {
-  return typeof app === 'string' ? app.split(' ') : app;
+function splitFirstShellWord(commandLine: string): [string, string] {
+  commandLine = commandLine.trim();
+  if (commandLine[0] === '"') {
+    // Split on the next quote, ignore any escaping
+    const endQuote = commandLine.indexOf('"', 1);
+    return endQuote > -1 ? [commandLine.slice(1, endQuote), commandLine.slice(endQuote + 1).trim()] : [commandLine, ''];
+  } else {
+    // Split on the first space
+    const space = commandLine.indexOf(' ');
+    return space > -1 ? [commandLine.slice(0, space), commandLine.slice(space + 1)] : [commandLine, ''];
+  }
+}
+
+/**
+ * Look up a file and see if it exists and is executable
+ */
+async function checkFile(fileName: string): Promise<FileInfo | undefined> {
+  try {
+    const fstat = await fs.stat(fileName);
+    return  {
+      fileName,
+      // eslint-disable-next-line no-bitwise
+      isExecutable: (fstat.mode & fs.constants.X_OK) !== 0,
+    };
+  } catch {
+    return undefined;
+  }
+}
+
+interface FileInfo {
+  readonly fileName: string;
+  readonly isExecutable: boolean;
+}
+
+/**
+ * Quote a shell part if it contains spaces
+ *
+ * We're only interested in spaces, nothing else.
+ */
+function quoteSpaces(part: string) {
+  if (part.includes(' ')) {
+    return `"${part}"`;
+  }
+  return part;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
@@ -199,7 +199,7 @@ function splitFirstShellWord(commandLine: string): [string, string] {
 async function checkFile(fileName: string): Promise<FileInfo | undefined> {
   try {
     const fstat = await fs.stat(fileName);
-    return  {
+    return {
       fileName,
       // eslint-disable-next-line no-bitwise
       isExecutable: (fstat.mode & fs.constants.X_OK) !== 0,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -12,7 +12,7 @@ interface ExecOptions {
 }
 
 /**
- * Execute a command and args in a child process
+ * Execute a command line in a child process
  */
 export async function execInChildProcess(commandAndArgs: string, options: ExecOptions = {}) {
   return new Promise<void>((ok, fail) => {
@@ -27,9 +27,15 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
     const proc = child_process.spawn(commandAndArgs, {
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
-      shell: true,
       cwd: options.cwd,
       env: options.env,
+
+      // We are using 'shell: true' on purprose. Traditionally we have allowed shell features in
+      // this string, so we have to continue to do so into the future. On Windows, this is simply
+      // necessary to run .bat and .cmd files properly.
+      // Code scanning tools will flag this as a risk. The input comes from a trusted source,
+      // so it does not represent a security risk.
+      shell: true,
     });
 
     const eventPublisher: EventPublisher = options.eventPublisher ?? ((type, line) => {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -163,7 +163,7 @@ export class ExecutionEnvironment implements AsyncDisposable {
    * verify if registry associations have or have not been set up for this
    * file type, so we'll assume the worst and take control.
    */
-  public guessExecutable(app: string) {
+  public guessExecutable(app: string): Promise<string> {
     return guessExecutable(app, this.debugFn);
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
@@ -432,7 +432,10 @@ export abstract class CloudAssemblySourceBuilder {
     };
   }
   /**
-   * Use a directory containing an AWS CDK app as source.
+   * Use an AWS CDK app exectuable as source.
+   *
+   * `app` is a command line that will be executed to produce a Cloud Assembly.
+   * The command will be executed in a shell, so it must come from a trusted source.
    *
    * The subprocess will execute in `workingDirectory`, which defaults to
    * the current process' working directory if not given.
@@ -512,7 +515,7 @@ export abstract class CloudAssemblySourceBuilder {
           });
           const cleanupTemp = writeContextToEnv(env, fullContext, 'env-is-complete');
           try {
-            await execInChildProcess(commandLine.join(' '), {
+            await execInChildProcess(commandLine, {
               eventPublisher: async (type, line) => {
                 switch (type) {
                   case 'data_stdout':

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
@@ -51,7 +51,6 @@ test.each([
   expect(actual).toEqual(expected);
 });
 
-
 /**
  * Explode all 'both's in a test array to both false and true
  */
@@ -65,7 +64,7 @@ function explodeBoth<F extends unknown, R extends unknown[]>(input: [F, ...R]): 
   }
   const explodedRest = explodeBoth(rest as any);
 
-  const ret: [NotBoth<F>, ...NotBothA<R>][]  = [];
+  const ret: [NotBoth<F>, ...NotBothA<R>][] = [];
   for (const value of values) {
     for (const remainder of explodedRest) {
       ret.push([value as any, ...remainder] as any);

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
@@ -1,0 +1,79 @@
+import * as fs from 'fs-extra';
+import { guessExecutable } from '../../../lib/api/cloud-assembly/environment';
+
+const BOTH = 'both' as const;
+const DONTCARE = 'DONT-CARE';
+
+test.each([
+  // Just a simple command
+  ...explodeBoth(['asdf', BOTH, 'asdf', BOTH, DONTCARE, 'asdf']),
+  ...explodeBoth(['asdf', BOTH, 'asdf', undefined, DONTCARE, 'asdf']),
+  // Simple command with args
+  ...explodeBoth(['asdf arg', BOTH, 'asdf', BOTH, DONTCARE, 'asdf arg']),
+  ...explodeBoth(['asdf arg', BOTH, 'asdf', undefined, DONTCARE, 'asdf arg']),
+  // If the full path contains spaces and it's a file, quote it and execute it
+  ...explodeBoth(['/path with/spaces', BOTH, '/path with/spaces', BOTH, DONTCARE, '"/path with/spaces"']),
+  ...explodeBoth(['/path with/spaces', BOTH, '/path with/spaces', BOTH, DONTCARE, '"/path with/spaces"']),
+  // If the path is a .js file on Windows, prepend the node interpreter (quoted if necessary)
+  ...explodeBoth(['/path with/spaces.js', true, '/path with/spaces.js', BOTH, '/path/to/node', '/path/to/node "/path with/spaces.js"']),
+  ...explodeBoth(['/path with/spaces.js', true, '/path with/spaces.js', BOTH, '/path to/node', '"/path to/node" "/path with/spaces.js"']),
+  // If the path is a non-executable .js file on Linux, prepend the node interpreter (quoted if necessary)
+  ...explodeBoth(['/path with/spaces.js', false, '/path with/spaces.js', false, '/path/to/node', '/path/to/node "/path with/spaces.js"']),
+  ...explodeBoth(['/path with/spaces.js', false, '/path with/spaces.js', false, '/path to/node', '"/path to/node" "/path with/spaces.js"']),
+  // If the path is an executable .js file on Linux, don't do anything (perhaps except quoting)
+  ...explodeBoth(['/path/file.js', false, '/path/file.js', true, '/path/to/node', '/path/file.js']),
+  ...explodeBoth(['/path with spaces/file.js', false, '/path with spaces/file.js', true, '/path to/node', '"/path with spaces/file.js"']),
+  // If the path is quoted with spaces that also works
+  ...explodeBoth(['"command with spaces" arg1 arg2', BOTH, 'command with spaces', BOTH, DONTCARE, '"command with spaces" arg1 arg2']),
+  ...explodeBoth(['"command with spaces.js" arg1 arg2', true, 'command with spaces.js', false, '/node', '/node "command with spaces.js" arg1 arg2']),
+])('cmd=%p win=%p (stat=%p) exe=%p node=%p => %p', async (commandLine: string, isWindows: boolean, statFile: string, isExecutable: boolean | undefined, nodePath: string, expected: string) => {
+  // GIVEN
+  process.execPath = nodePath;
+  Object.defineProperty(process, 'platform', { value: isWindows ? 'win32' : 'linux' }) ;
+  jest.spyOn(fs, 'stat').mockImplementation((p) => {
+    if (p !== statFile) {
+      throw new Error(`Expected a stat() call on '${statFile}' but got '${p}'`);
+    }
+    if (isExecutable === undefined) {
+      const e = new Error(`No such file: ${p}`);
+      (e as any).code = 'ENOENT';
+      return Promise.reject(e);
+    }
+    return Promise.resolve({
+      mode: isExecutable ? fs.constants.X_OK : 0,
+    });
+  });
+
+  // WHEN
+  const actual = await guessExecutable(commandLine, (_) => Promise.resolve());
+
+  // THEN
+  expect(actual).toEqual(expected);
+});
+
+
+/**
+ * Explode all 'both's in a test array to both false and true
+ */
+function explodeBoth<F extends unknown, R extends unknown[]>(input: [F, ...R]): [NotBoth<F>, ...NotBothA<R>][] {
+  const [first, ...rest] = input;
+
+  const values = first === 'both' ? [false, true] : [first];
+
+  if (rest.length === 0) {
+    return [values as any];
+  }
+  const explodedRest = explodeBoth(rest as any);
+
+  const ret: [NotBoth<F>, ...NotBothA<R>][]  = [];
+  for (const value of values) {
+    for (const remainder of explodedRest) {
+      ret.push([value as any, ...remainder] as any);
+    }
+  }
+
+  return ret;
+}
+
+type NotBoth<A> = Exclude<A, 'both'>;
+type NotBothA<A extends unknown[]> = { [I in keyof A]: NotBoth<A[I]> };

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -86,7 +86,7 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
 
   const cleanupTemp = writeContextToEnv(env, context, 'add-process-env-later');
   try {
-    await exec(commandLine.join(' '));
+    await exec(commandLine);
 
     const assembly = createAssembly(outdir);
 

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -41,7 +41,7 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
     await exec(build);
   }
 
-  const app = config.settings.get(['app']);
+  let app = config.settings.get(['app']);
   if (!app) {
     throw new ToolkitError(`--app is required either in command-line, in ${PROJECT_CONFIG} or in ${USER_DEFAULTS}`);
   }
@@ -56,6 +56,13 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
     return { assembly: createAssembly(app), lock };
   }
 
+  // Traditionally it has been possible, though not widely advertised, to put a string[] into `cdk.json`.
+  // However, we would just quickly join this array back up to string with spaces (unquoted even!) and proceed as usual,
+  // thereby losing all the benefits of a pre-segmented command line. This coercion is just here for backwards
+  // compatibility with existing configurations. An upcoming PR might retain the benefit of the string[].
+  if (Array.isArray(app)) {
+    app = app.join(' ');
+  }
   const commandLine = await guessExecutable(app, debugFn);
 
   const outdir = config.settings.get(['output']);


### PR DESCRIPTION
When executing CDK apps, users specify the command as a string. The only feasible interpretation of that is by executing the command line through a shell, either `bash` or `cmd.exe`.

We are using shell execution on purpose:

- It's used for tests
- It's necessary on Windows to properly execute `.bat` and `.cmd` files
- Since we have historically offered it you can bet dollars to doughnuts that customers have built workflows depending on that.

This is all a preface to explain why we don't have an `argv` array. Automated code scanning tools will probably complain, but we can't change any of this. And since the source of the string and the machine it's executing on are part of the same security domain (it's all "the customer": the customer writes the command string, then executes it on their own machine), that is fine.

On that string the user gave us, historically we did do a bit of trivial parsing and preprocessing of that `string` in order to help the user achieve success. Specifically: if the string pointed to a `.js` file we would run that `.js` file through a Node interpreter, even if there would be potential misconfiguration obstacles in the way:

- We're on POSIX and the file was not marked as executable (can happen if the file is freshly produced by a `tsc` invocation); or
- We're on Windows and there is no shell association set up for `.js` files on Windows.

In both cases we would prepend our own Node executable's path to the command line in order to successfully run the "naked" `.js` file.

That behavior used to fail in the following cases:

- If the pointed-to file had spaces in its path.
- If Node was installed in a location that had spaces in its path.

In this PR we document the choice of command line string a bit better, and handle the cases where the file or interpreter paths can have spaces in them.

We still don't do fully generic command line parsing, because it's extremely complex on Windows and we can probably not do it correctly; we're just concerned with quoting the target and interpreter.

Historically it has been possible (though not widely documented) for the `{ "app" }` entry to contain a `string[]` (argv array). We traditionally used to join this back to a single space-separated string, even without applying quotes, so you wouldn't really benefit from that. Nevertheless, this PR retains that behavior.

Closes #636


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
