### PR TITLE
fix(cli-integ): prevent watch integration tests from hanging on CodeBuild

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns-negative.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns-negative.integtest.ts
@@ -1,10 +1,10 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { waitForOutput } from './watch-helpers';
+import { waitForOutput, safeKillProcess } from './watch-helpers';
 import { integTest, withDefaultFixture, sleep } from '../../../lib';
 
-jest.setTimeout(3 * 60 * 1000); // 3 minutes for watch tests
+jest.setTimeout(5 * 60 * 1000); // 5 minutes for watch tests
 
 integTest(
   'cdk watch does NOT detect file changes for excluded patterns',
@@ -26,12 +26,11 @@ integTest(
 
     let output = '';
 
-    // Start cdk watch with detached process group for clean termination
+    // Start cdk watch
     const watchProcess = child_process.spawn('cdk', [
       'watch', '--hotswap', '-v', fixture.fullStackName('test-1'),
     ], {
       cwd: fixture.integTestDir,
-      shell: true,
       stdio: 'pipe',
       env: { ...process.env, ...fixture.cdkShellEnv() },
     });
@@ -79,11 +78,9 @@ integTest(
       await waitForOutput(() => output, 'Detected change to');
       fixture.log('✓ Watch still detects changes to included files');
     } finally {
-      try {
-        watchProcess.kill('SIGTERM');
-      } catch {
-        // process may have already exited
-      }
+      safeKillProcess(watchProcess);
     }
+
+    expect.assertions(5);
   }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-glob-patterns.integtest.ts
@@ -1,10 +1,10 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { waitForOutput, waitForCondition } from './watch-helpers';
+import { waitForOutput, waitForCondition, safeKillProcess } from './watch-helpers';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(3 * 60 * 1000); // 3 minutes for watch tests
+jest.setTimeout(5 * 60 * 1000); // 5 minutes for watch tests
 
 integTest(
   'cdk watch detects file changes with glob patterns',
@@ -25,12 +25,11 @@ integTest(
 
     let output = '';
 
-    // Start cdk watch with detached process group for clean termination
+    // Start cdk watch
     const watchProcess = child_process.spawn('cdk', [
       'watch', '--hotswap', '-v', fixture.fullStackName('test-1'),
     ], {
       cwd: fixture.integTestDir,
-      shell: true,
       stdio: 'pipe',
       env: { ...process.env, ...fixture.cdkShellEnv() },
     });
@@ -52,7 +51,7 @@ integTest(
       fixture.log('✓ Initial deployment completed');
 
       // Update the test file timestamp to trigger a watch event
-      child_process.spawn('touch', [testFile]);
+      child_process.spawnSync('touch', [testFile]);
 
       await waitForOutput(() => output, 'Detected change to');
       fixture.log('✓ Watch detected file change');
@@ -61,11 +60,9 @@ integTest(
       await waitForCondition(() => (output.match(/deployment time/g) || []).length >= 2);
       fixture.log('✓ Second deployment completed');
     } finally {
-      try {
-        watchProcess.kill('SIGTERM');
-      } catch (e) {
-        // process may have already exited
-      }
+      safeKillProcess(watchProcess);
     }
+
+    expect.assertions(4);
   }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/watch-helpers.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/watch-helpers.ts
@@ -1,14 +1,16 @@
-/**
- * Shared helper functions for watch integration tests.
- */
+import type { ChildProcess } from 'node:child_process';
+
+const DEFAULT_POLL_TIMEOUT = 120_000; // 2 minutes
 
 /**
- * Poll a condition until we see it.
+ * Poll a condition until we see it, with a timeout.
  */
-async function poll(condition: () => boolean): Promise<void> {
-  return new Promise((resolve) => {
+async function poll(condition: () => boolean, timeoutMs = DEFAULT_POLL_TIMEOUT): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
     const check = () => {
       if (condition()) return resolve();
+      if (Date.now() >= deadline) return reject(new Error(`poll timed out after ${timeoutMs}ms`));
       setTimeout(check, 1000);
     };
     check();
@@ -19,12 +21,25 @@ async function poll(condition: () => boolean): Promise<void> {
  * Wait for a specific string to appear in the output.
  */
 export async function waitForOutput(getOutput: () => string, searchString: string): Promise<void> {
-  return poll(() => getOutput().includes(searchString));
+  await poll(() => getOutput().includes(searchString));
+  expect(getOutput()).toContain(searchString);
 }
 
 /**
  * Wait for a condition to become true.
  */
 export async function waitForCondition(condition: () => boolean): Promise<void> {
-  return poll(condition);
+  await poll(condition);
+  expect(condition()).toBe(true);
+}
+
+/**
+ * Kill a spawned process.
+ */
+export function safeKillProcess(proc: ChildProcess): void {
+  try {
+    proc.kill('SIGKILL');
+  } catch {
+    // process may have already exited
+  }
 }


### PR DESCRIPTION
Follows up on #1212 which removed `detached: true` from the watch integration tests.

The watch integration tests have been hanging on CodeBuild until they eventually time out. Jest reports an open handle but cannot provide more details. The root causes are two-fold.

First, the tests were using `shell: true` when spawning the `cdk watch` process. This creates an intermediate `/bin/sh` process, making `cdk` a grandchild. When the test tries to kill the process in the `finally` block, `SIGTERM` only reaches the shell, not the actual `cdk` process. On macOS this often works because the shell forwards signals, but on Linux (CodeBuild runs Amazon Linux) the `cdk` process survives as an orphan, keeping the piped stdio streams open. Since the `cdk` binary at `bin/cdk` is a Node.js script with a proper shebang (`#!/usr/bin/env node`), `shell: true` is not needed — Node.js `spawn` resolves the shebang natively on Linux and macOS. Removing it means `SIGKILL` now reaches the `cdk` process directly.

Second, the `poll()` helper used a recursive `setTimeout` chain with no timeout. If any `waitForOutput` or `waitForCondition` call never matched (e.g. because the deployment was slower on CodeBuild), the `setTimeout` chain would run indefinitely. I don't think this was an issue, but adding it for additional saftey. The poll now rejects after 2 minutes with a clear error message. The total jest timeout has been increased to 5 minutes, in case the tests simply needed a little bit longer to complete.

Additionally, `expect.assertions()` has been added to both tests so that if something goes wrong, the test fails with a clear assertion count mismatch rather than a vague timeout. Also added expectation to the waiter, again this is to make sure we can better understand what's happening.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
