### PR TITLE
refactor: consolidate IO message to telemetry event logic

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -10,8 +10,10 @@ import type { IoHelper, ActivityPrinterProps, IActivityPrinter } from '../../../
 import { asIoHelper, IO, isMessageRelevantForLevel, CurrentActivityPrinter, HistoryActivityPrinter } from '../../../lib/api-private';
 import { StackActivityProgress } from '../../commands/deploy';
 import { canCollectTelemetry } from '../telemetry/collect-telemetry';
-import { CLI_PRIVATE_IO, EventResult } from '../telemetry/messages';
-import { TelemetryEvent, TelemetrySession } from '../telemetry/session';
+import type { EventResult } from '../telemetry/messages';
+import { CLI_PRIVATE_IO } from '../telemetry/messages';
+import type { TelemetryEvent } from '../telemetry/session';
+import { TelemetrySession } from '../telemetry/session';
 import { EndpointTelemetrySink } from '../telemetry/sink/endpoint-sink';
 import { FileTelemetrySink } from '../telemetry/sink/file-sink';
 import { Funnel } from '../telemetry/sink/funnel';
@@ -625,12 +627,11 @@ function eventFromMessage(msg: IoMessage<unknown>): TelemetryEvent | undefined {
   }
   return undefined;
 
-
-  function eventResult(eventType: TelemetryEvent['eventType'], msg: IoMessage<EventResult>): TelemetryEvent {
+  function eventResult(eventType: TelemetryEvent['eventType'], m: IoMessage<EventResult>): TelemetryEvent {
     return {
       eventType,
-      duration: msg.data.duration,
-      error: msg.data.error,
+      duration: m.data.duration,
+      error: m.data.error,
     };
   }
 }

--- a/packages/aws-cdk/lib/cli/telemetry/messages.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/messages.ts
@@ -66,9 +66,3 @@ export const CLI_PRIVATE_SPAN = {
     end: CLI_PRIVATE_IO.CDK_CLI_I3001,
   },
 } satisfies Record<string, SpanDefinition<any, any>>;
-
-export const CLI_TELEMETRY_CODES = [
-  CLI_PRIVATE_IO.CDK_CLI_I1001,
-  CLI_PRIVATE_IO.CDK_CLI_I2001,
-  CLI_PRIVATE_IO.CDK_CLI_I3001,
-];


### PR DESCRIPTION
The logic to convert I/O messages to telemetry events used to be a 3-step one:

1. First, check if the I/O message is in a list of special messages
2. Second, look at the I/O message again in a `switch` statement to come up with an event type.
3. Finally, copy some data like `duration` and `error` from the message.

In this change we consolidate all steps into a single function:

```ts
function eventFromMessage(msg: IoMessage<unknown>): TelemetryEvent | undefined;
```

If the function returns an event, it's fully formed and ready to send. Otherwise the message does need to lead to a telemetry event. This removes the ability for two lists of special messages to get out of sync, and it moves the logic that deals with building a full event message into a single place which purely deals with the conversion. Also use the `IoMessageMaker<>.is()` function to assert the type of a message so we can't accidentally get a wrong type cast.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
