### PR TITLE
refactor(cli-integ): speed up initial deployment in ECS hotswap tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
@@ -666,6 +666,7 @@ class EcsHotswapStack extends cdk.Stack {
       assignPublicIp: true, // required without NAT to pull image
       circuitBreaker: { rollback: false },
       desiredCount: 1,
+      minHealthyPercent: process.env.FAST_ECS_DEPLOY ? 0 : undefined,
     });
 
     new cdk.CfnOutput(this, 'ClusterName', { value: cluster.clusterName });

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-detects-failed-deployment-and-errors.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-detects-failed-deployment-and-errors.integtest.ts
@@ -6,7 +6,10 @@ integTest(
   'hotswap deployment for ecs service detects failed deployment and errors',
   withExtendedTimeoutFixture(async (fixture) => {
     // GIVEN
-    await fixture.cdkDeploy('ecs-hotswap', { verbose: true });
+    await fixture.cdkDeploy('ecs-hotswap', {
+      verbose: true,
+      modEnv: { FAST_ECS_DEPLOY: 'true' }, // make initial deployment faster
+    });
 
     // WHEN
     const deployOutput = await fixture.cdkDeploy('ecs-hotswap', {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-waits-for-deployment-to-complete.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-waits-for-deployment-to-complete.integtest.ts
@@ -10,6 +10,7 @@ integTest(
     // GIVEN
     const stackArn = await fixture.cdkDeploy('ecs-hotswap', {
       captureStderr: false,
+      modEnv: { FAST_ECS_DEPLOY: 'true' }, // make initial deployment faster
     });
 
     // WHEN

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-ecs-service.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-ecs-service.integtest.ts
@@ -9,6 +9,7 @@ integTest(
     // GIVEN
     const stackArn = await fixture.cdkDeploy('ecs-hotswap', {
       captureStderr: false,
+      modEnv: { FAST_ECS_DEPLOY: 'true' }, // make initial deployment faster
     });
 
     // WHEN

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-ecs-deployment-respects-properties-override.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-ecs-deployment-respects-properties-override.integtest.ts
@@ -26,6 +26,7 @@ integTest('hotswap ECS deployment respects properties override', withDefaultFixt
   // GIVEN
   const stackArn = await fixture.cdkDeploy('ecs-hotswap', {
     captureStderr: false,
+    modEnv: { FAST_ECS_DEPLOY: 'true' }, // make initial deployment faster
   });
 
   // WHEN


### PR DESCRIPTION
The ECS hotswap integration tests spend a significant amount of time waiting for the initial ECS deployment to complete before the actual hotswap behavior can be tested. This initial deployment phase is not what these tests are validating, yet it dominates the test execution time (~2min).

By setting `minHealthyPercent: 0` during the initial deployment, ECS can immediately stop the old task and start the new one without waiting for the new task to become healthy first. This is safe for the initial deployment in these tests because there is no traffic to serve and no availability requirements to maintain. The actual hotswap deployments that follow continue to use the default deployment configuration, ensuring the hotswap behavior itself is tested under realistic conditions.

The change introduces a `FAST_ECS_DEPLOY` environment variable that tests can opt into. When set, the `EcsHotswapStack` configures the service with `minHealthyPercent: 0`. All four ECS hotswap tests now use this flag for their initial deployment phase.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
