### PR TITLE
chore: skip unit tests during integration test workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -16,6 +16,7 @@ jobs:
       CI: "true"
       DEBUG: "true"
       TESTING_CDK: "1"
+      NO_UNIT_TESTS: "1"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout

--- a/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.projen/tasks.json
@@ -177,7 +177,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.projen/tasks.json
@@ -173,7 +173,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.projen/tasks.json
@@ -265,7 +265,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/@aws-cdk/cloudformation-diff/.projen/tasks.json
+++ b/packages/@aws-cdk/cloudformation-diff/.projen/tasks.json
@@ -163,6 +163,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "TESTING_CDK": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",
@@ -171,7 +174,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -173,6 +173,9 @@
     "test": {
       "name": "test",
       "description": "Run tests",
+      "env": {
+        "TESTING_CDK": "1"
+      },
       "steps": [
         {
           "exec": "jest --passWithNoTests --updateSnapshot",
@@ -181,7 +184,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -218,7 +218,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -198,7 +198,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/packages/cdk-assets/.projen/tasks.json
+++ b/packages/cdk-assets/.projen/tasks.json
@@ -179,7 +179,8 @@
         {
           "spawn": "eslint"
         }
-      ]
+      ],
+      "condition": "[ \"$NO_UNIT_TESTS\" != \"1\" ]"
     },
     "test:watch": {
       "name": "test:watch",

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -2,6 +2,14 @@ import { yarn } from 'cdklabs-projen-project-types';
 import type { javascript, Project } from 'projen';
 import { Component, github, TextFile } from 'projen';
 
+/**
+ * Amends the test task with special provisions for unit testing.
+ */
+export function fixupTestTask(project: Project, taskName = 'test'): void {
+  project.tasks.tryFind(taskName)?.env('TESTING_CDK', '1');
+  project.tasks.tryFind(taskName)?.addCondition('[ "$NO_UNIT_TESTS" != "1" ]');
+}
+
 const NOT_FLAGGED_EXPR = "!contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')";
 
 /**
@@ -372,6 +380,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
       },
       env: {
         CI: 'true',
+        DEBUG: 'true',
+        TESTING_CDK: '1',
+        NO_UNIT_TESTS: '1',
       },
       // Don't run again on the merge queue, we already got confirmation that it works and the
       // tests are quite expensive.


### PR DESCRIPTION
The integration test workflow currently runs unit tests as part of the build step before executing integration tests. This is redundant because unit tests already run in a separate dedicated workflow, and it significantly increases the time and cost of integration test runs.

This change introduces a `NO_UNIT_TESTS` environment variable that allows the test task to be conditionally skipped. When set to `1`, the test task exits early without running jest or eslint. The integration test workflow now sets this variable, ensuring that only integration tests are executed during those runs.

To implement this cleanly, the scattered test task configuration has been consolidated into a new `fixupTestTask` helper function. This function applies two modifications to test tasks: it sets `TESTING_CDK=1` (which was already being done inconsistently across packages) and adds the conditional skip logic. Using a helper function ensures consistent behavior across all packages and makes it easier to modify test task configuration in the future.

The environment variables for the integration workflow's prepare job (`DEBUG` and `TESTING_CDK`) have also been moved from the awkward `Object.assign` pattern in `.projenrc.ts` into the `CdkCliIntegTestsWorkflow` component where they belong, improving code organization.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
