### PR TITLE
fix(cli): flag is incorrectly modified when it's the only one detected

### DIFF
--- a/packages/aws-cdk/lib/commands/flags/operations.ts
+++ b/packages/aws-cdk/lib/commands/flags/operations.ts
@@ -390,7 +390,7 @@ export class FlagOperations {
     const cdkJsonContent = await fs.readFile(cdkJsonPath, 'utf-8');
     const cdkJson = JSON.parse(cdkJsonContent);
 
-    if (flagNames.length === 1 && !params.safe) {
+    if (flagNames.length === 1 && !params.safe && !params.all) {
       const boolValue = params.value === 'true';
       cdkJson.context[String(flagNames[0])] = boolValue;
       await this.ioHelper.defaults.info(`Setting flag '${flagNames}' to: ${boolValue}`);

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -951,6 +951,10 @@ describe('checkDefaultBehavior', () => {
     const flagOperations = new FlagCommandHandler(flagsWithUnconfiguredBehavior, ioHelper, options, mockToolkit);
     await flagOperations.processFlagsCommand();
 
+    const updatedContent = await fs.promises.readFile(cdkJsonPath, 'utf-8');
+    const updatedJson = JSON.parse(updatedContent);
+    expect(updatedJson.context['@aws-cdk/core:testFlag']).toBe(true);
+
     expect(mockToolkit.fromCdkApp).toHaveBeenCalled();
     expect(mockToolkit.synth).toHaveBeenCalled();
 


### PR DESCRIPTION
When the command `cdk flags --set --all --recommended` is run, and the CLI detects that a single flag needs to be modified, it always sets the value of that flag to `false`, regardless of the recommended value.

This is the result of conflating this use case with the one in which the user explicitly sets a single flag to be modified, and passes no value (which defaults to `false`).

Differentiate these two cases, by checking whether the `--all` option was passed.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
