### PR TITLE
feat(cloudformation-diff): add Fn::ForEach intrinsic function diff support

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/index.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/index.ts
@@ -26,7 +26,18 @@ export function diffParameter(oldValue: types.Parameter, newValue: types.Paramet
   return new types.ParameterDifference(oldValue, newValue);
 }
 
-export function diffResource(oldValue?: types.Resource, newValue?: types.Resource): types.ResourceDifference {
+export function diffResource(oldValue?: types.Resource, newValue?: types.Resource, logicalId?: string): types.ResourceDifference {
+  // Fn::ForEach entries are arrays, not standard {Type, Properties} resource objects.
+  // Synthesize a virtual resource type so isDifferent works correctly.
+  if (logicalId && logicalId.startsWith('Fn::ForEach::')) {
+    const forEachType = 'Fn::ForEach';
+    return new types.ResourceDifference(oldValue, newValue, {
+      resourceType: { oldType: oldValue ? forEachType : undefined, newType: newValue ? forEachType : undefined },
+      propertyDiffs: {},
+      otherDiffs: !deepEqual(oldValue, newValue) ? { Value: new types.Difference(oldValue, newValue) } : {},
+    });
+  }
+
   const resourceType = {
     oldType: oldValue && oldValue.Type,
     newType: newValue && newValue.Type,

--- a/packages/@aws-cdk/cloudformation-diff/lib/format-foreach.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format-foreach.ts
@@ -1,0 +1,105 @@
+import * as chalk from 'chalk';
+
+const ADDITION = chalk.green('[+]');
+const UPDATE = chalk.yellow('[~]');
+const REMOVAL = chalk.red('[-]');
+
+/**
+ * Formatter for Fn::ForEach diff output
+ */
+export class ForEachDiffFormatter {
+  /**
+   * Format a ForEach resource difference
+   */
+  public formatForEach(
+    key: string,
+    oldValue: any | undefined,
+    newValue: any | undefined,
+  ): string[] {
+    const lines: string[] = [];
+    const changeType = this.getChangeType(oldValue, newValue);
+    const value = newValue ?? oldValue;
+
+    const loopName = key.replace('Fn::ForEach::', '');
+    const [collection, templateObj] = value;
+    const [[templateKey, templateValue]] = Object.entries(templateObj as Record<string, any>);
+
+    const count = Array.isArray(collection)
+      ? `${collection.length} resources`
+      : 'dynamic count';
+
+    lines.push(
+      `${this.changeSymbol(changeType)} ${chalk.cyan(key)} (expands to ${count} at deploy time)`,
+    );
+    lines.push(`    Loop variable: ${chalk.blue(loopName)}`);
+    lines.push(`    Collection: ${this.formatCollection(collection)}`);
+    lines.push(`    └── ${templateKey} ${chalk.cyan(templateValue.Type)}`);
+
+    if (changeType === 'update' && oldValue && newValue) {
+      const oldProps = oldValue[1][Object.keys(oldValue[1])[0]]?.Properties ?? {};
+      const newProps = newValue[1][Object.keys(newValue[1])[0]]?.Properties ?? {};
+      const propDiff = this.diffProperties(oldProps, newProps);
+      lines.push(...propDiff.map(l => `        ${l}`));
+    } else {
+      for (const [propKey, propValue] of Object.entries(templateValue.Properties ?? {})) {
+        lines.push(`        ${propKey}: ${this.formatValue(propValue)}`);
+      }
+    }
+
+    return lines;
+  }
+
+  private changeSymbol(type: 'add' | 'remove' | 'update'): string {
+    switch (type) {
+      case 'add': return ADDITION;
+      case 'remove': return REMOVAL;
+      case 'update': return UPDATE;
+    }
+  }
+
+  private formatCollection(collection: any): string {
+    if (Array.isArray(collection)) {
+      if (collection.length <= 5) return JSON.stringify(collection);
+      return `[${collection.slice(0, 3).join(', ')}, ... +${collection.length - 3} more]`;
+    }
+    return JSON.stringify(collection);
+  }
+
+  private getChangeType(oldVal: any, newVal: any): 'add' | 'remove' | 'update' {
+    if (!oldVal) return 'add';
+    if (!newVal) return 'remove';
+    return 'update';
+  }
+
+  private formatValue(value: any): string {
+    if (typeof value === 'string') return value;
+    return JSON.stringify(value);
+  }
+
+  private diffProperties(oldProps: Record<string, any>, newProps: Record<string, any>): string[] {
+    const lines: string[] = [];
+    const allKeys = new Set([...Object.keys(oldProps), ...Object.keys(newProps)]);
+
+    for (const key of allKeys) {
+      const oldVal = oldProps[key];
+      const newVal = newProps[key];
+
+      if (oldVal === undefined) {
+        lines.push(`${ADDITION} ${key}: ${this.formatValue(newVal)}`);
+      } else if (newVal === undefined) {
+        lines.push(`${REMOVAL} ${key}: ${this.formatValue(oldVal)}`);
+      } else if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+        lines.push(`${UPDATE} ${key}: ${this.formatValue(oldVal)} → ${this.formatValue(newVal)}`);
+      }
+    }
+
+    return lines;
+  }
+}
+
+/**
+ * Check if a logical ID represents a ForEach construct
+ */
+export function isForEachKey(logicalId: string): boolean {
+  return logicalId.startsWith('Fn::ForEach::');
+}

--- a/packages/@aws-cdk/cloudformation-diff/lib/format-foreach.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format-foreach.ts
@@ -1,11 +1,16 @@
 import * as chalk from 'chalk';
+import { deepEqual } from './diff/util';
 
 const ADDITION = chalk.green('[+]');
 const UPDATE = chalk.yellow('[~]');
 const REMOVAL = chalk.red('[-]');
 
 /**
- * Formatter for Fn::ForEach diff output
+ * Formatter for Fn::ForEach diff output.
+ *
+ * Fn::ForEach is a CloudFormation intrinsic that expands a template fragment
+ * over a collection at deploy time. Its value is an array:
+ *   [collection, { "LogicalId${Var}": { Type, Properties } }]
  */
 export class ForEachDiffFormatter {
   /**
@@ -20,9 +25,21 @@ export class ForEachDiffFormatter {
     const changeType = this.getChangeType(oldValue, newValue);
     const value = newValue ?? oldValue;
 
+    if (!Array.isArray(value) || value.length < 2) {
+      lines.push(`${this.changeSymbol(changeType)} ${chalk.cyan(key)} (unrecognized ForEach structure)`);
+      return lines;
+    }
+
     const loopName = key.replace('Fn::ForEach::', '');
     const [collection, templateObj] = value;
-    const [[templateKey, templateValue]] = Object.entries(templateObj as Record<string, any>);
+    const entries = Object.entries(templateObj as Record<string, any>);
+
+    if (entries.length === 0) {
+      lines.push(`${this.changeSymbol(changeType)} ${chalk.cyan(key)} (empty ForEach template)`);
+      return lines;
+    }
+
+    const [[templateKey, templateValue]] = entries;
 
     const count = Array.isArray(collection)
       ? `${collection.length} resources`
@@ -33,15 +50,15 @@ export class ForEachDiffFormatter {
     );
     lines.push(`    Loop variable: ${chalk.blue(loopName)}`);
     lines.push(`    Collection: ${this.formatCollection(collection)}`);
-    lines.push(`    └── ${templateKey} ${chalk.cyan(templateValue.Type)}`);
+    lines.push(`    └── ${templateKey} ${chalk.cyan(templateValue?.Type ?? 'Unknown')}`);
 
     if (changeType === 'update' && oldValue && newValue) {
-      const oldProps = oldValue[1][Object.keys(oldValue[1])[0]]?.Properties ?? {};
-      const newProps = newValue[1][Object.keys(newValue[1])[0]]?.Properties ?? {};
+      const oldProps = oldValue[1]?.[Object.keys(oldValue[1])[0]]?.Properties ?? {};
+      const newProps = newValue[1]?.[Object.keys(newValue[1])[0]]?.Properties ?? {};
       const propDiff = this.diffProperties(oldProps, newProps);
       lines.push(...propDiff.map(l => `        ${l}`));
     } else {
-      for (const [propKey, propValue] of Object.entries(templateValue.Properties ?? {})) {
+      for (const [propKey, propValue] of Object.entries(templateValue?.Properties ?? {})) {
         lines.push(`        ${propKey}: ${this.formatValue(propValue)}`);
       }
     }
@@ -88,7 +105,7 @@ export class ForEachDiffFormatter {
         lines.push(`${ADDITION} ${key}: ${this.formatValue(newVal)}`);
       } else if (newVal === undefined) {
         lines.push(`${REMOVAL} ${key}: ${this.formatValue(oldVal)}`);
-      } else if (JSON.stringify(oldVal) !== JSON.stringify(newVal)) {
+      } else if (!deepEqual(oldVal, newVal)) {
         lines.push(`${UPDATE} ${key}: ${this.formatValue(oldVal)} → ${this.formatValue(newVal)}`);
       }
     }

--- a/packages/@aws-cdk/cloudformation-diff/lib/format.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/format.ts
@@ -4,6 +4,7 @@ import type { DifferenceCollection, Move, TemplateDiff } from './diff/types';
 import { deepEqual } from './diff/util';
 import type { Difference, ResourceDifference } from './diff-template';
 import { isPropertyDifference, ResourceImpact } from './diff-template';
+import { ForEachDiffFormatter, isForEachKey } from './format-foreach';
 import { formatTable } from './format-table';
 import type { IamChanges } from './iam/iam-changes';
 import type { SecurityGroupChanges } from './network/security-group-changes';
@@ -161,6 +162,16 @@ export class Formatter {
    */
   public formatResourceDifference(_type: string, logicalId: string, diff: ResourceDifference) {
     if (!diff.isDifferent) {
+      return;
+    }
+
+    // Handle Fn::ForEach resources specially
+    if (isForEachKey(logicalId)) {
+      const forEachFormatter = new ForEachDiffFormatter();
+      const lines = forEachFormatter.formatForEach(logicalId, diff.oldValue, diff.newValue);
+      for (const line of lines) {
+        this.print(line);
+      }
       return;
     }
 

--- a/packages/@aws-cdk/cloudformation-diff/lib/index.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/index.ts
@@ -1,5 +1,6 @@
 export * from './diff-template';
 export * from './format';
+export * from './format-foreach';
 export * from './format-table';
 export * from './mappings';
 export { deepEqual, mangleLikeCloudFormation } from './diff/util';

--- a/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
@@ -1,0 +1,116 @@
+import { ForEachDiffFormatter, isForEachKey } from '../lib/format-foreach';
+
+describe('isForEachKey', () => {
+  test('returns true for ForEach keys', () => {
+    expect(isForEachKey('Fn::ForEach::Env')).toBe(true);
+    expect(isForEachKey('Fn::ForEach::Item')).toBe(true);
+    expect(isForEachKey('Fn::ForEach::MyLoop')).toBe(true);
+  });
+
+  test('returns false for non-ForEach keys', () => {
+    expect(isForEachKey('MyBucket')).toBe(false);
+    expect(isForEachKey('AWS::S3::Bucket')).toBe(false);
+    expect(isForEachKey('Fn::GetAtt')).toBe(false);
+  });
+});
+
+describe('ForEachDiffFormatter', () => {
+  const formatter = new ForEachDiffFormatter();
+
+  const forEachValue = [
+    ['dev', 'prod'],
+    {
+      'Bucket${Env}': {
+        Type: 'AWS::S3::Bucket',
+        Properties: {
+          BucketName: 'test-${Env}',
+        },
+      },
+    },
+  ];
+
+  test('formats ForEach addition', () => {
+    const lines = formatter.formatForEach('Fn::ForEach::Env', undefined, forEachValue);
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('[+]');
+    expect(lines[0]).toContain('Fn::ForEach::Env');
+    expect(lines[0]).toContain('2 resources');
+    expect(lines.some(l => l.includes('Loop variable'))).toBe(true);
+    expect(lines.some(l => l.includes('Env'))).toBe(true);
+    expect(lines.some(l => l.includes('Collection'))).toBe(true);
+    expect(lines.some(l => l.includes('AWS::S3::Bucket'))).toBe(true);
+  });
+
+  test('formats ForEach removal', () => {
+    const lines = formatter.formatForEach('Fn::ForEach::Env', forEachValue, undefined);
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('[-]');
+    expect(lines[0]).toContain('Fn::ForEach::Env');
+  });
+
+  test('formats ForEach update', () => {
+    const oldValue = [
+      ['dev', 'prod'],
+      {
+        'Bucket${Env}': {
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            BucketName: 'old-${Env}',
+          },
+        },
+      },
+    ];
+
+    const newValue = [
+      ['dev', 'prod', 'staging'],
+      {
+        'Bucket${Env}': {
+          Type: 'AWS::S3::Bucket',
+          Properties: {
+            BucketName: 'new-${Env}',
+          },
+        },
+      },
+    ];
+
+    const lines = formatter.formatForEach('Fn::ForEach::Env', oldValue, newValue);
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(lines[0]).toContain('[~]');
+    expect(lines[0]).toContain('3 resources');
+  });
+
+  test('handles dynamic collection', () => {
+    const dynamicValue = [
+      { Ref: 'EnvList' },
+      {
+        'Bucket${Env}': {
+          Type: 'AWS::S3::Bucket',
+          Properties: {},
+        },
+      },
+    ];
+
+    const lines = formatter.formatForEach('Fn::ForEach::Env', undefined, dynamicValue);
+
+    expect(lines[0]).toContain('dynamic count');
+  });
+
+  test('truncates large collections', () => {
+    const largeValue = [
+      ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+      {
+        'Bucket${Item}': {
+          Type: 'AWS::S3::Bucket',
+          Properties: {},
+        },
+      },
+    ];
+
+    const lines = formatter.formatForEach('Fn::ForEach::Item', undefined, largeValue);
+
+    expect(lines.some(l => l.includes('+4 more'))).toBe(true);
+  });
+});

--- a/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
@@ -1,4 +1,4 @@
-import { ForEachDiffFormatter, isForEachKey } from '../lib/format-foreach';
+import { ForEachDiffFormatter, isForEachKey, fullDiff, formatDifferences } from '../lib';
 
 describe('isForEachKey', () => {
   test('returns true for ForEach keys', () => {
@@ -112,5 +112,137 @@ describe('ForEachDiffFormatter', () => {
     const lines = formatter.formatForEach('Fn::ForEach::Item', undefined, largeValue);
 
     expect(lines.some(l => l.includes('+4 more'))).toBe(true);
+  });
+
+  test('handles malformed ForEach value gracefully', () => {
+    const lines = formatter.formatForEach('Fn::ForEach::Bad', undefined, ['only-one-element']);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('unrecognized ForEach structure');
+  });
+
+  test('handles empty template object gracefully', () => {
+    const lines = formatter.formatForEach('Fn::ForEach::Empty', undefined, [['a'], {}]);
+    expect(lines.length).toBe(1);
+    expect(lines[0]).toContain('empty ForEach template');
+  });
+});
+
+describe('ForEach integration (fullDiff → formatDifferences)', () => {
+  function collectOutput(cb: (stream: NodeJS.WritableStream) => void): string {
+    const chunks: string[] = [];
+    const stream = {
+      write(chunk: string) { chunks.push(chunk); return true; },
+      end() {},
+      on() { return this; },
+      once() { return this; },
+      emit() { return false; },
+      addListener() { return this; },
+      removeListener() { return this; },
+    } as any;
+    cb(stream);
+    return chunks.join('');
+  }
+
+  test('adding a ForEach resource produces diff output', () => {
+    const diff = fullDiff(
+      { Resources: {} },
+      {
+        Resources: {
+          'Fn::ForEach::Env': [
+            ['dev', 'prod'],
+            { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'app-${Env}' } } },
+          ],
+        },
+      },
+    );
+
+    expect(diff.resources.differenceCount).toBe(1);
+
+    const output = collectOutput((stream) => formatDifferences(stream, diff));
+    expect(output).toContain('Fn::ForEach::Env');
+    expect(output).toContain('2 resources');
+    expect(output).toContain('AWS::S3::Bucket');
+  });
+
+  test('removing a ForEach resource produces diff output', () => {
+    const diff = fullDiff(
+      {
+        Resources: {
+          'Fn::ForEach::Env': [
+            ['dev', 'prod'],
+            { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: {} } },
+          ],
+        },
+      },
+      { Resources: {} },
+    );
+
+    expect(diff.resources.differenceCount).toBe(1);
+
+    const output = collectOutput((stream) => formatDifferences(stream, diff));
+    expect(output).toContain('Fn::ForEach::Env');
+    expect(output).toContain('[-]');
+  });
+
+  test('updating a ForEach resource produces diff output', () => {
+    const diff = fullDiff(
+      {
+        Resources: {
+          'Fn::ForEach::Env': [
+            ['dev', 'prod'],
+            { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'old-${Env}' } } },
+          ],
+        },
+      },
+      {
+        Resources: {
+          'Fn::ForEach::Env': [
+            ['dev', 'staging', 'prod'],
+            { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'new-${Env}' } } },
+          ],
+        },
+      },
+    );
+
+    expect(diff.resources.differenceCount).toBe(1);
+
+    const output = collectOutput((stream) => formatDifferences(stream, diff));
+    expect(output).toContain('[~]');
+    expect(output).toContain('3 resources');
+  });
+
+  test('unchanged ForEach resource produces no diff', () => {
+    const template = {
+      Resources: {
+        'Fn::ForEach::Env': [
+          ['dev', 'prod'],
+          { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: {} } },
+        ],
+      },
+    };
+
+    const diff = fullDiff(template, template);
+    expect(diff.resources.differenceCount).toBe(0);
+  });
+
+  test('ForEach alongside regular resources diffs correctly', () => {
+    const diff = fullDiff(
+      { Resources: {} },
+      {
+        Resources: {
+          MyBucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'solo' } },
+          'Fn::ForEach::Env': [
+            ['dev', 'prod'],
+            { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: {} } },
+          ],
+        },
+      },
+    );
+
+    expect(diff.resources.differenceCount).toBe(2);
+
+    const output = collectOutput((stream) => formatDifferences(stream, diff));
+    expect(output).toContain('MyBucket');
+    expect(output).toContain('Fn::ForEach::Env');
   });
 });

