### PR TITLE
fix(cli-integ): cannot use profiles locally

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/bin/run-suite
+++ b/packages/@aws-cdk-testing/cli-integ/bin/run-suite
@@ -1,2 +1,2 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --experimental-vm-modules
 require('../lib/cli/run-suite.js');


### PR DESCRIPTION
Without `--experimental-vm-modules`, Jest's module system doesn't fully support the dynamic imports used by AWS SDK credential providers like `fromIni` and `fromNodeProviderChain`. This causes credential resolution to fail when using `AWS_PROFILE`, making it impossible to run integration tests locally with profile-based credentials (e.g. SSO or assume-role profiles).

Adding the flag to the `run-suite` shebang via `env -S` ensures Jest workers can properly resolve AWS credentials from profiles. The flag merges with any existing `NODE_OPTIONS` in the environment.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
