### PR TITLE
docs: update contributing guide to reflect minimum node versions for contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ contributing guide will focus on technical aspects.
 
 ## Prerequisites
 
-- [Node.js >= 20.17.0](https://nodejs.org/download/release/latest-v20.x/)
+- Node.js [^20.17.0](https://nodejs.org/download/release/latest-v20.x/) or [>=22.9.0](https://nodejs.org/download/release/latest-v22.x/)
   - We recommend using a version in [Active LTS](https://nodejs.org/en/about/releases/)
 - [Yarn >= 1.19.1, < 2](https://yarnpkg.com/lang/en/docs/install)
 - [Docker >= 19.03](https://docs.docker.com/get-docker/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ contributing guide will focus on technical aspects.
 
 ## Prerequisites
 
-- [Node.js >= 18.18.0](https://nodejs.org/download/release/latest-v18.x/)
+- [Node.js >= 20.17.0](https://nodejs.org/download/release/latest-v20.x/)
   - We recommend using a version in [Active LTS](https://nodejs.org/en/about/releases/)
 - [Yarn >= 1.19.1, < 2](https://yarnpkg.com/lang/en/docs/install)
 - [Docker >= 19.03](https://docs.docker.com/get-docker/)


### PR DESCRIPTION
Fixes incorrect info in CONTRIBUTING.md.

In https://github.com/aws/aws-cdk-cli/commit/ba598167173ebaf23d5ecd8b9cfdf6faff766424, we upgraded our dependency `npm` from major version 10 to 11. This changed our Node version requirement to:
- `^20.17.0`
- `>=22.9.0`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
