### PR TITLE
fix: primitive export values are not properly handled by `refactor`

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -115,11 +115,16 @@ function stripReferences(value: any, exports: { [p: string]: { stackName: string
     const exp = exports[value['Fn::ImportValue']];
     if (exp != null) {
       const v = exp.value;
-      // Treat Fn::ImportValue as if it were a reference with the same stack
-      if ('Ref' in v) {
-        return { __cloud_ref__: 'Ref' };
-      } else if ('Fn::GetAtt' in v) {
-        return { __cloud_ref__: 'Fn::GetAtt' };
+      if (v != null && typeof v === 'object') {
+        // Treat Fn::ImportValue as if it were a reference with the same stack
+        if ('Ref' in v) {
+          return { __cloud_ref__: 'Ref' };
+        } else if ('Fn::GetAtt' in v) {
+          return { __cloud_ref__: 'Fn::GetAtt' };
+        }
+      } else {
+        // If the export value is a primitive, we can just use it directly
+        return v;
       }
     }
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/graph.ts
@@ -58,12 +58,14 @@ export class ResourceGraph {
         const exp = exports[value['Fn::ImportValue']];
         if (exp != null) {
           const v = exp.value;
-          if ('Fn::GetAtt' in v) {
-            const id = Array.isArray(v['Fn::GetAtt']) ? v['Fn::GetAtt'][0] : v['Fn::GetAtt'].split('.')[0];
-            return [`${exp.stackName}.${id}`];
-          }
-          if ('Ref' in v) {
-            return [`${exp.stackName}.${v.Ref}`];
+          if (v != null && typeof v === 'object') {
+            if ('Fn::GetAtt' in v) {
+              const id = Array.isArray(v['Fn::GetAtt']) ? v['Fn::GetAtt'][0] : v['Fn::GetAtt'].split('.')[0];
+              return [`${exp.stackName}.${id}`];
+            }
+            if ('Ref' in v) {
+              return [`${exp.stackName}.${v.Ref}`];
+            }
           }
           return [`${exp.stackName}.${v}`];
         }

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -493,7 +493,7 @@ describe(computeResourceDigests, () => {
     expect(result['Stack1.Bucket']).toEqual(result['Stack2.AnotherBucket']);
   });
 
-  test('XXXXXXXXXXXXXXXXXXXXXXXXXXXX', () => {
+  test('resources with same final values via different sources have identical digests', () => {
     const template1 = {
       Resources: {
         Bucket1: {


### PR DESCRIPTION
An assumption in the `refactor` code is that the value obtained by `Fn::ImportValue` is always an object. This is not true, since primitive values are also allowed.

Handle the primitive case both when computing the digest and when finding the dependencies of a given resource.

Fixes https://github.com/aws/aws-cdk-cli/issues/1118


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
