### PR TITLE
fix(aws-cdk): re-instated bin/cdk export

### DIFF
--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -154,6 +154,7 @@
   "version": "0.0.0",
   "types": "lib/index.d.ts",
   "exports": {
+    "./bin/cdk": "./bin/cdk",
     "./package.json": "./package.json",
     "./build-info.json": "./build-info.json",
     "./lib/api/bootstrap/bootstrap-template.yaml": "./lib/api/bootstrap/bootstrap-template.yaml"


### PR DESCRIPTION
looks like this was accidentally removed when removing legacy-exports

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
