### PR TITLE
feat(integ-runner): support comments in `--from-file` input

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/cli.ts
+++ b/packages/@aws-cdk/integ-runner/lib/cli.ts
@@ -79,7 +79,10 @@ export function parseCliArgs(args: string[] = []) {
   }
 
   const requestedTests = fromFile
-    ? (fs.readFileSync(fromFile, { encoding: 'utf8' })).split('\n').filter(x => x)
+    ? (fs.readFileSync(fromFile, { encoding: 'utf8' }))
+      .split('\n')
+      .filter(x => x)
+      .filter(x => !x.startsWith('#'))
     : (tests.length > 0 ? tests : undefined); // 'undefined' means no request
 
   if (argv['disable-update-workflow'] !== undefined && argv['update-workflow'] !== undefined) {

--- a/packages/@aws-cdk/integ-runner/test/cli.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/cli.test.ts
@@ -136,6 +136,84 @@ describe.each([
   });
 });
 
+describe('--from-file comment filtering', () => {
+  const currentCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'integ-runner-test-'));
+    process.chdir(tempDir);
+  });
+
+  afterEach(() => {
+    process.chdir(currentCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('filters out comment lines starting with #', () => {
+    // Create temp file with mix of comments and test names
+    const testFile = path.join(tempDir, 'tests.txt');
+    fs.writeFileSync(testFile, [
+      '# This is a comment',
+      'test1.js',
+      '# Another comment',
+      'test2.js',
+      'test3.js',
+      '# Final comment',
+    ].join('\n'));
+
+    const options = parseCliArgs(['--from-file', testFile]);
+
+    // Verify comments are excluded and test names are included
+    expect(options.tests).toEqual(['test1.js', 'test2.js', 'test3.js']);
+  });
+
+  test('returns empty array for comment-only file', () => {
+    // Create temp file with only # lines
+    const testFile = path.join(tempDir, 'comments-only.txt');
+    fs.writeFileSync(testFile, [
+      '# Comment 1',
+      '# Comment 2',
+      '# Comment 3',
+    ].join('\n'));
+
+    const options = parseCliArgs(['--from-file', testFile]);
+
+    // Verify empty array is returned
+    expect(options.tests).toEqual([]);
+  });
+
+  test('preserves lines with # not at start (inline hash)', () => {
+    // Create temp file with lines like test#1.js
+    const testFile = path.join(tempDir, 'inline-hash.txt');
+    fs.writeFileSync(testFile, [
+      'test#1.js',
+      'my-test#feature.js',
+      'another#test#file.js',
+    ].join('\n'));
+
+    const options = parseCliArgs(['--from-file', testFile]);
+
+    // Verify lines with # not at start are preserved
+    expect(options.tests).toEqual(['test#1.js', 'my-test#feature.js', 'another#test#file.js']);
+  });
+
+  test('preserves lines with whitespace before # as test names', () => {
+    // Create temp file with lines like "  #not-a-comment"
+    const testFile = path.join(tempDir, 'whitespace-hash.txt');
+    fs.writeFileSync(testFile, [
+      '  #not-a-comment',
+      '\t#also-not-a-comment',
+      '   #test-name',
+    ].join('\n'));
+
+    const options = parseCliArgs(['--from-file', testFile]);
+
+    // Verify lines with whitespace before # are preserved as test names
+    expect(options.tests).toEqual(['  #not-a-comment', '\t#also-not-a-comment', '   #test-name']);
+  });
+});
+
 describe('CLI config file', () => {
   const configFile = 'integ.config.json';
   const withConfig = (settings: any, fileName = configFile) => {


### PR DESCRIPTION
When using `--from-file` to specify a list of integration tests, lines starting with `#` are now treated as comments and filtered out. This allows users to annotate their test list files with explanations or temporarily disable tests by commenting them out.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
