### PR TITLE
fix(cli): `--require-approval any-change` only asks for confirmation on broadening changes

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -504,13 +504,13 @@ export class CdkToolkit {
         });
         const securityDiff = formatter.formatSecurityDiff();
         if (requiresApproval(requireApproval, securityDiff.permissionChangeType)) {
-          const motivation = requireApproval === RequireApproval.ANYCHANGE 
-            ? `"--require-approval" is set to '${RequireApproval.ANYCHANGE}'` 
+          const motivation = requireApproval === RequireApproval.ANYCHANGE
+            ? `"--require-approval" is set to '${RequireApproval.ANYCHANGE}'`
             : '"--require-approval" is enabled and stack includes security-sensitive updates';
           await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
 
           // the ioHost uses this internally to determine if a confirmation
-          // is actually needed, so it needs the same value we have here. 
+          // is actually needed, so it needs the same value we have here.
           // ideally this would threaded into the request instead of it being an instance field.
           this.ioHost.requireDeployApproval = requireApproval;
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -504,8 +504,16 @@ export class CdkToolkit {
         });
         const securityDiff = formatter.formatSecurityDiff();
         if (requiresApproval(requireApproval, securityDiff.permissionChangeType)) {
-          const motivation = '"--require-approval" is enabled and stack includes security-sensitive updates';
+          const motivation = requireApproval === RequireApproval.ANYCHANGE 
+            ? `"--require-approval" is set to '${RequireApproval.ANYCHANGE}'` 
+            : '"--require-approval" is enabled and stack includes security-sensitive updates';
           await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
+
+          // the ioHost uses this internally to determine if a confirmation
+          // is actually needed, so it needs the same value we have here. 
+          // ideally this would threaded into the request instead of it being an instance field.
+          this.ioHost.requireDeployApproval = requireApproval;
+
           await askUserConfirmation(
             this.ioHost,
             IO.CDK_TOOLKIT_I5060.req(`${motivation}: 'Do you wish to deploy these changes'`, {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -402,13 +402,16 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           throw new ToolkitError('Can not supply both --[no-]execute and --method at the same time');
         }
 
+        const requireDeployApproval = configuration.settings.get(['requireApproval']);
+        // ioHost.requireDeployApproval = requireDeployApproval;
+
         return cli.deploy({
           selector,
           exclusively: args.exclusively,
           toolkitStackName,
           roleArn: args.roleArn,
           notificationArns: args.notificationArns,
-          requireApproval: configuration.settings.get(['requireApproval']),
+          requireApproval: requireDeployApproval,
           reuseAssets: args['build-exclude'],
           tags: configuration.settings.get(['tags']),
           deploymentMethod: determineDeploymentMethod(args, configuration),

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -402,16 +402,13 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           throw new ToolkitError('Can not supply both --[no-]execute and --method at the same time');
         }
 
-        const requireDeployApproval = configuration.settings.get(['requireApproval']);
-        // ioHost.requireDeployApproval = requireDeployApproval;
-
         return cli.deploy({
           selector,
           exclusively: args.exclusively,
           toolkitStackName,
           roleArn: args.roleArn,
           notificationArns: args.notificationArns,
-          requireApproval: requireDeployApproval,
+          requireApproval: configuration.settings.get(['requireApproval']),
           reuseAssets: args['build-exclude'],
           tags: configuration.settings.get(['tags']),
           deploymentMethod: determineDeploymentMethod(args, configuration),

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -377,7 +377,7 @@ export class CliIoHost implements IIoHost {
   private skipApprovalStep(msg: IoRequest<any, any>): boolean {
     const approvalToolkitCodes = ['CDK_TOOLKIT_I5060'];
     if (!(msg.code && approvalToolkitCodes.includes(msg.code))) {
-      false;
+      return false;
     }
 
     switch (this.requireDeployApproval) {

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -195,8 +195,6 @@ describe('list', () => {
 
 describe('deploy', () => {
   test('sets requireDeployApproval on CliIoHost', async () => {
-    // GIVEN
-
     const toolkit = defaultToolkitSetup();
     const requireApproval = RequireApproval.ANYCHANGE;
     await toolkit.deploy({

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -194,6 +194,20 @@ describe('list', () => {
 });
 
 describe('deploy', () => {
+  test('sets requireDeployApproval on CliIoHost', async () => {
+    // GIVEN
+
+    const toolkit = defaultToolkitSetup();
+    const requireApproval = RequireApproval.ANYCHANGE;
+    await toolkit.deploy({
+      selector: { patterns: ['**'] },
+      deploymentMethod: { method: 'change-set' },
+      requireApproval,
+    });
+
+    expect(ioHost.requireDeployApproval).toEqual(requireApproval);
+  });
+
   test('fails when no valid stack names are given', async () => {
     // GIVEN
     const toolkit = defaultToolkitSetup();


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk-cli/issues/1236

### Problem

The value of `--require-approval` is not being passed to the `CliIoHost`, which defaults it to `RequireApproval.BROADENING`.

### Solution

The correct `requireApproval` value is already being passed to `deploy`, so we just need to propagate it into the `CliIoHost` via the setter. This isn't ideal because it prevents concurrent deployments with different `requireApproval` values, but the CLI can't do that anyway so its not an actual issue. 

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
