### PR TITLE
fix(toolkit-lib): handle AWS SDK v3 ValidationError format change for non-existent stacks

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/evaluate-cloudformation-template.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/evaluate-cloudformation-template.ts
@@ -1,11 +1,11 @@
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
 import type { Export, ListExportsCommandOutput, StackResourceSummary } from '@aws-sdk/client-cloudformation';
-import type { NestedStackTemplates } from './nested-stack-helpers';
-import type { Template } from './stack-helpers';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { SDK } from '../aws-auth/private';
 import type { ResourceMetadata } from '../resource-metadata';
 import { resourceMetadata } from '../resource-metadata';
+import type { NestedStackTemplates } from './nested-stack-helpers';
+import type { Template } from './stack-helpers';
 
 export interface ListStackResources {
   listStackResources(): Promise<StackResourceSummary[]>;
@@ -17,14 +17,25 @@ export class LazyListStackResources implements ListStackResources {
   constructor(
     private readonly sdk: SDK,
     private readonly stackName: string,
-  ) {
-  }
+  ) {}
 
   public async listStackResources(): Promise<StackResourceSummary[]> {
     if (this.stackResources === undefined) {
-      this.stackResources = this.sdk.cloudFormation().listStackResources({
-        StackName: this.stackName,
-      });
+      this.stackResources = this.sdk
+        .cloudFormation()
+        .listStackResources({
+          StackName: this.stackName,
+        })
+        .catch((e: any) => {
+          if (
+            e.Code === 'ValidationError' ||
+            e.name === 'ValidationError' ||
+            (e.message && e.message.includes('ValidationError'))
+          ) {
+            return [];
+          }
+          throw e;
+        });
     }
     return this.stackResources;
   }
@@ -34,14 +45,12 @@ export interface LookupExport {
   lookupExport(name: string): Promise<Export | undefined>;
 }
 
-export class LookupExportError extends Error {
-}
+export class LookupExportError extends Error {}
 
 export class LazyLookupExport implements LookupExport {
   private cachedExports: { [name: string]: Export } = {};
 
-  constructor(private readonly sdk: SDK) {
-  }
+  constructor(private readonly sdk: SDK) {}
 
   async lookupExport(name: string): Promise<Export | undefined> {
     if (this.cachedExports[name]) {
@@ -79,8 +88,7 @@ export class LazyLookupExport implements LookupExport {
   }
 }
 
-export class CfnEvaluationException extends Error {
-}
+export class CfnEvaluationException extends Error {}
 
 export interface ResourceDefinition {
   readonly LogicalId: string;
@@ -479,7 +487,7 @@ export class EvaluateCloudFormationTemplate {
     return specialCaseResourceType
       ? specialCaseResourceType
       : // this is the default case
-      resourceType.split('::')[2].toLowerCase();
+        resourceType.split('::')[2].toLowerCase();
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
@@ -1,10 +1,10 @@
-import * as path from 'path';
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
 import * as fs from 'fs-extra';
-import { LazyListStackResources, type ListStackResources } from './evaluate-cloudformation-template';
-import { CloudFormationStack, type Template } from './stack-helpers';
+import * as path from 'path';
 import { formatErrorMessage } from '../../util';
 import type { SDK } from '../aws-auth/private';
+import { LazyListStackResources, type ListStackResources } from './evaluate-cloudformation-template';
+import { CloudFormationStack, type Template } from './stack-helpers';
 
 export interface RootTemplateWithNestedStacks {
   readonly deployedRootTemplate: Template;
@@ -121,7 +121,11 @@ async function getNestedStackArn(
     const stackResources = await listStackResources?.listStackResources();
     return stackResources?.find((sr) => sr.LogicalResourceId === nestedStackLogicalId)?.PhysicalResourceId;
   } catch (e: any) {
-    if (formatErrorMessage(e).startsWith('Stack with id ') && formatErrorMessage(e).endsWith(' does not exist')) {
+    if (
+      e.Code === 'ValidationError' ||
+      e.name === 'ValidationError' ||
+      (formatErrorMessage(e).startsWith('Stack with id ') && formatErrorMessage(e).endsWith(' does not exist'))
+    ) {
       return;
     }
     throw e;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/stack-helpers.ts
@@ -1,6 +1,6 @@
 import type { Stack, Tag } from '@aws-sdk/client-cloudformation';
 import { ToolkitError } from '../../toolkit/toolkit-error';
-import { formatErrorMessage, deserializeStructure } from '../../util';
+import { deserializeStructure } from '../../util';
 import type { ICloudFormationClient } from '../aws-auth/private';
 import { StackStatus } from '../stack-events';
 
@@ -32,7 +32,11 @@ export class CloudFormationStack {
       const response = await cfn.describeStacks({ StackName: stackName });
       return new CloudFormationStack(cfn, stackName, response.Stacks && response.Stacks[0], retrieveProcessedTemplate);
     } catch (e: any) {
-      if (e.name === 'ValidationError' && formatErrorMessage(e) === `Stack with id ${stackName} does not exist`) {
+      if (
+        e.name === 'ValidationError' ||
+        e.Code === 'ValidationError' ||
+        (e.message && e.message.includes('does not exist'))
+      ) {
         return new CloudFormationStack(cfn, stackName, undefined);
       }
       throw e;
@@ -62,8 +66,7 @@ export class CloudFormationStack {
     public readonly stackName: string,
     private readonly stack?: Stack,
     private readonly retrieveProcessedTemplate: boolean = false,
-  ) {
-  }
+  ) {}
 
   /**
    * Retrieve the stack's deployed template

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/lazy-list-stack-resources.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/lazy-list-stack-resources.test.ts
@@ -1,10 +1,18 @@
+/**
+ * Additional tests for lazy-list-stack-resources.test.ts
+ * Append these test cases to the existing describe block.
+ */
 import 'aws-sdk-client-mock-jest';
 
 import { ListStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { LazyListStackResources } from '../../../lib/api/cloudformation';
-import { MockSdk, mockCloudFormationClient } from '../../_helpers/mock-sdk';
+import { MockSdk, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../_helpers/mock-sdk';
 
 describe('Lazy ListStackResources', () => {
+  beforeEach(() => {
+    restoreSdkMocksToDefault();
+  });
+
   test('correctly caches calls to the CloudFormation API', async () => {
     // GIVEN
     const mockSdk = new MockSdk();
@@ -22,6 +30,72 @@ describe('Lazy ListStackResources', () => {
 
     // THEN
     expect(result.length).toBe(0);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(ListStackResourcesCommand, 1);
+  });
+
+  test('returns empty array when stack does not exist (SDK v3 ValidationError format)', async () => {
+    // GIVEN — SDK v3 3.993.0+ throws Error with message "ValidationError"
+    // when ListStackResources is called on a non-existent stack
+    const error = Object.assign(new Error('ValidationError'), {
+      name: 'Error',
+      Code: 'ValidationError',
+      $metadata: { httpStatusCode: 400 },
+    });
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'NonExistentStack');
+
+    // WHEN
+    const result = await res.listStackResources();
+
+    // THEN
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array when stack does not exist (SDK v2 ValidationError format)', async () => {
+    // GIVEN — older SDK format with name="ValidationError"
+    const error = new Error('Stack with id NonExistentStack does not exist');
+    error.name = 'ValidationError';
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'NonExistentStack');
+
+    // WHEN
+    const result = await res.listStackResources();
+
+    // THEN
+    expect(result).toEqual([]);
+  });
+
+  test('throws for non-ValidationError exceptions from ListStackResources', async () => {
+    // GIVEN
+    const error = new Error('Rate exceeded');
+    error.name = 'Throttling';
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'StackName');
+
+    // WHEN / THEN
+    await expect(res.listStackResources()).rejects.toThrow('Rate exceeded');
+  });
+
+  test('caches the empty result for non-existent stacks', async () => {
+    // GIVEN — SDK v3 error
+    const error = Object.assign(new Error('ValidationError'), {
+      name: 'Error',
+      Code: 'ValidationError',
+    });
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'NonExistentStack');
+
+    // WHEN — call multiple times
+    const result1 = await res.listStackResources();
+    const result2 = await res.listStackResources();
+
+    // THEN — should only call API once and cache the empty result
+    expect(result1).toEqual([]);
+    expect(result2).toEqual([]);
     expect(mockCloudFormationClient).toHaveReceivedCommandTimes(ListStackResourcesCommand, 1);
   });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/nested-stack-helpers.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/nested-stack-helpers.test.ts
@@ -1,0 +1,66 @@
+import 'aws-sdk-client-mock-jest';
+
+import { ListStackResourcesCommand } from '@aws-sdk/client-cloudformation';
+import { LazyListStackResources, loadCurrentTemplate } from '../../../lib/api/cloudformation';
+import { MockSdk, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../_helpers/mock-sdk';
+
+/**
+ * Since getNestedStackArn is not exported, we test it indirectly through
+ * loadNestedStacks / getNestedStackTemplates behavior. However, the core
+ * error handling we're fixing can be tested via LazyListStackResources
+ * combined with the nested stack helpers.
+ *
+ * The key scenario: when a parent stack doesn't exist yet, ListStackResources
+ * throws ValidationError. The nested-stack-helpers catch block must handle
+ * both old (name=ValidationError) and new (Code=ValidationError) SDK formats.
+ */
+describe('nested-stack-helpers error handling', () => {
+  beforeEach(() => {
+    restoreSdkMocksToDefault();
+  });
+
+  test('handles SDK v2 ValidationError format (message starts with "Stack with id")', async () => {
+    // GIVEN — old SDK error format
+    const error = new Error('Stack with id my-nested-stack does not exist');
+    error.name = 'ValidationError';
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'my-nested-stack');
+
+    // WHEN
+    const result = await res.listStackResources();
+
+    // THEN — should return empty array, not throw
+    expect(result).toEqual([]);
+  });
+
+  test('handles SDK v3 ValidationError format (name=Error, Code=ValidationError)', async () => {
+    // GIVEN — new SDK v3 error format
+    const error = Object.assign(new Error('ValidationError'), {
+      name: 'Error',
+      Code: 'ValidationError',
+      $metadata: { httpStatusCode: 400 },
+    });
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'my-nested-stack');
+
+    // WHEN
+    const result = await res.listStackResources();
+
+    // THEN — should return empty array, not throw
+    expect(result).toEqual([]);
+  });
+
+  test('throws for non-ValidationError exceptions', async () => {
+    // GIVEN
+    const error = new Error('Access Denied');
+    error.name = 'AccessDeniedException';
+    mockCloudFormationClient.on(ListStackResourcesCommand).rejects(error);
+    const mockSdk = new MockSdk();
+    const res = new LazyListStackResources(mockSdk, 'my-nested-stack');
+
+    // WHEN / THEN
+    await expect(res.listStackResources()).rejects.toThrow('Access Denied');
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/stack-helpers.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/stack-helpers.test.ts
@@ -1,0 +1,89 @@
+import 'aws-sdk-client-mock-jest';
+
+import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { CloudFormationStack } from '../../../lib/api/cloudformation';
+import { MockSdk, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../_helpers/mock-sdk';
+
+describe('CloudFormationStack.lookup', () => {
+  beforeEach(() => {
+    restoreSdkMocksToDefault();
+  });
+
+  test('returns existing stack when DescribeStacks succeeds', async () => {
+    // GIVEN
+    mockCloudFormationClient.on(DescribeStacksCommand).resolves({
+      Stacks: [
+        {
+          StackName: 'my-stack',
+          StackStatus: 'CREATE_COMPLETE',
+          CreationTime: new Date(),
+        },
+      ],
+    });
+    const mockSdk = new MockSdk();
+
+    // WHEN
+    const stack = await CloudFormationStack.lookup(mockSdk.cloudFormation(), 'my-stack');
+
+    // THEN
+    expect(stack.exists).toBe(true);
+    expect(stack.stackName).toBe('my-stack');
+  });
+
+  test('returns non-existent stack for SDK v2 ValidationError format (name=ValidationError)', async () => {
+    // GIVEN — SDK v2 / early v3 error format
+    const error = new Error('Stack with id my-stack does not exist');
+    error.name = 'ValidationError';
+    mockCloudFormationClient.on(DescribeStacksCommand).rejects(error);
+    const mockSdk = new MockSdk();
+
+    // WHEN
+    const stack = await CloudFormationStack.lookup(mockSdk.cloudFormation(), 'my-stack');
+
+    // THEN
+    expect(stack.exists).toBe(false);
+  });
+
+  test('returns non-existent stack for SDK v3 ValidationError format (name=Error, Code=ValidationError)', async () => {
+    // GIVEN — SDK v3 3.993.0+ error format
+    // The newer AWS SDK puts "ValidationError" as the message and sets name to "Error"
+    const error = Object.assign(new Error('ValidationError'), {
+      name: 'Error',
+      Code: 'ValidationError',
+      $metadata: { httpStatusCode: 400 },
+    });
+    mockCloudFormationClient.on(DescribeStacksCommand).rejects(error);
+    const mockSdk = new MockSdk();
+
+    // WHEN
+    const stack = await CloudFormationStack.lookup(mockSdk.cloudFormation(), 'my-stack');
+
+    // THEN
+    expect(stack.exists).toBe(false);
+  });
+
+  test('returns non-existent stack when error message contains "does not exist"', async () => {
+    // GIVEN — any future format where the message includes "does not exist"
+    const error = new Error('Stack with id my-stack does not exist');
+    error.name = 'SomeOtherErrorName';
+    mockCloudFormationClient.on(DescribeStacksCommand).rejects(error);
+    const mockSdk = new MockSdk();
+
+    // WHEN
+    const stack = await CloudFormationStack.lookup(mockSdk.cloudFormation(), 'my-stack');
+
+    // THEN
+    expect(stack.exists).toBe(false);
+  });
+
+  test('throws for non-ValidationError exceptions', async () => {
+    // GIVEN
+    const error = new Error('Access Denied');
+    error.name = 'AccessDeniedException';
+    mockCloudFormationClient.on(DescribeStacksCommand).rejects(error);
+    const mockSdk = new MockSdk();
+
+    // WHEN / THEN
+    await expect(CloudFormationStack.lookup(mockSdk.cloudFormation(), 'my-stack')).rejects.toThrow('Access Denied');
+  });
+});


### PR DESCRIPTION
AWS SDK v3 (`@aws-sdk/client-cloudformation@3.993.0+`) changed the error object shape for
CloudFormation `ValidationError`. The CDK toolkit uses exact string matching on error
properties that no longer hold the expected values, causing **all first-time stack deployments
to fail** when using hotswap mode.

### Problem

When `DescribeStacks` or `ListStackResources` is called on a non-existent stack, the SDK
returns a `ValidationError`. The toolkit catches this to handle the "stack doesn't exist yet"
case gracefully. However, the error shape changed between SDK versions:

**Before (SDK v2 / early v3):**
```json
{ "name": "ValidationError", "message": "Stack with id my-stack does not exist" }
```

After (SDK v3 @aws-sdk/client-cloudformation@3.993.0+):
```json
{ "name": "Error", "message": "ValidationError", "Code": "ValidationError" }
```

The change originates from @aws-sdk/core's ProtocolLib.getErrorSchemaOrThrowBaseException
which creates a generic Error with the error code as the message when it cannot match the
error to a known schema.

Three locations in the toolkit rely on the old format:

1.`stack-helpers.js` — `CloudFormationStack.lookup()` checks
```
e.name === 'ValidationError' (now "Error") and formatErrorMessage(e) === "Stack with id X does not exist" (now just "ValidationError")
```
2.`nested-stack-helpers.js` — `getNestedStackArn()` checks
```
formatErrorMessage(e).startsWith('Stack with id ') which fails since the message
is now "ValidationError"
```
3. `evaluate-cloudformation-template.js` — `LazyListStackResources.listStackResources()`
has no error handling at all. During hotswap deployment on a new stack,
ListStackResources throws ValidationError and crashes the deployment.

Impact

- Only affects first-time deployments — existing stacks return valid responses
- Only affects hotswap mode — which is the default for cdk watch and Amplify sandbox
- Affects all aws-cdk-lib versions when paired with @aws-sdk/client-cloudformation@3.993.0+

Authorship

The fix was implemented with assistance from Claude and verified through testing.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license_