### PR TITLE
chore: remove `detached: true` for watch test

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns-negative.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns-negative.integtest.ts
@@ -32,7 +32,7 @@ integTest(
     ], {
       cwd: fixture.integTestDir,
       shell: true,
-      detached: true,
+      stdio: 'pipe',
       env: { ...process.env, ...fixture.cdkShellEnv() },
     });
 
@@ -79,9 +79,10 @@ integTest(
       await waitForOutput(() => output, 'Detected change to');
       fixture.log('✓ Watch still detects changes to included files');
     } finally {
-      // Kill the entire process group (negative PID)
-      if (watchProcess.pid) {
-        process.kill(-watchProcess.pid, 'SIGTERM');
+      try {
+        watchProcess.kill('SIGTERM');
+      } catch {
+        // process may have already exited
       }
     }
   }),

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns.integtest.ts
@@ -31,7 +31,7 @@ integTest(
     ], {
       cwd: fixture.integTestDir,
       shell: true,
-      detached: true,
+      stdio: 'pipe',
       env: { ...process.env, ...fixture.cdkShellEnv() },
     });
 
@@ -61,9 +61,10 @@ integTest(
       await waitForCondition(() => (output.match(/deployment time/g) || []).length >= 2);
       fixture.log('✓ Second deployment completed');
     } finally {
-      // Kill the entire process group (negative PID)
-      if (watchProcess.pid) {
-        process.kill(-watchProcess.pid, 'SIGTERM');
+      try {
+        watchProcess.kill('SIGTERM');
+      } catch (e) {
+        // process may have already exited
       }
     }
   }),


### PR DESCRIPTION
On macOS (developer machines), `detached: true` with `shell: true` still attaches stdout/stderr to the parent process. On Linux (CodeBuild runs Amazon Linux), `detached: true` causes the child process to become a session leader and its stdio streams may not be inherited or piped correctly — especially when combined with `shell: true`, which spawns an intermediate shell process. The actual cdk process is a grandchild, so `watchProcess.stdout` may be the shell's stdout, not `cdk`'s.

In addition, On Linux, if the process group kill fails (e.g., the PID is already gone or the group doesn't exist), it throws an uncaught exception. This can mask the real timeout error and leave zombie processes. Just try to kill it and continue silently, if it fails.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
