### PR TITLE
feat(toolkit-lib): emit structured IO messages for asset publishing events

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -94,6 +94,10 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_TOOLKIT_I5211` | Building the asset has completed | `trace` | {@link Duration} |
 | `CDK_TOOLKIT_I5220` | Started publishing a specific asset | `trace` | {@link PublishAsset} |
 | `CDK_TOOLKIT_I5221` | Publishing the asset has completed | `trace` | {@link Duration} |
+| `CDK_ASSETS_I5270` | Publishing the asset has started | `info` | {@link PublishAssetEvent} |
+| `CDK_ASSETS_I5271` | Debug messaged emitted during publishing of the asset | `debug` | {@link PublishAssetEvent} |
+| `CDK_ASSETS_I5275` | Publishing the asset has completed successfully | `info` | {@link PublishAssetEvent} |
+| `CDK_ASSETS_E5279` | There was an error while publishing the asset | `error` | {@link PublishAssetEvent} |
 | `CDK_TOOLKIT_I5310` | The computed settings used for file watching | `debug` | {@link WatchSettings} |
 | `CDK_TOOLKIT_I5311` | File watching started | `info` | {@link FileWatchEvent} |
 | `CDK_TOOLKIT_I5312` | File event detected, starting deployment | `info` | {@link FileWatchEvent} |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -649,7 +649,7 @@ export class Deployments {
       force: options.forcePublish,
     });
     if (publisher.hasFailures) {
-      throw new ToolkitError(`Failed to publish asset ${asset.displayName(true)}`);
+      throw ToolkitError.withCause(`Failed to publish asset ${asset.displayName(true)}`, new AggregateError(publisher.failures.map(f => f.error)));
     }
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -4,7 +4,7 @@ import type { SpanDefinition } from './span';
 import type { StackDiff, DiffResult } from '../../../payloads';
 import type { BootstrapEnvironmentProgress } from '../../../payloads/bootstrap-environment-progress';
 import type { MissingContext, UpdatedContext } from '../../../payloads/context';
-import type { BuildAsset, DeployConfirmationRequest, PublishAsset, StackDeployProgress, SuccessfulDeployStackResult } from '../../../payloads/deploy';
+import type { BuildAsset, DeployConfirmationRequest, PublishAsset, PublishAssetEvent, StackDeployProgress, SuccessfulDeployStackResult } from '../../../payloads/deploy';
 import type { StackDestroy, StackDestroyProgress } from '../../../payloads/destroy';
 import type { DriftResultPayload } from '../../../payloads/drift';
 import type { FeatureFlagChangeRequest } from '../../../payloads/flags';
@@ -212,6 +212,27 @@ export const IO = {
     code: 'CDK_TOOLKIT_I5221',
     description: 'Publishing the asset has completed',
     interface: 'Duration',
+  }),
+
+  CDK_ASSETS_I5270: make.info<PublishAssetEvent>({
+    code: 'CDK_ASSETS_I5270',
+    description: 'Publishing the asset has started',
+    interface: 'PublishAssetEvent',
+  }),
+  CDK_ASSETS_I5271: make.debug<PublishAssetEvent>({
+    code: 'CDK_ASSETS_I5271',
+    description: 'Debug messaged emitted during publishing of the asset',
+    interface: 'PublishAssetEvent',
+  }),
+  CDK_ASSETS_I5275: make.info<PublishAssetEvent>({
+    code: 'CDK_ASSETS_I5275',
+    description: 'Publishing the asset has completed successfully',
+    interface: 'PublishAssetEvent',
+  }),
+  CDK_ASSETS_E5279: make.error<PublishAssetEvent>({
+    code: 'CDK_ASSETS_E5279',
+    description: 'There was an error while publishing the asset',
+    interface: 'PublishAssetEvent',
   }),
 
   // Watch (53xx)

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/deploy.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/deploy.ts
@@ -1,4 +1,4 @@
-import type { IManifestEntry } from '@aws-cdk/cdk-assets-lib';
+import type { EventType, IManifestEntry } from '@aws-cdk/cdk-assets-lib';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import type { TemplateDiff } from '@aws-cdk/cloudformation-diff';
 import type { PermissionChangeType } from './diff';
@@ -48,9 +48,30 @@ export interface BuildAsset {
 }
 
 export interface PublishAsset {
-
   /**
    * The asset that is published
    */
   readonly asset: IManifestEntry;
+}
+
+export interface PublishAssetEvent {
+  /**
+   * The type of the asset publishing event
+   */
+  readonly type: EventType;
+
+  /**
+   * Event message
+   */
+  readonly message: string;
+
+  /**
+   * How far is the publishing along (as percentage).
+   */
+  readonly progressPercentage: number;
+
+  /**
+   * Asset currently being published (if any)
+   */
+  readonly asset?: IManifestEntry;
 }


### PR DESCRIPTION
Asset publishing events in toolkit-lib were previously emitted as unstructured log messages, using only a severity level to route them. This made it impossible for programmatic consumers of the toolkit to reliably react to specific asset publishing lifecycle events, since all they received was a plain text string at a given log level.

This change introduces a new `PublishAssetEvent` payload interface and four dedicated IO message codes (`CDK_ASSETS_I5270`, `CDK_ASSETS_I5271`, `CDK_ASSETS_I5275`, `CDK_ASSETS_E5279`) that map to the start, debug, success, and error phases of asset publishing. Each event now carries structured data including the event type, a human-readable message, the current progress percentage, and optionally the asset being published. This allows consumers to build progress indicators, filter on specific event types, or programmatically handle failures without parsing log strings.

The old `EVENT_TO_MSG_LEVEL` mapping that translated `cdk-assets-lib` event types to plain log levels has been replaced with `EVENT_TO_MSG_MAKER`, which maps each event type to a typed `IoMessageMaker<PublishAssetEvent>`. The `onPublishEvent` method in `BasePublishProgressListener` now calls `ioHelper.notify()` with a fully structured message instead of dispatching through `ioHelper.defaults[level]()`.

Additionally, when asset publishing fails, the error thrown now uses `ToolkitError.withCause` wrapping an `AggregateError` of all individual publisher failures. Previously, the underlying errors were silently discarded and only a generic message was thrown. Preserving the error chain makes it significantly easier to diagnose what actually went wrong during publishing.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
