### PR TITLE
fix: clean up temporary `cdk-bootstrap` directory after bootstrap

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap.test.ts
@@ -384,3 +384,17 @@ test('do showTemplate JSON', async () => {
   // WHEN
   await bootstrapper.showTemplate(true);
 });
+
+test('cleans up temporary directory after bootstrap', async () => {
+  const fse = jest.requireActual('fs-extra');
+  const mkdtempSpy = jest.spyOn(fse, 'mkdtemp');
+
+  // WHEN
+  await bootstrapper.bootstrapEnvironment(env, sdk, { toolkitStackName: 'mockStack' });
+
+  // THEN
+  const tempDir = await mkdtempSpy.mock.results[0].value;
+  expect(fse.existsSync(tempDir)).toBe(false);
+
+  mkdtempSpy.mockRestore();
+});


### PR DESCRIPTION
The bootstrap process creates a temporary directory using `fs.mkdtemp` to build the CloudFormation template before deploying it. However, this directory was never cleaned up after the deployment completed, regardless of whether it succeeded or failed.

Over time, especially in CI/CD environments or on developer machines where bootstrap is run frequently, these orphaned directories accumulate in the system's temp folder. While each directory is small, the cumulative effect can waste disk space unnecessarily.

This change wraps the deployment logic in a `try/finally` block to ensure the temporary directory is always removed after the bootstrap operation completes. Using `finally` guarantees cleanup happens even when the deployment throws an error, preventing resource leaks in all scenarios.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
