### PR TITLE
chore(cli-integ): log constructs library version in test output

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -166,6 +166,9 @@ async function main() {
   const librarySource: IRunnerSource<ITestLibrarySource>
     = new RunnerLibraryNpmSource('aws-cdk-lib', args['framework-version'] ? args['framework-version'] : 'latest');
 
+  // constructs is installed with aws-cdk-lib
+  const constructsSource = new RunnerLibraryPreinstalledSource('constructs');
+
   // Toolkit lib source is either the given one, or the one that's being brought by 'package.json' already, or 'latest'
   const toolkitLibPackage = '@aws-cdk/toolkit-lib';
   let toolkitSource: IRunnerSource<ITestLibrarySource> | undefined;
@@ -183,6 +186,7 @@ async function main() {
   console.log(`        Test version:       ${thisPackageVersion()}`);
   console.log(`        CLI source:         ${cliSource.assert().sourceDescription}`);
   console.log(`        Library source:     ${librarySource.sourceDescription}`);
+  console.log(`        Constructs source:  ${constructsSource.sourceDescription}`);
   console.log(`        Toolkit lib source: ${toolkitSource.sourceDescription}`);
   console.log(`        cdk-assets source:  ${cdkAssetsSource.assert().sourceDescription}`);
 
@@ -210,6 +214,9 @@ async function main() {
     const library = await librarySource.runnerPrepare();
     disposables.push(library);
     console.log(`        Library:         ${library.version}`);
+
+    const constructs = await constructsSource.runnerPrepare();
+    console.log(`        Constructs:      ${constructs.version}`);
 
     const toolkitLib = await toolkitSource.runnerPrepare();
     disposables.push(toolkitLib);


### PR DESCRIPTION
The CLI integration test suite logs version information for all the packages it uses during test runs. This is helpful when debugging test failures, as version mismatches between packages can cause subtle issues.

However, the `constructs` library version was not being logged, even though it's a critical peer dependency of `aws-cdk-lib`. When `aws-cdk-lib` is installed, it brings along a specific version of `constructs` that must be compatible. If there's a version mismatch or an unexpected version is being used, it can lead to confusing test failures that are hard to diagnose.

This change adds the `constructs` library to the version logging output. Since `constructs` is already installed as a transitive dependency of `aws-cdk-lib`, we use `RunnerLibraryPreinstalledSource` to detect and report its version without installing it separately.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
