### PR TITLE
chore(deps-dev): bump eslint-plugin-jest and @cdklabs/typewriter

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "glob": "^11.1.0",
     "jest-junit": "^16",

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -56,7 +56,7 @@
     "eslint-config-prettier": "^9.1.2",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/cdk-assets-lib/package.json
+++ b/packages/@aws-cdk/cdk-assets-lib/package.json
@@ -48,7 +48,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "fs-extra": "^11.3.3",

--- a/packages/@aws-cdk/cdk-cli-wrapper/package.json
+++ b/packages/@aws-cdk/cdk-cli-wrapper/package.json
@@ -41,7 +41,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/cli-plugin-contract/package.json
+++ b/packages/@aws-cdk/cli-plugin-contract/package.json
@@ -43,7 +43,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/cloud-assembly-schema/package.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/package.json
@@ -52,7 +52,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/cloudformation-diff/package.json
+++ b/packages/@aws-cdk/cloudformation-diff/package.json
@@ -44,7 +44,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "fast-check": "^3.23.2",

--- a/packages/@aws-cdk/integ-runner/package.json
+++ b/packages/@aws-cdk/integ-runner/package.json
@@ -52,7 +52,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -59,7 +59,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "fast-check": "^4.4.0",

--- a/packages/@aws-cdk/user-input-gen/package.json
+++ b/packages/@aws-cdk/user-input-gen/package.json
@@ -45,7 +45,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",
@@ -55,7 +55,7 @@
     "typescript": "5.9"
   },
   "dependencies": {
-    "@cdklabs/typewriter": "^0.0.14",
+    "@cdklabs/typewriter": "^0.0.15",
     "lodash.clonedeep": "^4.5.0",
     "prettier": "^2.8"
   },

--- a/packages/@aws-cdk/user-input-gen/test/__snapshots__/yargs-gen.test.ts.snap
+++ b/packages/@aws-cdk/user-input-gen/test/__snapshots__/yargs-gen.test.ts.snap
@@ -6,8 +6,8 @@ exports[`render can generate global options 1`] = `
 // Do not edit by hand; all changes will be overwritten at build time from the config file.
 // -------------------------------------------------------------------------------------------
 /* eslint-disable @stylistic/max-len, @typescript-eslint/consistent-type-imports */
-import * as helpers from './util/yargs-helpers';
 import { Argv } from 'yargs';
+import * as helpers from './util/yargs-helpers';
 
 // @ts-ignore TS6133
 export function parseCommandLineArguments(args: Array<string>): any {
@@ -54,8 +54,8 @@ exports[`render can generate negativeAlias 1`] = `
 // Do not edit by hand; all changes will be overwritten at build time from the config file.
 // -------------------------------------------------------------------------------------------
 /* eslint-disable @stylistic/max-len, @typescript-eslint/consistent-type-imports */
-import * as helpers from './util/yargs-helpers';
 import { Argv } from 'yargs';
+import * as helpers from './util/yargs-helpers';
 
 // @ts-ignore TS6133
 export function parseCommandLineArguments(args: Array<string>): any {
@@ -94,8 +94,8 @@ exports[`render special notification-arn option gets NO default value 1`] = `
 // Do not edit by hand; all changes will be overwritten at build time from the config file.
 // -------------------------------------------------------------------------------------------
 /* eslint-disable @stylistic/max-len, @typescript-eslint/consistent-type-imports */
-import * as helpers from './util/yargs-helpers';
 import { Argv } from 'yargs';
+import * as helpers from './util/yargs-helpers';
 
 // @ts-ignore TS6133
 export function parseCommandLineArguments(args: Array<string>): any {

--- a/packages/@aws-cdk/yarn-cling/package.json
+++ b/packages/@aws-cdk/yarn-cling/package.json
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "fast-check": "^4.4.0",

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -61,7 +61,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "fast-check": "^3.23.2",

--- a/packages/cdk-assets/package.json
+++ b/packages/cdk-assets/package.json
@@ -51,7 +51,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -46,7 +46,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^28.14.0",
+    "eslint-plugin-jest": "^29.12.1",
     "eslint-plugin-jsdoc": "^62.4.1",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^29.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,10 +2968,10 @@
   resolved "https://registry.yarnpkg.com/@cdklabs/tskb/-/tskb-0.0.4.tgz#6d7af32427ef947dddcb6f1f1d76d75924e33323"
   integrity sha512-NFx1X0l7p5DyHtLLEyNeh1hPN4UN9hTkZkzFs/Mp+kFk7dpdINGmGVpCfRDjJ2DrcNSNENUmT+w8g73TvmBbTw==
 
-"@cdklabs/typewriter@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@cdklabs/typewriter/-/typewriter-0.0.14.tgz#57f10a3acb36c1e3604a8c5233e381579939d03e"
-  integrity sha512-Om+W7PT4OOwdgkxXGm6Xyk3sj3aGWcAys3qMs9tWivENKfluD2WvL4J7+ZhmIcNdJ9oqE8X/9kR+ne92QdsJLA==
+"@cdklabs/typewriter@^0.0.15":
+  version "0.0.15"
+  resolved "https://registry.yarnpkg.com/@cdklabs/typewriter/-/typewriter-0.0.15.tgz#7f10149dfad8ba96cbdbe13c897581d8ebf0c6ac"
+  integrity sha512-plRMUPYH8yQN+4C9UhyMNFa+rQGVkH3S2sADdy7Rw4D/wYZNrwIi8Pt9TV+JEPVIwzlEpIWffVIE643/aY3fCQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -5552,7 +5552,7 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@8.50.0", "@typescript-eslint/utils@^6.0.0 || ^7.0.0 || ^8.0.0", "@typescript-eslint/utils@^8.13.0":
+"@typescript-eslint/utils@8.50.0", "@typescript-eslint/utils@^8.13.0":
   version "8.50.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.50.0.tgz#107f20a5747eab5db988c5f6ad462b59851cdd1f"
   integrity sha512-87KgUXET09CRjGCi2Ejxy3PULXna63/bMYv72tCAlDJC3Yqwln0HiFJ3VJMst2+mEtNtZu5oFvX4qJGjKsnAgg==
@@ -8049,13 +8049,6 @@ eslint-plugin-import@^2.32.0:
     semver "^6.3.1"
     string.prototype.trimend "^1.0.9"
     tsconfig-paths "^3.15.0"
-
-eslint-plugin-jest@^28.14.0:
-  version "28.14.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-28.14.0.tgz#02da77dc27d7b4c5480df3552ea26de056857b36"
-  integrity sha512-P9s/qXSMTpRTerE2FQ0qJet2gKbcGyFTPAJipoKxmWqR6uuFqIqk8FuEfg5yBieOezVrEfAMZrEwJ6yEp+1MFQ==
-  dependencies:
-    "@typescript-eslint/utils" "^6.0.0 || ^7.0.0 || ^8.0.0"
 
 eslint-plugin-jest@^29.12.1:
   version "29.12.1"


### PR DESCRIPTION
This PR updates development dependencies across all packages in the monorepo.

The main changes are:
- `eslint-plugin-jest` from v28 to v29 - this is a major version bump that brings improved ESLint 9 compatibility and updated rules
- `@cdklabs/typewriter` from v0.0.14 to v0.0.15 in user-input-gen - this minor update changes import ordering in generated code, which is reflected in the snapshot updates. Without the ordering, the generated code was conflicting with our ESLint rule, causing confusion.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
