### PR TITLE
fix(cli): `cdk init` fails to run `dotnet restore && dotnet build` for C# & F# projects

### DIFF
--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -900,7 +900,8 @@ async function postInstallGo(ioHelper: IoHelper, canUseNetwork: boolean, cwd: st
 }
 
 async function postInstallCSharp(ioHelper: IoHelper, canUseNetwork: boolean, cwd: string) {
-  const dotnetWarning = "Please run 'dotnet restore && dotnet build'!";
+  const solutionDir = path.join(cwd, 'src'); // the dotnet solution is inside the src dir
+  const dotnetWarning = "Please run 'cd src && dotnet restore && dotnet build'!";
   if (!canUseNetwork) {
     await ioHelper.defaults.warn(dotnetWarning);
     return;
@@ -908,9 +909,9 @@ async function postInstallCSharp(ioHelper: IoHelper, canUseNetwork: boolean, cwd
 
   await ioHelper.defaults.info(`Executing ${chalk.green('dotnet restore')}...`);
   try {
-    await execute(ioHelper, 'dotnet', ['restore'], { cwd });
+    await execute(ioHelper, 'dotnet', ['restore'], { cwd: solutionDir });
     await ioHelper.defaults.info(`Executing ${chalk.green('dotnet build')}...`);
-    await execute(ioHelper, 'dotnet', ['build'], { cwd });
+    await execute(ioHelper, 'dotnet', ['build'], { cwd: solutionDir });
   } catch (e: any) {
     await ioHelper.defaults.warn('Unable to restore/build .NET project: ' + formatErrorMessage(e));
     await ioHelper.defaults.warn(dotnetWarning);


### PR DESCRIPTION
The C# template places the solution file (`.sln`) and project files (`.csproj`) inside a `src` subdirectory, but `cdk init` was running `dotnet restore` and `dotnet build` in the project root directory. This caused the commands to fail with:

```
MSBUILD : error MSB1003: Specify a project or solution file. The current working directory does not contain a project or solution file.
```

This change updates `postInstallCSharp` to execute dotnet commands in the `src` subdirectory where the solution actually lives. The warning message is also updated to guide users to the correct directory if they need to run the commands manually.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
