### PR TITLE
refactor(cli-integ): split test matrix into separate jobs

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -142,7 +142,242 @@ jobs:
         run: |-
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
-  integ_matrix:
+  integ_cli:
+    needs:
+      - prepare
+      - telemetry_tests
+    runs-on: aws-cdk_ubuntu-latest_16-core
+    permissions:
+      contents: read
+      id-token: write
+    environment: run-tests
+    env:
+      MAVEN_ARGS: --no-transfer-progress
+      IS_CANARY: "true"
+      CI: "true"
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: packages
+      - name: Download scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: script-artifact
+          path: .projen
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Set up JDK 18
+        if: matrix.suite == 'init-java' || matrix.suite == 'cli-integ-tests'
+        uses: actions/setup-java@v4
+        with:
+          java-version: "18"
+          distribution: corretto
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 3600
+          role-to-assume: ${{ vars.CDK_ATMOSPHERE_PROD_OIDC_ROLE }}
+          role-session-name: run-tests@aws-cdk-cli-integ
+          output-credentials: true
+      - name: Set git identity
+        run: |-
+          git config --global user.name "aws-cdk-cli-integ"
+          git config --global user.email "noreply@example.com"
+      - name: Prepare Verdaccio
+        run: chmod +x .projen/prepare-verdaccio.sh && .projen/prepare-verdaccio.sh
+      - name: Download and install the test artifact
+        run: npm install @aws-cdk-testing/cli-integ
+      - name: Determine latest package versions
+        id: versions
+        run: |-
+          CLI_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk version)
+          echo "CLI version: ${CLI_VERSION}"
+          echo "cli_version=${CLI_VERSION}" >> $GITHUB_OUTPUT
+          LIB_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk-lib version)
+          echo "lib version: ${LIB_VERSION}"
+          echo "lib_version=${LIB_VERSION}" >> $GITHUB_OUTPUT
+      - name: "Run the test suite: ${{ matrix.suite }}"
+        env:
+          JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION: "true"
+          DOCKERHUB_DISABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENDPOINT: ${{ vars.CDK_ATMOSPHERE_PROD_ENDPOINT }}
+          CDK_INTEG_ATMOSPHERE_POOL: ${{ vars.CDK_INTEG_ATMOSPHERE_POOL }}
+          CDK_MAJOR_VERSION: "2"
+          RELEASE_TAG: latest
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INTEG_LOGS: logs
+        run: npx run-suite --shard="${{ matrix.shard }}/12" --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+      - name: Set workflow summary
+        if: always()
+        run: |-
+          if compgen -G "logs/md/*.md" > /dev/null; then
+            cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;
+          fi
+      - name: Slugify artifact id
+        id: artifactid
+        if: always()
+        env:
+          INPUT: logs-${{ matrix.suite }}-${{ matrix.node }}-${{ matrix.shard }}
+        run: |-
+          slug=$(node -p 'process.env.INPUT.replace(/[^a-z0-9._-]/gi, "-")')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Upload logs
+        id: logupload
+        if: always()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: ${{ steps.artifactid.outputs.slug }}
+          path: logs/
+          overwrite: "true"
+      - name: Append artifact URL
+        if: always()
+        run: |-
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - cli-integ-tests
+        node:
+          - lts/*
+        shard:
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
+          - 6
+          - 7
+          - 8
+          - 9
+          - 10
+          - 11
+          - 12
+  integ_toolkit-lib:
+    needs:
+      - prepare
+      - telemetry_tests
+    runs-on: aws-cdk_ubuntu-latest_16-core
+    permissions:
+      contents: read
+      id-token: write
+    environment: run-tests
+    env:
+      MAVEN_ARGS: --no-transfer-progress
+      IS_CANARY: "true"
+      CI: "true"
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: packages
+      - name: Download scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: script-artifact
+          path: .projen
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Set up JDK 18
+        if: matrix.suite == 'init-java' || matrix.suite == 'cli-integ-tests'
+        uses: actions/setup-java@v4
+        with:
+          java-version: "18"
+          distribution: corretto
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 3600
+          role-to-assume: ${{ vars.CDK_ATMOSPHERE_PROD_OIDC_ROLE }}
+          role-session-name: run-tests@aws-cdk-cli-integ
+          output-credentials: true
+      - name: Set git identity
+        run: |-
+          git config --global user.name "aws-cdk-cli-integ"
+          git config --global user.email "noreply@example.com"
+      - name: Prepare Verdaccio
+        run: chmod +x .projen/prepare-verdaccio.sh && .projen/prepare-verdaccio.sh
+      - name: Download and install the test artifact
+        run: npm install @aws-cdk-testing/cli-integ
+      - name: Determine latest package versions
+        id: versions
+        run: |-
+          CLI_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk version)
+          echo "CLI version: ${CLI_VERSION}"
+          echo "cli_version=${CLI_VERSION}" >> $GITHUB_OUTPUT
+          LIB_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk-lib version)
+          echo "lib version: ${LIB_VERSION}"
+          echo "lib_version=${LIB_VERSION}" >> $GITHUB_OUTPUT
+      - name: "Run the test suite: ${{ matrix.suite }}"
+        env:
+          JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION: "true"
+          DOCKERHUB_DISABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENDPOINT: ${{ vars.CDK_ATMOSPHERE_PROD_ENDPOINT }}
+          CDK_INTEG_ATMOSPHERE_POOL: ${{ vars.CDK_INTEG_ATMOSPHERE_POOL }}
+          CDK_MAJOR_VERSION: "2"
+          RELEASE_TAG: latest
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INTEG_LOGS: logs
+        run: npx run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+      - name: Set workflow summary
+        if: always()
+        run: |-
+          if compgen -G "logs/md/*.md" > /dev/null; then
+            cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;
+          fi
+      - name: Slugify artifact id
+        id: artifactid
+        if: always()
+        env:
+          INPUT: logs-${{ matrix.suite }}-${{ matrix.node }}
+        run: |-
+          slug=$(node -p 'process.env.INPUT.replace(/[^a-z0-9._-]/gi, "-")')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Upload logs
+        id: logupload
+        if: always()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: ${{ steps.artifactid.outputs.slug }}
+          path: logs/
+          overwrite: "true"
+      - name: Append artifact URL
+        if: always()
+        run: |-
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - toolkit-lib-integ-tests
+        node:
+          - lts/*
+          - 18.17.0
+          - "20"
+          - "22"
+          - "24"
+  integ_init-templates:
     needs:
       - prepare
       - telemetry_tests
@@ -256,22 +491,7 @@ jobs:
             node: "22"
           - suite: init-typescript-app
             node: "24"
-          - suite: toolkit-lib-integ-tests
-            node: 18.17.0
-          - suite: toolkit-lib-integ-tests
-            node: "20"
-          - suite: toolkit-lib-integ-tests
-            node: "22"
-          - suite: toolkit-lib-integ-tests
-            node: "24"
-          - suite: tool-integrations
-            node: 20
-        exclude:
-          - suite: tool-integrations
-            node: lts/*
         suite:
-          - cli-integ-tests
-          - toolkit-lib-integ-tests
           - init-csharp
           - init-fsharp
           - init-go
@@ -280,20 +500,135 @@ jobs:
           - init-python
           - init-typescript-app
           - init-typescript-lib
-          - tool-integrations
         node:
           - lts/*
-  integ:
+  integ_tool-integrations:
     needs:
       - prepare
       - telemetry_tests
-      - integ_matrix
     runs-on: aws-cdk_ubuntu-latest_16-core
+    permissions:
+      contents: read
+      id-token: write
+    environment: run-tests
+    env:
+      MAVEN_ARGS: --no-transfer-progress
+      IS_CANARY: "true"
+      CI: "true"
+    if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifact
+          path: packages
+      - name: Download scripts
+        uses: actions/download-artifact@v4
+        with:
+          name: script-artifact
+          path: .projen
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+      - name: Set up JDK 18
+        if: matrix.suite == 'init-java' || matrix.suite == 'cli-integ-tests'
+        uses: actions/setup-java@v4
+        with:
+          java-version: "18"
+          distribution: corretto
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: us-east-1
+          role-duration-seconds: 3600
+          role-to-assume: ${{ vars.CDK_ATMOSPHERE_PROD_OIDC_ROLE }}
+          role-session-name: run-tests@aws-cdk-cli-integ
+          output-credentials: true
+      - name: Set git identity
+        run: |-
+          git config --global user.name "aws-cdk-cli-integ"
+          git config --global user.email "noreply@example.com"
+      - name: Prepare Verdaccio
+        run: chmod +x .projen/prepare-verdaccio.sh && .projen/prepare-verdaccio.sh
+      - name: Download and install the test artifact
+        run: npm install @aws-cdk-testing/cli-integ
+      - name: Determine latest package versions
+        id: versions
+        run: |-
+          CLI_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk version)
+          echo "CLI version: ${CLI_VERSION}"
+          echo "cli_version=${CLI_VERSION}" >> $GITHUB_OUTPUT
+          LIB_VERSION=$(cd ${TMPDIR:-/tmp} && npm view aws-cdk-lib version)
+          echo "lib version: ${LIB_VERSION}"
+          echo "lib_version=${LIB_VERSION}" >> $GITHUB_OUTPUT
+      - name: "Run the test suite: ${{ matrix.suite }}"
+        env:
+          JSII_SILENCE_WARNING_DEPRECATED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_UNTESTED_NODE_VERSION: "true"
+          JSII_SILENCE_WARNING_KNOWN_BROKEN_NODE_VERSION: "true"
+          DOCKERHUB_DISABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENABLED: "true"
+          CDK_INTEG_ATMOSPHERE_ENDPOINT: ${{ vars.CDK_ATMOSPHERE_PROD_ENDPOINT }}
+          CDK_INTEG_ATMOSPHERE_POOL: ${{ vars.CDK_INTEG_ATMOSPHERE_POOL }}
+          CDK_MAJOR_VERSION: "2"
+          RELEASE_TAG: latest
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INTEG_LOGS: logs
+        run: npx run-suite --use-cli-release=${{ steps.versions.outputs.cli_version }} --framework-version=${{ steps.versions.outputs.lib_version }} ${{ matrix.suite }}
+      - name: Set workflow summary
+        if: always()
+        run: |-
+          if compgen -G "logs/md/*.md" > /dev/null; then
+            cat logs/md/*.md >> $GITHUB_STEP_SUMMARY;
+          fi
+      - name: Slugify artifact id
+        id: artifactid
+        if: always()
+        env:
+          INPUT: logs-${{ matrix.suite }}-${{ matrix.node }}
+        run: |-
+          slug=$(node -p 'process.env.INPUT.replace(/[^a-z0-9._-]/gi, "-")')
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+      - name: Upload logs
+        id: logupload
+        if: always()
+        uses: actions/upload-artifact@v4.4.0
+        with:
+          name: ${{ steps.artifactid.outputs.slug }}
+          path: logs/
+          overwrite: "true"
+      - name: Append artifact URL
+        if: always()
+        run: |-
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "[Logs](${{ steps.logupload.outputs.artifact-url }})" >> $GITHUB_STEP_SUMMARY
+    strategy:
+      fail-fast: false
+      matrix:
+        suite:
+          - tool-integrations
+        node:
+          - "20"
+  integ:
+    needs:
+      - integ_cli
+      - integ_toolkit-lib
+      - integ_init-templates
+      - integ_tool-integrations
+    runs-on: ubuntu-latest
     permissions: {}
     if: always()
     steps:
-      - name: Integ test result
-        run: echo ${{ needs.integ_matrix.result }}
-      - name: Set status based on matrix job
-        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.prepare.result) && contains(fromJSON('["success", "skipped"]'), needs.telemetry_tests.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_matrix.result)) }}
+      - name: integ_cli result
+        run: echo ${{ needs.integ_cli.result }}
+      - name: integ_toolkit-lib result
+        run: echo ${{ needs.integ_toolkit-lib.result }}
+      - name: integ_init-templates result
+        run: echo ${{ needs.integ_init-templates.result }}
+      - name: integ_tool-integrations result
+        run: echo ${{ needs.integ_tool-integrations.result }}
+      - name: Set status based on test results
+        if: ${{ !(contains(fromJSON('["success", "skipped"]'), needs.integ_cli.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_toolkit-lib.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_init-templates.result) && contains(fromJSON('["success", "skipped"]'), needs.integ_tool-integrations.result)) }}
         run: exit 1

--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -109,6 +109,11 @@ async function main() {
         describe: 'Specifies the maximum number of workers the worker-pool will spawn for running tests. We use a sensible default for running cli integ tests.',
         type: 'string',
         requiresArg: true,
+      })
+      .options('shard', {
+        describe: 'The test suite shard to execute in a format of (?<shardIndex>\d+)/(?<shardCount>\d+). `shardIndex` describes which shard to select while `shardCount` controls the number of shards the suite should be split into. `shardIndex` and `shardCount` have to be 1-based, positive numbers, and `shardIndex` has to be lower than or equal to `shardCount`.',
+        type: 'string',
+        requiresArg: true,
       }), () => {
     },
     )
@@ -241,6 +246,7 @@ async function main() {
       ...args.maxWorkers ? [`--maxWorkers=${args.maxWorkers}`] : [],
       ...passWithNoTests ? ['--passWithNoTests'] : [],
       ...args['test-file'] ? [args['test-file']] : [],
+      ...args.shard ? [`--shard=${args.shard}`] : [],
     ], jestConfig);
   } finally {
     for (const disp of disposables) {

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -268,12 +268,19 @@ export interface CdkCliIntegTestsWorkflowProps {
  * so they're unfortunately duplicated here.
  */
 export class CdkCliIntegTestsWorkflow extends Component {
-  constructor(repo: javascript.NodeProject, props: CdkCliIntegTestsWorkflowProps) {
+  private workflow: github.GithubWorkflow;
+
+  private readonly JOB_PREPARE = 'prepare';
+  private readonly JOB_TELEMETRY = 'telemetry_tests';
+
+  private readonly maxWorkersArg: string = '';
+
+  constructor(repo: javascript.NodeProject, private readonly props: CdkCliIntegTestsWorkflowProps) {
     super(repo);
 
     const buildWorkflow = repo.buildWorkflow;
-    const runTestsWorkflow = repo.github?.addWorkflow('integ');
-    if (!buildWorkflow || !runTestsWorkflow) {
+    this.workflow = repo.github?.addWorkflow('integ')!;
+    if (!buildWorkflow || !this.workflow) {
       throw new Error('Expected build and run tests workflow');
     }
     ((buildWorkflow as any).workflow as github.GithubWorkflow);
@@ -281,16 +288,15 @@ export class CdkCliIntegTestsWorkflow extends Component {
     const localPackages = repo.subprojects
       .filter(p => p instanceof yarn.TypeScriptWorkspace && !p.isPrivatePackage)
       .map(p => p.name);
-    const upstreamVersions = (props.allowUpstreamVersions ?? [])?.map(p => p.name);
+    const upstreamVersions = (this.props.allowUpstreamVersions ?? [])?.map(p => p.name);
     upstreamVersions.forEach((pack) => {
       if (!localPackages.includes(pack)) {
         throw new Error(`Package in allowUpstreamVersions is not a local monorepo package: ${pack}`);
       }
     });
 
-    let maxWorkersArg = '';
-    if (props.maxWorkers) {
-      maxWorkersArg = ` --maxWorkers=${props.maxWorkers}`;
+    if (this.props.maxWorkers) {
+      this.maxWorkersArg = ` --maxWorkers=${this.props.maxWorkers}`;
     }
 
     const verdaccioConfig = {
@@ -352,7 +358,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
       ],
     });
 
-    runTestsWorkflow.on({
+    this.workflow.on({
       pullRequestTarget: {
         branches: [],
       },
@@ -371,10 +377,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
     // - The build job is only one job, versus the tests which are a matrix build.
     //   If the matrix test job needs approval, the Pull Request timeline gets spammed
     //   with an approval request for every individual run.
-    const JOB_PREPARE = 'prepare';
-    runTestsWorkflow.addJob(JOB_PREPARE, {
-      environment: props.approvalEnvironment,
-      runsOn: [props.buildRunsOn],
+
+    this.workflow.addJob(this.JOB_PREPARE, {
+      environment: this.props.approvalEnvironment,
+      runsOn: [this.props.buildRunsOn],
       permissions: {
         contents: github.workflows.JobPermission.READ,
       },
@@ -407,7 +413,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           run: [
             // Can be either aws/aws-cdk-cli or aws/aws-cdk-cli-testing
             // (Must clone over HTTPS because we have no SSH auth set up)
-            `git remote add upstream https://github.com/${props.sourceRepo}.git`,
+            `git remote add upstream https://github.com/${this.props.sourceRepo}.git`,
             'git fetch upstream \'refs/tags/*:refs/tags/*\'',
           ].join('\n'),
         },
@@ -462,11 +468,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
     });
 
     // Add a job for telemetry tests that runs before the main matrix
-    const JOB_TELEMETRY = 'telemetry_tests';
-    runTestsWorkflow.addJob(JOB_TELEMETRY, {
-      environment: props.testEnvironment,
-      runsOn: [props.testRunsOn],
-      needs: [JOB_PREPARE],
+    this.workflow.addJob(this.JOB_TELEMETRY, {
+      environment: this.props.testEnvironment,
+      runsOn: [this.props.testRunsOn],
+      needs: [this.JOB_PREPARE],
       permissions: {
         contents: github.workflows.JobPermission.READ,
         idToken: github.workflows.JobPermission.WRITE,
@@ -480,37 +485,112 @@ export class CdkCliIntegTestsWorkflow extends Component {
       steps: [
         ...downloadArtifactsSteps(),
         setupNodeStep('lts/*'),
-        awsAuthStep(props, 'telemetry-tests@aws-cdk-cli-integ'),
+        awsAuthStep(this.props, 'telemetry-tests@aws-cdk-cli-integ'),
         gitIdentityStep(),
         ...verdaccioSteps(),
         determineVersionsStep(),
         {
           name: 'Run telemetry tests',
-          run: `npx run-suite${maxWorkersArg} --use-cli-release=\${{ steps.versions.outputs.cli_version }} --framework-version=\${{ steps.versions.outputs.lib_version }} telemetry-integ-tests`,
-          env: testEnvVars(props),
+          run: `npx run-suite${this.maxWorkersArg} --use-cli-release=\${{ steps.versions.outputs.cli_version }} --framework-version=\${{ steps.versions.outputs.lib_version }} telemetry-integ-tests`,
+          env: testEnvVars(this.props),
         },
         ...logUploadSteps('logs-telemetry-tests'),
       ],
     });
 
-    // We create a matrix job for the test.
-    // This job will run all the different test suites in parallel.
-    const matrixInclude: github.workflows.JobMatrix['include'] = [];
-    const matrixExclude: github.workflows.JobMatrix['exclude'] = [];
+    // Ensure this is an array
+    const additionalNodeVersionsToTest = this.props.additionalNodeVersionsToTest ?? [];
 
-    // In addition to the default runs, run these suites under different Node versions
-    matrixInclude.push(...['init-typescript-app', 'toolkit-lib-integ-tests'].flatMap(
-      suite => (props.additionalNodeVersionsToTest ?? []).map(node => ({ suite, node }))));
+    const testJobs = [
+      // cli-integ-tests
+      this.addMatrixJob('cli', {
+        domain: {
+          suite: ['cli-integ-tests'],
+          shards: 12,
+        },
+      }),
 
-    // We are finding that Amplify works on Node 20, but fails on Node >=22.10. Remove the 'lts/*' test and use a Node 20 for now.
-    matrixExclude.push({ suite: 'tool-integrations', node: 'lts/*' });
-    matrixInclude.push({ suite: 'tool-integrations', node: 20 });
+      // toolkit-lib
+      this.addMatrixJob('toolkit-lib', {
+        domain: {
+          suite: [
+            'toolkit-lib-integ-tests',
+          ],
+          node: ['lts/*', ...additionalNodeVersionsToTest],
+        },
+      }),
 
-    const JOB_INTEG_MATRIX = 'integ_matrix';
-    runTestsWorkflow.addJob(JOB_INTEG_MATRIX, {
-      environment: props.testEnvironment,
-      runsOn: [props.testRunsOn],
-      needs: [JOB_PREPARE, JOB_TELEMETRY],
+      // init-templates
+      this.addMatrixJob('init-templates', {
+        domain: {
+          suite: [
+            'init-csharp',
+            'init-fsharp',
+            'init-go',
+            'init-java',
+            'init-javascript',
+            'init-python',
+            'init-typescript-app',
+            'init-typescript-lib',
+          ],
+          node: ['lts/*'],
+        },
+        // Run the the typescript-app test with multiple Node versions
+        include: additionalNodeVersionsToTest.map(node => ({
+          suite: 'init-typescript-app',
+          node,
+        })),
+      }),
+
+      // We are finding that Amplify works on Node 20, but fails on Node >=22.10. Remove the 'lts/*' test and use a Node 20 for now.
+      this.addMatrixJob('tool-integrations', {
+        domain: {
+          suite: ['tool-integrations'],
+          node: ['20'],
+        },
+      }),
+    ];
+
+    // Add a job that collates all matrix jobs into a single status
+    // This is required so that we can setup required status checks
+    // and if we ever change the test matrix, we don't need to update
+    // the status check configuration.
+    this.workflow.addJob('integ', {
+      runsOn: ['ubuntu-latest'],
+      if: 'always()',
+      needs: [...testJobs],
+      permissions: {},
+      steps: [
+        ...testJobs.map(jobName => ({
+          name: `${jobName} result`,
+          run: `echo \${{ needs.${jobName}.result }}`,
+        })),
+        {
+          // Don't fail the job if the test was successful or intentionally skipped
+          if: `\${{ !(${testJobs.map(jobName => `contains(fromJSON('["success", "skipped"]'), needs.${jobName}.result)`).join(' && ')}) }}`,
+          name: 'Set status based on test results',
+          run: 'exit 1',
+        },
+      ],
+    });
+  }
+
+  private addMatrixJob(testName: string, props: MatrixIntegTestProps): string {
+    const jobName = `integ_${testName}`;
+
+    let shard: any;
+    let shardArg = '';
+    let logName = 'logs-${{ matrix.suite }}-${{ matrix.node }}';
+    if (props.domain.shards) {
+      shard = Array(props.domain.shards).fill(0).map((_, i) => i + 1);
+      shardArg = ` --shard="\${{ matrix.shard }}/${props.domain.shards}"`;
+      logName += '-${{ matrix.shard }}';
+    }
+
+    this.workflow.addJob(jobName, {
+      environment: this.props.testEnvironment,
+      runsOn: [this.props.testRunsOn],
+      needs: [this.JOB_PREPARE, this.JOB_TELEMETRY],
       permissions: {
         contents: github.workflows.JobPermission.READ,
         idToken: github.workflows.JobPermission.WRITE,
@@ -530,23 +610,12 @@ export class CdkCliIntegTestsWorkflow extends Component {
         failFast: false,
         matrix: {
           domain: {
-            suite: [
-              'cli-integ-tests',
-              'toolkit-lib-integ-tests',
-              'init-csharp',
-              'init-fsharp',
-              'init-go',
-              'init-java',
-              'init-javascript',
-              'init-python',
-              'init-typescript-app',
-              'init-typescript-lib',
-              'tool-integrations',
-            ],
-            node: ['lts/*'],
+            suite: props.domain.suite,
+            node: props.domain.node ?? ['lts/*'],
+            shard,
           },
-          include: matrixInclude,
-          exclude: matrixExclude,
+          include: props.include,
+          exclude: props.exclude,
         },
       },
       steps: [
@@ -561,14 +630,14 @@ export class CdkCliIntegTestsWorkflow extends Component {
             'distribution': 'corretto',
           },
         },
-        awsAuthStep(props, 'run-tests@aws-cdk-cli-integ'),
+        awsAuthStep(this.props, 'run-tests@aws-cdk-cli-integ'),
         gitIdentityStep(),
         ...verdaccioSteps(),
         determineVersionsStep(),
         {
           name: 'Run the test suite: ${{ matrix.suite }}',
-          run: `npx run-suite${maxWorkersArg} --use-cli-release=\${{ steps.versions.outputs.cli_version }} --framework-version=\${{ steps.versions.outputs.lib_version }} \${{ matrix.suite }}`,
-          env: testEnvVars(props),
+          run: `npx run-suite${this.maxWorkersArg}${shardArg} --use-cli-release=\${{ steps.versions.outputs.cli_version }} --framework-version=\${{ steps.versions.outputs.lib_version }} \${{ matrix.suite }}`,
+          env: testEnvVars(this.props),
         },
         {
           name: 'Set workflow summary',
@@ -590,7 +659,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
             'echo "slug=$slug" >> "$GITHUB_OUTPUT"',
           ].join('\n'),
           env: {
-            INPUT: 'logs-${{ matrix.suite }}-${{ matrix.node }}',
+            INPUT: logName,
           },
         },
         {
@@ -614,28 +683,31 @@ export class CdkCliIntegTestsWorkflow extends Component {
         },
       ],
     });
-
-    // Add a job that collates all matrix jobs into a single status
-    // This is required so that we can setup required status checks
-    // and if we ever change the test matrix, we don't need to update
-    // the status check configuration.
-    runTestsWorkflow.addJob('integ', {
-      permissions: {},
-      runsOn: [props.testRunsOn],
-      needs: [JOB_PREPARE, JOB_TELEMETRY, JOB_INTEG_MATRIX],
-      if: 'always()',
-      steps: [
-        {
-          name: 'Integ test result',
-          run: `echo \${{ needs.${JOB_INTEG_MATRIX}.result }}`,
-        },
-        {
-          // Don't fail the job if the test was successful or intentionally skipped
-          if: `\${{ !(contains(fromJSON('["success", "skipped"]'), needs.${JOB_PREPARE}.result) && contains(fromJSON('["success", "skipped"]'), needs.${JOB_TELEMETRY}.result) && contains(fromJSON('["success", "skipped"]'), needs.${JOB_INTEG_MATRIX}.result)) }}`,
-          name: 'Set status based on matrix job',
-          run: 'exit 1',
-        },
-      ],
-    });
+    return jobName;
   }
+}
+
+interface IntegTestJobDomain {
+  /**
+   * The test suites to run.
+   */
+  readonly suite: string[];
+
+  /**
+   * The number of shards to run the suites in.
+   * @default - no sharding
+   */
+  readonly shards?: number;
+
+  /**
+   * The Node versions to test against.
+   * @default ["lts/*"]
+   */
+  readonly node?: string[];
+}
+
+interface MatrixIntegTestProps {
+  readonly domain: IntegTestJobDomain;
+  readonly include?: github.workflows.JobMatrix['include'];
+  readonly exclude?: github.workflows.JobMatrix['exclude'];
 }


### PR DESCRIPTION
The current integration test workflow uses a single monolithic matrix job (`integ_matrix`) that runs all test suites together. This approach has become problematic as the test suite has grown, because GitHub Actions matrix jobs share a single configuration and the different test types have diverging requirements.

The CLI integration tests benefit significantly from sharding since they contain many individual test cases that can run in parallel. However, the init template tests and toolkit library tests don't need sharding at all. Mixing these in a single matrix leads to either unnecessary complexity in the matrix configuration (with many `include` and `exclude` entries) or suboptimal parallelization.

This change splits the monolithic matrix into four purpose-built jobs:

`integ_cli` runs the CLI integration tests with 10-way sharding. These tests are the most numerous and benefit the most from parallel execution. The sharding is implemented using Jest's native `--shard` argument, which this PR also adds to the `run-suite` command.

`integ_toolkit-lib` runs the toolkit library tests across multiple Node.js versions (18.17.0, 20, 22, 24, and lts/*). These tests verify the programmatic API works correctly across the supported Node.js range.

`integ_init-templates` runs the init template tests for all supported languages (TypeScript, JavaScript, Python, Java, Go, C#, F#). The TypeScript app template is additionally tested across multiple Node.js versions to catch version-specific issues.

`integ_tool-integrations` runs the tool integration tests, currently pinned to Node 20 due to Amplify compatibility issues with Node 22.10+.

The final `integ` job now depends on all four test jobs and reports their combined status. This maintains the single status check that branch protection rules can reference.

The projenrc changes refactor the workflow generation to use a new `addMatrixJob` helper method, making it easier to define additional test matrix jobs in the future. The helper encapsulates the common job configuration while allowing each job to specify its own matrix domain, includes, and excludes.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
