### PR TITLE
chore: use exact version for cloud assembly schema in cloud assembly api

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -507,7 +507,7 @@ const cloudAssemblyApi = configureProject(
     srcdir: 'lib',
     bundledDeps: ['jsonschema@~1.4.1', 'semver'],
     devDeps: [
-      cloudAssemblySchema.customizeReference({ versionType: 'exact' })
+      cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
     ],
     peerDeps: [
       cloudAssemblySchema.customizeReference({ versionType: 'any-future' }),

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -506,7 +506,9 @@ const cloudAssemblyApi = configureProject(
     description: 'API for working with Cloud Assemblies',
     srcdir: 'lib',
     bundledDeps: ['jsonschema@~1.4.1', 'semver'],
-    devDeps: [cloudAssemblySchema],
+    devDeps: [
+      cloudAssemblySchema.customizeReference({ versionType: 'exact' })
+    ],
     peerDeps: [
       cloudAssemblySchema.customizeReference({ versionType: 'any-future' }),
     ],


### PR DESCRIPTION
Fixes release failure:

https://github.com/aws/aws-cdk-cli/actions/runs/21218905022

due to:

```
👾 release | git diff --ignore-space-at-eol --exit-code
diff --git a/packages/@aws-cdk/cloud-assembly-api/package.json b/packages/@aws-cdk/cloud-assembly-api/package.json
index eaaee9fc..1c6e8e07 100644
--- a/packages/@aws-cdk/cloud-assembly-api/package.json
+++ b/packages/@aws-cdk/cloud-assembly-api/package.json
@@ -31,7 +31,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@aws-cdk/cloud-assembly-schema": "0.0.0",
+    "@aws-cdk/cloud-assembly-schema": "^0.0.0",
     "@cdklabs/eslint-plugin": "^1.5.0",
     "@stylistic/eslint-plugin": "^3",
     "@types/jest": "^30.0.0",
👾 Task "release" failed when executing "git diff --ignore-space-at-eol --exit-code" (cwd: /home/runner/work/aws-cdk-cli/aws-cdk-cli)
Error: Process completed with exit code 1.
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
