### PR TITLE
fix(cloud-assembly-schema): manifest validation takes up majority of synthesis time

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       CI: "true"
       DEBUG: "true"
+      TESTING_CDK: "1"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -421,6 +421,7 @@ const cloudAssemblySchema = configureProject(
     nextVersionCommand: 'tsx ../../../projenrc/next-version.ts majorFromRevision:schema/version.json maybeRc',
   }),
 );
+cloudAssemblySchema.tasks.tryFind('test')?.env('CDK_TESTING', '1');
 
 new JsiiBuild(cloudAssemblySchema, {
   docgen: false,
@@ -548,6 +549,8 @@ const cloudAssemblyApi = configureProject(
     nextVersionCommand: 'tsx ../../../projenrc/next-version.ts atLeast:2.0.0 maybeRc',
   }),
 );
+
+cloudAssemblyApi.tasks.tryFind('test')?.env('CDK_TESTING', '1');
 
 // #endregion
 
@@ -710,6 +713,8 @@ const cdkAssetsLib = configureProject(
   }),
 );
 
+cdkAssetsLib.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+
 // Prevent imports of private API surface
 cdkAssetsLib.package.addField('exports', {
   '.': {
@@ -786,6 +791,8 @@ const cdkAssetsCli = configureProject(
     ]),
   }),
 );
+
+cdkAssetsCli.tasks.tryFind('test')?.env('CDK_TESTING', '1');
 
 cdkAssetsCli.gitignore.addPatterns(
   '*.js',
@@ -941,6 +948,7 @@ const toolkitLib = configureProject(
   }),
 );
 
