### PR TITLE
fix(toolkit-lib): synth time is not measured accurately

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -62,7 +62,7 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | Code | Description | Level | Payload data interface |
 |------|-------------|-------|------------------------|
 | `CDK_TOOLKIT_W0100` | Credential plugin warnings | `warn` | n/a |
-| `CDK_TOOLKIT_I1000` | Provides synthesis times. | `info` | {@link Duration} |
+| `CDK_TOOLKIT_I1000` | Provides synthesis times. | `info` | {@link Operation} |
 | `CDK_TOOLKIT_I1001` | Cloud Assembly synthesis is starting | `trace` | {@link StackSelectionDetails} |
 | `CDK_TOOLKIT_I1901` | Provides stack data | `result` | {@link StackAndAssemblyData} |
 | `CDK_TOOLKIT_I1902` | Successfully deployed stacks | `result` | {@link AssemblyData} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -24,6 +24,7 @@ import type {
   ContextProviderMessageSource,
   Duration,
   ErrorPayload,
+  Operation,
   SingleStack,
   StackAndAssemblyData,
 } from '../../../payloads/types';
@@ -43,10 +44,10 @@ export const IO = {
   }),
 
   // 1: Synth (1xxx)
-  CDK_TOOLKIT_I1000: make.info<Duration>({
+  CDK_TOOLKIT_I1000: make.info<Operation>({
     code: 'CDK_TOOLKIT_I1000',
     description: 'Provides synthesis times.',
-    interface: 'Duration',
+    interface: 'Operation',
   }),
   CDK_TOOLKIT_I1001: make.trace<StackSelectionDetails>({
     code: 'CDK_TOOLKIT_I1001',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/span.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/span.ts
@@ -50,7 +50,7 @@ type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>;
 /**
  * Ending the span returns the observed duration
  */
-interface ElapsedTime {
+export interface ElapsedTime {
   readonly asMs: number;
   readonly asSec: number;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/types.ts
@@ -91,6 +91,16 @@ export interface ErrorPayload {
 }
 
 /**
+ * Operation information that *definitely* took time, and *maybe* produced an error
+ */
+export interface Operation extends Duration {
+  /**
+   * Optionally, an error that occurred
+   */
+  readonly error?: Error;
+}
+
+/**
  * Generic payload of a simple yes/no question.
  *
  * The expectation is that 'yes' means moving on,

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -60,7 +60,7 @@ import {
 import { sdkRequestHandler } from '../api/aws-auth/awscli-compatible';
 import { IoHostSdkLogger, SdkProvider } from '../api/aws-auth/private';
 import { Bootstrapper } from '../api/bootstrap';
-import type { ICloudAssemblySource } from '../api/cloud-assembly';
+import type { ICloudAssemblySource, StackSelector } from '../api/cloud-assembly';
 import { CachedCloudAssembly, StackSelectionStrategy } from '../api/cloud-assembly';
 import type { StackAssembly } from '../api/cloud-assembly/private';
 import { ALL_STACKS } from '../api/cloud-assembly/private';
@@ -71,7 +71,7 @@ import { DiffFormatter } from '../api/diff';
 import { detectStackDrift } from '../api/drift';
 import { DriftFormatter } from '../api/drift/drift-formatter';
 import type { IIoHost, IoMessageLevel, ToolkitAction } from '../api/io';
-import type { IoHelper } from '../api/io/private';
+import type { ElapsedTime, IoHelper } from '../api/io/private';
 import { asIoHelper, IO, SPAN, withoutColor, withoutEmojis, withTrimmedWhitespace } from '../api/io/private';
 import { CloudWatchLogEventMonitor, findCloudWatchLogGroups } from '../api/logs-monitor';
 import { Mode, PluginHost } from '../api/plugin';
@@ -317,16 +317,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async synth(cx: ICloudAssemblySource, options: SynthOptions = {}): Promise<CachedCloudAssembly> {
     const ioHelper = asIoHelper(this.ioHost, 'synth');
-    const selectStacks = options.stacks ?? ALL_STACKS;
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
 
     // NOTE: NOT 'await using' because we return ownership to the caller
-    const assembly = await assemblyFromSource(synthSpan.asHelper, cx);
+    const assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
 
-    const stacks = await assembly.selectStacksV2(selectStacks);
+    const stacks = await assembly.selectStacksV2(stacksOpt(options));
     const autoValidateStacks = options.validateStacks ? [assembly.selectStacksForValidation()] : [];
-    await this.validateStacksMetadata(stacks.concat(...autoValidateStacks), synthSpan.asHelper);
-    await synthSpan.end();
+    await this.validateStacksMetadata(stacks.concat(...autoValidateStacks), ioHelper);
 
     // if we have a single stack, print it to STDOUT
     const message = `Successfully synthesized to ${chalk.blue(path.resolve(stacks.assembly.directory))}`;
@@ -364,12 +361,10 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async diff(cx: ICloudAssemblySource, options: DiffOptions = {}): Promise<{ [name: string]: TemplateDiff }> {
     const ioHelper = asIoHelper(this.ioHost, 'diff');
-    const selectStacks = options.stacks ?? ALL_STACKS;
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
-    await using assembly = await assemblyFromSource(synthSpan.asHelper, cx);
-    const stacks = await assembly.selectStacksV2(selectStacks);
-    await synthSpan.end();
+    const selectStacks = stacksOpt(options);
+    await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
+    const stacks = await assembly.selectStacksV2(selectStacks);
     const diffSpan = await ioHelper.span(SPAN.DIFF_STACK).begin({ stacks: selectStacks });
     const deployments = await this.deploymentsForAction('diff');
 
@@ -422,11 +417,10 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async drift(cx: ICloudAssemblySource, options: DriftOptions = {}): Promise<{ [name: string]: DriftResult }> {
     const ioHelper = asIoHelper(this.ioHost, 'drift');
-    const selectStacks = options.stacks ?? ALL_STACKS;
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
-    await using assembly = await assemblyFromSource(synthSpan.asHelper, cx);
+    const selectStacks = stacksOpt(options);
+    await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
+
     const stacks = await assembly.selectStacksV2(selectStacks);
-    await synthSpan.end();
 
     const driftSpan = await ioHelper.span(SPAN.DRIFT_APP).begin({ stacks: selectStacks });
     const allDriftResults: { [name: string]: DriftResult } = {};
@@ -500,12 +494,10 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async list(cx: ICloudAssemblySource, options: ListOptions = {}): Promise<StackDetails[]> {
     const ioHelper = asIoHelper(this.ioHost, 'list');
-    const selectStacks = options.stacks ?? ALL_STACKS;
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
-    await using assembly = await assemblyFromSource(ioHelper, cx);
-    const stackCollection = await assembly.selectStacksV2(selectStacks);
-    await synthSpan.end();
+    const selectStacks = stacksOpt(options);
+    await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
+    const stackCollection = await assembly.selectStacksV2(selectStacks);
     const stacks = stackCollection.withDependencies();
     const message = stacks.map(s => s.id).join('\n');
 
@@ -520,20 +512,19 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async deploy(cx: ICloudAssemblySource, options: DeployOptions = {}): Promise<DeployResult> {
     const ioHelper = asIoHelper(this.ioHost, 'deploy');
-    await using assembly = await assemblyFromSource(ioHelper, cx);
-    return await this._deploy(assembly, 'deploy', options);
+    await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
+
+    return await this._deploy(assembly, 'deploy', assembly.synthDuration, options);
   }
 
   /**
    * Helper to allow deploy being called as part of the watch action.
    */
-  private async _deploy(assembly: StackAssembly, action: 'deploy' | 'watch', options: PrivateDeployOptions = {}): Promise<DeployResult> {
+  private async _deploy(assembly: StackAssembly, action: 'deploy' | 'watch', synthDuration: ElapsedTime, options: PrivateDeployOptions = {}): Promise<DeployResult> {
     const ioHelper = asIoHelper(this.ioHost, action);
-    const selectStacks = options.stacks ?? ALL_STACKS;
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
+    const selectStacks = stacksOpt(options);
     const stackCollection = await assembly.selectStacksV2(selectStacks);
     await this.validateStacksMetadata(stackCollection, ioHelper);
-    const synthDuration = await synthSpan.end();
 
     const ret: DeployResult = {
       stacks: [],
@@ -997,7 +988,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async rollback(cx: ICloudAssemblySource, options: RollbackOptions = {}): Promise<RollbackResult> {
     const ioHelper = asIoHelper(this.ioHost, 'rollback');
-    await using assembly = await assemblyFromSource(ioHelper, cx);
+    await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
+
     return await this._rollback(assembly, 'rollback', options);
   }
 
@@ -1005,12 +997,11 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * Helper to allow rollback being called as part of the deploy or watch action.
    */
   private async _rollback(assembly: StackAssembly, action: 'rollback' | 'deploy' | 'watch', options: RollbackOptions): Promise<RollbackResult> {
-    const selectStacks = options.stacks ?? ALL_STACKS;
+    const selectStacks = stacksOpt(options);
     const ioHelper = asIoHelper(this.ioHost, action);
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
+
     const stacks = await assembly.selectStacksV2(selectStacks);
     await this.validateStacksMetadata(stacks, ioHelper);
-    await synthSpan.end();
 
     const ret: RollbackResult = {
       stacks: [],
@@ -1072,13 +1063,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     this.requireUnstableFeature('refactor');
 
     const ioHelper = asIoHelper(this.ioHost, 'refactor');
-    await using assembly = await assemblyFromSource(ioHelper, cx);
+    await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
     return await this._refactor(assembly, ioHelper, cx, options);
   }
 
   private async _refactor(assembly: StackAssembly, ioHelper: IoHelper, cx: ICloudAssemblySource, options: RefactorOptions = {}): Promise<void> {
     const sdkProvider = await this.sdkProvider('refactor');
-    const selectedStacks = await assembly.selectStacksV2(options.stacks ?? ALL_STACKS);
+    const selectedStacks = await assembly.selectStacksV2(stacksOpt(options));
     const groups = await groupStacks(sdkProvider, selectedStacks.stackArtifacts, options.additionalStackNames ?? []);
 
     for (let { environment, localStacks, deployedStacks } of groups) {
@@ -1236,7 +1227,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async destroy(cx: ICloudAssemblySource, options: DestroyOptions = {}): Promise<DestroyResult> {
     const ioHelper = asIoHelper(this.ioHost, 'destroy');
-    await using assembly = await assemblyFromSource(ioHelper, cx);
+    await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
     return await this._destroy(assembly, 'destroy', options);
   }
 
@@ -1244,12 +1235,10 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * Helper to allow destroy being called as part of the deploy action.
    */
   private async _destroy(assembly: StackAssembly, action: 'deploy' | 'destroy', options: DestroyOptions): Promise<DestroyResult> {
-    const selectStacks = options.stacks ?? ALL_STACKS;
+    const selectStacks = stacksOpt(options);
     const ioHelper = asIoHelper(this.ioHost, action);
-    const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
     // The stacks will have been ordered for deployment, so reverse them for deletion.
     const stacks = (await assembly.selectStacksV2(selectStacks)).reversed();
-    await synthSpan.end();
 
     const ret: DestroyResult = {
       stacks: [],
@@ -1352,7 +1341,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     };
 
     try {
-      await this._deploy(assembly, 'watch', deployOptions);
+      await this._deploy(assembly, 'watch', zeroTime(), deployOptions);
     } catch {
       // just continue - deploy will show the error
     }
@@ -1410,3 +1399,29 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   }
 }
 
+/**
+ * Centralize the default stack selection logic in a single place
+ */
+function stacksOpt(o: { stacks?: StackSelector }): StackSelector {
+  return o.stacks ?? ALL_STACKS;
+}
+
+/**
+ * Perform synthesis and emit the time taken to a new span
+ */
+async function synthAndMeasure(ioHelper: IoHelper, cx: ICloudAssemblySource, selectStacks: StackSelector): Promise<StackAssembly & { synthDuration: ElapsedTime }> {
+  const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
+  try {
+    const ret = await assemblyFromSource(synthSpan.asHelper, cx);
+    const synthDuration = await synthSpan.end({});
+    return Object.assign(ret, { synthDuration });
+  } catch (error: any) {
+    // End the span even if we had a failure
+    await synthSpan.end({ error });
+    throw error;
+  }
+}
+
+function zeroTime(): ElapsedTime {
+  return { asMs: 0, asSec: 0 };
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1409,7 +1409,11 @@ function stacksOpt(o: { stacks?: StackSelector }): StackSelector {
 /**
  * Perform synthesis and emit the time taken to a new span
  */
-async function synthAndMeasure(ioHelper: IoHelper, cx: ICloudAssemblySource, selectStacks: StackSelector): Promise<StackAssembly & { synthDuration: ElapsedTime }> {
+async function synthAndMeasure(
+  ioHelper: IoHelper,
+  cx: ICloudAssemblySource,
+  selectStacks: StackSelector,
+): Promise<StackAssembly & { synthDuration: ElapsedTime }> {
   const synthSpan = await ioHelper.span(SPAN.SYNTH_ASSEMBLY).begin({ stacks: selectStacks });
   try {
     const ret = await assemblyFromSource(synthSpan.asHelper, cx);

--- a/packages/@aws-cdk/toolkit-lib/test/actions/list.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/list.test.ts
@@ -470,7 +470,9 @@ describe('list', () => {
 
     // THEN
     await expect(() => toolkit.list(cx)).rejects.toThrow('Could not determine ordering');
-    expect(ioHost.notifySpy).not.toHaveBeenCalled();
+    expect(ioHost.notifySpy).not.toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_I2901',
+    }));
   });
 
   test('action disposes of assembly produced by source', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -609,7 +609,7 @@ test('computes one set of mappings per environment', async () => {
   });
 
   // THEN
-  expect(ioHost.notifySpy).toHaveBeenCalledTimes(4);
+  expect(ioHost.notifySpy).toHaveBeenCalledTimes(5);
 
   expect(ioHost.notifySpy).toHaveBeenNthCalledWith(
     1,

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -612,14 +612,14 @@ test('computes one set of mappings per environment', async () => {
   expect(ioHost.notifySpy).toHaveBeenCalledTimes(5);
 
   expect(ioHost.notifySpy).toHaveBeenNthCalledWith(
-    1,
+    2,
     expect.objectContaining({
       message: expect.stringMatching('aws://123456789012/us-east-1'),
     }),
   );
 
   expect(ioHost.notifySpy).toHaveBeenNthCalledWith(
-    2,
+    3,
     expect.objectContaining({
       action: 'refactor',
       level: 'result',
@@ -640,14 +640,14 @@ test('computes one set of mappings per environment', async () => {
   );
 
   expect(ioHost.notifySpy).toHaveBeenNthCalledWith(
-    3,
+    4,
     expect.objectContaining({
       message: expect.stringMatching('aws://123456789012/us-east-2'),
     }),
   );
 
   expect(ioHost.notifySpy).toHaveBeenNthCalledWith(
-    4,
+    5,
     expect.objectContaining({
       action: 'refactor',
       level: 'result',

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
@@ -162,11 +162,11 @@ describe('watch', () => {
     await fakeChokidarWatcherOn.readyCallback();
 
     // THEN
-    expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.objectContaining({
+    expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.anything(), expect.objectContaining({
       cloudWatchLogMonitor: expect.anything(), // Not undefined
     }));
 
-    const logMonitorSpy = jest.spyOn((deploySpy.mock.calls[0]?.[2] as any).cloudWatchLogMonitor, 'deactivate');
+    const logMonitorSpy = jest.spyOn((deploySpy.mock.calls[0]?.[3] as any).cloudWatchLogMonitor, 'deactivate');
 
     // Deactivate the watcher and cloudWatchLogMonitor that we created, otherwise the tests won't exit
     await watcher.dispose();
@@ -209,7 +209,7 @@ describe('watch', () => {
       await fakeChokidarWatcherOn.readyCallback();
 
       // THEN
-      expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.objectContaining({
+      expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.anything(), expect.objectContaining({
         deploymentMethod: deploymentMethod,
         extraUserAgent: `cdk-watch/hotswap-${userAgent}`,
       }));
@@ -228,7 +228,7 @@ describe('watch', () => {
     await fakeChokidarWatcherOn.readyCallback();
 
     // THEN
-    expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.objectContaining({
+    expect(deploySpy).toHaveBeenCalledWith(expect.anything(), 'watch', expect.anything(), expect.objectContaining({
       deploymentMethod: { method: 'hotswap' },
       extraUserAgent: 'cdk-watch/hotswap-on',
     }));


### PR DESCRIPTION
In multiple places the `SYNTH` span doesn't measure the time to synthesize the assembly, but rather the time to select stacks from an already-synthesized assembly.

Presumably this was done in order to avoid duplicating this line:

```ts
    const selectStacks = options.stacks ?? ALL_STACKS;
```

Instead, introduce a helper function that gets called from all places, and centralize the `selectStacks` logic so we don't fear duplication anymore.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
