### PR TITLE
chore: remove `quiet` flag from `ClientOptions` and `SdkProvider.forEnvironment`

### DIFF
--- a/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
@@ -93,7 +93,6 @@ export interface ClientOptions {
   assumeRoleArn?: string;
   assumeRoleExternalId?: string;
   assumeRoleAdditionalOptions?: AssumeRoleAdditionalOptions;
-  quiet?: boolean;
 }
 
 const USER_AGENT = 'cdk-assets';

--- a/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/container-images.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/container-images.ts
@@ -64,7 +64,7 @@ export class ContainerImageAssetHandler implements IAssetHandler {
 
   public async isPublished(): Promise<boolean> {
     try {
-      const initOnce = await this.initOnce({ quiet: true });
+      const initOnce = await this.initOnce();
       return initOnce.destinationAlreadyExists;
     } catch (e: any) {
       this.host.emitMessage(EventType.DEBUG, `${e.message}`);
@@ -99,18 +99,13 @@ export class ContainerImageAssetHandler implements IAssetHandler {
     });
   }
 
-  private async initOnce(
-    options: { quiet?: boolean } = {},
-  ): Promise<ContainerImageAssetHandlerInit> {
+  private async initOnce(): Promise<ContainerImageAssetHandlerInit> {
     if (this.init) {
       return this.init;
     }
 
     const destination = await replaceAwsPlaceholders(this.asset.destination, this.host.aws);
-    const ecr = await this.host.aws.ecrClient({
-      ...destinationToClientOptions(destination),
-      quiet: options.quiet,
-    });
+    const ecr = await this.host.aws.ecrClient(destinationToClientOptions(destination));
     const account = async () => (await this.host.aws.discoverCurrentAccount())?.accountId;
 
     const repoUri = await repositoryUri(ecr, destination.repositoryName);

--- a/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/files.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/files.ts
@@ -39,10 +39,7 @@ export class FileAssetHandler implements IAssetHandler {
     const destination = await replaceAwsPlaceholders(this.asset.destination, this.host.aws);
     const s3Url = `s3://${destination.bucketName}/${destination.objectKey}`;
     try {
-      const s3 = await this.host.aws.s3Client({
-        ...destinationToClientOptions(destination),
-        quiet: true,
-      });
+      const s3 = await this.host.aws.s3Client(destinationToClientOptions(destination));
       this.host.emitMessage(EventType.CHECK, `Check ${s3Url}`);
 
       if (await objectExists(s3, destination.bucketName, destination.objectKey)) {

--- a/packages/@aws-cdk/cdk-assets-lib/lib/publishing.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/publishing.ts
@@ -54,6 +54,9 @@ export interface AssetPublishingOptions {
   readonly publishAssets?: boolean;
 
   /**
+   * Whether to suppress subprocess output
+   *
+   * @default false
    * @deprecated use {@link #subprocessOutputDestination} instead
    */
   readonly quiet?: boolean;
@@ -63,7 +66,7 @@ export interface AssetPublishingOptions {
    *
    * @default 'stdio'
    */
-  subprocessOutputDestination?: SubprocessOutputDestination;
+  readonly subprocessOutputDestination?: SubprocessOutputDestination;
 }
 
 /**
@@ -101,6 +104,7 @@ export class AssetPublishing implements IPublishProgress {
   private readonly publishInParallel: boolean;
   private readonly buildAssets: boolean;
   private readonly publishAssets: boolean;
+  private readonly subprocessOutputDestination: SubprocessOutputDestination;
   private readonly handlerCache = new Map<IManifestEntry, IAssetHandler>();
 
   constructor(
@@ -112,6 +116,7 @@ export class AssetPublishing implements IPublishProgress {
     this.publishInParallel = options.publishInParallel ?? false;
     this.buildAssets = options.buildAssets ?? true;
     this.publishAssets = options.publishAssets ?? true;
+    this.subprocessOutputDestination = options.subprocessOutputDestination ?? (options.quiet ? 'ignore' : 'stdio');
 
     const self = this;
     this.handlerHost = {
@@ -292,15 +297,8 @@ export class AssetPublishing implements IPublishProgress {
     if (existing) {
       return existing;
     }
-    if (this.options.quiet !== undefined && this.options.subprocessOutputDestination) {
-      throw new Error(
-        'Cannot set both quiet and subprocessOutputDestination. Please use only subprocessOutputDestination',
-      );
-    }
-    const subprocessOutputDestination =
-      this.options.subprocessOutputDestination ?? (this.options.quiet ? 'ignore' : 'stdio');
     const ret = makeAssetHandler(this.manifest, asset, this.handlerHost, {
-      subprocessOutputDestination,
+      subprocessOutputDestination: this.subprocessOutputDestination,
     });
     this.handlerCache.set(asset, ret);
     return ret;

--- a/packages/@aws-cdk/cdk-assets-lib/test/placeholders.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/placeholders.test.ts
@@ -81,7 +81,6 @@ test('correct calls are made', async () => {
 
   expect(ecrClient).toHaveBeenCalledWith({
     assumeRoleArn: 'arn:aws:role-current_account',
-    quiet: undefined,
     region: 'explicit_region',
   });
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk-provider.ts
@@ -144,7 +144,6 @@ export class SdkProvider {
     environment: Environment,
     mode: Mode,
     options?: CredentialsOptions,
-    quiet = false,
   ): Promise<SdkForEnvironment> {
     const env = await this.resolveEnvironment(environment);
 
@@ -192,8 +191,7 @@ export class SdkProvider {
       if (baseCreds.source === 'correctDefault' || baseCreds.source === 'plugin') {
         await this.ioHelper.defaults.debug(err.message);
 
-        const level = quiet ? 'debug' : 'warn';
-        await this.ioHelper.defaults[level](
+        await this.ioHelper.defaults.warn(
           `${fmtObtainedCredentials(baseCreds)} could not be used to assume '${options.assumeRoleArn}', but are for the right account. Proceeding anyway.`,
         );
         return {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/asset-publishing.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/asset-publishing.ts
@@ -65,7 +65,6 @@ export async function publishAssets(
     publishInParallel: options.parallel ?? true,
     buildAssets: true,
     publishAssets: true,
-    quiet: false,
   });
   await publisher.publish({ allowCrossAccount: options.allowCrossAccount });
   if (publisher.hasFailures) {
@@ -136,7 +135,6 @@ export class PublishingAws implements IAws {
       env, // region, name, account
       assumeRuleArn: options.assumeRoleArn,
       assumeRoleExternalId: options.assumeRoleExternalId,
-      quiet: options.quiet,
     };
 
     if (options.assumeRoleAdditionalOptions) {
@@ -159,7 +157,6 @@ export class PublishingAws implements IAws {
           assumeRoleExternalId: options.assumeRoleExternalId,
           assumeRoleAdditionalOptions: options.assumeRoleAdditionalOptions,
         },
-        options.quiet,
       )
     ).sdk;
     this.sdkCache.set(cacheKey, sdk);


### PR DESCRIPTION
Fixes #840

The `quiet` flag existed solely for the integration between `cdk-assets` and the CDK CLI's `SdkProvider`. It was threaded through multiple layers across two packages, but only had an effect in one specific place: controlling whether an assume-role fallback warning was logged at `warn` or `debug` level.

This PR removes the flag from `ClientOptions` and `SdkProvider.forEnvironment()`, and simplifies how `AssetPublishing` handles subprocess output configuration.

### Impact to users

**CDK CLI users:** When asset publishing triggers an assume-role fallback (i.e. the role cannot be assumed but the current credentials are for the correct account), the warning message will now always be logged at `warn` level. Previously, this message was suppressed to `debug` during the "is already published?" check. In practice, because `PublishingAws` caches the SDK per role ARN, this warning was already shown at most once per deployment. Users who encounter this fallback path might now see at most one warning, when they previously didn't. I believe this is a desired change.

**`cdk-assets-lib` consumers:** `ClientOptions.quiet` is removed. Since the property was already optional, any custom `IAws` implementation already had to handle the case where it's `undefined`. 

### How `quiet` was threaded before

```
┌─ cdk-assets-lib ──────────────────────────────────────────────────────┐
│                                                                       │
│  FileAssetHandler.isPublished()                                       │
│    └─ s3Client({ ...opts, quiet: true })                              │
│                                                                       │
│  ContainerImageAssetHandler.isPublished()                             │
│    └─ initOnce({ quiet: true })                                       │
│       └─ ecrClient({ ...opts, quiet: true })                          │
│                                                                       │
│  ClientOptions.quiet ──────────────────────────────────────────────┐  │
│                                                                    │  │
└────────────────────────────────────────────────────────────────────│──┘
                                                                     │
┌─ toolkit-lib ──────────────────────────────────────────────────────│──┐
│                                                                    │  │
│  PublishingAws.sdk(options)                                        │  │
│    └─ reads options.quiet ◄────────────────────────────────────────┘  │
│       └─ SdkProvider.forEnvironment(env, mode, creds, options.quiet)  │
│          └─ if quiet: log at debug                                    │
│             else: log at warn                                         │
│                                                                       │
└───────────────────────────────────────────────────────────────────────┘
```

The `quiet` flag on `ClientOptions` had **no effect** within `cdk-assets-lib` itself. `DefaultAwsClient` (used by the standalone `cdk-assets` CLI) completely ignored it. It only became meaningful when the `IAws` implementation was `PublishingAws` from `toolkit-lib`, which forwarded it to `SdkProvider.forEnvironment()`.

Since `PublishingAws` caches the SDK by the full set of options (including the role ARN), the `forEnvironment()` call and its potential warning only fires once per unique role. This makes the `warn` level appropriate without the `quiet` suppression.

### What changed

**`cdk-assets-lib`:**
- Removed `quiet` from `ClientOptions` — it had no effect within the package
- Removed `quiet: true` from `FileAssetHandler.isPublished()` and `ContainerImageAssetHandler.initOnce()`
- Simplified `ContainerImageAssetHandler.initOnce()` to take no options
- `AssetPublishingOptions.quiet` is kept as a deprecated public prop (maps to `subprocessOutputDestination`)
- `AssetPublishing` now resolves `subprocessOutputDestination` once in the constructor as a private class prop, instead of re-evaluating it on every `assetHandler()` call

**`toolkit-lib`:**
- Removed the `quiet` parameter from `SdkProvider.forEnvironment()` — the assume-role fallback message now always logs at `warn` level
- Removed `quiet` forwarding and cache key usage from `PublishingAws.sdk()`
- Removed `quiet: false` from `publishAssets()`

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
