### PR TITLE
feat(cli-integ): allow configuring skipped tests via environment variables

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/integ-test.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/integ-test.ts
@@ -2,9 +2,11 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { MemoryStream } from './corking';
 
-const SKIP_TESTS = fs.readFileSync(path.join(__dirname, '..', 'skip-tests.txt'), { encoding: 'utf-8' })
-  .split('\n')
-  .map(x => x.trim())
+const SKIP_TESTS = [
+  ...readSkipFile(path.join(__dirname, '..', 'skip-tests.txt')),
+  ...readSkipFile(process.env.CDK_INTEG_SKIP_TESTS_FILE),
+  ...(process.env.CDK_INTEG_SKIP_TESTS ?? '').split(','),
+].map(x => x.trim())
   .filter(x => x && !x.startsWith('#'));
 
 if (SKIP_TESTS.length > 0) {
@@ -232,4 +234,15 @@ async function atomicWrite(fileName: string, contents: string) {
   const tmp = `${fileName}.${process.pid}`;
   await fs.promises.writeFile(tmp, contents);
   await fs.promises.rename(tmp, fileName);
+}
+
+function readSkipFile(filePath?: string): string[] {
+  if (!filePath) {
+    return [];
+  }
+  try {
+    return fs.readFileSync(filePath, { encoding: 'utf-8' }).split('\n');
+  } catch {
+    return [];
+  }
 }


### PR DESCRIPTION
The integration test skip list is currently hardcoded to read from a single `skip-tests.txt` file that is checked into the repository. This works well for persistent, known-broken tests, but makes it difficult to dynamically skip tests in CI/CD pipelines or during local development without modifying a tracked file.

This change introduces two new environment variables that provide additional ways to configure which tests to skip:

`CDK_INTEG_SKIP_TESTS_FILE` points to an additional skip file, following the same format as the existing `skip-tests.txt`. This is useful in CI environments where a separate, dynamically generated file can be provided without touching the repository. For example, a pipeline step could write a skip file based on the current environment or known infrastructure issues, and pass it to the test runner.

`CDK_INTEG_SKIP_TESTS` accepts a comma-separated list of test names directly. This is the quickest option for ad-hoc skipping during local development, e.g. `CDK_INTEG_SKIP_TESTS=test-foo,test-bar npx jest`.

All three sources (the original file, the env-specified file, and the inline list) are merged together, so existing behavior is fully preserved. The file reading logic has been extracted into a `readSkipFile` helper that gracefully handles missing or unreadable files, which also makes the original `skip-tests.txt` read more resilient.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
