### PR TITLE
fix(toolkit-lib): wrap assembly in CachedCloudAssembly when caching is enabled

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/index.ts
@@ -1,6 +1,6 @@
 
 import type { SdkProvider } from '../../api/aws-auth/private';
-import type { ICloudAssemblySource } from '../../api/cloud-assembly';
+import { CachedCloudAssembly, type ICloudAssemblySource } from '../../api/cloud-assembly';
 import { StackAssembly } from '../../api/cloud-assembly/private';
 import type { IoHelper } from '../../api/io/private';
 import type { PluginHost } from '../../api/plugin';
@@ -30,8 +30,7 @@ export async function assemblyFromSource(ioHelper: IoHelper, assemblySource: ICl
   }
 
   if (cache) {
-    const ret = new StackAssembly(await assemblySource.produce(), ioHelper);
-    return ret;
+    return new StackAssembly(new CachedCloudAssembly(await assemblySource.produce()), ioHelper);
   }
 
   return new StackAssembly(await assemblySource.produce(), ioHelper);


### PR DESCRIPTION
The `assemblyFromSource` function has a `cache` parameter that controls whether the produced cloud assembly should be cached. However, when `cache=true`, the code was not actually wrapping the assembly in a `CachedCloudAssembly`. This presumingly got lost as part of https://github.com/aws/aws-cdk-cli/pull/344. It also meant that the caching semantics described in the `CachedCloudAssembly` class documentation were not being applied.

The `CachedCloudAssembly` wrapper is important because it manages the lifetime of borrowed assemblies. When multiple toolkit operations need to work with the same assembly, the `CachedCloudAssembly` ensures that `dispose()` calls on borrowed copies are no-ops, and only the parent's `dispose()` actually cleans up resources. Without this wrapper, each `StackAssembly` would manage its own lifecycle independently, which could lead to premature disposal or resource leaks.

This change wraps the produced assembly in `CachedCloudAssembly` when caching is enabled, ensuring the intended caching behavior is actually applied.

Initial benchmarking showed a 5% performance improvement in `integ-runner` due to this change (based on a full run of integ tests in `aws/aws-cdk`).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
