### PR TITLE
fix(cli-integ): suppress Node.js warnings in integ test workflow

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -64,6 +64,7 @@ jobs:
       id-token: write
     environment: run-tests
     env:
+      NODE_NO_WARNINGS: "1"
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
@@ -184,6 +185,7 @@ jobs:
       id-token: write
     environment: run-tests
     env:
+      NODE_NO_WARNINGS: "1"
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
@@ -295,6 +297,7 @@ jobs:
       id-token: write
     environment: run-tests
     env:
+      NODE_NO_WARNINGS: "1"
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
@@ -402,6 +405,7 @@ jobs:
       id-token: write
     environment: run-tests
     env:
+      NODE_NO_WARNINGS: "1"
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"
@@ -525,6 +529,7 @@ jobs:
       id-token: write
     environment: run-tests
     env:
+      NODE_NO_WARNINGS: "1"
       MAVEN_ARGS: --no-transfer-progress
       IS_CANARY: "true"
       CI: "true"

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -537,6 +537,9 @@ export class CdkCliIntegTestsWorkflow extends Component {
         idToken: github.workflows.JobPermission.WRITE,
       },
       env: {
+        // Integ tests heavily rely on processing stdout, node warnings (mostly deprecations) are muddying this.
+        // We can disable any warnings here, there's plenty of other places we will see them.
+        NODE_NO_WARNINGS: '1',
         // Otherwise Maven is too noisy
         MAVEN_ARGS: '--no-transfer-progress',
         // This is not actually a canary, but this prevents the tests from making


### PR DESCRIPTION
After a recent Node.js update, deprecation warnings like `DEP0169` (`url.parse()` behavior) are now emitted to stdout during integration test runs. Several integ tests assert on the exact stdout output of CDK CLI commands, expecting it to be empty or contain only specific content. When Node.js prints these warnings to the same stream, the assertions fail because the received output no longer matches expectations.

This is not a problem with the CDK CLI itself, but with the test environment picking up noise from the Node.js runtime. The `NODE_NO_WARNINGS=1` environment variable suppresses these warnings for the integ test workflow jobs specifically. This is a safe and targeted fix because the warnings are still visible in all other CI jobs, unit test runs, and local development — there is no risk of silencing something important.

The change is made in the projenrc source (`cdk-cli-integ-tests.ts`) and the generated workflow file (`.github/workflows/integ.yml`) reflects it across all five integ test job definitions.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
