### PR TITLE
fix: show diff when requesting approval for any-change

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-any-change-approval-shows-diff.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-any-change-approval-shows-diff.integtest.ts
@@ -1,0 +1,21 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
+
+integTest(
+  'deploy with any-change approval shows diff',
+  withDefaultFixture(async (fixture) => {
+    // Deploy with --require-approval=any-change and --yes to auto-confirm.
+    // The output should contain the stack diff so the user knows what they're approving.
+    const output = await fixture.cdkDeploy('test-2', {
+      options: ['--require-approval=any-change', '--yes'],
+      neverRequireApproval: false,
+    });
+
+    // The deploy confirmation message should contain the diff with resource information
+    expect(output).toContain('AWS::SNS::Topic');
+    expect(output).toContain('"--require-approval" is set to \'any-change\'');
+    expect(output).toContain('Do you wish to deploy these changes');
+    expect(output).toContain('(auto-confirmed)');
+  }),
+);

--- a/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/common.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/commands/common.ts
@@ -1,19 +1,19 @@
 /**
- * In what scenarios should the CLI ask for approval
+ * Specify what changes require manual approval.
  */
 export enum RequireApproval {
   /**
-   * Never ask for approval
+   * Approval is not required
    */
   NEVER = 'never',
 
   /**
-   * Prompt for approval for any type of change to the stack
+   * Manual approval required for any change to the stack
    */
   ANYCHANGE = 'any-change',
 
   /**
-   * Only prompt for approval if there are security related changes
+   * Manual approval required if changes involve a broadening of permissions or security group rules
    */
   BROADENING = 'broadening',
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -627,12 +627,17 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       });
 
       const securityDiff = formatter.formatSecurityDiff();
+      const stackDiff = formatter.formatStackDiff();
 
-      // Send a request response with the formatted security diff as part of the message,
+      // Send a request response with the diff as part of the message,
       // and the template diff as data
       // (IoHost decides whether to print depending on permissionChangeType)
-      const deployMotivation = '"--require-approval" is enabled and stack includes security-sensitive updates.';
-      const deployQuestion = `${securityDiff.formattedDiff}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
+      const hasSecurityChanges = securityDiff.permissionChangeType !== PermissionChangeType.NONE;
+      const deployMotivation = hasSecurityChanges
+        ? '"--require-approval" is enabled and stack includes security-sensitive updates.'
+        : '"--require-approval" is enabled and stack includes updates.';
+      const diffOutput = hasSecurityChanges ? securityDiff.formattedDiff : stackDiff.formattedDiff;
+      const deployQuestion = `${diffOutput}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
       const deployConfirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I5060.req(deployQuestion, {
         motivation: deployMotivation,
         concurrency,

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -102,6 +102,27 @@ IAM Statement Changes
     }));
   });
 
