### PR TITLE
docs: update AgentCore Runtime S3-based hotswap recommendation to use `fromCodeAsset()`

### DIFF
--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -519,29 +519,22 @@ Hotswapping is currently supported for the following changes
 - Schema changes for AppSync GraphQL Apis.
 - Code files (S3-based) and container image (ECR-based) changes, along with environment variable
   and description changes of Amazon Bedrock AgentCore Runtimes.
-  - **Note**: For S3-based code changes to be detected, use `Asset` from `aws-cdk-lib/aws-s3-assets`:
+  - **Note**: For S3-based code changes to be detected, use `AgentRuntimeArtifact.fromCodeAsset()`:
 
     ```typescript
     // ✅ Recommended (hotswap works)
-    const asset = new aws_s3_assets.Asset(this, 'CodeAsset', {
+    const agentRuntimeArtifact = AgentRuntimeArtifact.fromCodeAsset({
       path: path.join(__dirname, 'agent-code'),
+      runtime: AgentCoreRuntime.PYTHON_3_13,
+      entrypoint: ['app.py'],
     });
-
-    const agentRuntimeArtifact = AgentRuntimeArtifact.fromS3(
-      {
-        bucketName: asset.s3BucketName,
-        objectKey: asset.s3ObjectKey, // Content hash, changes when code changes
-      },
-      AgentCoreRuntime.PYTHON_3_13,
-      ['app.py'],
-    );
     new Runtime(this, 'Runtime', {
       runtimeName: 'runtime',
       agentRuntimeArtifact,
     });
     ```
 
-  - Do not use `Source.asset()` with `BucketDeployment`, as the generated object key is a token resolved at deployment time and does not change in the CloudFormation template (hotswap will not work):
+  - Do not use `AgentRuntimeArtifact.fromS3()` with `Source.asset()` and `BucketDeployment`, as the generated object key is a token resolved at deployment time and does not change in the CloudFormation template (hotswap will not work):
 
     ```typescript
     // ❌ Not recommended (hotswap doesn't work)


### PR DESCRIPTION
Since `AgentRuntimeArtifact.fromCodeAsset()` was introduced in [this PR](https://github.com/aws/aws-cdk/pull/36472), updated the README to use it instead of the `Asset`-based example.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
