### PR TITLE
fix: CLI ignores root cause of CDK App termination

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -1,8 +1,8 @@
 import * as child_process from 'child_process';
+import { readFileSync } from 'fs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import split = require('split2');
 import { AssemblyError } from '../../../toolkit/toolkit-error';
-import { readFileSync } from 'fs';
 
 type EventPublisher = (event: 'open' | 'data_stdout' | 'data_stderr' | 'close', line: string) => void;
 
@@ -87,8 +87,8 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
           const contents = tryReadFile(options.errorCodeFile);
           if (contents) {
             const errorInStdErr = contents
-              .split('\n').
-              find(code => stdErrString.includes(`${SYNTH_ERROR_CODE_MARKERS[0]}${code}${SYNTH_ERROR_CODE_MARKERS[1]}`));
+              .split('\n')
+              .find(c => stdErrString.includes(`${SYNTH_ERROR_CODE_MARKERS[0]}${c}${SYNTH_ERROR_CODE_MARKERS[1]}`));
 
             if (errorInStdErr) {
               // Attach the synth error code. We don't need to change the message; the underlying error will already have been

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -1,7 +1,8 @@
-import * as child_process from 'node:child_process';
+import * as child_process from 'child_process';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import split = require('split2');
 import { AssemblyError } from '../../../toolkit/toolkit-error';
+import { readFileSync } from 'fs';
 
 type EventPublisher = (event: 'open' | 'data_stdout' | 'data_stderr' | 'close', line: string) => void;
 
@@ -9,10 +10,13 @@ interface ExecOptions {
   eventPublisher?: EventPublisher;
   env?: { [key: string]: string | undefined };
   cwd?: string;
+  errorCodeFile?: string;
 }
 
 /**
  * Execute a command line in a child process
+ *
+ * Based on the errors it throws, this assumes the process it is executing is a CDK app.
  */
 export async function execInChildProcess(commandAndArgs: string, options: ExecOptions = {}) {
   return new Promise<void>((ok, fail) => {
@@ -60,19 +64,55 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
       return eventPublisher('data_stderr', line);
     });
 
-    proc.on('error', fail);
+    proc.on('error', (e) => {
+      fail(AssemblyError.withCause(`Failed to execute CDK app: ${commandAndArgs}`, e));
+    });
 
     proc.on('exit', code => {
       if (code === 0) {
         return ok();
       } else {
+        const stdErrString = stderr.join('\n');
+
         let cause: Error | undefined;
         if (stderr.length) {
-          cause = new Error(stderr.join('\n'));
+          cause = new Error(stdErrString);
           cause.name = 'ExecutionError';
         }
-        return fail(AssemblyError.withCause(`${commandAndArgs}: Subprocess exited with error ${code}`, cause));
+
+        let error = AssemblyError.withCause(`${commandAndArgs}: Subprocess exited with error ${code}`, cause);
+
+        // Search for an error code, and throw that if we have it
+        if (options.errorCodeFile) {
+          const contents = tryReadFile(options.errorCodeFile);
+          if (contents) {
+            const errorInStdErr = contents
+              .split('\n').
+              find(code => stdErrString.includes(`${SYNTH_ERROR_CODE_MARKERS[0]}${code}${SYNTH_ERROR_CODE_MARKERS[1]}`));
+
+            if (errorInStdErr) {
+              // Attach the synth error code. We don't need to change the message; the underlying error will already have been
+              // printed to stderr.
+              error.attachSynthesisErrorCode(errorInStdErr);
+            }
+          }
+        }
+
+        return fail(error);
       }
     });
   });
+}
+
+const SYNTH_ERROR_CODE_MARKERS = ['«', '»'];
+
+function tryReadFile(name: string): string | undefined {
+  try {
+    return readFileSync(name, 'utf-8');
+  } catch (e: any) {
+    if (e.code === 'ENOENT') {
+      return undefined;
+    }
+    throw e;
+  }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
@@ -62,9 +62,9 @@ export class ToolkitError extends Error {
 
   constructor(message: string, type: string = 'toolkit', cause?: unknown) {
     super(message);
+    this.name = this.constructor.name;
     Object.setPrototypeOf(this, ToolkitError.prototype);
     Object.defineProperty(this, TOOLKIT_ERROR_SYMBOL, { value: true });
-    this.name = new.target.name;
     this.type = type;
     this.source = 'toolkit';
     this.cause = cause;
@@ -120,11 +120,24 @@ export class AssemblyError extends ToolkitError {
    */
   public readonly stacks?: cxapi.CloudFormationStackArtifact[];
 
+  private _synthErrorCode: string | undefined;
+
   private constructor(message: string, stacks?: cxapi.CloudFormationStackArtifact[], cause?: unknown) {
     super(message, 'assembly', cause);
     Object.setPrototypeOf(this, AssemblyError.prototype);
     Object.defineProperty(this, ASSEMBLY_ERROR_SYMBOL, { value: true });
     this.stacks = stacks;
+  }
+
+  /**
+   * The synthesis error code
+   */
+  public get synthErrorCode(): string | undefined {
+    return this._synthErrorCode;
+  }
+
+  public attachSynthesisErrorCode(synthesisErrorCode: string) {
+    this._synthErrorCode = synthesisErrorCode;
   }
 }
 

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -1,10 +1,10 @@
+import * as path from 'path';
 import { format } from 'util';
 import { CloudAssembly } from '@aws-cdk/cloud-assembly-api';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import * as cxapi from '@aws-cdk/cx-api';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as fs from 'fs-extra';
-import * as path from 'path';
 import type { IoHelper } from '../../lib/api-private';
 import type { SdkProvider, IReadLock } from '../api';
 import { RWLock, guessExecutable, prepareDefaultEnvironment, writeContextToEnv, synthParametersFromSettings, execInChildProcess } from '../api';

--- a/packages/aws-cdk/lib/cxapp/exec.ts
+++ b/packages/aws-cdk/lib/cxapp/exec.ts
@@ -1,13 +1,13 @@
-import * as childProcess from 'child_process';
 import { format } from 'util';
 import { CloudAssembly } from '@aws-cdk/cloud-assembly-api';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import * as cxapi from '@aws-cdk/cx-api';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as fs from 'fs-extra';
+import * as path from 'path';
 import type { IoHelper } from '../../lib/api-private';
 import type { SdkProvider, IReadLock } from '../api';
-import { RWLock, guessExecutable, prepareDefaultEnvironment, writeContextToEnv, synthParametersFromSettings } from '../api';
+import { RWLock, guessExecutable, prepareDefaultEnvironment, writeContextToEnv, synthParametersFromSettings, execInChildProcess } from '../api';
 import type { Configuration } from '../cli/user-configuration';
 import { PROJECT_CONFIG, USER_DEFAULTS } from '../cli/user-configuration';
 import { versionNumber } from '../cli/version';
@@ -20,6 +20,7 @@ export interface ExecProgramResult {
 /** Invokes the cloud executable and returns JSON output */
 export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: Configuration): Promise<ExecProgramResult> {
   const debugFn = (msg: string) => ioHelper.defaults.debug(msg);
+  let errorFile: string | undefined;
 
   const params = synthParametersFromSettings(config.settings);
 
@@ -82,12 +83,17 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
 
   env[cxapi.OUTDIR_ENV] = outdir;
 
-  // Acquire a lock on the output directory
-  const writerLock = await new RWLock(outdir).acquireWrite();
-
   // Send version information
   env[cxapi.CLI_ASM_VERSION_ENV] = cxschema.Manifest.version();
   env[cxapi.CLI_VERSION_ENV] = versionNumber();
+
+  // Acquire a lock on the output directory
+  const writerLock = await new RWLock(outdir).acquireWrite();
+
+  // Prepare an errorFile location
+  errorFile = path.join(outdir, 'error.txt');
+  await fs.promises.rm(errorFile, { force: true });
+  env.CDK_ERROR_FILE = errorFile;
 
   await debugFn(format('env:', env));
 
@@ -107,36 +113,12 @@ export async function execProgram(aws: SdkProvider, ioHelper: IoHelper, config: 
 
   async function exec(commandAndArgs: string) {
     try {
-      await new Promise<void>((ok, fail) => {
-        // We use a slightly lower-level interface to:
-        //
-        // - Pass arguments in an array instead of a string, to get around a
-        //   number of quoting issues introduced by the intermediate shell layer
-        //   (which would be different between Linux and Windows).
-        //
-        // - Inherit stderr from controlling terminal. We don't use the captured value
-        //   anyway, and if the subprocess is printing to it for debugging purposes the
-        //   user gets to see it sooner. Plus, capturing doesn't interact nicely with some
-        //   processes like Maven.
-        const proc = childProcess.spawn(commandAndArgs, {
-          stdio: ['ignore', 'inherit', 'inherit'],
-          detached: false,
-          shell: true,
-          env: {
-            ...process.env,
-            ...env,
-          },
-        });
-
-        proc.on('error', fail);
-
-        proc.on('exit', code => {
-          if (code === 0) {
-            return ok();
-          } else {
-            return fail(new ToolkitError(`${commandAndArgs}: Subprocess exited with error ${code}`));
-          }
-        });
+      return await execInChildProcess(commandAndArgs, {
+        env: {
+          ...process.env,
+          ...env,
+        },
+        errorCodeFile: errorFile,
       });
     } catch (e: any) {
       await debugFn(`failed command: ${commandAndArgs}`);

--- a/packages/aws-cdk/test/_helpers/mock-child_process.ts
+++ b/packages/aws-cdk/test/_helpers/mock-child_process.ts
@@ -1,6 +1,7 @@
 /* eslint-disable import/order */
 import * as child_process from 'child_process';
 import * as events from 'events';
+import * as stream from 'node:stream';
 
 if (!(child_process as any).spawn.mockImplementationOnce) {
   throw new Error('Call "jest.mock(\'child_process\');" at the top of the test file!');
@@ -11,11 +12,12 @@ export interface Invocation {
   cwd?: string;
   exitCode?: number;
   stdout?: string;
+  stderr?: string;
 
   /**
    * Run this function as a side effect, if present
    */
-  sideEffect?: () => void;
+  sideEffect?: (binary: string, options: child_process.SpawnOptions) => void;
 }
 
 export function mockSpawn(...invocations: Invocation[]) {
@@ -30,18 +32,23 @@ export function mockSpawn(...invocations: Invocation[]) {
       }
 
       if (invocation.sideEffect) {
-        invocation.sideEffect();
+        invocation.sideEffect(binary, options);
       }
 
       const child: any = new events.EventEmitter();
-      child.stdin = new events.EventEmitter();
+      child.stdin = new stream.Writable();
       child.stdin.write = jest.fn();
       child.stdin.end = jest.fn();
-      child.stdout = new events.EventEmitter();
-      child.stderr = new events.EventEmitter();
+      child.stdout = new stream.PassThrough();
+      child.stderr = new stream.PassThrough();
 
       if (invocation.stdout) {
-        mockEmit(child.stdout, 'data', invocation.stdout);
+        child.stdout.push(invocation.stdout);
+        child.stdout.push(null);
+      }
+      if (invocation.stderr) {
+        child.stderr.push(invocation.stderr);
+        child.stderr.push(null);
       }
       mockEmit(child, 'close', invocation.exitCode ?? 0);
       mockEmit(child, 'exit', invocation.exitCode ?? 0);

--- a/packages/aws-cdk/test/cxapp/exec.test.ts
+++ b/packages/aws-cdk/test/cxapp/exec.test.ts
@@ -1,10 +1,10 @@
 jest.mock('child_process');
+import * as fs from 'fs';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as cdk from 'aws-cdk-lib';
 import * as semver from 'semver';
 import * as sinon from 'sinon';
-import * as fs from 'fs';
 import { ImportMock } from 'ts-mock-imports';
 import { RWLock } from '../../lib/api';
 import { Configuration } from '../../lib/cli/user-configuration';

--- a/packages/aws-cdk/test/cxapp/exec.test.ts
+++ b/packages/aws-cdk/test/cxapp/exec.test.ts
@@ -4,6 +4,7 @@ import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as cdk from 'aws-cdk-lib';
 import * as semver from 'semver';
 import * as sinon from 'sinon';
+import * as fs from 'fs';
 import { ImportMock } from 'ts-mock-imports';
 import { RWLock } from '../../lib/api';
 import { Configuration } from '../../lib/cli/user-configuration';
@@ -292,6 +293,58 @@ test('cli releases the outdir lock when execProgram throws', async () => {
   // check that the lock is released
   const lock = await new RWLock(output).acquireWrite();
   await lock.release();
+});
+
+test('errors in the subprocess stderr output are captured if they are also written to the $CDK_ERROR_FILE', async () => {
+  // GIVEN
+  config.settings.set(['app'], 'cloud-executable');
+  mockSpawn({
+    commandLine: 'cloud-executable',
+    sideEffect: (_, options) => {
+      const errFile = options.env?.CDK_ERROR_FILE;
+      if (!errFile) {
+        throw new Error('Expecting $CDK_ERROR_FILE, but not set');
+      }
+
+      fs.writeFileSync(errFile, 'SomeErrorCode', 'utf-8');
+    },
+    stderr: '«SomeErrorCode» There was an error',
+    exitCode: 1,
+  });
+
+  // WHEN
+  try {
+    await execProgram(sdkProvider, ioHelper, config);
+  } catch (e: any) {
+    if (!ToolkitError.isAssemblyError(e)) {
+      throw new Error(`Expected AssemblyError but got ${e}`);
+    }
+    expect(e.synthErrorCode).toEqual('SomeErrorCode');
+    return;
+  }
+  throw new Error('Expected execProgram() to throw, but it didn\'t');
+});
+
+test('marked-up error codes are ignored if they do not match the error file', async () => {
+  // GIVEN
+  config.settings.set(['app'], 'cloud-executable');
+  mockSpawn({
+    commandLine: 'cloud-executable',
+    stderr: '«SomeErrorCode» There was an error',
+    exitCode: 1,
+  });
+
+  // WHEN
+  try {
+    await execProgram(sdkProvider, ioHelper, config);
+  } catch (e: any) {
+    if (!ToolkitError.isAssemblyError(e)) {
+      throw new Error(`Expected AssemblyError but got ${e}`);
+    }
+    expect(e.synthErrorCode).toEqual(undefined);
+    return;
+  }
+  throw new Error('Expected execProgram() to throw, but it didn\'t');
 });
 
 function writeOutputAssembly() {


### PR DESCRIPTION
This is the companion PR to https://github.com/aws/aws-cdk/pull/37294, to have the CLI read the synthesis failure root cause from the CDK app output.

Rather than introduce a new error type, the error code is stored on `AssemblyError.synthErrorCode` instead (if available).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
