### PR TITLE
fix(cli-integ): tests are unnecessarily retried locally

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -114,6 +114,13 @@ async function main() {
         describe: 'The test suite shard to execute in a format of (?<shardIndex>\d+)/(?<shardCount>\d+). `shardIndex` describes which shard to select while `shardCount` controls the number of shards the suite should be split into. `shardIndex` and `shardCount` have to be 1-based, positive numbers, and `shardIndex` has to be lower than or equal to `shardCount`.',
         type: 'string',
         requiresArg: true,
+      })
+      .options('retry', {
+        describe: 'Number of times to retry failed tests.',
+        type: 'number',
+        requiresArg: true,
+        default: !!(process.env.CI || process.env.CODEBUILD_BUILD_ID) ? 2 : 0,
+        defaultDescription: '2 in CI/CodeBuild, 0 otherwise',
       }), () => {
     },
     )
@@ -183,6 +190,8 @@ async function main() {
       : new RunnerLibraryGlobalInstallSource(toolkitLibPackage, 'latest');
   }
 
+  process.env.JEST_RETRY_TIMES = String(args.retry);
+
   console.log('------> Configuration');
   console.log(`        Test suite:         ${suiteName}`);
   console.log(`        Test version:       ${thisPackageVersion()}`);
@@ -190,6 +199,7 @@ async function main() {
   console.log(`        Library source:     ${librarySource.sourceDescription}`);
   console.log(`        Toolkit lib source: ${toolkitSource.sourceDescription}`);
   console.log(`        cdk-assets source:  ${cdkAssetsSource.assert().sourceDescription}`);
+  console.log(`        Retry:              ${args.retry}`);
 
   if (args.verbose) {
     process.env.VERBOSE = '1';

--- a/packages/@aws-cdk-testing/cli-integ/lib/integ-test.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/integ-test.ts
@@ -37,9 +37,7 @@ export function integTest(
 ): void {
   const runner = shouldSkip(name) ? test.skip : test;
 
-  // we're quite a bit of sporadic failures due to environmental causes.
-  // lets retry 3 times to try and mitigate that.
-  jest.retryTimes(3);
+  jest.retryTimes(parseInt(process.env.JEST_RETRY_TIMES ?? '0'));
 
   runner(name, async () => {
     const output = new MemoryStream();


### PR DESCRIPTION
The hardcoded `jest.retryTimes(3)` in `integTest` is useful in CI where sporadic environmental failures are common, but locally it means every failing test runs 3 additional times before reporting — making the feedback loop painfully slow during development.

This adds a `--retry` flag to `run-suite` that controls the number of additional retries after the initial run. The default is environment-aware: retry when `CI` or `CODEBUILD_BUILD_ID` are set, don't retry otherwise (i.e. locally).

I've also change the number of retry attempts to `2` (was `3`) for a total of 3 attempts including the first failure. This seems plenty to me. Otherwise the CI behavior stays unchanged while making local runs fail fast.

### Proof this works as intended

https://github.com/aws/aws-cdk-cli/actions/runs/23590925937/job/68696775102?pr=1256#step:11:35

<img width="793" height="181" alt="image" src="https://github.com/user-attachments/assets/878d026d-ae58-43d2-8565-e8db10bcccdd" />



### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
