### PR TITLE
fix(cli): incorrect cdk diff output for nested stacks

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
@@ -268,7 +268,7 @@ export class DiffFormatter {
       // detect and filter out mangled characters from the diff
       if (diff.differenceCount && !options.strict) {
         const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(this.newTemplate.template)));
-        const mangledDiff = fullDiff(this.oldTemplate, mangledNewTemplate, this.changeSet);
+        const mangledDiff = fullDiff(oldTemplate, mangledNewTemplate, this.changeSet);
         filteredChangesCount = Math.max(0, diff.differenceCount - mangledDiff.differenceCount);
         if (filteredChangesCount > 0) {
           diff = mangledDiff;

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -229,3 +229,62 @@ describe('formatSecurityDiff', () => {
     );
   });
 });
+
+describe('nested stack mangled character filtering', () => {
+  test('filters mangled characters using the nested stack deployed template', () => {
+    const nestedDeployed = {
+      Description: '????',
+      Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+    };
+
+    const nestedGenerated = {
+      Description: '文字化け',
+      Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+    };
+
+    const rootTemplate = {
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    // Mock must support _template mutation used by formatStackDiffHelper for nested stacks
+    let _template = rootTemplate;
+    const mockArtifact = {
+      get template() {
+        return _template;
+      },
+      set _template(v: any) {
+        _template = v;
+      },
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks: {
+          Nested: {
+            deployedTemplate: nestedDeployed,
+            generatedTemplate: nestedGenerated,
+            physicalName: 'nested-stack',
+            nestedStackTemplates: {},
+          },
+        },
+      },
+    });
+
+    const result = formatter.formatStackDiff();
+    const sanitized = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+    // Root stack resources must not leak into nested stack diff
+    expect(sanitized).not.toContain('AWS::CloudFormation::Stack');
+    expect(sanitized).toContain('nested-stack');
+    // The non-ASCII description diff should be filtered as mangled noise
+    expect(sanitized).toContain('Omitted');
+  });
+});
+

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -230,7 +230,92 @@ describe('formatSecurityDiff', () => {
   });
 });
 
-describe('nested stack mangled character filtering', () => {
+describe('mangled character filtering', () => {
+  test('filters mangled non-ASCII diffs for root stacks', () => {
+    const oldTemplate = {
+      Description: '????',
+      Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+    };
+
+    const newTemplate = {
+      template: {
+        Description: '文字化け',
+        Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+      },
+      templateFile: 'template.json',
+      stackName: 'test-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const formatter = new DiffFormatter({
+      templateInfo: { oldTemplate, newTemplate },
+    });
+
+    const result = formatter.formatStackDiff();
+    const sanitized = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+    expect(result.numStacksWithChanges).toBe(0);
+    expect(sanitized).toContain('Omitted');
+    expect(sanitized).toContain('There were no differences');
+  });
+
+  test('does not filter mangled diffs when strict is true', () => {
+    const oldTemplate = {
+      Description: '????',
+      Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+    };
+
+    const newTemplate = {
+      template: {
+        Description: '文字化け',
+        Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+      },
+      templateFile: 'template.json',
+      stackName: 'test-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const formatter = new DiffFormatter({
+      templateInfo: { oldTemplate, newTemplate },
+    });
+
+    const result = formatter.formatStackDiff({ strict: true });
+    const sanitized = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+    expect(result.numStacksWithChanges).toBe(1);
+    expect(sanitized).not.toContain('Omitted');
+    expect(sanitized).toContain('Description');
+  });
+
+  test('does not filter when diffs are real, not mangled', () => {
+    const oldTemplate = {
+      Resources: { Bucket: { Type: 'AWS::S3::Bucket' } },
+    };
+
+    const newTemplate = {
+      template: {
+        Resources: {
+          Bucket: { Type: 'AWS::S3::Bucket' },
+          Queue: { Type: 'AWS::SQS::Queue' },
+        },
+      },
+      templateFile: 'template.json',
+      stackName: 'test-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const formatter = new DiffFormatter({
+      templateInfo: { oldTemplate, newTemplate },
+    });
+
+    const result = formatter.formatStackDiff();
+    const sanitized = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+    expect(result.numStacksWithChanges).toBe(1);
+    expect(sanitized).not.toContain('Omitted');
+    expect(sanitized).toContain('AWS::SQS::Queue');
+  });
+
   test('filters mangled characters using the nested stack deployed template', () => {
     const nestedDeployed = {
       Description: '????',
@@ -248,7 +333,6 @@ describe('nested stack mangled character filtering', () => {
       },
     };
 
-    // Mock must support _template mutation used by formatStackDiffHelper for nested stacks
     let _template = rootTemplate;
     const mockArtifact = {
       get template() {
@@ -280,10 +364,8 @@ describe('nested stack mangled character filtering', () => {
     const result = formatter.formatStackDiff();
     const sanitized = result.formattedDiff!.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
 
-    // Root stack resources must not leak into nested stack diff
     expect(sanitized).not.toContain('AWS::CloudFormation::Stack');
     expect(sanitized).toContain('nested-stack');
-    // The non-ASCII description diff should be filtered as mangled noise
     expect(sanitized).toContain('Omitted');
   });
 });


### PR DESCRIPTION
Fixes #1228 

`cdk diff` produces incorrect output for nested stacks when the mangled character filter triggers. The mangled diff computation in `formatStackDiffHelper` uses `this.oldTemplate` (root stack's deployed template) instead of the `oldTemplate` parameter (nested stack's deployed template). This causes the correct nested diff to be overwritten with a meaningless comparison between the root and nested templates.

The fix replaces `this.oldTemplate` with `oldTemplate` on one line.

Added unit test for nested stack mangled character filtering.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
