### PR TITLE
fix(cli): notices with complex component matching using DNF format are not backwards compatible

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/types.ts
@@ -14,17 +14,20 @@ export interface Notice {
   issueNumber: number;
   overview: string;
   /**
-   * A set of affected components
+   * A flat list of affected components, evaluated as an OR.
    *
-   * The canonical form of a list of components is in Disjunctive Normal Form
-   * (i.e., an OR of ANDs). This is the form when the list of components is a
-   * doubly nested array: the notice matches if all components of at least one
-   * of the top-level array matches.
-   *
-   * If the `components` is a single-level array, it is evaluated as an OR; it
-   * matches if any of the components matches.
+   * The notice matches if any single component matches.
    */
-  components: Array<Component | Component[]>;
+  components: Array<Component>;
+  /**
+   * A list of affected components in Disjunctive Normal Form (OR of ANDs).
+   *
+   * The outer array is an OR, the inner arrays are ANDs. The notice matches
+   * if all components of at least one inner array match.
+   *
+   * Only available when `schemaVersion` is `'2'`.
+   */
+  componentsV2?: Array<Component | Component[]>;
   schemaVersion: string;
   severity?: string;
 }


### PR DESCRIPTION
DNF (Disjunctive Normal Form) component matching was introduced in https://github.com/aws/aws-cdk-cli/pull/128. The `components` field was typed as `Array<Component | Component[]>`, which made it look like DNF was fully supported. Based on this, new notices with nested component arrays were published to the data source. However, CLI versions 2.1000.0 and older do not understand nested arrays in `components` and fail to process these notices correctly, causing a regression for users on older CLI versions.

Instead we will be using `schemaVersion` to gate support for this new feature. The `components` field is now again (correctly) typed as a flat `Array<Component>` (OR-only), which is all that schema version 1 ever supported. A new `componentsV2` field (`Array<Component | Component[]>`) carries the DNF data and is only read when `schemaVersion` is `'2'`. This way, older CLIs that don't know about `componentsV2` will simply ignore it and continue to work with the flat `components` array, while newer CLIs can take advantage of the full DNF matching through `componentsV2`.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
