### PR TITLE
fix(integ-runner): snapshot tests warn with confusing message about stacks with region

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -264,7 +264,12 @@ export class ToolkitLibRunnerEngine implements ICdk {
    *
    * This catches that misconfiguration.
    */
-  private async validateRegion(asm: IReadableCloudAssembly) {
+  private async validateRegion(asm: IReadableCloudAssembly): Promise<void> {
+    // this happens for existing snapshots, in that case nothing to check
+    if (this.options.region === UNKNOWN_REGION) {
+      return;
+    }
+
     for (const stack of asm.cloudAssembly.stacksRecursively) {
       if (stack.environment.region !== this.options.region && stack.environment.region !== UNKNOWN_REGION) {
         this.ioHost.notify({

--- a/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import type { WritableOptions } from 'stream';
 import { Writable } from 'stream';
 import { StringDecoder } from 'string_decoder';
+import { UNKNOWN_REGION } from '@aws-cdk/cloud-assembly-api';
 import type { ResourceDifference } from '@aws-cdk/cloudformation-diff';
 import { fullDiff, formatDifferences, ResourceImpact } from '@aws-cdk/cloudformation-diff';
 import { AssemblyManifestReader } from './private/cloud-assembly';
@@ -37,7 +38,7 @@ export class IntegSnapshotRunner extends IntegRunner {
   constructor(options: Omit<IntegRunnerOptions, 'region'>) {
     super({
       ...options,
-      region: 'unused',
+      region: UNKNOWN_REGION,
     });
   }
 


### PR DESCRIPTION
When running snapshot tests, the integ-runner doesn't need a real AWS region since it only compares CloudFormation templates without deploying anything. Previously, the code used a placeholder string `'unused'` for this purpose.

However, the region validation logic introduced in #949 doesn't account for this case. When a snapshot test encounters a stack with a hardcoded region, it produces a confusing warning message like:

```
Stack <stack-name> synthesizes for region eu-west-1, even though unused was requested.
```

The word "unused" in this message is meaningless to users and makes the warning difficult to understand.

This change replaces the placeholder with the proper `UNKNOWN_REGION` constant from `@aws-cdk/cloud-assembly-api` and adds an early return in the validation logic to skip region checks entirely when no real region was configured. This is the correct behavior because snapshot tests intentionally don't care about regions. The warning will still be printed when the integ test is actually deployed. 

## Why this change?

I choose to replace `unused` with `UNKNOWN_REGION` since the former has some entirely undefined meaning and the latter has at least some precedence in the CDK.

I also believe that it's not valuable to print this warning when snapshots are validated. It will be enough to print this when a test case is deployed. In fact there's a bug here that neither the stacks region nor the test case's `regions` list are properly taken into account to select a region for deployment. But this will be a future fix.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
