### PR TITLE
fix(cli): buildSecrets argument is lost and not passed to docker build command#1179

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/assets.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/assets.ts
@@ -134,6 +134,7 @@ async function prepareDockerImageAsset(
   assetManifest.addDockerImageAsset(asset.sourceHash, {
     directory: asset.path,
     dockerBuildArgs: asset.buildArgs,
+    dockerBuildSecrets: asset.buildSecrets,
     dockerBuildSsh: asset.buildSsh,
     dockerBuildTarget: asset.target,
     dockerFile: asset.file,


### PR DESCRIPTION
buildSecrets argument, defined as follows:

```
DockerImageCode.fromImageAsset('path/to/folder', {
    buildSecrets: {
        some_secret: 'env=some_secret',
    },
});
```
is not passed to `docker build ...` command when `cdk deploy` is invoked with legacy synthesizer.

Fixes #
This PR adds missing property to docker asset manifest.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
