### PR TITLE
fix(cli): trap errors from notices to prevent CLI breakage

### DIFF
--- a/packages/@aws-cdk/cdk-assets-lib/lib/aws-types.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/aws-types.ts
@@ -1109,7 +1109,7 @@ export interface PutObjectRequest {
    *          server-side encryption using Key Management Service (KMS) keys (SSE-KMS). Setting this header to
    *             <code>true</code> causes Amazon S3 to use an S3 Bucket Key for object encryption with
    *          SSE-KMS.</p>
-   *          <p>Specifying this header with a PUT action doesn’t affect bucket-level settings for S3
+   *          <p>Specifying this header with a PUT action doesn't affect bucket-level settings for S3
    *          Bucket Key.</p>
    *          <note>
    *             <p>This functionality is not supported for directory buckets.</p>

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/notices.ts
@@ -210,7 +210,7 @@ export class Notices {
         }
       }
       await this.ioHelper.notify(IO.CDK_TOOLKIT_I0100.msg(
-        `If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge ${filteredNotices[0].notice.issueNumber}".`,
+        `If you don't want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge ${filteredNotices[0].notice.issueNumber}".`,
       ));
     }
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
@@ -1111,7 +1111,7 @@ describe(Notices, () => {
       ioHost.expectMessage({ containing: new FilteredNotice(BASIC_NOTICE).format() });
       ioHost.expectMessage({
         containing:
-          'If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
+          'If you don\'t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
       });
     });
 
@@ -1144,7 +1144,7 @@ describe(Notices, () => {
       });
       ioHost.expectMessage({
         containing:
-          'If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
+          'If you don\'t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
       });
     });
 
@@ -1158,7 +1158,7 @@ describe(Notices, () => {
       ioHost.expectMessage({ containing: new FilteredNotice(BASIC_NOTICE).format() });
       ioHost.expectMessage({
         containing:
-          'If you don’t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
+          'If you don\'t want to see a notice anymore, use "cdk acknowledge <id>". For example, "cdk acknowledge 16603".',
       });
     });
 

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -12,9 +12,14 @@ import { CliIoHost } from './io-host';
 import { parseCommandLineArguments } from './parse-command-line-arguments';
 import { checkForPlatformWarnings } from './platform-warnings';
 import { prettyPrintError } from './pretty-print-error';
+import { ProxyAgentProvider } from './proxy-agent';
 import { GLOBAL_PLUGIN_HOST } from './singleton-plugin-host';
+import { cdkCliErrorName } from './telemetry/error';
+import type { ErrorDetails } from './telemetry/schema';
 import type { Command } from './user-configuration';
 import { Configuration } from './user-configuration';
+import { trapErrors } from './util/trap-errors';
+import { isDeveloperBuildVersion, versionWithBuild, versionNumber } from './version';
 import { asIoHelper } from '../../lib/api-private';
 import type { IReadLock } from '../api';
 import { ToolkitInfo, Notices } from '../api';
@@ -33,11 +38,7 @@ import { getLanguageFromAlias } from '../commands/language';
 import { getMigrateScanType } from '../commands/migrate';
 import { execProgram, CloudExecutable } from '../cxapp';
 import type { StackSelector, Synthesizer } from '../cxapp';
-import { ProxyAgentProvider } from './proxy-agent';
-import { cdkCliErrorName } from './telemetry/error';
-import type { ErrorDetails } from './telemetry/schema';
 import { isCI } from './util/ci';
-import { isDeveloperBuildVersion, versionWithBuild, versionNumber } from './version';
 
 export async function exec(args: string[], synthesizer?: Synthesizer): Promise<number | void> {
   const argv = await parseCommandLineArguments(args);
@@ -154,11 +155,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   const refreshNotices = (async () => {
     // the cdk notices command has it's own refresh
     if (shouldDisplayNotices && cmd !== 'notices') {
-      try {
-        return await notices.refresh();
-      } catch (e: any) {
-        await ioHelper.defaults.debug(`Could not refresh notices: ${e}`);
-      }
+      await trapErrors(ioHelper, 'Could not refresh notices', () => notices.refresh());
     }
   })();
 
@@ -220,13 +217,15 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
     await refreshNotices;
     if (cmd === 'notices') {
+      // do not trap errors here
+      // this is the notices command itself, any error should be loud
       await notices.refresh({ force: true });
       await notices.display({
         includeAcknowledged: !argv.unacknowledged,
         showTotal: argv.unacknowledged,
       });
     } else if (shouldDisplayNotices && cmd !== 'version') {
-      await notices.display();
+      await trapErrors(ioHelper, 'Could not display notices', () => notices.display());
     }
   }
 

--- a/packages/aws-cdk/lib/cli/util/trap-errors.ts
+++ b/packages/aws-cdk/lib/cli/util/trap-errors.ts
@@ -1,0 +1,14 @@
+import type { IoHelper } from '../../api-private';
+
+/**
+ * Run an async callback, swallowing any errors and logging them as debug messages.
+ * Use this for code paths that must never break CLI execution.
+ */
+export async function trapErrors<T>(ioHelper: IoHelper, message: string, cb: () => Promise<T>): Promise<T | undefined> {
+  try {
+    return await cb();
+  } catch (e) {
+    await ioHelper.defaults.debug(`${message}: ${e}`);
+    return undefined;
+  }
+}

--- a/packages/aws-cdk/test/cli/util/trap-errors.test.ts
+++ b/packages/aws-cdk/test/cli/util/trap-errors.test.ts
@@ -1,0 +1,29 @@
+import { trapErrors } from '../../../lib/cli/util/trap-errors';
+
+const mockDebug = jest.fn();
+const ioHelper = {
+  defaults: { debug: mockDebug },
+} as any;
+
+beforeEach(() => {
+  mockDebug.mockReset();
+});
+
+test('does not throw when callback throws', async () => {
+  await expect(trapErrors(ioHelper, 'oops', async () => {
+    throw new Error('boom');
+  })).resolves.toBeUndefined();
+});
+
+test('logs message and error as debug', async () => {
+  await trapErrors(ioHelper, 'oops', async () => {
+    throw new Error('boom');
+  });
+  expect(mockDebug).toHaveBeenCalledWith('oops: Error: boom');
+});
+
+test('returns callback result on success', async () => {
+  const result = await trapErrors(ioHelper, 'oops', async () => 42);
+  expect(result).toBe(42);
+  expect(mockDebug).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
In the past, a malformed notice payload caused the CLI to crash for users (see cdklabs/aws-cdk-notices#1044). The root cause was on the notices side and has been fixed, but the CLI should have never broken in the first place — notices are informational and must not affect CLI execution.

The `notices.refresh()` call already had inline error handling, but `notices.display()` did not. This meant that even after successfully fetching notices, a problem during display could still crash the CLI. The inline try/catch pattern is also easy to forget or get wrong when adding new call sites.

This change introduces a `trapErrors` utility that encapsulates the "swallow and log as debug" pattern into a single reusable function. Both `notices.refresh()` and `notices.display()` now use it, ensuring that notice-related failures can never break CLI execution going forward. While we cannot fix old CLI versions, we can make sure that future versions are resilient to this class of issues.

The `notices` command itself intentionally does not use `trapErrors` — when a user explicitly runs `cdk notices`, errors should surface loudly since that's the whole point of the command.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
