### PR TITLE
fix(cli): use NuGet floating version for constructs in .NET templates

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/testcase.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/testcase.ts
@@ -9,14 +9,14 @@ export async function deploysSuccessfully(fixture: TestFixture, language: string
     await fixture.shell(['pip', 'install', '-r', 'requirements.txt']);
   }
 
-  const stackArn = await fixture.cdkDeploy(
+  await fixture.cdkDeploy(
     fixture.stackNamePrefix,
     { neverRequireApproval: true, verbose: true, captureStderr: false },
     true,
   );
   const response = await fixture.aws.cloudFormation.send(
     new DescribeStacksCommand({
-      StackName: stackArn,
+      StackName: fixture.stackNamePrefix,
     }),
   );
 

--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -581,10 +581,13 @@ export function expandPlaceholders(template: string, language: string, project: 
 
   switch (language) {
     case 'java':
-    case 'csharp':
-    case 'fsharp':
       cdkVersion = rangeFromSemver(cdkVersion, 'bracket');
       constructsVersion = rangeFromSemver(constructsVersion, 'bracket');
+      break;
+    case 'csharp':
+    case 'fsharp':
+      cdkVersion = rangeFromSemver(cdkVersion, 'bracket'); // ^2.123.0 => [2.123.0,3.0.0)
+      constructsVersion = rangeFromSemver(constructsVersion, 'major.*'); // ^10.0.0 => 10.*/
       break;
     case 'python':
       cdkVersion = rangeFromSemver(cdkVersion, 'pep');

--- a/packages/aws-cdk/test/commands/init.test.ts
+++ b/packages/aws-cdk/test/commands/init.test.ts
@@ -181,7 +181,7 @@ describe('constructs version', () => {
     const csproj = (await fs.readFile(csprojFile, 'utf8')).split(/\r?\n/);
     const sln = (await fs.readFile(slnFile, 'utf8')).split(/\r?\n/);
 
-    expect(csproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="\[10\..*,11\..*\)"/));
+    expect(csproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="10\.\*"/));
     expect(csproj).toContainEqual(expect.stringMatching(/\<TargetFramework>net8.0<\/TargetFramework>/));
     expect(sln).toContainEqual(expect.stringMatching(/\"AwsCdkTest[a-zA-Z0-9]{6}\\AwsCdkTest[a-zA-Z0-9]{6}.csproj\"/));
   });
@@ -204,7 +204,7 @@ describe('constructs version', () => {
     const fsproj = (await fs.readFile(fsprojFile, 'utf8')).split(/\r?\n/);
     const sln = (await fs.readFile(slnFile, 'utf8')).split(/\r?\n/);
 
-    expect(fsproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="\[10\..*,11\..*\)"/));
+    expect(fsproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="10\.\*"/));
     expect(fsproj).toContainEqual(expect.stringMatching(/\<TargetFramework>net8.0<\/TargetFramework>/));
     expect(sln).toContainEqual(expect.stringMatching(/\"AwsCdkTest[a-zA-Z0-9]{6}\\AwsCdkTest[a-zA-Z0-9]{6}.fsproj\"/));
   });
@@ -224,7 +224,7 @@ describe('constructs version', () => {
 
     const csproj = (await fs.readFile(csprojFile, 'utf8')).split(/\r?\n/);
 
-    expect(csproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="\[10\..*,11\..*\)"/));
+    expect(csproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="10\.\*"/));
     expect(csproj).toContainEqual(expect.stringMatching(/\<TargetFramework>net8.0<\/TargetFramework>/));
   });
 
@@ -243,7 +243,7 @@ describe('constructs version', () => {
 
     const fsproj = (await fs.readFile(fsprojFile, 'utf8')).split(/\r?\n/);
 
-    expect(fsproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="\[10\..*,11\..*\)"/));
+    expect(fsproj).toContainEqual(expect.stringMatching(/\<PackageReference Include="Constructs" Version="10\.\*"/));
     expect(fsproj).toContainEqual(expect.stringMatching(/\<TargetFramework>net8.0<\/TargetFramework>/));
   });
 


### PR DESCRIPTION
NuGet's default behavior is to install the lowest version that satisfies a version range. For `aws-cdk-lib` this works well because we specify the minimum required version. However, for the `constructs` library, users benefit from having the latest version installed since it contains important fixes and improvements.

The previous bracket notation `[10.x,11.x)` would cause NuGet to install `constructs` version `10.0.0` - the lowest version in the range. This is problematic because early 10.x versions lack features and fixes that have been added over time.

By switching to NuGet's floating version syntax `10.*`, NuGet will instead resolve to the highest available 10.x version. This ensures that new CDK projects start with a current version of constructs, providing a better out-of-the-box experience for .NET developers.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