+  test('request response contains stack diff when there are no security changes', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-bucket');
+    await toolkit.deploy(cx);
+
+    // THEN
+    const request = ioHost.requestSpy.mock.calls[0][0].message.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+
+    // Message includes formatted stack diff (not just security diff)
+    expect(request).toContain('AWS::S3::Bucket');
+    expect(request).toContain('Do you wish to deploy these changes');
+
+    expect(ioHost.requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_I5060',
+      data: expect.objectContaining({
+        motivation: expect.stringContaining('stack includes updates.'),
+        permissionChangeType: 'none',
+      }),
+    }));
+  });
+
   describe('deployment options', () => {
     test('parameters are passed in', async () => {
       // WHEN

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -510,10 +510,12 @@ export class CdkToolkit {
         });
         const securityDiff = formatter.formatSecurityDiff();
         if (requiresApproval(requireApproval, securityDiff.permissionChangeType)) {
-          const motivation = requireApproval === RequireApproval.ANYCHANGE
-            ? `"--require-approval" is set to '${RequireApproval.ANYCHANGE}'`
-            : '"--require-approval" is enabled and stack includes security-sensitive updates';
-          await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
+          const hasSecurityChanges = securityDiff.permissionChangeType !== PermissionChangeType.NONE;
+          const motivation = hasSecurityChanges
+            ? '"--require-approval" is enabled and stack includes security-sensitive updates'
+            : `"--require-approval" is set to '${RequireApproval.ANYCHANGE}'`;
+          const diffOutput = hasSecurityChanges ? securityDiff.formattedDiff : formatter.formatStackDiff().formattedDiff;
+          await this.ioHost.asIoHelper().defaults.info(diffOutput);
 
           await askUserConfirmation(
             this.ioHost,
@@ -2236,7 +2238,7 @@ function stackMetadataLogger(ioHelper: IoHelper, verbose?: boolean): (level: 'in
 
 /**
  * Determine if manual approval is required or not. Requires approval for
- * - RequireApproval.ANY_CHANGE
+ * - RequireApproval.ANYCHANGE
  * - RequireApproval.BROADENING and the changes are indeed broadening permissions
  */
 function requiresApproval(requireApproval: RequireApproval, permissionChangeType: PermissionChangeType) {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -143,7 +143,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'all': { type: 'boolean', desc: 'Deploy all available stacks', default: false },
           'build-exclude': { type: 'array', alias: 'E', desc: 'Do not rebuild asset with the given ID. Can be specified multiple times', default: [] },
           'exclusively': { type: 'boolean', alias: 'e', desc: 'Only deploy requested stacks, don\'t include dependencies' },
-          'require-approval': { type: 'string', choices: [RequireApproval.NEVER, RequireApproval.ANYCHANGE, RequireApproval.BROADENING], desc: 'What security-sensitive changes need manual approval' },
+          'require-approval': { type: 'string', choices: [RequireApproval.NEVER, RequireApproval.ANYCHANGE, RequireApproval.BROADENING], desc: 'What changes require manual approval' },
           'notification-arns': { type: 'array', desc: 'ARNs of SNS topics that CloudFormation will notify with stack related events. These will be added to ARNs specified with the \'notificationArns\' stack property.' },
           // @deprecated(v2) -- tags are part of the Cloud Assembly and tags specified here will be overwritten on the next deployment
           'tags': { type: 'array', alias: 't', desc: 'Tags to add to the stack (KEY=VALUE), overrides tags from Cloud Assembly (deprecated)' },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -437,7 +437,7 @@
             "any-change",
             "broadening"
           ],
-          "desc": "What security-sensitive changes need manual approval"
+          "desc": "What changes require manual approval"
         },
         "notification-arns": {
           "type": "array",

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -460,7 +460,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
           default: undefined,
           type: 'string',
           choices: ['never', 'any-change', 'broadening'],
-          desc: 'What security-sensitive changes need manual approval',
+          desc: 'What changes require manual approval',
         })
         .option('notification-arns', {
           type: 'array',

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -749,7 +749,7 @@ export interface DeployOptions {
   readonly exclusively?: boolean;
 
   /**
-   * What security-sensitive changes need manual approval
+   * What changes require manual approval
    *
    * @default - undefined
    */

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -206,6 +206,25 @@ describe('deploy', () => {
     expect(ioHost.requireDeployApproval).toEqual(requireApproval);
   });
 
+  test('any-change approval shows stack diff when there are no security changes', async () => {
+    const toolkit = defaultToolkitSetup();
+    requestSpy = jest.spyOn(ioHost, 'requestResponse');
+    await toolkit.deploy({
+      selector: { patterns: ['Test-Stack-A-Display-Name'] },
+      deploymentMethod: { method: 'change-set' },
+      requireApproval: RequireApproval.ANYCHANGE,
+    });
+
+    // The confirmation prompt should use the non-security motivation and report no permission changes
+    expect(requestSpy).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_I5060',
+      message: expect.stringContaining("'any-change'"),
+      data: expect.objectContaining({
+        permissionChangeType: 'none',
+      }),
+    }));
+  });
+
   test('fails when no valid stack names are given', async () => {
     // GIVEN
     const toolkit = defaultToolkitSetup();


### PR DESCRIPTION
When `--require-approval` is set to `any-change`, the deploy confirmation prompt only included the security diff in its message. Since non-security changes don't produce a security diff, users were asked to approve changes without being able to see what those changes are. This makes the approval step useless because a human cannot make an informed decision without seeing the diff.

The fix ensures that when there are no security-related changes, the full stack diff is shown instead. When there are security changes, the behavior remains unchanged and the security diff is displayed as before. The motivation text in the prompt has also been updated to accurately reflect whether the approval is for security-sensitive changes or general changes.

This is fixed in both the CLI (`aws-cdk`) and the programmatic toolkit (`toolkit-lib`), which had slightly different but equally broken implementations.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
