### PR TITLE
chore: skip approval gate for same-repo PRs

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -7,11 +7,27 @@ on:
   merge_group: {}
   workflow_dispatch: {}
 jobs:
+  determine_env:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      env_name: ${{ steps.output.outputs.env_name }}
+    steps:
+      - name: Start requiring approval
+        run: echo integ-approval > .envname
+      - name: Skip approval for mergeGroup or PR created from this repo
+        if: ${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}
+        run: echo no-approval > .envname
+      - name: Output the value
+        id: output
+        run: echo "env_name=$(cat .envname)" >> "$GITHUB_OUTPUT"
   prepare:
+    needs: determine_env
     runs-on: aws-cdk_ubuntu-latest_16-core
     permissions:
       contents: read
-    environment: integ-approval
+    environment: ${{ needs.determine_env.outputs.env_name }}
     env:
       CI: "true"
       DEBUG: "true"

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -235,6 +235,7 @@ export interface CdkCliIntegTestsWorkflowProps {
  */
 export class CdkCliIntegTestsWorkflow extends Component {
   private workflow: github.GithubWorkflow;
+  private readonly JOB_DETERMINE_ENV = 'determine_env';
   private readonly JOB_PREPARE = 'prepare';
   private readonly maxWorkersArg: string = '';
 
@@ -330,19 +331,51 @@ export class CdkCliIntegTestsWorkflow extends Component {
       // Never hurts to be able to run this manually
       workflowDispatch: {},
     });
-    // The 'build' part runs on the 'integ-approval' environment, which requires
-    // approval. The actual runs access the real environment, not requiring approval
-    // anymore.
+    // Determine the environment dynamically: PRs from the same repo and merge_group
+    // events skip the approval environment, while external PRs require approval.
+    // This follows the publib pattern.
+    this.workflow.addJob(this.JOB_DETERMINE_ENV, {
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        contents: github.workflows.JobPermission.READ,
+      },
+      outputs: {
+        env_name: {
+          stepId: 'output',
+          outputName: 'env_name',
+        },
+      },
+      steps: [
+        {
+          name: 'Start requiring approval',
+          run: `echo ${this.props.approvalEnvironment} > .envname`,
+        },
+        {
+          name: 'Skip approval for mergeGroup or PR created from this repo',
+          if: "${{ github.event_name == 'merge_group' || github.event.pull_request.head.repo.full_name == github.repository }}",
+          run: 'echo no-approval > .envname',
+        },
+        {
+          name: 'Output the value',
+          id: 'output',
+          run: 'echo "env_name=$(cat .envname)" >> "$GITHUB_OUTPUT"',
+        },
+      ],
+    });
+
+    // The 'build' part runs on the dynamically determined environment.
+    // External PRs get the approval environment, while same-repo PRs and merge_group
+    // events skip approval. The actual test runs access the real environment.
     //
-    // This is for 2 reasons:
-    // - The build job is the first one that runs. That means you get asked approval
-    //   immediately after push, instead of 5 minutes later after the build completes.
-    // - The build job is only one job, versus the tests which are a matrix build.
-    //   If the matrix test job needs approval, the Pull Request timeline gets spammed
-    //   with an approval request for every individual run.
+    // The build job is the first one that runs. That means you get asked approval
+    // immediately after push, instead of 5 minutes later after the build completes.
+    // The build job is only one job, versus the tests which are a matrix build.
+    // If the matrix test job needs approval, the Pull Request timeline gets spammed
+    // with an approval request for every individual run.
 
     this.workflow.addJob(this.JOB_PREPARE, {
-      environment: this.props.approvalEnvironment,
+      needs: [this.JOB_DETERMINE_ENV],
+      environment: `\${{ needs.${this.JOB_DETERMINE_ENV}.outputs.env_name }}`,
       runsOn: [this.props.buildRunsOn],
       permissions: {
         contents: github.workflows.JobPermission.READ,


### PR DESCRIPTION
The integ workflow currently requires manual approval via the `integ-approval` environment for every PR, including those created by team members from the same repo. This is unnecessary friction for first-party contributors.

This adopts the [publib pattern](https://github.com/cdklabs/publib/blob/main/.github/workflows/integ.yml) by adding a `determine_env` job that dynamically selects the GitHub environment for the `prepare` job. PRs from the same repository and merge group events use the `no-approval` environment (no protection rules), while external contributor PRs continue to require approval via `integ-approval`.

### Why this is safe

The `determine_env` job runs no user code — it only checks event metadata (`github.event_name`, `github.event.pull_request.head.repo.full_name`) which is provided by GitHub and cannot be spoofed by a PR author. The `prepare` job only has `contents: read` permissions and neither `integ-approval` nor `no-approval` expose any secrets or OIDC roles. The actual credentials live exclusively in the `run-tests` environment on the downstream test jobs, which are unchanged and still gated behind `prepare`. A fork contributor cannot fake `head.repo.full_name == github.repository` since GitHub populates this from source repo metadata. The trust boundary hasn't moved: external PRs still need approval before any privileged job runs.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
