### PR TITLE
fix(integ-runner): comma-separated values are not interpreted as lists in `--parallel-regions` and `--profiles` options

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/cli.ts
+++ b/packages/@aws-cdk/integ-runner/lib/cli.ts
@@ -32,9 +32,9 @@ export function parseCliArgs(args: string[] = []) {
     .option('dry-run', { type: 'boolean', default: false, desc: 'do not actually deploy the stack. just update the snapshot (not recommended!)' })
     .option('update-on-failed', { type: 'boolean', default: false, desc: 'rerun integration tests and update snapshots for failed tests.' })
     .option('force', { type: 'boolean', default: false, desc: 'Rerun all integration tests even if tests are passing' })
-    .option('parallel-regions', { type: 'array', desc: 'Tests are run in parallel across these regions. To prevent tests from running in parallel, provide only a single region', default: [] })
+    .option('parallel-regions', { type: 'array', desc: 'Tests are run in parallel across these regions. To prevent tests from running in parallel, provide only a single region', default: [], coerce: splitByComma })
     .options('directory', { type: 'string', default: 'test', desc: 'starting directory to discover integration tests. Tests will be discovered recursively from this directory' })
-    .options('profiles', { type: 'array', desc: 'list of AWS profiles to use. Tests will be run in parallel across each profile+regions', default: [] })
+    .options('profiles', { type: 'array', desc: 'list of AWS profiles to use. Tests will be run in parallel across each profile+regions', default: [], coerce: splitByComma })
     .options('max-workers', { type: 'number', desc: 'The max number of workerpool workers to use when running integration tests in parallel', default: 16 })
     .options('exclude', { type: 'boolean', desc: 'Run all tests in the directory, except the specified TESTs', default: false })
     .option('strict', { type: 'boolean', default: false, desc: 'Fail if any specified tests are not found' })
@@ -340,4 +340,12 @@ function engineFromOptions(options: { unstable?: string[] }): Required<EngineOpt
     return { engine: 'cli-wrapper' };
   }
   return { engine: 'toolkit-lib' };
+}
+
+/**
+ * Coerce function for yargs array options to support comma-separated values.
+ * Yargs doesn't natively split `--option=a,b,c` into ['a', 'b', 'c'].
+ */
+function splitByComma(xs: string[]): string[] {
+  return xs.flatMap(x => x.split(',')).map(x => x.trim());
 }

--- a/packages/@aws-cdk/integ-runner/test/cli.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/cli.test.ts
@@ -171,6 +171,36 @@ describe('CLI config file', () => {
     ]);
   });
 
+  test('parallel-regions parses comma-separated values', async () => {
+    // WHEN
+    const options = parseCliArgs(['--parallel-regions=us-east-1,us-east-2']);
+
+    // THEN
+    expect(options.testRegions).toEqual([
+      'us-east-1',
+      'us-east-2',
+    ]);
+  });
+
+  test('parallel-regions trims whitespace from comma-separated values', async () => {
+    // WHEN
+    const options = parseCliArgs(['--parallel-regions=us-east-1, us-east-2']);
+
+    // THEN
+    expect(options.testRegions).toEqual([
+      'us-east-1',
+      'us-east-2',
+    ]);
+  });
+
+  test('profiles parses comma-separated values', async () => {
+    // WHEN
+    const options = parseCliArgs(['--profiles=dev,prod']);
+
+    // THEN
+    expect(options.profiles).toEqual(['dev', 'prod']);
+  });
+
   test('cli options take precedent', async () => {
     // WHEN
     withConfig({ maxWorkers: 3 });


### PR DESCRIPTION
Yargs doesn't natively split `--option=a,b,c` into `['a', 'b', 'c']`. This adds a coerce function to enable comma-separated values for the `--parallel-regions` and `--profiles` array options. The values for both options cannot legally contain commas, so this is a safe change.

This makes it easier to pass multiple values in CI/CD environments or scripts where using multiple flags can be cumbersome.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
