### PR TITLE
chore(cli): remove unused legacy deployment options

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -34,7 +34,7 @@ import type { TemplateBodyParameter } from '../cloudformation';
 import { makeBodyParameter, CfnEvaluationException, CloudFormationStack } from '../cloudformation';
 import type { EnvironmentResources, StringWithoutPlaceholders } from '../environment';
 import { EnvironmentResourcesRegistry } from '../environment';
-import { HotswapPropertyOverrides, HotswapMode, ICON, createHotswapPropertyOverrides } from '../hotswap/common';
+import { HotswapPropertyOverrides, ICON, createHotswapPropertyOverrides } from '../hotswap/common';
 import { tryHotswapDeployment } from '../hotswap/hotswap-deployments';
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
@@ -161,24 +161,6 @@ export interface DeployStackOptions {
   readonly rollback?: boolean;
 
   /**
-   * Whether to perform a 'hotswap' deployment.
-   * A 'hotswap' deployment will attempt to short-circuit CloudFormation
-   * and update the affected resources like Lambda functions directly.
-   *
-   * @default - `HotswapMode.FULL_DEPLOYMENT` for regular deployments, `HotswapMode.HOTSWAP_ONLY` for 'watch' deployments
-   *
-   * @deprecated  Use 'deploymentMethod' instead
-   */
-  readonly hotswap?: HotswapMode;
-
-  /**
-   * Extra properties that configure hotswap behavior
-   *
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  readonly hotswapPropertyOverrides?: HotswapPropertyOverrides;
-
-  /**
    * The extra string to append to the User-Agent header when performing AWS SDK calls.
    *
    * @default - Nothing extra is appended to the User-Agent header
@@ -211,28 +193,6 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
   const stackEnv = options.resolvedEnvironment;
 
   let deploymentMethod = options.deploymentMethod ?? { method: 'change-set' };
-  // Honor the old hotswap option because this API is exported from the CLI as part of the legacy exports
-  // @TODO remove when we don't have legacy exports anymore
-  if (options.hotswap && deploymentMethod?.method !== 'hotswap') {
-    switch (options.hotswap) {
-      case HotswapMode.HOTSWAP_ONLY:
-        deploymentMethod = {
-          method: 'hotswap',
-          properties: options.hotswapPropertyOverrides,
-        };
-        break;
-      case HotswapMode.FALL_BACK:
-        deploymentMethod = {
-          method: 'hotswap',
-          properties: options.hotswapPropertyOverrides,
-          fallback: deploymentMethod,
-        };
-        break;
-      case HotswapMode.FULL_DEPLOYMENT:
-        break;
-    }
-  }
-
   options.sdk.appendCustomUserAgent(options.extraUserAgent);
   const cfn = options.sdk.cloudFormation();
   const deployName = options.deployName || stackArtifact.stackName;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -30,7 +30,6 @@ import {
   makeBodyParameter,
 } from '../cloudformation';
 import { type EnvironmentResources, EnvironmentAccess } from '../environment';
-import type { HotswapMode, HotswapPropertyOverrides } from '../hotswap/common';
 import type { IoHelper } from '../io/private';
 import type { ResourceIdentifierSummaries, ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor, StackEventPoller, RollbackChoice } from '../stack-events';
@@ -86,22 +85,6 @@ export interface DeployStackOptions {
   readonly tags?: Tag[];
 
   /**
-   * Stage the change set but don't execute it
-   *
-   * @default true
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  readonly execute?: boolean;
-
-  /**
-   * Optional name to use for the CloudFormation change set.
-   * If not provided, a name will be generated automatically.
-   *
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  readonly changeSetName?: string;
-
-  /**
    * Select the deployment method (direct or using a change set)
    *
    * @default - Change set with default options
@@ -137,24 +120,6 @@ export interface DeployStackOptions {
   readonly rollback?: boolean;
 
   /**
-   * Whether to perform a 'hotswap' deployment.
-   * A 'hotswap' deployment will attempt to short-circuit CloudFormation
-   * and update the affected resources like Lambda functions directly.
-   *
-   * @default - `HotswapMode.FULL_DEPLOYMENT` for regular deployments, `HotswapMode.HOTSWAP_ONLY` for 'watch' deployments
-   *
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  readonly hotswap?: HotswapMode;
-
-  /**
-   * Properties that configure hotswap behavior
-   *
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  readonly hotswapPropertyOverrides?: HotswapPropertyOverrides;
-
-  /**
    * The extra string to append to the User-Agent header when performing AWS SDK calls.
    *
    * @default - Nothing extra is appended to the User-Agent header
@@ -179,14 +144,6 @@ export interface DeployStackOptions {
    * @default true To remain backward compatible.
    */
   readonly assetParallelism?: boolean;
-
-  /**
-   * Whether to deploy if the app contains no stacks.
-   *
-   * @deprecated this option seems to be unsed inside deployments
-   * @default false
-   */
-  readonly ignoreNoStacks?: boolean;
 }
 
 export interface RollbackStackOptions {
@@ -398,23 +355,6 @@ export class Deployments {
   }
 
   public async deployStack(options: DeployStackOptions): Promise<DeployStackResult> {
-    let deploymentMethod = options.deploymentMethod;
-    // Honor the old options because this API is exported from the CLI as part of the legacy exports
-    // @TODO remove when we don't have legacy exports anymore
-    if (options.changeSetName || options.execute !== undefined) {
-      if (deploymentMethod) {
-        throw new ToolkitError(
-          'ConflictingDeploymentOptions',
-          "You cannot supply both 'deploymentMethod' and 'changeSetName/execute'. Supply one or the other.",
-        );
-      }
-      deploymentMethod = {
-        method: 'change-set',
-        changeSetName: options.changeSetName,
-        execute: options.execute,
-      };
-    }
-
     const env = await this.envs.accessStackForMutableStackOperations(options.stack);
 
     // Do a verification of the bootstrap stack version
@@ -437,13 +377,11 @@ export class Deployments {
       reuseAssets: options.reuseAssets,
       envResources: env.resources,
       tags: options.tags,
-      deploymentMethod,
+      deploymentMethod: options.deploymentMethod,
       forceDeployment: options.forceDeployment,
       parameters: options.parameters,
       usePreviousParameters: options.usePreviousParameters,
       rollback: options.rollback,
-      hotswap: options.hotswap,
-      hotswapPropertyOverrides: options.hotswapPropertyOverrides,
       extraUserAgent: options.extraUserAgent,
       resourcesToImport: options.resourcesToImport,
       overrideTemplate: options.overrideTemplate,

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -16,7 +16,6 @@ import { CloudFormationStack } from '../../../lib/api/cloudformation';
 import { Deployments } from '../../../lib/api/deployments';
 import * as cfnApi from '../../../lib/api/deployments/cfn-api';
 import { deployStack } from '../../../lib/api/deployments/deploy-stack';
-import { HotswapMode } from '../../../lib/api/hotswap';
 import { ToolkitInfo } from '../../../lib/api/toolkit-info';
 import { testStack } from '../../_helpers/assembly';
 import {
@@ -76,19 +75,19 @@ function mockSuccessfulBootstrapStackLookup(props?: Record<string, any>) {
   mockToolkitInfoLookup.mockResolvedValue(ToolkitInfo.fromStack(fakeStack));
 }
 
-test('passes through hotswap=true to deployStack()', async () => {
+test('passes through deploymentMethod with hotswap to deployStack()', async () => {
   // WHEN
   await deployments.deployStack({
     stack: testStack({
       stackName: 'boop',
     }),
-    hotswap: HotswapMode.FALL_BACK,
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
   });
 
   // THEN
   expect(deployStack).toHaveBeenCalledWith(
     expect.objectContaining({
-      hotswap: HotswapMode.FALL_BACK,
+      deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     }),
     expect.anything(),
   );

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -21,7 +21,6 @@ import { assertIsSuccessfulDeployStackResult } from '../../../lib/api/deployment
 import type { DeployStackOptions as DeployStackApiOptions } from '../../../lib/api/deployments/deploy-stack';
 import { deployStack } from '../../../lib/api/deployments/deploy-stack';
 import { NoBootstrapStackEnvironmentResources } from '../../../lib/api/environment';
-import { HotswapMode } from '../../../lib/api/hotswap/common';
 import { tryHotswapDeployment } from '../../../lib/api/hotswap/hotswap-deployments';
 import { DEFAULT_FAKE_TEMPLATE, testStack } from '../../_helpers/assembly';
 import {
@@ -125,12 +124,12 @@ function standardDeployStackArguments(): DeployStackApiOptions {
   };
 }
 
-test("calls tryHotswapDeployment() if 'hotswap' is `HotswapMode.CLASSIC`", async () => {
+test('calls tryHotswapDeployment() if deploymentMethod is hotswap with fallback', async () => {
   // WHEN
   const spyOnSdk = jest.spyOn(sdk, 'appendCustomUserAgent');
   await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: HotswapMode.FALL_BACK,
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     extraUserAgent: 'extra-user-agent',
   });
 
@@ -142,7 +141,7 @@ test("calls tryHotswapDeployment() if 'hotswap' is `HotswapMode.CLASSIC`", async
   expect(spyOnSdk).toHaveBeenCalledWith('cdk-hotswap/fallback');
 });
 
-test("calls tryHotswapDeployment() if 'hotswap' is `HotswapMode.HOTSWAP_ONLY`", async () => {
+test('calls tryHotswapDeployment() if deploymentMethod is hotswap-only', async () => {
   // we need the first call to return something in the Stacks prop,
   // otherwise the access to `stackId` will fail
   mockCloudFormationClient.on(DescribeStacksCommand).resolves({
@@ -152,7 +151,7 @@ test("calls tryHotswapDeployment() if 'hotswap' is `HotswapMode.HOTSWAP_ONLY`", 
   // WHEN
   const deployStackResult = await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: HotswapMode.HOTSWAP_ONLY,
+    deploymentMethod: { method: 'hotswap' },
     extraUserAgent: 'extra-user-agent',
     forceDeployment: true, // otherwise, deployment would be skipped
   });
@@ -170,7 +169,7 @@ test('correctly passes CFN parameters when hotswapping', async () => {
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: HotswapMode.FALL_BACK,
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     parameters: {
       A: 'A-value',
       B: 'B=value',
@@ -186,7 +185,7 @@ test('correctly passes CFN parameters when hotswapping', async () => {
     { A: 'A-value', B: 'B=value' },
     expect.anything(),
     expect.anything(),
-    HotswapMode.FALL_BACK,
+    'fall-back',
     expect.anything(),
   );
 });
@@ -216,7 +215,7 @@ test('correctly passes SSM parameters when hotswapping', async () => {
         },
       },
     }),
-    hotswap: HotswapMode.FALL_BACK,
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     usePreviousParameters: true,
   });
 
@@ -227,7 +226,7 @@ test('correctly passes SSM parameters when hotswapping', async () => {
     { SomeParameter: 'SomeValue' },
     expect.anything(),
     expect.anything(),
-    HotswapMode.FALL_BACK,
+    'fall-back',
     expect.anything(),
   );
 });
@@ -279,11 +278,10 @@ test('method=direct and no updates to be performed', async () => {
   expect(ret).toEqual(expect.objectContaining({ noOp: true }));
 });
 
-test("does not call tryHotswapDeployment() if 'hotswap' is false", async () => {
+test('does not call tryHotswapDeployment() if deploymentMethod is not hotswap', async () => {
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: undefined,
   });
 
   // THEN
@@ -294,7 +292,7 @@ test("rollback still defaults to enabled even if 'hotswap' is enabled", async ()
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: HotswapMode.FALL_BACK,
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     rollback: undefined,
   });
 
@@ -307,11 +305,10 @@ test("rollback still defaults to enabled even if 'hotswap' is enabled", async ()
   );
 });
 
-test("rollback defaults to enabled if 'hotswap' is undefined", async () => {
+test('rollback defaults to enabled if deploymentMethod is not hotswap', async () => {
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    hotswap: undefined,
     rollback: undefined,
   });
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -585,8 +585,6 @@ export class CdkToolkit {
             reuseAssets: options.reuseAssets,
             notificationArns,
             tags,
-            execute: options.execute,
-            changeSetName: options.changeSetName,
             deploymentMethod: options.deploymentMethod,
             forceDeployment: options.force,
             parameters: Object.assign({}, parameterMap['*'], parameterMap[stack.stackName]),
@@ -594,7 +592,6 @@ export class CdkToolkit {
             rollback,
             extraUserAgent: options.extraUserAgent,
             assetParallelism: options.assetParallelism,
-            ignoreNoStacks: options.ignoreNoStacks,
           });
 
           switch (r.type) {
@@ -1670,23 +1667,6 @@ interface CfnDeployOptions {
    * Role to pass to CloudFormation for deployment
    */
   roleArn?: string;
-
-  /**
-   * Optional name to use for the CloudFormation change set.
-   * If not provided, a name will be generated automatically.
-   *
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  changeSetName?: string;
-
-  /**
-   * Whether to execute the ChangeSet
-   * Not providing `execute` parameter will result in execution of ChangeSet
-   *
-   * @default true
-   * @deprecated Use 'deploymentMethod' instead
-   */
-  execute?: boolean;
 
   /**
    * Deployment method


### PR DESCRIPTION
This was made possible by the migration in #1250, which moved all callers to use `deploymentMethod` directly.

The `DeployStackOptions` interfaces in both `deploy-stack.ts` and `deployments.ts` still carried several deprecated properties that served as legacy compatibility shims, translating old-style options into the newer `deploymentMethod` parameter. Since all callers have been migrated to use `deploymentMethod` directly, these shims are no longer needed and the translation code was dead weight.

This removes the deprecated `hotswap`, `hotswapPropertyOverrides`, `execute`, `changeSetName`, and `ignoreNoStacks` properties from the internal deployment interfaces, along with the compatibility translation logic in `Deployments.deployStack()` and `deployStack()`. The `CfnDeployOptions` interface in the CLI's `cdk-toolkit.ts` is cleaned up accordingly, no longer passing the removed options through to `Deployments`.

Tests are updated to use `deploymentMethod` directly instead of the removed options.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
