### PR TITLE
chore(cli-integ): centralize jest timeout and reporter config

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1548,7 +1548,7 @@ const cliInteg = configureProject(
       'yargs@^16',
       // Jest is a runtime dependency here!
       'jest@^29',
-      'jest-junit@^15',
+      'jest-junit@^16',
       'ts-jest@^29',
       'proxy-agent',
       'node-pty',

--- a/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
@@ -211,7 +211,7 @@
     },
     {
       "name": "jest-junit",
-      "version": "^15",
+      "version": "^16",
       "type": "runtime"
     },
     {

--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -247,7 +247,16 @@ async function main() {
     // (but slowly) if this flag is set.
     process.env.TESTING_CDK = '1';
 
+    // jest-junit reporter configuration
+    process.env.JEST_SUITE_NAME = 'jest tests';
+    process.env.JEST_JUNIT_OUTPUT_DIR = 'coverage';
+
     await jest.run([
+      '--reporters=default',
+      '--reporters=jest-junit',
+      // Override Jest's default 5s timeout which is too low for integ tests.
+      // Tests using withAws() will further override this to 2 hours to account for region lock wait times.
+      '--testTimeout=60000',
       '--randomize',
       ...args.seed ? [`--seed=${args.seed}`] : [],
       ...args.runInBand ? ['-i'] : [],

--- a/packages/@aws-cdk-testing/cli-integ/lib/process.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/process.ts
@@ -59,7 +59,10 @@ export class Process {
    * Spawn a process without a forcing a TTY.
    */
   public static spawn(command: string, args: string[], options: child.SpawnOptions = {}): IProcess {
-    const process = child.spawn(command, args, {
+    // Join command and args into a single shell string to avoid DEP0190 deprecation warning
+    // (passing args with shell: true is deprecated because they are not escaped).
+    const fullCommand = [command, ...args].join(' ');
+    const process = child.spawn(fullCommand, [], {
       shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
       ...options,

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-aws.ts
@@ -53,6 +53,10 @@ export function withAws<A extends TestContext>(
   block: (context: A & AwsContext & DisableBootstrapContext) => Promise<void>,
   options: AwsContextOptions = {},
 ): (context: A) => Promise<void> {
+  // Set a high Jest timeout because it includes the time waiting for locks; account for worst-case single-threaded runtime.
+  // This is not the actual test execution time. The effective test timeout is handled by withTimeout().
+  jest.setTimeout(2 * 60 * 60_000);
+
   return async (context: A) => {
     const disableBootstrap = options.disableBootstrap ?? false;
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
@@ -188,7 +188,7 @@ export async function shellWithAction(
 
   const env = options.env ?? (options.modEnv ? { ...process.env, ...options.modEnv } : undefined);
 
-  const child = child_process.spawn(command[0], command.slice(1), {
+  const child = child_process.spawn(command.join(' '), [], {
     ...options,
     env,
     // Need this for Windows where we want .cmd and .bat to be found as well.

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -89,7 +89,7 @@
     "fast-glob": "^3.3.3",
     "fs-extra": "^9",
     "jest": "^29",
-    "jest-junit": "^15",
+    "jest-junit": "^16",
     "make-runnable": "^1",
     "mockttp": "^3",
     "node-pty": "^1.1.0",

--- a/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/integ.jest.config.js
@@ -11,15 +11,7 @@ module.exports = {
 
   testEnvironment: "node",
 
-  // Because of the way Jest concurrency works, this timeout includes waiting
-  // for the lock. Which is almost never what we actually care about. Set it high.
-  testTimeout: 2 * 60 * 60_000,
-
   maxWorkers: maxWorkers(),
-  reporters: [
-    "default",
-    ["jest-junit", { suiteName: "jest tests", outputDirectory: "coverage" }]
-  ],
 
   // Both of the following things are necessary to discover test files that are
   // potentially installed into `node_modules`.

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-a-customized-template-vendor-will-not-overwrite-the-default-template.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-a-customized-template-vendor-will-not-overwrite-the-default-template.integtest.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import * as yaml from 'yaml';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('a customized template vendor will not overwrite the default template', withoutBootstrap(async (fixture) => {
   // Initial bootstrap
   const toolkitStackName = fixture.bootstrapStackName;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-add-tags.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-add-tags.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('add tags, left alone on re-bootstrap', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-add-tags-then-update-tags-during-re-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-add-tags-then-update-tags-during-re-bootstrap.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can add tags then update tags during re-bootstrap', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-and-deploy-if-omitting-execution-policies.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-and-deploy-if-omitting-execution-policies.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can and deploy if omitting execution policies', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-bootstrap-without-execution.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-bootstrap-without-execution.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can bootstrap without execution', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-create-a-legacy-bootstrap-stack-with---public-access-block-configuration-false.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-create-a-legacy-bootstrap-stack-with---public-access-block-configuration-false.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can create a legacy bootstrap stack with --public-access-block-configuration=false', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-create-multiple-legacy-bootstrap-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-create-multiple-legacy-bootstrap-stacks.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can create multiple legacy bootstrap stacks', withoutBootstrap(async (fixture) => {
   const bootstrapStackName1 = `${fixture.bootstrapStackName}-1`;
   const bootstrapStackName2 = `${fixture.bootstrapStackName}-2`;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-modern-synthesized-stack-even-if-bootstrap-stack-name-is-unknown.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-modern-synthesized-stack-even-if-bootstrap-stack-name-is-unknown.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can deploy modern-synthesized stack even if bootstrap stack name is unknown', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-with-session-tags-on-the-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-with-session-tags-on-the-deploy.integtest.ts
@@ -1,8 +1,6 @@
 import * as path from 'path';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can deploy with session tags on the deploy, lookup, file asset, and image asset publishing roles', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-without-execution-role-and-with-session-tags-on-deploy-role.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-deploy-without-execution-role-and-with-session-tags-on-deploy-role.integtest.ts
@@ -1,8 +1,6 @@
 import * as path from 'path';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can deploy without execution role and with session tags on deploy role', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-dump-the-template.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-dump-the-template.integtest.ts
@@ -2,8 +2,6 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can dump the template, modify and use it to deploy a custom bootstrap stack', withoutBootstrap(async (fixture) => {
   let template = await fixture.cdkBootstrapModern({
     // toolkitStackName doesn't matter for this particular invocation

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-remove-custompermissionsboundary.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-remove-custompermissionsboundary.integtest.ts
@@ -3,8 +3,6 @@ import { CreatePolicyCommand, DeletePolicyCommand, GetRoleCommand } from '@aws-s
 import { integTest, withoutBootstrap } from '../../../lib';
 import eventually from '../../../lib/eventually';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can remove customPermissionsBoundary', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
   const policyName = `${bootstrapStackName}-pb`;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-remove-trusted-account.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-remove-trusted-account.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can remove trusted account', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-custom-permissions-boundary-(with-slashes)-to-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-custom-permissions-boundary-(with-slashes)-to-bootstrap.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can use the custom permissions boundary (with slashes) to bootstrap', withoutBootstrap(async (fixture) => {
   let template = await fixture.cdkBootstrapModern({
     // toolkitStackName doesn't matter for this particular invocation

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-custom-permissions-boundary-to-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-custom-permissions-boundary-to-bootstrap.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can use the custom permissions boundary to bootstrap', withoutBootstrap(async (fixture) => {
   let template = await fixture.cdkBootstrapModern({
     // toolkitStackName doesn't matter for this particular invocation

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-default-permissions-boundary-to-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-use-the-default-permissions-boundary-to-bootstrap.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('can use the default permissions boundary to bootstrap', withoutBootstrap(async (fixture) => {
   let template = await fixture.cdkBootstrapModern({
     // toolkitStackName doesn't matter for this particular invocation

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-create-ecr-with-tag-immutability-to-set-on.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-create-ecr-with-tag-immutability-to-set-on.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { DescribeRepositoriesCommand } from '@aws-sdk/client-ecr';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('create ECR with tag IMMUTABILITY to set on', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-new-style-synthesis-to-new-style-bootstrap-(with-docker-image).integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-new-style-synthesis-to-new-style-bootstrap-(with-docker-image).integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy new style synthesis to new style bootstrap (with docker image)', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-new-style-synthesis-to-new-style-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-new-style-synthesis-to-new-style-bootstrap.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy new style synthesis to new style bootstrap', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-old-style-synthesis-to-new-style-bootstrap.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-old-style-synthesis-to-new-style-bootstrap.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy old style synthesis to new style bootstrap', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-role-cannot-be-assumed-with-external-id.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-deploy-role-cannot-be-assumed-with-external-id.integtest.ts
@@ -1,8 +1,6 @@
 import { AssumeRoleCommand } from '@aws-sdk/client-sts';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy role cannot be assumed with external id', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-switch-on-termination-protection.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-switch-on-termination-protection.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('switch on termination protection, switch is left alone on re-bootstrap', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-upgrade-legacy-bootstrap-stack-to-new-bootstrap-stack-while-in-use.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-upgrade-legacy-bootstrap-stack-to-new-bootstrap-stack-while-in-use.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('upgrade legacy bootstrap stack to new bootstrap stack while in use', withoutBootstrap(async (fixture) => {
   const bootstrapStackName = fixture.bootstrapStackName;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-docker-credential.integtest.ts
@@ -7,8 +7,6 @@ import type { DockerDomainCredentialSource } from '../../../../../@aws-cdk/cdk-a
 import type { TestFixture } from '../../../lib';
 import { integTest, withDefaultFixture, withRetry, retry } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'docker-credential-cdk-assets can assume role and fetch ECR credentials',
   withRetry(withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-uses-profile.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/cdk-assets-uses-profile.integtest.ts
@@ -3,8 +3,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('cdk-assets uses profile when specified', withDefaultFixture(async (fixture) => {
   const currentCreds = await fixture.aws.credentials();
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/smoketest.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/cdk-assets/smoketest.integtest.ts
@@ -6,8 +6,6 @@ import * as path from 'path';
 import { writeDockerAsset, writeFileAsset } from './asset_helpers';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk-assets smoke test',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-output-to-stderr.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-output-to-stderr.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'ci output to stderr',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-true-output-to-stdout.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/ci-output/cdk-ci-true-output-to-stdout.integtest.ts
@@ -1,8 +1,6 @@
 import type { CdkCliOptions } from '../../../lib';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'ci=true output to stdout',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/context/cdk-context-in-stage-propagates-to-top.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/context/cdk-context-in-stage-propagates-to-top.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'context in stage propagates to top',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/context/cdk-context-setting.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/context/cdk-context-setting.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'context setting',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk---exclusively-selects-only-selected-stack.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk---exclusively-selects-only-selected-stack.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   '--exclusively selects only selected stack',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-ordering-with-concurrency.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-ordering-with-concurrency.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'automatic ordering with concurrency',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-ordering.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-ordering.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'automatic ordering',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-paused-and---no-rollback-is-removed-from-flags.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-paused-and---no-rollback-is-removed-from-flags.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'automatic rollback if paused and --no-rollback is removed from flags',
   withSpecificFixture('rollback-test-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-paused-and-change-contains-a-replacement.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-paused-and-change-contains-a-replacement.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'automatic rollback if paused and change contains a replacement',
   withSpecificFixture('rollback-test-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-replacement-and---no-rollback-is-removed-from-flags.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-automatic-rollback-if-replacement-and---no-rollback-is-removed-from-flags.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'automatic rollback if replacement and --no-rollback is removed from flags',
   withSpecificFixture('rollback-test-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-construct-with-builtin-lambda-function.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-construct-with-builtin-lambda-function.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Construct with builtin Lambda function',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy---method-direct.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy---method-direct.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy --method=direct',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-all-concurrently.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-all-concurrently.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy all concurrently',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-all.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-all.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy all',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-and-test-stack-with-lambda-asset.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-and-test-stack-with-lambda-asset.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { InvokeCommand } from '@aws-sdk/client-lambda';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy and test stack with lambda asset',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-deletes-all-notification-arns-when-empty-array-is-passed.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-deletes-all-notification-arns-when-empty-array-is-passed.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy deletes ALL notification arns when empty array is passed', withDefaultFixture(async (fixture) => {
   const topicName = `${fixture.stackNamePrefix}-topic`;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-early-validation.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-early-validation.integtest.ts
@@ -1,8 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy - early validation error',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-no-stacks-error.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-no-stacks-error.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy no stacks error',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-no-stacks-with---ignore-no-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-no-stacks-with---ignore-no-stacks.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy no stacks with --ignore-no-stacks',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-preserves-existing-notification-arns-when-not-specified.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-preserves-existing-notification-arns-when-not-specified.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand, UpdateStackCommand, waitUntilStackUpdateComplete
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy preserves existing notification arns when not specified', withDefaultFixture(async (fixture) => {
   const topicName = `${fixture.stackNamePrefix}-topic`;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-docker-asset.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-docker-asset.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy stack with docker asset',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-lambda-asset-to-object-lock-enabled-asset-bucket.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-lambda-asset-to-object-lock-enabled-asset-bucket.integtest.ts
@@ -1,8 +1,6 @@
 import { PutObjectLockConfigurationCommand } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy stack with Lambda Asset to Object Lock-enabled asset bucket', withoutBootstrap(async (fixture) => {
   // Bootstrapping with custom toolkit stack name and qualifier
   const qualifier = fixture.qualifier;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-multiple-docker-assets.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-with-multiple-docker-assets.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy stack with multiple docker assets',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-without-resource.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-stack-without-resource.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy stack without resource',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-wildcard-with-outputs.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-wildcard-with-outputs.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy wildcard with outputs',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-import-existing-resources-true.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-import-existing-resources-true.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand, ListChangeSetsCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy with import-existing-resources true', withDefaultFixture(async (fixture) => {
   const stackArn = await fixture.cdkDeploy('test-2', {
     options: ['--no-execute', '--import-existing-resources'],

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-method-direct-and-import-existing-resources-fails.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-method-direct-and-import-existing-resources-fails.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy with method=direct and import-existing-resources fails', withDefaultFixture(async (fixture) => {
   const stackName = 'iam-test';
   await expect(fixture.cdkDeploy(stackName, {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-flag.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-flag.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy with notification ARN as flag',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-prop-and-flag.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-prop-and-flag.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy with notification ARN as prop and flag', withDefaultFixture(async (fixture) => {
   const topic1Name = `${fixture.stackNamePrefix}-topic1`;
   const topic2Name = `${fixture.stackNamePrefix}-topic1`;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-prop.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-notification-arn-as-prop.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { CreateTopicCommand, DeleteTopicCommand } from '@aws-sdk/client-sns';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy with notification ARN as prop', withDefaultFixture(async (fixture) => {
   const topicName = `${fixture.stackNamePrefix}-test-topic-prop`;
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-parameters-multi.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-parameters-multi.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy with parameters multi',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-parameters.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-parameters.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy with parameters',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-revert-drift.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-revert-drift.integtest.ts
@@ -3,8 +3,6 @@ import { UpdateFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
 import { integTest, withDefaultFixture } from '../../../lib';
 import { waitForLambdaUpdateComplete } from '../drift/drift_helpers';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy with revert-drift true',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-wildcard-and-parameters.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-with-wildcard-and-parameters.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy with wildcard and parameters',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-without-execute-a-named-change-set.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-without-execute-a-named-change-set.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand, ListChangeSetsCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy without execute a named change set',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-without-import-existing-resources.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-without-import-existing-resources.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand, ListChangeSetsCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('deploy without import-existing-resources', withDefaultFixture(async (fixture) => {
   const stackArn = await fixture.cdkDeploy('test-2', {
     options: ['--no-execute'],

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'deploy',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-doubly-nested-stack.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-doubly-nested-stack.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('doubly nested stack',
   withDefaultFixture(async (fixture) => {
     await fixture.cdkDeploy('with-doubly-nested-stack', {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-failed-deploy-does-not-hang.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-failed-deploy-does-not-hang.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'failed deploy does not hang',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-fast-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-fast-deploy.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'fast deploy',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-generating-and-loading-assembly.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-generating-and-loading-assembly.integtest.ts
@@ -3,8 +3,6 @@ import * as os from 'os';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'generating and loading assembly',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-nested-stack-with-parameters.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-nested-stack-with-parameters.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'nested stack with parameters',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-security-related-changes-without-a-cli-are-expected-to-fail.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-security-related-changes-without-a-cli-are-expected-to-fail.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'security related changes without a CLI are expected to fail',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-stage-with-bundled-lambda-function.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-stage-with-bundled-lambda-function.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Stage with bundled Lambda function',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-termination-protection.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-termination-protection.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Termination protection',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-all-concurrently.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-all-concurrently.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'destroy all concurrently',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-with-concurrency.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-with-concurrency.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'destroy with concurrency respects dependency ordering',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---fail-on-multiple-stacks-exits-with-error-if-any-of-the-stacks-contains-a-diff.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---fail-on-multiple-stacks-exits-with-error-if-any-of-the-stacks-contains-a-diff.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --fail on multiple stacks exits with error if any of the stacks contains a diff',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---fail-with-multiple-stack-exits-with-if-any-of-the-stacks-contains-a-diff.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---fail-with-multiple-stack-exits-with-if-any-of-the-stacks-contains-a-diff.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --fail with multiple stack exits with if any of the stacks contains a diff',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---quiet-does-not-print-there-were-no-differences-message-for-stacks-which-have-no-differences.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---quiet-does-not-print-there-were-no-differences-message-for-stacks-which-have-no-differences.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   "cdk diff --quiet does not print 'There were no differences' message for stacks which have no differences",
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-changes-are-present.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-changes-are-present.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only --fail exits when security changes are present',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-access-control-config.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-access-control-config.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only --fail exits when security diff for sso access control config',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-assignment.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-assignment.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only --fail exits when security diff for sso-assignment',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-perm-set-with-managed-policy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-perm-set-with-managed-policy.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only --fail exits when security diff for sso-perm-set-with-managed-policy',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-perm-set-without-managed-policy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only---fail-exits-when-security-diff-for-sso-perm-set-without-managed-policy.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only --fail exits when security diff for sso-perm-set-without-managed-policy',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-access-control-information.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-access-control-information.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only successfully outputs sso-access-control information',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-assignment-information.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-assignment-information.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only successfully outputs sso-assignment information',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-permission-set-with-managed-policy-information.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-permission-set-with-managed-policy-information.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only successfully outputs sso-permission-set-with-managed-policy information',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-permission-set-without-managed-policy-information.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-successfully-outputs-sso-permission-set-without-managed-policy-information.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --security-only successfully outputs sso-permission-set-without-managed-policy information',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff--import-existing-resources-shows-import.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff --import-existing-resources show resource being imported',
   withSpecificFixture('import-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff doesnt show resource metadata changes',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-shows-resource-metadata-changes-with---no-change-set.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-shows-resource-metadata-changes-with---no-change-set.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff shows resource metadata changes with --no-change-set',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-with-large-changeset-and-custom-toolkit-stack-name-and-qualifier-does-not-fail.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-with-large-changeset-and-custom-toolkit-stack-name-and-qualifier-does-not-fail.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('cdk diff with large changeset and custom toolkit stack name and qualifier does not fail', withoutBootstrap(async (fixture) => {
   // Bootstrapping with custom toolkit stack name and qualifier
   const qualifier = fixture.qualifier;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-with-large-changeset-does-not-fail.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-with-large-changeset-does-not-fail.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff with large changeset does not fail',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk diff',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-enablediffnofail.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-enablediffnofail.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'enableDiffNoFail',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-iam-diff.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-iam-diff.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'IAM diff',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/doctor/cdk-doctor.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/doctor/cdk-doctor.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000);
-
 integTest(
   'cdk doctor displays diagnostic information',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift---fail-throws-when-drift-is-detected.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift---fail-throws-when-drift-is-detected.integtest.ts
@@ -3,8 +3,6 @@ import { UpdateFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
 import { waitForLambdaUpdateComplete } from './drift_helpers';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk drift --fail throws when drift is detected',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift---verbose-shows-unchecked-resources.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift---verbose-shows-unchecked-resources.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk drift --verbose shows unchecked resources',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/drift/cdk-cdk-drift.integtest.ts
@@ -3,8 +3,6 @@ import { UpdateFunctionConfigurationCommand } from '@aws-sdk/client-lambda';
 import { waitForLambdaUpdateComplete } from './drift_helpers';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk drift',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/flags/cdk-flags-with-cli-context.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/flags/cdk-flags-with-cli-context.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withAws, withSpecificCdkApp } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'flags command works with CLI context parameters',
   withAws(

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-deletes-unused-s3-objects-rollback.integtest.ts
@@ -1,8 +1,6 @@
 import { ListObjectsV2Command, PutObjectTaggingCommand } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 const DAY = 24 * 60 * 60 * 1000;
 const S3_ISOLATED_TAG = 'aws-cdk:isolated';
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-deletes-unused-ecr-images.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-deletes-unused-ecr-images.integtest.ts
@@ -1,8 +1,6 @@
 import { ListImagesCommand } from '@aws-sdk/client-ecr';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection deletes unused ecr images',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-deletes-unused-s3-objects.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-deletes-unused-s3-objects.integtest.ts
@@ -1,8 +1,6 @@
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection deletes unused s3 objects',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-keeps-in-use-ecr-images.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-keeps-in-use-ecr-images.integtest.ts
@@ -1,8 +1,6 @@
 import { ListImagesCommand } from '@aws-sdk/client-ecr';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection keeps in use ecr images',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-keeps-in-use-s3-objects.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-keeps-in-use-s3-objects.integtest.ts
@@ -1,8 +1,6 @@
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection keeps in use s3 objects',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-tags-unused-ecr-images.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-tags-unused-ecr-images.integtest.ts
@@ -1,8 +1,6 @@
 import { ListImagesCommand } from '@aws-sdk/client-ecr';
 import { integTest, withoutBootstrap } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection tags unused ecr images',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-tags-unused-s3-objects.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-tags-unused-s3-objects.integtest.ts
@@ -1,8 +1,6 @@
 import { GetObjectTaggingCommand, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection tags unused s3 objects',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-untags-in-use-ecr-images.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-untags-in-use-ecr-images.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withoutBootstrap } from '../../../lib';
 
 const ECR_ISOLATED_TAG = 'aws-cdk.isolated';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection untags in-use ecr images',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-untags-in-use-s3-objects.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/gc/cdk-gc-garbage-collection-untags-in-use-s3-objects.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withoutBootstrap, randomString } from '../../../lib';
 
 const S3_ISOLATED_TAG = 'aws-cdk:isolated';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Garbage Collection untags in-use s3 objects',
   withoutBootstrap(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-detects-failed-deployment-and-errors.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-detects-failed-deployment-and-errors.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'hotswap deployment for ecs service detects failed deployment and errors',
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-waits-for-deployment-to-complete.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-for-ecs-service-waits-for-deployment-to-complete.integtest.ts
@@ -2,8 +2,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { DescribeServicesCommand } from '@aws-sdk/client-ecs';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'hotswap deployment for ecs service waits for deployment to complete',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-appsync-apis-with-many-functions.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-appsync-apis-with-many-functions.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('hotswap deployment supports AppSync APIs with many functions',
   withDefaultFixture(async (fixture) => {
     // GIVEN

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-bedrock-agentcore-runtime.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-bedrock-agentcore-runtime.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'hotswap deployment supports Bedrock AgentCore Runtime',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-ecs-service.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-ecs-service.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'hotswap deployment supports ecs service',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-fn::importvalue-intrinsic.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-fn::importvalue-intrinsic.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'hotswap deployment supports Fn::ImportValue intrinsic',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-lambda-functions-description-and-environment-variables.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-lambda-functions-description-and-environment-variables.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   "hotswap deployment supports Lambda function's description and environment variables",
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-ecs-deployment-respects-properties-override.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-ecs-deployment-respects-properties-override.integtest.ts
@@ -4,8 +4,6 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { DescribeServicesCommand } from '@aws-sdk/client-ecs';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('hotswap ECS deployment respects properties override', withDefaultFixture(async (fixture) => {
   // Update the CDK context with the new ECS properties
   let ecsMinimumHealthyPercent = 100;

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/import/cdk-test-resource-import-with-construct-that-requires-bundling.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/import/cdk-test-resource-import-with-construct-that-requires-bundling.integtest.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import { DescribeStacksCommand, GetTemplateCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'test resource import with construct that requires bundling',
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/import/cdk-test-resource-import.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/import/cdk-test-resource-import.integtest.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import { DescribeStacksCommand, GetTemplateCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture, randomString } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'test resource import',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls---show-dependencies---json---long.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls---show-dependencies---json---long.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk ls --show-dependencies --json --long',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls---show-dependencies---json.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls---show-dependencies---json.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk ls --show-dependencies --json',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/list/cdk-cdk-ls.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk ls',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/lookup/cdk-ssm-parameter-provider-error.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/lookup/cdk-ssm-parameter-provider-error.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'ssm parameter provider error',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/lookup/cdk-vpc-lookup.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/lookup/cdk-vpc-lookup.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'VPC Lookup',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/metadata/cdk-metadata.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/metadata/cdk-metadata.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000);
-
 integTest(
   'cdk metadata displays stack metadata',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-csharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-csharp.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
 const language = 'csharp';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-java.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
 const language = 'java';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-python.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-python.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
 const language = 'python';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-typescript.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate--from-stack-creates-deployable-app-typescript.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withExtendedTimeoutFixture } from '../../../lib';
 
 const language = 'typescript';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate --from-stack creates deployable ${language} app`,
   withExtendedTimeoutFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-csharp.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-csharp.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withCDKMigrateFixture } from '../../../lib';
 
 const language = 'csharp';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-java.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-java.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withCDKMigrateFixture, withRetry } from '../../../lib';
 
 const language = 'java';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withRetry(withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-python.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-python.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withCDKMigrateFixture } from '../../../lib';
 
 const language = 'python';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-typescript.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-deploys-successfully-typescript.integtest.ts
@@ -3,8 +3,6 @@ import { integTest, withCDKMigrateFixture } from '../../../lib';
 
 const language = 'typescript';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   `cdk migrate ${language} deploys successfully`,
   withCDKMigrateFixture(language, async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-generates-migrate.json.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-migrate-generates-migrate.json.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withCDKMigrateFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk migrate generates migrate.json',
   withCDKMigrateFixture('typescript', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-test-migrate-deployment-for-app-with-localfile-source-in-migrate.json.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/migrate/cdk-test-migrate-deployment-for-app-with-localfile-source-in-migrate.json.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'test migrate deployment for app with localfile source in migrate.json',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-cdk-notices-are-displayed-correctly.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-cdk-notices-are-displayed-correctly.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('cdk notices are displayed correctly', withDefaultFixture(async (fixture) => {
   const cache = {
     expiration: 4125963264000, // year 2100 so we never overwrite the cache

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-cdk-notices-with---unacknowledged.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-cdk-notices-with---unacknowledged.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk notices with --unacknowledged',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-skips-notice-refresh.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/notices/cdk-skips-notice-refresh.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'skips notice refresh',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/proxy/cdk-requests-go-through-a-proxy-when-configured.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/proxy/cdk-requests-go-through-a-proxy-when-configured.integtest.ts
@@ -3,8 +3,6 @@ import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 import { awsActionsFromRequests, startProxyServer } from '../../../lib/proxy';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('requests go through a proxy when configured',
   withDefaultFixture(async (fixture) => {
     const proxyServer = await startProxyServer();

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-stack-in-update_rollback_complete-state-can-be-updated.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-stack-in-update_rollback_complete-state-can-be-updated.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'stack in UPDATE_ROLLBACK_COMPLETE state can be updated',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-test-cdk-rollback---force.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-test-cdk-rollback---force.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'test cdk rollback --force',
   withSpecificFixture('rollback-test-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-test-cdk-rollback.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-test-cdk-rollback.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'test cdk rollback',
   withSpecificFixture('rollback-test-app', async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-update-to-stack-in-rollback_complete-state-will-delete-stack-and-create-a-new-one.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/rollback/cdk-update-to-stack-in-rollback_complete-state-will-delete-stack-and-create-a-new-one.integtest.ts
@@ -1,8 +1,6 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'update to stack in ROLLBACK_COMPLETE state will delete stack and create a new one',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/sam/cdk-sam-can-locally-test-the-synthesized-cdk-application.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/sam/cdk-sam-can-locally-test-the-synthesized-cdk-application.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSamIntegrationFixture, randomInteger } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'sam can locally test the synthesized cdk application',
   withSamIntegrationFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-can-still-load-old-assemblies.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-can-still-load-old-assemblies.integtest.ts
@@ -3,8 +3,6 @@ import * as os from 'os';
 import * as path from 'path';
 import { integTest, RESOURCES_DIR, shell, withDefaultFixture, cloneDirectory } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'can still load old assemblies',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth-add-the-metadata-properties-expected-by-sam.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth-add-the-metadata-properties-expected-by-sam.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSamIntegrationFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'CDK synth add the metadata properties expected by sam',
   withSamIntegrationFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth-bundled-functions-as-expected.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth-bundled-functions-as-expected.integtest.ts
@@ -2,8 +2,6 @@ import { existsSync } from 'fs';
 import * as path from 'path';
 import { integTest, withSamIntegrationFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'CDK synth bundled functions as expected',
   withSamIntegrationFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-cdk-synth.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk synth',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth---quiet-can-be-specified-in-cdk.json.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synth---quiet-can-be-specified-in-cdk.json.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'synth --quiet can be specified in cdk.json',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synthing-a-stage-with-errors-can-be-suppressed.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synthing-a-stage-with-errors-can-be-suppressed.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'synthing a stage with errors can be suppressed',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synthing-a-stage-with-errors-leads-to-failure.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-synthing-a-stage-with-errors-leads-to-failure.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'synthing a stage with errors leads to failure',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-templates-on-disk-contain-metadata-resource.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/synth/cdk-templates-on-disk-contain-metadata-resource.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'templates on disk contain metadata resource, also in nested assemblies',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/version/cdk-two-ways-of-showing-the-version.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/version/cdk-two-ways-of-showing-the-version.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'Two ways of showing the version',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-cli-telemetry-disable-sends-no-data.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-cli-telemetry-disable-sends-no-data.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'CLI Telemetry --disable does not send to endpoint',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-telemetry.integtest.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk deploy with telemetry data',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-hotswap-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-hotswap-telemetry.integtest.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk hotswap deploy emits HOTSWAP telemetry event',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-invalid-command-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-invalid-command-telemetry.integtest.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest('no telemetry is collected if command is invalid', withDefaultFixture(async (fixture) => {
   const telemetryFile = path.join(fixture.integTestDir, `telemetry-${Date.now()}.json`);
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-guessagent.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-guessagent.integtest.ts
@@ -2,8 +2,6 @@ import * as path from 'path';
 import * as fs from 'fs-extra';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk synth telemetry contains an agent guess',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-errors.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-errors.integtest.ts
@@ -3,8 +3,6 @@ import * as fs from 'fs-extra';
 import { CURRENT_TELEMETRY_VERSION } from './constants';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk synth with telemetry and validation error leads to invoke failure',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry.integtest.ts
@@ -3,8 +3,6 @@ import * as fs from 'fs-extra';
 import { CURRENT_TELEMETRY_VERSION } from './constants';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'cdk synth with telemetry data',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cli-telemetry/cdk-cli-telemetry-adds-context-value.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cli-telemetry/cdk-cli-telemetry-adds-context-value.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'CLI Telemetry adds context value to cdk.context.json',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cli-telemetry/cdk-cli-telemetry-reports-status.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cli-telemetry/cdk-cli-telemetry-reports-status.integtest.ts
@@ -2,8 +2,6 @@ import { promises as fs } from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'CLI Telemetry reports status',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-deploy-stack-with-multiple-docker-assets.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/toolkit-lib-integ-tests/toolkit-deploy-stack-with-multiple-docker-assets.integtest.ts
@@ -3,8 +3,6 @@ import * as toolkit from '@aws-cdk/toolkit-lib';
 import { assemblyFromCdkAppDir, toolkitFromFixture } from './toolkit-helpers';
 import { integTest, withDefaultFixture } from '../../lib';
 
-jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
-
 integTest(
   'toolkit deploy stack with multiple docker assets',
   withDefaultFixture(async (fixture) => {

--- a/packages/@aws-cdk-testing/cli-integ/tests/uberpackage/uberpackage.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/uberpackage/uberpackage.integtest.ts
@@ -1,7 +1,5 @@
 import { integTest, withSpecificFixture } from '../../lib';
 
-jest.setTimeout(600_000);
-
 describe('uberpackage', () => {
   integTest('works with cloudformation-include', withSpecificFixture('cfn-include-app', async (fixture) => {
     fixture.log('Starting test of cfn-include with monolithic CDK');

--- a/yarn.lock
+++ b/yarn.lock
@@ -8958,16 +8958,6 @@ jest-haste-map@^29.7.0:
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-junit@^15:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-15.0.0.tgz#a47544ab42e9f8fe7ada56306c218e09e52bd690"
-  integrity sha512-Z5sVX0Ag3HZdMUnD5DFlG+1gciIFSy7yIVPhOdGUi8YJaI9iLvvBb530gtQL2CHmv0JJeiwRZenr0VrSR7frvg==
-  dependencies:
-    mkdirp "^1.0.4"
-    strip-ansi "^6.0.1"
-    uuid "^8.3.2"
-    xml "^1.0.1"
-
 jest-junit@^16:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-16.0.0.tgz#d838e8c561cf9fdd7eb54f63020777eee4136785"


### PR DESCRIPTION
Every integration test file had a `jest.setTimeout(2 * 60 * 60_000)` call at the top. This high timeout is needed because Jest's test timeout includes the time spent waiting for region locks, not just the actual test execution (the effective test timeout is handled separately by `withTimeout()`).

Instead of repeating this in every file, the timeout is now set once in `withAws()` at test registration time. This is the right place because only tests that use AWS resources need the extended timeout for lock waiting. Individual tests can still override with a lower value if needed (e.g. the watch tests use 5 minutes).

Additionally, `integ.jest.config.js` had `testTimeout` and `reporters` options that produced "Unknown option" validation warnings. These options aren't valid in a project-level config passed to `jest.run()`. The reporters are now passed as CLI args, and the jest-junit configuration uses environment variables.

The `DEP0190` deprecation warning about passing args to `child_process.spawn` with `shell: true` is fixed by joining command and args into a single shell string before spawning. This is controlled input and safe in this case.

Also bumps jest-junit from ^15 to ^16.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
