### PR TITLE
fix(cloud-assembly-api): propagate load options to nested assemblies

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-api/lib/artifacts/nested-cloud-assembly-artifact-aug.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/artifacts/nested-cloud-assembly-artifact-aug.ts
@@ -11,7 +11,7 @@ const cacheSym = Symbol();
 Object.defineProperty(NestedCloudAssemblyArtifact.prototype, 'nestedAssembly', {
   get() {
     if (!this[cacheSym]) {
-      this[cacheSym] = new CloudAssembly(this.fullPath);
+      this[cacheSym] = new CloudAssembly(this.fullPath, this.assembly.loadOptions);
     }
     return this[cacheSym];
   },

--- a/packages/@aws-cdk/cloud-assembly-api/lib/cloud-assembly.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/cloud-assembly.ts
@@ -103,15 +103,21 @@ export class CloudAssembly implements ICloudAssembly {
   public readonly manifest: cxschema.AssemblyManifest;
 
   /**
+   * The load options used to create this assembly, propagated to nested assemblies.
+   */
+  private readonly loadOptions?: cxschema.LoadManifestOptions;
+
+  /**
    * Reads a cloud assembly from the specified directory.
    * @param directory - The root directory of the assembly.
    */
   constructor(directory: string, loadOptions?: cxschema.LoadManifestOptions) {
     this.directory = directory;
+    this.loadOptions = loadOptions;
 
-    this.manifest = cxschema.Manifest.loadAssemblyManifest(path.join(directory, MANIFEST_FILE), loadOptions);
+    this.manifest = cxschema.Manifest.loadAssemblyManifest(path.join(directory, MANIFEST_FILE), this.loadOptions);
     this.version = this.manifest.version;
-    this.artifacts = this.renderArtifacts(loadOptions?.topoSort ?? true);
+    this.artifacts = this.renderArtifacts(this.loadOptions?.topoSort ?? true);
     this.runtime = this.manifest.runtime || { libraries: { } };
 
     Object.defineProperty(this, CLOUD_ASSEMBLY_SYMBOL, { value: true });

--- a/packages/@aws-cdk/cloud-assembly-api/test/cloud-assembly-builder.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/test/cloud-assembly-builder.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema/lib';
+import * as semver from 'semver';
 import * as cxapi from '../lib';
 
 test('cloud assembly builder', () => {
@@ -174,6 +175,67 @@ test('write and read nested cloud assembly artifact', () => {
 
   const nested = art?.nestedAssembly;
   expect(nested?.artifacts.length).toEqual(0);
+});
+
+test('nested assembly inherits load options from parent', () => {
+  // GIVEN
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-assembly-builder-tests'));
+  const session = new cxapi.CloudAssemblyBuilder(outdir);
+  const futureVersion = semver.inc(cxschema.Manifest.version(), 'major')!;
+
+  const innerAsmDir = path.join(outdir, 'nested');
+  new cxapi.CloudAssemblyBuilder(innerAsmDir).buildAssembly();
+
+  const nestedManifestPath = path.join(innerAsmDir, 'manifest.json');
+  const nestedManifest = JSON.parse(fs.readFileSync(nestedManifestPath, 'utf-8'));
+  nestedManifest.version = futureVersion;
+  fs.writeFileSync(nestedManifestPath, JSON.stringify(nestedManifest));
+
+  session.addArtifact('NestedAssembly', {
+    type: cxschema.ArtifactType.NESTED_CLOUD_ASSEMBLY,
+    properties: {
+      directoryName: 'nested',
+    } as cxschema.NestedCloudAssemblyProperties,
+  });
+  session.buildAssembly();
+
+  // WHEN
+  const asm = new cxapi.CloudAssembly(outdir, { skipVersionCheck: true });
+  const art = asm.nestedAssemblies[0];
+
+  // THEN
+  expect(() => art.nestedAssembly).not.toThrow();
+  expect(art.nestedAssembly.version).toEqual(futureVersion);
+});
+
+test('nested assembly without load options fails on version mismatch', () => {
+  // GIVEN
+  const outdir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-assembly-builder-tests'));
+  const session = new cxapi.CloudAssemblyBuilder(outdir);
+  const futureVersion = semver.inc(cxschema.Manifest.version(), 'major')!;
+
+  const innerAsmDir = path.join(outdir, 'nested');
+  new cxapi.CloudAssemblyBuilder(innerAsmDir).buildAssembly();
+
+  const nestedManifestPath = path.join(innerAsmDir, 'manifest.json');
+  const nestedManifest = JSON.parse(fs.readFileSync(nestedManifestPath, 'utf-8'));
+  nestedManifest.version = futureVersion;
+  fs.writeFileSync(nestedManifestPath, JSON.stringify(nestedManifest));
+
+  session.addArtifact('NestedAssembly', {
+    type: cxschema.ArtifactType.NESTED_CLOUD_ASSEMBLY,
+    properties: {
+      directoryName: 'nested',
+    } as cxschema.NestedCloudAssemblyProperties,
+  });
+  session.buildAssembly();
+
+  // WHEN
+  const asm = new cxapi.CloudAssembly(outdir);
+  const art = asm.nestedAssemblies[0];
+
+  // THEN
+  expect(() => art.nestedAssembly).toThrow(/Cloud assembly schema version mismatch/);
 });
 
 test('missing values are reported to top-level asm', () => {


### PR DESCRIPTION
Fixes #749

Nested assemblies (e.g. Stages) are instantiated without the parent's `LoadManifestOptions`, so setting `skipVersionCheck: true` on the root assembly has no effect on nested assemblies — they still fail with a version mismatch error.

Store `loadOptions` on `CloudAssembly` and pass them through when creating nested assemblies via `NestedCloudAssemblyArtifact.nestedAssembly`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license