### PR TITLE
refactor(integ-runner): simplify CDK interface and use toolkit-lib types

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1451,7 +1451,7 @@ const integRunner = configureProject(
     allowPrivateDeps: true,
     tsconfig: {
       compilerOptions: {
-        ...defaultTsOptions,
+        ...toolkitLibTsCompilerOptions,
       },
     },
     jestOptions: jestOptionsForProject({

--- a/packages/@aws-cdk/integ-runner/lib/engines/cdk-interface.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/cdk-interface.ts
@@ -1,4 +1,5 @@
 import type { DefaultCdkOptions, DestroyOptions as BaseDestroyOptions, DeployOptions as BaseDeployOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
+import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
 
 /**
  * Events emitted during watch mode
@@ -10,9 +11,9 @@ export type WatchEvents = {
 };
 
 /**
- * Options for synthing and bypassing the CDK CLI
+ * Options to use with cdk synth
  */
-export interface SynthFastOptions {
+export interface SynthOptions {
   /**
    * The command to use to execute the app.
    * This is typically the same thing that normally
@@ -21,7 +22,7 @@ export interface SynthFastOptions {
    * e.g. "node 'bin/my-app.ts'"
    * or 'go run main.go'
    */
-  readonly execCmd: string[];
+  readonly app: string;
 
   /**
    * Emits the synthesized cloud assembly into a directory
@@ -47,114 +48,15 @@ export interface SynthFastOptions {
 }
 
 /**
- * Options to use with cdk synth
- */
-export interface SynthOptions extends DefaultCdkOptions {
-  /**
-   * After synthesis, validate stacks with the "validateOnSynth"
-   * attribute set (can also be controlled with CDK_VALIDATION)
-   *
-   * @default true;
-   */
-  readonly validation?: boolean;
-
-  /**
-   * Do not output CloudFormation Template to stdout
-   * @default false;
-   */
-  readonly quiet?: boolean;
-
-  /**
-   * Only synthesize the given stack
-   *
-   * @default false
-   */
-  readonly exclusively?: boolean;
-}
-
-/**
  * Options for cdk list
  */
 export interface ListOptions extends DefaultCdkOptions {
-  /**
-   * Display environment information for each stack
-   *
-   * @default false
-   */
-  readonly long?: boolean;
 }
-
-/**
- * Hotswap deployment mode
- */
-export enum HotswapMode {
-  /**
-   * Will fall back to CloudFormation when a non-hotswappable change is detected
-   */
-  FALL_BACK = 'fall-back',
-
-  /**
-   * Will not fall back to CloudFormation when a non-hotswappable change is detected
-   */
-  HOTSWAP_ONLY = 'hotswap-only',
-
-  /**
-   * Will not attempt to hotswap anything and instead go straight to CloudFormation
-   */
-  FULL_DEPLOYMENT = 'full-deployment',
-}
-
-/**
- * Supported display modes for stack deployment activity
- */
-export enum StackActivityProgress {
-  /**
-   * Displays a progress bar with only the events for the resource currently being deployed
-   */
-  BAR = 'bar',
-
-  /**
-   * Displays complete history with all CloudFormation stack events
-   */
-  EVENTS = 'events',
-}
-
-/**
- * Deployment method type
- */
-export type DeploymentMethod = 'direct' | 'change-set';
 
 /**
  * Options to use with cdk deploy
  */
 export interface DeployOptions extends BaseDeployOptions {
-  /**
-   * Display mode for stack activity events
-   *
-   * The default in the CLI is StackActivityProgress.BAR, but
-   * since the cli-wrapper will most likely be run in automation it makes
-   * more sense to set the default to StackActivityProgress.EVENTS
-   *
-   * @default StackActivityProgress.EVENTS
-   */
-  readonly progress?: StackActivityProgress;
-
-  /**
-   * Whether this 'deploy' command should actually delegate to the 'watch' command.
-   *
-   * @default false
-   */
-  readonly watch?: boolean;
-
-  /**
-   * Whether to perform a 'hotswap' deployment.
-   * A 'hotswap' deployment will attempt to short-circuit CloudFormation
-   * and update the affected resources like Lambda functions directly.
-   *
-   * @default - `HotswapMode.FALL_BACK` for regular deployments, `HotswapMode.HOTSWAP_ONLY` for 'watch' deployments
-   */
-  readonly hotswap?: HotswapMode;
-
   /**
    * Whether to show CloudWatch logs for hotswapped resources
    * locally in the users terminal
@@ -162,7 +64,12 @@ export interface DeployOptions extends BaseDeployOptions {
    * @default - false
    */
   readonly traceLogs?: boolean;
+}
 
+/**
+ * Options to use with cdk watch
+ */
+export interface WatchOptions extends DeployOptions {
   /**
    * Deployment method
    */
@@ -175,6 +82,26 @@ export interface DeployOptions extends BaseDeployOptions {
 export type DestroyOptions = BaseDestroyOptions;
 
 /**
+ * Options to create a Cloud Assembly
+ */
+export interface CxOptions extends DefaultCdkOptions {
+  /**
+   * Resolve the current default environment an provide as environment variables to the app.
+   *
+   * @default true
+   */
+  readonly resolveDefaultEnvironment?: boolean;
+  /**
+   * Additional environment variables
+   *
+   * These environment variables will be set in addition to the environment
+   * variables currently set in the process. A value of `undefined` will
+   * unset a particular environment variable.
+   */
+  readonly env?: Record<string, string | undefined>;
+}
+
+/**
  * AWS CDK CLI operations interface
  *
  * This interface defines the contract for CDK operations that can be
@@ -182,19 +109,9 @@ export type DestroyOptions = BaseDestroyOptions;
  */
 export interface ICdk {
   /**
-   * cdk deploy
-   */
-  deploy(options: DeployOptions): Promise<void>;
-
-  /**
    * cdk synth
    */
   synth(options: SynthOptions): Promise<void>;
-
-  /**
-   * cdk destroy
-   */
-  destroy(options: DestroyOptions): Promise<void>;
 
   /**
    * cdk list
@@ -202,9 +119,14 @@ export interface ICdk {
   list(options: ListOptions): Promise<string[]>;
 
   /**
-   * cdk synth fast
+   * cdk deploy
    */
-  synthFast(options: SynthFastOptions): Promise<void>;
+  deploy(options: DeployOptions): Promise<void>;
+
+  /**
+   * cdk destroy
+   */
+  destroy(options: DestroyOptions): Promise<void>;
 
   /**
    * cdk watch

--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -1,11 +1,11 @@
 import * as path from 'node:path';
 import { UNKNOWN_REGION } from '@aws-cdk/cloud-assembly-api';
-import type { DefaultCdkOptions, DestroyOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
-import type { DeploymentMethod, ICloudAssemblySource, IIoHost, IoMessage, IoRequest, IReadableCloudAssembly, NonInteractiveIoHostProps, StackSelector } from '@aws-cdk/toolkit-lib';
+import type { DefaultCdkOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
+import type { ICloudAssemblySource, IIoHost, IoMessage, IoRequest, IReadableCloudAssembly, NonInteractiveIoHostProps, StackSelector } from '@aws-cdk/toolkit-lib';
 import { BaseCredentials, ExpandStackSelection, MemoryContext, NonInteractiveIoHost, StackSelectionStrategy, Toolkit } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
-import type { DeployOptions, ICdk, ListOptions, SynthFastOptions, SynthOptions, WatchEvents } from './cdk-interface';
+import type { CxOptions, DeployOptions, DestroyOptions, ICdk, ListOptions, SynthOptions, WatchEvents, WatchOptions } from './cdk-interface';
 
 export interface ToolkitLibEngineOptions {
   /**
@@ -76,68 +76,46 @@ export class ToolkitLibRunnerEngine implements ICdk {
       // Logging
       //  - options.color
       // SDK
-      //  - options.profile
       //  - options.proxy
       //  - options.caBundlePath
     });
 
     // @TODO - similar to the above, but in toolkit-lib these options would go on the IoHost
-    //  - options.quiet
     //  - options.trace
     //  - options.verbose
     //  - options.json
   }
 
   /**
-   * Synthesizes the CDK app through the Toolkit
+   * Synthesizes the CDK app
    */
   public async synth(options: SynthOptions) {
-    const cx = await this.cx(options);
-    const lock = await this.toolkit.synth(cx, {
-      stacks: this.stackSelector(options),
-      validateStacks: options.validation,
-    });
-    await this.validateRegion(lock);
-    await lock.dispose();
-  }
-
-  /**
-   * Synthesizes the CDK app quickly, by bypassing the Toolkit and just invoking the app command
-   */
-  public async synthFast(options: SynthFastOptions) {
-    const cx = await this.toolkit.fromCdkApp(options.execCmd.join(' '), {
-      workingDirectory: this.options.workingDirectory,
-      outdir: options.output ? path.join(this.options.workingDirectory, options.output) : undefined,
-      contextStore: new MemoryContext(options.context),
+    const cx = await this.cx({
+      app: options.app,
+      output: options.output,
+      context: options.context,
       lookups: false,
       resolveDefaultEnvironment: false,
-      env: {
-        ...this.options.env,
-        ...options.env,
-      },
-      synthOptions: {
-        versionReporting: false,
-        pathMetadata: false,
-        assetMetadata: false,
-      },
+      env: options.env,
+      versionReporting: false,
+      pathMetadata: false,
+      assetMetadata: false,
     });
 
     try {
-      // @TODO - use produce to mimic the current behavior more closely
-      const lock = await cx.produce();
+      await using lock = await this.toolkit.synth(cx, {
+        validateStacks: false,
+        stacks: {
+          strategy: StackSelectionStrategy.ALL_STACKS,
+          failOnEmpty: false,
+        },
+      });
       await this.validateRegion(lock);
-      await lock.dispose();
-      // We should fix this once we have stabilized toolkit-lib as engine.
-      // What we really should do is this:
-      // const lock = await this.toolkit.synth(cx, {
-      //   validateStacks: false,
-      // });
-      // await lock.dispose();
     } catch (e: any) {
       if (e.message.includes('Missing context keys')) {
         // @TODO - silently ignore missing context
         // This is actually an undefined case in the old implementation, which doesn't use the toolkit code
-        // and won't fail for missing context. To persevere existing behavior, we do the same here.
+        // and won't fail for missing context. To preserve existing behavior, we do the same here.
         // However in future we need to find a way for integ tests to provide context through snapshots.
         return;
       }
@@ -149,9 +127,6 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Lists the stacks in the CDK app
    */
   public async list(options: ListOptions): Promise<string[]> {
-    // @TODO - existing list specific option, doesn't really make sense to support this in the context of integ-runner
-    //  - options.long
-
     const cx = await this.cx(options);
     const stacks = await this.toolkit.list(cx, {
       stacks: this.stackSelector(options),
@@ -164,19 +139,14 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Deploys the CDK app
    */
   public async deploy(options: DeployOptions) {
-    // @TODO - existing deploy specific option, doesn't really make sense to support this in the context of integ-runner
-    //  - options.progress
-
-    if (options.watch) {
-      return this.watch(options);
-    }
-
     const cx = await this.cx(options);
     await this.toolkit.deploy(cx, {
       roleArn: options.roleArn,
       traceLogs: options.traceLogs,
       stacks: this.stackSelector(options),
-      deploymentMethod: this.deploymentMethod(options),
+      deploymentMethod: {
+        method: 'change-set',
+      },
       outputsFile: options.outputsFile ? path.join(this.options.workingDirectory, options.outputsFile) : undefined,
     });
   }
@@ -184,14 +154,14 @@ export class ToolkitLibRunnerEngine implements ICdk {
   /**
    * Watches the CDK app for changes and deploys them automatically
    */
-  public async watch(options: DeployOptions, events?: WatchEvents) {
+  public async watch(options: WatchOptions, events?: WatchEvents) {
     const cx = await this.cx(options);
     try {
       const watcher = await this.toolkit.watch(cx, {
         roleArn: options.roleArn,
         traceLogs: options.traceLogs,
         stacks: this.stackSelector(options),
-        deploymentMethod: this.deploymentMethod(options),
+        deploymentMethod: options.deploymentMethod,
       });
       await watcher.waitForEnd();
     } catch (e: unknown) {
@@ -224,7 +194,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
   /**
    * Creates a Cloud Assembly Source from the provided options.
    */
-  private async cx(options: DefaultCdkOptions): Promise<ICloudAssemblySource> {
+  private async cx(options: CxOptions): Promise<ICloudAssemblySource> {
     if (!options.app) {
       throw new Error('No app provided');
     }
@@ -245,7 +215,11 @@ export class ToolkitLibRunnerEngine implements ICdk {
       outdir,
       lookups: options.lookups,
       contextStore: new MemoryContext(options.context),
-      env: this.options.env,
+      resolveDefaultEnvironment: options.resolveDefaultEnvironment,
+      env: {
+        ...this.options.env,
+        ...options.env,
+      },
       synthOptions: {
         debug: options.debug,
         versionReporting: options.versionReporting ?? false,
@@ -264,22 +238,6 @@ export class ToolkitLibRunnerEngine implements ICdk {
       strategy: options.all ? StackSelectionStrategy.ALL_STACKS : StackSelectionStrategy.PATTERN_MUST_MATCH,
       patterns: options.stacks ?? ['**'],
       expand: options.exclusively ? ExpandStackSelection.NONE : ExpandStackSelection.UPSTREAM,
-    };
-  }
-
-  /**
-   * Creates a DeploymentMethod from the provided options.
-   */
-  private deploymentMethod(options: DeployOptions): DeploymentMethod {
-    if (options.hotswap && options.hotswap !== 'full-deployment') {
-      return {
-        method: 'hotswap',
-        fallback: options.hotswap === 'fall-back' ? { method: 'change-set' } : undefined,
-      };
-    }
-
-    return {
-      method: options.deploymentMethod ?? 'change-set',
     };
   }
 

--- a/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
@@ -182,8 +182,8 @@ export abstract class IntegRunner {
    * This will synth and then load the integration test manifest
    */
   public async generateActualSnapshot(): Promise<IntegTestSuite | LegacyIntegTestSuite> {
-    await this.cdk.synthFast({
-      execCmd: this.cdkApp.split(' '),
+    await this.cdk.synth({
+      app: this.cdkApp,
       // we don't know the "actual" context yet (this method is what generates it) so just
       // use the "expected" context. This is only run in order to read the manifest
       context: this.getContext((await this.expectedTestSuite())?.synthContext),
@@ -358,8 +358,8 @@ export abstract class IntegRunner {
 
     // if lookups are enabled then we need to synth again
     // using dummy context and save that as the snapshot
-    await this.cdk.synthFast({
-      execCmd: this.cdkApp.split(' '),
+    await this.cdk.synth({
+      app: this.cdkApp,
       context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
       output: path.relative(this.directory, this.snapshotDir),

--- a/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
@@ -63,8 +63,8 @@ export class IntegSnapshotRunner extends IntegRunner {
       // generates an incorrect snapshot and I have no idea why so synth again here
       // to produce the "correct" snapshot
       const env = DEFAULT_SYNTH_OPTIONS.env;
-      await this.cdk.synthFast({
-        execCmd: this.cdkApp.split(' '),
+      await this.cdk.synth({
+        app: this.cdkApp,
         context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
         env,
         output: path.relative(this.directory, this.cdkOutDir),

--- a/packages/@aws-cdk/integ-runner/lib/utils.ts
+++ b/packages/@aws-cdk/integ-runner/lib/utils.ts
@@ -98,11 +98,12 @@ export function chunks(command: string): string[] {
  * If it takes too long to cross off a new item, print the list.
  */
 export class WorkList<A> {
-  private readonly remaining = new Set(this.items);
+  private readonly remaining: Set<A>;
   private readonly timeout: number;
   private timer?: NodeJS.Timeout;
 
   constructor(private readonly items: A[], private readonly options: WorkListOptions<A> = {}) {
+    this.remaining = new Set(this.items);
     this.timeout = options.timeout ?? 60_000;
     this.scheduleTimer();
   }

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib-snapshot-path.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib-snapshot-path.test.ts
@@ -33,7 +33,7 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
     const snapshotPath = 'test.snapshot';
     const fullSnapshotPath = path.join('/test/dir', snapshotPath);
     const mockCx = { produce: jest.fn() };
-    const mockLock = { dispose: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
+    const mockLock = { dispose: jest.fn(), [Symbol.asyncDispose]: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
 
     // Mock fs to indicate the snapshot directory exists
     mockedFs.pathExistsSync.mockReturnValue(true);
@@ -44,7 +44,6 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
 
     await engine.synth({
       app: snapshotPath,
-      stacks: ['stack1'],
     });
 
     expect(mockedFs.pathExistsSync).toHaveBeenCalledWith(fullSnapshotPath);
@@ -56,7 +55,7 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
   it('should use fromCdkApp when app is not a path to existing directory', async () => {
     const appCommand = 'node bin/app.js';
     const mockCx = { produce: jest.fn() };
-    const mockLock = { dispose: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
+    const mockLock = { dispose: jest.fn(), [Symbol.asyncDispose]: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
 
     // Mock fs to indicate the path doesn't exist
     mockedFs.pathExistsSync.mockReturnValue(false);
@@ -66,7 +65,6 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
 
     await engine.synth({
       app: appCommand,
-      stacks: ['stack1'],
     });
 
     expect(mockToolkit.fromCdkApp).toHaveBeenCalledWith(appCommand, expect.any(Object));
@@ -77,7 +75,7 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
     const appPath = 'app.js';
     const fullAppPath = path.join('/test/dir', appPath);
     const mockCx = { produce: jest.fn() };
-    const mockLock = { dispose: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
+    const mockLock = { dispose: jest.fn(), [Symbol.asyncDispose]: jest.fn(), cloudAssembly: { stacksRecursively: [] } };
 
     // Mock fs to indicate the path exists but is not a directory
     mockedFs.pathExistsSync.mockReturnValue(true);
@@ -88,7 +86,6 @@ describe('ToolkitLibRunnerEngine - Snapshot Path Handling', () => {
 
     await engine.synth({
       app: appPath,
-      stacks: ['stack1'],
     });
 
     expect(mockedFs.pathExistsSync).toHaveBeenCalledWith(fullAppPath);

--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import type { DestroyOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
-import type { DeployOptions, ICdk, ListOptions, SynthFastOptions, SynthOptions } from '../lib/engines/cdk-interface';
+import type { DeployOptions, ICdk, ListOptions, SynthOptions } from '../lib/engines/cdk-interface';
 import { IntegSnapshotRunner, IntegTest } from '../lib/runner';
 import type { DestructiveChange, Diagnostic } from '../lib/workers';
 
@@ -32,7 +32,6 @@ export interface MockCdkMocks {
   deploy?: jest.MockedFn<(options: DeployOptions) => Promise<void>>;
   watch?: jest.MockedFn<(options: DeployOptions) => Promise<void>>;
   synth?: jest.MockedFn<(options: SynthOptions) => Promise<void>>;
-  synthFast?: jest.MockedFn<(options: SynthFastOptions) => Promise<void>>;
   destroy?: jest.MockedFn<(options: DestroyOptions) => Promise<void>>;
   list?: jest.MockedFn<(options: ListOptions) => Promise<string[]>>;
 }
@@ -46,7 +45,6 @@ export class MockCdkProvider {
       deploy: jest.fn().mockImplementation(),
       watch: jest.fn().mockImplementation(),
       synth: jest.fn().mockImplementation(),
-      synthFast: jest.fn().mockImplementation(),
       destroy: jest.fn().mockImplementation(),
       list: jest.fn().mockResolvedValue([]),
     };
@@ -69,10 +67,6 @@ export class MockCdkProvider {
     this.mocks.synth = mock ?? jest.fn().mockImplementation();
     this.cdk.synth = this.mocks.synth;
   }
-  public mockSynthFast(mock?: MockCdkMocks['synthFast']) {
-    this.mocks.synthFast = mock ?? jest.fn().mockImplementation();
-    this.cdk.synthFast = this.mocks.synthFast;
-  }
   public mockDestroy(mock?: MockCdkMocks['destroy']) {
     this.mocks.destroy = mock ?? jest.fn().mockImplementation();
     this.cdk.destroy = this.mocks.destroy;
@@ -85,7 +79,6 @@ export class MockCdkProvider {
     this.mockDeploy(mocks.deploy);
     this.mockWatch(mocks.watch);
     this.mockSynth(mocks.synth);
-    this.mockSynthFast(mocks.synthFast);
     this.mockDestroy(mocks.destroy);
     this.mockList(mocks.list);
 
@@ -117,14 +110,14 @@ export class MockCdkProvider {
     const results = await integTest.testSnapshot();
 
     // THEN
-    expect(this.mocks.synthFast).toHaveBeenCalledTimes(2);
-    expect(this.mocks.synthFast).toHaveBeenCalledWith({
+    expect(this.mocks.synth).toHaveBeenCalledTimes(2);
+    expect(this.mocks.synth).toHaveBeenCalledWith({
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',
         CDK_INTEG_REGION: 'test-region',
       }),
       context: expect.any(Object),
-      execCmd: ['node', 'test/test-data/' + integTestFile],
+      app: 'node test/test-data/' + integTestFile,
       output: actualSnapshotLocation ?? `test/test-data/cdk-integ.out.${integTestFile}.snapshot`,
     });
 

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -3,7 +3,6 @@ import * as builtinFs from 'fs';
 import { AVAILABILITY_ZONE_FALLBACK_CONTEXT_KEY } from '@aws-cdk/cloud-assembly-api';
 import { Manifest } from '@aws-cdk/cloud-assembly-schema';
 import * as fs from 'fs-extra';
-import { HotswapMode } from '../../lib/engines/cdk-interface';
 import { IntegTestRunner, IntegTest } from '../../lib/runner';
 import { MockCdkProvider } from '../helpers';
 
@@ -60,7 +59,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(3);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
       app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       requireApproval: 'never',
@@ -126,7 +125,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
       app: 'node test/test-data/xxxxx.integ-test1.js',
       requireApproval: 'never',
@@ -170,7 +169,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
       app: 'node test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
       requireApproval: 'never',
@@ -187,8 +186,8 @@ describe('IntegTest runIntegTests', () => {
       output: 'test/test-data/cdk-integ.out.xxxxx.test-with-snapshot-assets-diff.js.snapshot',
       profile: undefined,
     });
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-      execCmd: ['node', 'test/test-data/xxxxx.test-with-snapshot-assets-diff.js'],
+    expect(cdkMock.mocks.synth).toHaveBeenCalledWith({
+      app: 'node test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',
         CDK_INTEG_REGION: 'test-region',
@@ -233,7 +232,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(3);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenNthCalledWith(1, expect.objectContaining({
       app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       context: expect.any(Object),
@@ -281,7 +280,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(0);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
   });
 
   test('dryrun', async () => {
@@ -302,7 +301,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(0);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(0);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
   });
 
   test('generate snapshot', async () => {
@@ -318,9 +317,9 @@ describe('IntegTest runIntegTests', () => {
     await runner.actualTests();
 
     // THEN
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-      execCmd: ['node', 'test/test-data/xxxxx.integ-test1.js'],
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(1);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledWith({
+      app: 'node test/test-data/xxxxx.integ-test1.js',
       output: 'test/test-data/cdk-integ.out.xxxxx.integ-test1.js.snapshot',
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',
@@ -348,7 +347,7 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(1);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
       app: 'node test/test-data/xxxxx.integ-test1.js',
       requireApproval: 'never',
@@ -643,12 +642,12 @@ describe('IntegTest runIntegTests', () => {
     // THEN
     expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(3);
     expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(2);
+    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith(expect.objectContaining({
       app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
     }));
-    expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith(expect.objectContaining({
-      execCmd: ['node', '--no-warnings', 'test/test-data/xxxxx.test-with-snapshot.js'],
+    expect(cdkMock.mocks.synth).toHaveBeenCalledWith(expect.objectContaining({
+      app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
     }));
     expect(cdkMock.mocks.destroy).toHaveBeenCalledWith(expect.objectContaining({
       app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
@@ -715,10 +714,13 @@ describe('IntegTest watchIntegTest', () => {
     // THEN
     expect(cdkMock.mocks.watch).toHaveBeenCalledWith(expect.objectContaining({
       app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
-      hotswap: HotswapMode.FALL_BACK,
-      watch: true,
+      deploymentMethod: {
+        method: 'hotswap',
+        fallback: {
+          method: 'change-set',
+        },
+      },
       traceLogs: false,
-      deploymentMethod: 'direct',
       verbose: undefined,
     }), expect.anything());
   });
@@ -744,10 +746,13 @@ describe('IntegTest watchIntegTest', () => {
     // THEN
     expect(cdkMock.mocks.watch).toHaveBeenCalledWith(expect.objectContaining({
       app: 'node --no-warnings test/test-data/xxxxx.test-with-snapshot.js',
-      hotswap: HotswapMode.FALL_BACK,
-      watch: true,
+      deploymentMethod: {
+        method: 'hotswap',
+        fallback: {
+          method: 'change-set',
+        },
+      },
       traceLogs: true,
-      deploymentMethod: 'direct',
       verbose: undefined,
     }), expect.anything());
   });

--- a/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
@@ -217,9 +217,9 @@ describe('IntegTest runSnapshotTests', () => {
           stacks: ['stackabc'],
         },
       }));
-      expect(cdkMock.mocks.synthFast).toHaveBeenCalledTimes(1);
-      expect(cdkMock.mocks.synthFast).toHaveBeenCalledWith({
-        execCmd: ['node', 'test/test-data/xxxxx.integ-test2.js'],
+      expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(1);
+      expect(cdkMock.mocks.synth).toHaveBeenCalledWith({
+        app: 'node test/test-data/xxxxx.integ-test2.js',
         env: expect.objectContaining({
           CDK_INTEG_ACCOUNT: '12345678',
           CDK_INTEG_REGION: 'test-region',

--- a/packages/@aws-cdk/integ-runner/tsconfig.dev.json
+++ b/packages/@aws-cdk/integ-runner/tsconfig.dev.json
@@ -8,9 +8,10 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2020"
+      "es2022",
+      "esnext.disposable"
     ],
-    "module": "commonjs",
+    "module": "NodeNext",
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -23,10 +24,11 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020",
+    "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "declarationMap": true,
     "composite": true,
     "outDir": "lib"
   },

--- a/packages/@aws-cdk/integ-runner/tsconfig.json
+++ b/packages/@aws-cdk/integ-runner/tsconfig.json
@@ -10,9 +10,10 @@
     "inlineSourceMap": true,
     "inlineSources": true,
     "lib": [
-      "es2020"
+      "es2022",
+      "esnext.disposable"
     ],
-    "module": "commonjs",
+    "module": "NodeNext",
     "noEmitOnError": false,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -25,10 +26,11 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "stripInternal": true,
-    "target": "ES2020",
+    "target": "es2022",
     "incremental": true,
     "skipLibCheck": true,
     "isolatedModules": true,
+    "declarationMap": true,
     "composite": true
   },
   "include": [


### PR DESCRIPTION
This PR simplifies the CDK interface in integ-runner by consolidating the `synthFast` method into `synth` and removing options that were inherited from the CLI wrapper but never used in the context of integration testing.

The `synthFast` method was originally introduced to bypass the toolkit for faster synthesis during snapshot generation. It was also the only method used by `integ-runner`. With the toolkit-lib engine now handling synthesis uniformly, we can consolidate both methods into one.

Several enums and options have been removed because they were never actually used by `integ-runner.` The `HotswapMode` and `StackActivityProgress` enums were carried over from the CLI wrapper interface but integ-runner always used fixed values. Instead of maintaining these unused abstractions, the code now uses the `DeploymentMethod` type directly from toolkit-lib where needed. Similarly, the `watch` flag on deploy has been removed since watch functionality is accessed through a dedicated method, and options like `progress` and `long` were never applicable to automated testing scenarios.

The TypeScript configuration has been updated to ES2022 with support for `esnext.disposable`. This enables the `await using` syntax which provides proper resource cleanup when working with the toolkit-lib's lock mechanism, replacing manual `dispose()` calls with automatic cleanup that's guaranteed to run even when exceptions occur.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
