### PR TITLE
fix(toolkit-lib): join dynamic values with spaces instead of commas

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
@@ -52,7 +52,7 @@ interface ActualComponent {
    * placeholders look like `{resolve:XYZ}`.
    *
    * If there is more than one component with the same dynamic name, they are
-   * joined by ','.
+   * joined by ' '.
    *
    * @default - Don't add to the set of dynamic values
    */
@@ -188,7 +188,7 @@ export class NoticesFilter {
    * Adds dynamic values from the given ActualComponents
    *
    * If there are multiple components with the same dynamic name, they are joined
-   * by a comma.
+   * by a space.
    */
   private addDynamicValues(comps: ActualComponent[], notice: FilteredNotice) {
     const dynamicValues: Record<string, string[]> = {};
@@ -199,7 +199,7 @@ export class NoticesFilter {
       }
     }
     for (const [key, values] of Object.entries(dynamicValues)) {
-      notice.addDynamicValue(key, values.join(','));
+      notice.addDynamicValue(key, values.join(' '));
     }
   }
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
@@ -424,7 +424,7 @@ describe(NoticesFilter, () => {
         bootstrappedEnvironments: bootstrappedEnvironments,
       });
       expect((await filtered).map((f) => f.notice)).toEqual([BASIC_BOOTSTRAP_NOTICE]);
-      expect((await filtered).map((f) => f.format()).join('\n')).toContain('env1,env2');
+      expect((await filtered).map((f) => f.format()).join('\n')).toContain('env1 env2');
     });
 
     test('ignores invalid bootstrap versions', async () => {


### PR DESCRIPTION
### Issue

Closes aws/aws-cdk#31963

### Reason for this change

The `addDynamicValues` method in `NoticesFilter` joins multiple dynamic values with commas, producing invalid `cdk bootstrap` commands like:

```
cdk bootstrap aws://ACCOUNT/us-east-1,aws://ACCOUNT/us-west-2
```

Running this command fails with:
```
Expected environment name in format 'aws://<account>/<region>'
```

### Description of changes

Changed the join separator from `,` to ` ` (space) in `addDynamicValues()` so the suggested command is valid:

```
cdk bootstrap aws://ACCOUNT/us-east-1 aws://ACCOUNT/us-west-2
```

Also updated two JSDoc comments that referenced the old comma separator.

### Description of how you validated changes

- All 55 existing unit tests in `notices.test.ts` pass
- Updated the test assertion that verified comma-separated output to expect space-separated output
- ESLint and TypeScript compilation clean

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md)
- [x] If my change affects existing tests, I have updated those tests accordingly

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license