### PR TITLE
chore(deps): bump @aws-sdk/xml-builder to 3.972.13

### DIFF
--- a/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
@@ -12154,7 +12154,7 @@ Apache License
 
 ----------------
 
-** @aws-sdk/xml-builder@3.972.10 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.10 | Apache-2.0
+** @aws-sdk/xml-builder@3.972.13 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.13 | Apache-2.0
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -23438,7 +23438,7 @@ SOFTWARE.
 
 ----------------
 
-** fast-xml-parser@5.4.1 - https://www.npmjs.com/package/fast-xml-parser/v/5.4.1 | MIT
+** fast-xml-parser@5.5.6 - https://www.npmjs.com/package/fast-xml-parser/v/5.5.6 | MIT
 MIT License
 
 Copyright (c) 2017 Amit Kumar Gupta

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -12154,7 +12154,7 @@ Apache License
 
 ----------------
 
-** @aws-sdk/xml-builder@3.972.10 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.10 | Apache-2.0
+** @aws-sdk/xml-builder@3.972.13 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.13 | Apache-2.0
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -23829,7 +23829,7 @@ SOFTWARE.
 
 ----------------
 
-** fast-xml-parser@5.4.1 - https://www.npmjs.com/package/fast-xml-parser/v/5.4.1 | MIT
+** fast-xml-parser@5.5.6 - https://www.npmjs.com/package/fast-xml-parser/v/5.5.6 | MIT
 MIT License
 
 Copyright (c) 2017 Amit Kumar Gupta

--- a/packages/cdk-assets/THIRD_PARTY_LICENSES
+++ b/packages/cdk-assets/THIRD_PARTY_LICENSES
@@ -8243,7 +8243,7 @@ Apache License
 
 ----------------
 
-** @aws-sdk/xml-builder@3.972.10 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.10 | Apache-2.0
+** @aws-sdk/xml-builder@3.972.13 - https://www.npmjs.com/package/@aws-sdk/xml-builder/v/3.972.13 | Apache-2.0
 Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -19435,7 +19435,7 @@ SOFTWARE.
 
 ----------------
 
-** fast-xml-parser@5.4.1 - https://www.npmjs.com/package/fast-xml-parser/v/5.4.1 | MIT
+** fast-xml-parser@5.5.6 - https://www.npmjs.com/package/fast-xml-parser/v/5.5.6 | MIT
 MIT License
 
 Copyright (c) 2017 Amit Kumar Gupta

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,12 +2338,12 @@
     tslib "^1.8.0"
 
 "@aws-sdk/xml-builder@^3.972.10":
-  version "3.972.10"
-  resolved "https://registry.yarnpkg.com/@aws-sdk/xml-builder/-/xml-builder-3.972.10.tgz#d8a7171b70c8ee9354747f0ac7d368dd27d50e46"
-  integrity sha512-OnejAIVD+CxzyAUrVic7lG+3QRltyja9LoNqCE/1YVs8ichoTbJlVSaZ9iSMcnHLyzrSNtvaOGjSDRP+d/ouFA==
+  version "3.972.13"
+  resolved "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.13.tgz#3ad84361fadca5011c6774ebabcf5dd1e8a36563"
+  integrity sha512-I/+BMxM4WE/6xL0tyV7tAUDOAXmyw/va1oGr/eSly43HmLUcD1G+v96vEKAA8VoLcZ03ZQo/PWzjmN9zQErqPQ==
   dependencies:
-    "@smithy/types" "^4.13.0"
-    fast-xml-parser "5.4.1"
+    "@smithy/types" "^4.13.1"
+    fast-xml-parser "5.5.6"
     tslib "^2.6.2"
 
 "@aws/lambda-invoke-store@^0.2.2":
@@ -4468,6 +4468,13 @@
   version "4.13.0"
   resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.13.0.tgz#9787297a07ee72ef74d4f7d93c744d10ed664c21"
   integrity sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==
+  dependencies:
+    tslib "^2.6.2"
+
+"@smithy/types@^4.13.1":
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/@smithy/types/-/types-4.13.1.tgz#8aaf15bb0f42b4e7c93c87018a3678a06d74691d"
+  integrity sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==
   dependencies:
     tslib "^2.6.2"
 
@@ -8008,12 +8015,20 @@ fast-xml-builder@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz#a485d7e8381f1db983cf006f849d1066e2935241"
   integrity sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==
 
-fast-xml-parser@5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz#0c81b8ecfb3021e5ad83aa3df904af19a05bc601"
-  integrity sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==
+fast-xml-builder@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz#0c407a1d9d5996336c0cd76f7ff785cac6413017"
+  integrity sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==
   dependencies:
-    fast-xml-builder "^1.0.0"
+    path-expression-matcher "^1.1.3"
+
+fast-xml-parser@5.5.6:
+  version "5.5.6"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz#6fc61f5ae06a55a1f058abd6a4f4b5d3e9972cd0"
+  integrity sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==
+  dependencies:
+    fast-xml-builder "^1.1.4"
+    path-expression-matcher "^1.1.3"
     strnum "^2.1.2"
 
 fast-xml-parser@^3.16.0:
@@ -11801,6 +11816,11 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-expression-matcher@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.1.3.tgz#8bf7c629dc1b114e42b633c071f06d14625b4e0d"
+  integrity sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==
 
 path-is-absolute@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
This PR bumps `@aws-sdk/xml-builder` from `3.972.10` to `3.972.13` in the lockfile.

The previous version used `fast-xml-parser@5.4.1` which has a default entity expansion limit of `1000`. The `test resource import` integ test creates a 143-resource stack whose CloudFormation XML response hits 5522 expansions, causing all PRs to fail CI. The SDK team fixed this in 3.972.13 by upgrading to `fast-xml-parser@5.5.6` which removes the limit.

`@aws-sdk/xml-builder` is a transitive dependency and no package.json in the repo lists it directly. It's pulled in via `@aws-sdk/client-cloudformation` (direct dep, "^3") → `@aws-sdk/core` → `@aws-sdk/xml-builder`. The ^3 range already allows 3.972.13 and only the lockfile was pinning it to the old version.

The new `fast-xml-parser@5.5.6` brings in one new transitive dependency (path-expression-matcher) and bumps fast-xml-builder from ^1.0.0 to ^1.1.4. No package.json changes, lockfile only.

ref: https://github.com/aws/aws-sdk-js-v3/issues/7853

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