--- a/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/format-foreach.test.ts
@@ -131,13 +131,26 @@ describe('ForEach integration (fullDiff → formatDifferences)', () => {
   function collectOutput(cb: (stream: NodeJS.WritableStream) => void): string {
     const chunks: string[] = [];
     const stream = {
-      write(chunk: string) { chunks.push(chunk); return true; },
-      end() {},
-      on() { return this; },
-      once() { return this; },
-      emit() { return false; },
-      addListener() { return this; },
-      removeListener() { return this; },
+      write(chunk: string) {
+        chunks.push(chunk); return true;
+      },
+      end() {
+      },
+      on() {
+        return this;
+      },
+      once() {
+        return this;
+      },
+      emit() {
+        return false;
+      },
+      addListener() {
+        return this;
+      },
+      removeListener() {
+        return this;
+      },
     } as any;
     cb(stream);
     return chunks.join('');
@@ -230,7 +243,7 @@ describe('ForEach integration (fullDiff → formatDifferences)', () => {
       { Resources: {} },
       {
         Resources: {
-          MyBucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'solo' } },
+          'MyBucket': { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'solo' } },
           'Fn::ForEach::Env': [
             ['dev', 'prod'],
             { 'Bucket${Env}': { Type: 'AWS::S3::Bucket', Properties: {} } },


### PR DESCRIPTION
## Problem

When a CloudFormation template uses `Fn::ForEach` to loop over a collection and create resources at deploy time, `cdk diff` has no way to display those entries. The diff engine treats `Fn::ForEach::*` keys as standard resources, but since their values are arrays (not `{Type, Properties}` objects), `ResourceDifference.isDifferent` always returns `false` and they are silently dropped from the output.

This means users get no visibility into additions, removals, or changes to ForEach loops when running `cdk diff`.

## Solution

- Add `ForEachDiffFormatter` for specialized ForEach formatting that shows the loop variable, collection, resource template type, and property-level diffs.
- Fix `diffResource` to accept the logical ID and synthesize a virtual `Fn::ForEach` resource type for ForEach keys, so the diff engine correctly detects additions, removals, and updates.
- Guard against malformed ForEach values (non-array, missing template object) with graceful fallbacks.
- Add integration tests through the full `fullDiff` / `formatDifferences` pipeline.

## Before

ForEach entries are completely invisible in `cdk diff` output:

```
Resources

(empty - ForEach resources silently dropped)
```

## After

### Adding a ForEach loop

```
Resources
[+] Fn::ForEach::Env (expands to 3 resources at deploy time)
    Loop variable: Env
    Collection: ["dev","staging","prod"]
    └── Bucket${Env} AWS::S3::Bucket
        BucketName: myapp-${Env}
        VersioningConfiguration: {"Status":"Enabled"}
```

### Updating a ForEach loop (add env + change property)

```
Resources
[~] Fn::ForEach::Env (expands to 3 resources at deploy time)
    Loop variable: Env
    Collection: ["dev","staging","prod"]
    └── Bucket${Env} AWS::S3::Bucket
        [~] BucketName: myapp-${Env} → myapp-v2-${Env}
        [+] VersioningConfiguration: {"Status":"Enabled"}
```

### Removing a ForEach loop

```
Resources
[-] Fn::ForEach::Env (expands to 2 resources at deploy time)
    Loop variable: Env
    Collection: ["dev","prod"]
    └── Bucket${Env} AWS::S3::Bucket
        BucketName: myapp-${Env}
```

### Dynamic collection (Ref-based)

```
Resources
[+] Fn::ForEach::Region (expands to dynamic count at deploy time)
    Loop variable: Region
    Collection: {"Ref":"TargetRegions"}
    └── Table${Region} AWS::DynamoDB::Table
        TableName: data-${Region}
        BillingMode: PAY_PER_REQUEST
```

### ForEach alongside regular resources

```
Resources
[+] AWS::Logs::LogGroup LogGroup
[+] Fn::ForEach::Env (expands to 2 resources at deploy time)
    Loop variable: Env
    Collection: ["dev","prod"]
    └── Bucket${Env} AWS::S3::Bucket
        BucketName: myapp-${Env}
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license