### PR TITLE
fix(cli): outdated instructions in README of python init template

### DIFF
--- a/packages/aws-cdk/lib/init-templates/app/python/README.template.md
+++ b/packages/aws-cdk/lib/init-templates/app/python/README.template.md
@@ -44,7 +44,7 @@ $ cdk synth
 ```
 
 To add additional dependencies, for example other CDK libraries, just add
-them to your `setup.py` file and rerun the `pip install -r requirements.txt`
+them to your `requirements.txt` file and rerun the `python -m pip install -r requirements.txt`
 command.
 
 ## Useful commands


### PR DESCRIPTION
Fixes issue [#9135](https://github.com/aws/aws-cdk/issues/9135) by updating the README to be consistent with [AWS docs](https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-python.html#work-with-cdk-python-dependencies)

Note that setup.py was removed from the python init-template in PR [#17062](https://github.com/aws/aws-cdk/pull/17062)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