+toolkitLib.tasks.tryFind('test')?.env('CDK_TESTING', '1');
 toolkitLib.tasks.tryFind('test')?.updateStep(0, {
   // https://github.com/aws/aws-sdk-js-v3/issues/7420
   exec: 'NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" jest --passWithNoTests --updateSnapshot',
@@ -1284,6 +1292,8 @@ new pj.javascript.UpgradeDependencies(cli, {
 });
 
 new TypecheckTests(cli);
+
+cli.tasks.tryFind('test')?.env('CDK_TESTING', '1');
 
 // Eslint rules
 cli.eslint?.addRules({
@@ -1715,7 +1725,10 @@ new LargePrChecker(repo, {
   excludeFiles: ['*.md', '*.test.ts', '*.yml', '*.lock'],
 });
 
-((repo.github?.tryFindWorkflow('integ')?.getJob('prepare') as Job | undefined)?.env ?? {}).DEBUG = 'true';
+Object.assign((repo.github?.tryFindWorkflow('integ')?.getJob('prepare') as Job | undefined)?.env ?? {}, {
+  DEBUG: 'true',
+  TESTING_CDK: '1',
+});
 
 // Set allowed scopes based on monorepo packages
 const disallowed = new Set([

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -421,7 +421,7 @@ const cloudAssemblySchema = configureProject(
     nextVersionCommand: 'tsx ../../../projenrc/next-version.ts majorFromRevision:schema/version.json maybeRc',
   }),
 );
-cloudAssemblySchema.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+cloudAssemblySchema.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 
 new JsiiBuild(cloudAssemblySchema, {
   docgen: false,
@@ -550,7 +550,7 @@ const cloudAssemblyApi = configureProject(
   }),
 );
 
-cloudAssemblyApi.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+cloudAssemblyApi.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 
 // #endregion
 
@@ -713,7 +713,7 @@ const cdkAssetsLib = configureProject(
   }),
 );
 
-cdkAssetsLib.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+cdkAssetsLib.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 
 // Prevent imports of private API surface
 cdkAssetsLib.package.addField('exports', {
@@ -792,7 +792,7 @@ const cdkAssetsCli = configureProject(
   }),
 );
 
-cdkAssetsCli.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+cdkAssetsCli.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 
 cdkAssetsCli.gitignore.addPatterns(
   '*.js',
@@ -948,7 +948,7 @@ const toolkitLib = configureProject(
   }),
 );
 
-toolkitLib.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+toolkitLib.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 toolkitLib.tasks.tryFind('test')?.updateStep(0, {
   // https://github.com/aws/aws-sdk-js-v3/issues/7420
   exec: 'NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" jest --passWithNoTests --updateSnapshot',
@@ -1293,7 +1293,7 @@ new pj.javascript.UpgradeDependencies(cli, {
 
 new TypecheckTests(cli);
 
-cli.tasks.tryFind('test')?.env('CDK_TESTING', '1');
+cli.tasks.tryFind('test')?.env('TESTING_CDK', '1');
 
 // Eslint rules
 cli.eslint?.addRules({

--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -228,6 +228,10 @@ async function main() {
 
     const jestConfig = path.resolve(__dirname, '..', '..', 'resources', 'integ.jest.config.js');
 
+    // Flip a flag to indicate we're testing CDK itself. Some parts of CDK behave more thoroughly
+    // (but slowly) if this flag is set.
+    process.env.TESTING_CDK = '1';
+
     await jest.run([
       '--randomize',
       ...args.seed ? [`--seed=${args.seed}`] : [],

--- a/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
@@ -167,7 +167,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
@@ -166,6 +166,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",

--- a/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
@@ -162,6 +162,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",

--- a/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
@@ -163,7 +163,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
@@ -255,7 +255,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
@@ -254,6 +254,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",

--- a/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
@@ -15,8 +15,6 @@ import {
 
 const FIXTURES = path.join(__dirname, 'fixtures');
 
-console.log(process.env);
-
 function fixture(name: string) {
   return path.join(FIXTURES, name, 'manifest.json');
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
@@ -15,6 +15,8 @@ import {
 
 const FIXTURES = path.join(__dirname, 'fixtures');
 
+process.env.TESTING_CDK = '1';
+
 function fixture(name: string) {
   return path.join(FIXTURES, name, 'manifest.json');
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/test/manifest.test.ts
@@ -15,6 +15,8 @@ import {
 
 const FIXTURES = path.join(__dirname, 'fixtures');
 
+console.log(process.env);
+
 function fixture(name: string) {
   return path.join(FIXTURES, name, 'manifest.json');
 }

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -208,6 +208,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" jest --passWithNoTests --updateSnapshot"

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -209,7 +209,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
@@ -45,7 +45,7 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
     this.url = props.url ?? 'https://cli.cdk.dev-tools.aws.dev/notices.json';
   }
 
-  async fetch(opts?: { forceShortTimeout?: boolean }): Promise<Notice[]> {
+  async fetch(): Promise<Notice[]> {
     // Check connectivity before attempting network request
     const hasConnectivity = await NetworkDetector.hasConnectivity(this.agent);
     if (!hasConnectivity) {
@@ -56,7 +56,10 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
     // integration test environment, so wait for a longer timeout there.
     //
     // In production, have a short timeout to not hold up the user experience.
-    const timeout = process.env.TESTING_CDK && !opts?.forceShortTimeout ? 30_000 : 3_000;
+    const timeout = process.env.CDK_NOTICES_TIMEOUT !== undefined
+      ? parseInt(process.env.CDK_NOTICES_TIMEOUT, 10)
+      : process.env.TESTING_CDK
+      ? 30_000 : 3_000;
 
     const options: RequestOptions = {
       agent: this.agent,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
@@ -59,7 +59,7 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
     const timeout = process.env.CDK_NOTICES_TIMEOUT !== undefined
       ? parseInt(process.env.CDK_NOTICES_TIMEOUT, 10)
       : process.env.TESTING_CDK
-      ? 30_000 : 3_000;
+        ? 30_000 : 3_000;
 
     const options: RequestOptions = {
       agent: this.agent,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/web-data-source.ts
@@ -45,7 +45,7 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
     this.url = props.url ?? 'https://cli.cdk.dev-tools.aws.dev/notices.json';
   }
 
-  async fetch(): Promise<Notice[]> {
+  async fetch(opts?: { forceShortTimeout?: boolean }): Promise<Notice[]> {
     // Check connectivity before attempting network request
     const hasConnectivity = await NetworkDetector.hasConnectivity(this.agent);
     if (!hasConnectivity) {
@@ -56,7 +56,7 @@ export class WebsiteNoticeDataSource implements NoticeDataSource {
     // integration test environment, so wait for a longer timeout there.
     //
     // In production, have a short timeout to not hold up the user experience.
-    const timeout = process.env.TESTING_CDK ? 30_000 : 3_000;
+    const timeout = process.env.TESTING_CDK && !opts?.forceShortTimeout ? 30_000 : 3_000;
 
     const options: RequestOptions = {
       agent: this.agent,

--- a/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
@@ -617,7 +617,7 @@ describe(WebsiteNoticeDataSource, () => {
         notices: [BASIC_NOTICE],
       });
 
-    const result = dataSource.fetch();
+    const result = dataSource.fetch({ forceShortTimeout: true });
 
     await expect(result).rejects.toThrow(/timed out/);
   });
@@ -630,7 +630,7 @@ describe(WebsiteNoticeDataSource, () => {
         notices: [BASIC_NOTICE],
       });
 
-    const result = dataSource.fetch();
+    const result = dataSource.fetch({ forceShortTimeout: true });
 
     await expect(result).rejects.toThrow(/timed out/);
   });

--- a/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
@@ -14,6 +14,8 @@ import { WebsiteNoticeDataSource } from '../../lib/api/notices/web-data-source';
 import { Settings } from '../../lib/api/settings';
 import { TestIoHost } from '../_helpers';
 
+process.env.CDK_NOTICES_TIMEOUT = '3000';
+
 const BASIC_BOOTSTRAP_NOTICE = {
   title: 'Exccessive permissions on file asset publishing role',
   issueNumber: 16600,
@@ -617,7 +619,7 @@ describe(WebsiteNoticeDataSource, () => {
         notices: [BASIC_NOTICE],
       });
 
-    const result = dataSource.fetch({ forceShortTimeout: true });
+    const result = dataSource.fetch();
 
     await expect(result).rejects.toThrow(/timed out/);
   });
@@ -630,7 +632,7 @@ describe(WebsiteNoticeDataSource, () => {
         notices: [BASIC_NOTICE],
       });
 
-    const result = dataSource.fetch({ forceShortTimeout: true });
+    const result = dataSource.fetch();
 
     await expect(result).rejects.toThrow(/timed out/);
   });

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -188,7 +188,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -187,6 +187,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",

--- a/packages/aws-cdk/test/commands/notices.test.ts
+++ b/packages/aws-cdk/test/commands/notices.test.ts
@@ -9,6 +9,8 @@ jest.mock('../../../@aws-cdk/toolkit-lib/lib/api/network-detector/network-detect
 import * as nock from 'nock';
 import { exec } from '../../lib/cli/cli';
 
+process.env.CDK_NOTICES_TIMEOUT = '3000';
+
 const NOTICES_URL = 'https://cli.cdk.dev-tools.aws.dev';
 const NOTICES_PATH = '/notices.json';
 

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -169,7 +169,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
-        "CDK_TESTING": "1"
+        "TESTING_CDK": "1"
       },
       "steps": [
         {

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -168,6 +168,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "CDK_TESTING": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",


### PR DESCRIPTION
We use `jsonschema` to validate the Cloud Assembly manifest on every write and read. Synthesizing a CDK app results in both a save and load every time.

Not only is that wasteful, JSON Schema validation is also extremely slow, which starts to get noticeable on large CDK applications. In fact, on sizeable applications validation takes up ~85-90% of the entire synthesis time. Some synthetic benchmarks went from 20s to 2s, and from 54s to 6s without validation.

In this PR, I'm making validation configurable but most importantly: switching it off by default.

That is slightly dangerous, so we're doing something else: introduce an environment variable, `TESTING_CDK=1`. If this is set, we will do validation by default, otherwise we will not.

In all our tests we switch on `TESTING_CDK`, so that if we ever make a mistake we will catch it in tests, but our customers don't pay this price on every single synthesis.

(If you are concerned about this: to my knowledge this JSON schema validation hasn't caught a single problem in the ~8 years that CDK has existed.)


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
