### PR TITLE
feat(cli): add `cdk deploy --method=execute-change-set` for two-step deployment workflows

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-two-step-deploy-prepare-then-execute-change-set.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-two-step-deploy-prepare-then-execute-change-set.integtest.ts
@@ -1,0 +1,48 @@
+import { DescribeChangeSetCommand, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'two-step deploy: prepare then execute change set',
+  withDefaultFixture(async (fixture) => {
+    const changeSetName = `review-${fixture.stackNamePrefix}`;
+    const stackName = 'test-2';
+    const fullStackName = fixture.fullStackName(stackName);
+
+    // Step 1: Create the change set without executing it
+    await fixture.cdkDeploy(stackName, {
+      options: ['--method=prepare-change-set', '--change-set-name', changeSetName],
+      captureStderr: false,
+    });
+
+    // Verify the stack is in REVIEW_IN_PROGRESS
+    const describeResponse = await fixture.aws.cloudFormation.send(
+      new DescribeStacksCommand({ StackName: fullStackName }),
+    );
+    expect(describeResponse.Stacks?.[0].StackStatus).toEqual('REVIEW_IN_PROGRESS');
+
+    // Verify the change set exists and is ready
+    const changeSetResponse = await fixture.aws.cloudFormation.send(
+      new DescribeChangeSetCommand({
+        StackName: fullStackName,
+        ChangeSetName: changeSetName,
+      }),
+    );
+    expect(changeSetResponse.Status).toEqual('CREATE_COMPLETE');
+
+    // Step 2: Execute the change set
+    await fixture.cdk([
+      'deploy',
+      '--require-approval=never',
+      '--method=execute-change-set',
+      '--change-set-name', changeSetName,
+      '--progress', 'events',
+      fullStackName,
+    ]);
+
+    // Verify the stack is now deployed
+    const finalResponse = await fixture.aws.cloudFormation.send(
+      new DescribeStacksCommand({ StackName: fullStackName }),
+    );
+    expect(finalResponse.Stacks?.[0].StackStatus).toEqual('CREATE_COMPLETE');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -1,7 +1,7 @@
 import type { StackSelector } from '../../api/cloud-assembly';
 import type { Tag } from '../../api/tags';
 
-export type DeploymentMethod = DirectDeployment | ChangeSetDeployment | HotswapDeployment;
+export type DeploymentMethod = DirectDeployment | ChangeSetDeployment | ExecuteChangeSetDeployment | HotswapDeployment;
 
 /**
  * Use stack APIs to the deploy stack changes
@@ -42,6 +42,22 @@ export interface ChangeSetDeployment {
    * @default false
    */
   readonly revertDrift?: boolean;
+}
+
+/**
+ * Execute an existing change set that was previously created
+ *
+ * This bypasses change set creation and asset publishing entirely.
+ * The stack name and change set name must refer to an existing change set
+ * in CREATE_COMPLETE status.
+ */
+export interface ExecuteChangeSetDeployment {
+  readonly method: 'execute-change-set';
+
+  /**
+   * The name of the change set to execute.
+   */
+  readonly changeSetName: string;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/private/deployment-method.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/private/deployment-method.ts
@@ -1,15 +1,6 @@
-import type { ChangeSetDeployment, DeploymentMethod } from '..';
+import type { ChangeSetDeployment, DeploymentMethod, ExecuteChangeSetDeployment } from '..';
 
 export const DEFAULT_DEPLOY_CHANGE_SET_NAME = 'cdk-deploy-change-set';
-
-/**
- * Execute a previously created change set.
- * This is an internal deployment method used by the two-phase deploy flow.
- */
-export interface ExecuteChangeSetDeployment {
-  readonly method: 'execute-change-set';
-  readonly changeSetName: string;
-}
 
 /**
  * A change set deployment that will execute.
@@ -40,6 +31,13 @@ export function isExecutingChangeSetDeployment(method?: DeploymentMethod): metho
  */
 export function isNonExecutingChangeSetDeployment(method?: DeploymentMethod): method is NonExecutingChangeSetDeployment {
   return isChangeSetDeployment(method) && (method.execute === false);
+}
+
+/**
+ * Returns true if the deployment method is a execute-change-set deployment.
+ */
+export function isExecuteChangeSetDeployment(method?: DeploymentMethod): method is ExecuteChangeSetDeployment {
+  return method?.method === 'execute-change-set';
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -13,9 +13,9 @@ import * as uuid from 'uuid';
 import { AssetManifestBuilder } from './asset-manifest-builder';
 import { publishAssets } from './asset-publishing';
 import { addMetadataAssetsToManifest } from './assets';
-import type {
+import {
+  type ParameterChanges,
   ParameterValues,
-  ParameterChanges,
 } from './cfn-api';
 import {
   changeSetHasNoChanges,
@@ -27,7 +27,7 @@ import {
 } from './cfn-api';
 import { determineAllowCrossAccountAssetPublishing } from './checks';
 import type { DeployStackResult, SuccessfulDeployStackResult } from './deployment-result';
-import type { ChangeSetDeployment, DeploymentMethod, DirectDeployment } from '../../actions/deploy';
+import type { ChangeSetDeployment, DeploymentMethod, DirectDeployment, ExecuteChangeSetDeployment } from '../../actions/deploy';
 import { DEFAULT_DEPLOY_CHANGE_SET_NAME } from '../../actions/deploy/private/deployment-method';
 import { DeploymentError, DeploymentErrorCodes, ToolkitError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
@@ -43,7 +43,6 @@ import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
 import { EarlyValidationReporter } from './early-validation';
-import type { ExecuteChangeSetDeployment } from '../../actions/deploy/private/deployment-method';
 
 export interface DeployStackOptions {
   /**
@@ -129,7 +128,7 @@ export interface DeployStackOptions {
    *
    * @default - Change set with defaults
    */
-  readonly deploymentMethod?: DeploymentMethod | ExecuteChangeSetDeployment;
+  readonly deploymentMethod?: DeploymentMethod;
 
   /**
    * The collection of extra parameters
@@ -196,11 +195,27 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
   const stackArtifact = options.stack;
   const stackEnv = options.resolvedEnvironment;
 
-  let deploymentMethod = options.deploymentMethod ?? { method: 'change-set' };
+  const inputMethod = options.deploymentMethod ?? { method: 'change-set' };
+  let deploymentMethod: DeploymentMethod = inputMethod;
+
   options.sdk.appendCustomUserAgent(options.extraUserAgent);
   const cfn = options.sdk.cloudFormation();
   const deployName = options.deployName || stackArtifact.stackName;
   let cloudFormationStack = await CloudFormationStack.lookup(cfn, deployName);
+
+  // execute-change-set: skip template/asset work, go straight to FullCloudFormationDeployment
+  if (deploymentMethod.method === 'execute-change-set') {
+    const fullDeployment = new FullCloudFormationDeployment(
+      deploymentMethod,
+      options,
+      cloudFormationStack,
+      stackArtifact,
+      new ParameterValues({}, {}),
+      {},
+      ioHelper,
+    );
+    return fullDeployment.performDeployment();
+  }
 
   if (cloudFormationStack.stackStatus.isCreationFailure) {
     await ioHelper.defaults.debug(

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import * as cdk_assets from '@aws-cdk/cdk-assets-lib';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
+import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as chalk from 'chalk';
 import { AssetManifestBuilder } from './asset-manifest-builder';
 import {
@@ -10,6 +11,7 @@ import {
 import {
   stabilizeStack,
   uploadStackTemplateAssets,
+  waitForChangeSet,
   waitForStackDelete,
 } from './cfn-api';
 import { determineAllowCrossAccountAssetPublishing } from './checks';
@@ -18,7 +20,6 @@ import { deployStack, destroyStack } from './deploy-stack';
 import type { DeployStackResult, SuccessfulDeployStackResult } from './deployment-result';
 import type { ChangeSetDeployment, DeploymentMethod } from '../../actions/deploy';
 import { DEFAULT_DEPLOY_CHANGE_SET_NAME } from '../../actions/deploy/private/deployment-method';
-import type { ExecuteChangeSetDeployment } from '../../actions/deploy/private/deployment-method';
 import { DeploymentError, ToolkitError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
 import type { SdkProvider } from '../aws-auth/private';
@@ -92,7 +93,7 @@ export interface DeployStackOptions {
    *
    * @default - Change set with default options
    */
-  readonly deploymentMethod?: DeploymentMethod | ExecuteChangeSetDeployment;
+  readonly deploymentMethod?: DeploymentMethod;
 
   /**
    * Force deployment, even if the deployed template is identical to the one we are about to deploy.
@@ -463,6 +464,12 @@ export class Deployments {
       await cfn.deleteStack({ StackName: deployName });
       await waitForStackDelete(cfn, this.ioHelper, deployName);
     }
+  }
+
+  public async describeChangeSet(stack: cxapi.CloudFormationStackArtifact, changeSetName: string): Promise<DescribeChangeSetCommandOutput> {
+    const env = await this.envs.accessStackForMutableStackOperations(stack);
+    const cfn = env.sdk.cloudFormation();
+    return waitForChangeSet(cfn, this.ioHelper, stack.stackName, changeSetName, { fetchAll: true });
   }
 
   public async rollbackStack(options: RollbackStackOptions): Promise<RollbackStackResult> {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/work-graph/work-graph.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/work-graph/work-graph.ts
@@ -6,6 +6,12 @@ import type { IoHelper } from '../io/private';
 export type Concurrency = number | Record<WorkNode['type'], number>;
 
 export class WorkGraph {
+  /**
+   * A helper to declare a noop action.
+   */
+  public static readonly NOOP: (..._: any[]) => Promise<void> = async () => {
+  };
+
   public readonly nodes: Record<string, WorkNode>;
   private readonly readyPool: Array<WorkNode> = [];
   private readonly lazyDependencies = new Map<string, string[]>();

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -39,6 +39,7 @@ import { AssetBuildTime, type DeployOptions } from '../actions/deploy';
 import {
   buildParameterMap,
   isChangeSetDeployment,
+  isExecuteChangeSetDeployment,
   isExecutingChangeSetDeployment,
   isNonExecutingChangeSetDeployment,
   type PrivateDeployOptions,
@@ -95,7 +96,7 @@ import { ResourceMigrator } from '../api/resource-import';
 import { tagsForStack } from '../api/tags/private';
 import { DEFAULT_TOOLKIT_STACK_NAME } from '../api/toolkit-info';
 import type { AssetBuildNode, AssetPublishNode, Concurrency, StackNode } from '../api/work-graph';
-import { WorkGraphBuilder, buildDestroyWorkGraph } from '../api/work-graph';
+import { WorkGraph, WorkGraphBuilder, buildDestroyWorkGraph } from '../api/work-graph';
 import type { AssemblyData, RefactorResult, StackDetails, SuccessfulDeployStackResult } from '../payloads';
 import { PermissionChangeType } from '../payloads';
 import { formatErrorMessage, formatTime, obscureTemplate, serializeStructure, validateSnsTopicArn } from '../util';
@@ -557,9 +558,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     };
 
     await workGraph.doParallel(graphConcurrency, {
-      deployStack: async () => {
-        // No-op: we're only publishing assets, not deploying
-      },
+      // No-op: we're only publishing assets, not deploying
+      deployStack: WorkGraph.NOOP,
       buildAsset: this.createBuildAssetFunction(ioHelper, deployments, undefined),
       publishAsset: this.createPublishAssetFunction(ioHelper, deployments, undefined, options.force),
     });
@@ -620,9 +620,11 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     }
 
     const deployments = await this.deploymentsForAction('deploy');
-    const migrator = new ResourceMigrator({ deployments, ioHelper });
 
-    await migrator.tryMigrateResources(stackCollection, options);
+    if (!isExecuteChangeSetDeployment(options.deploymentMethod)) {
+      const migrator = new ResourceMigrator({ deployments, ioHelper });
+      await migrator.tryMigrateResources(stackCollection, options);
+    }
 
     const parameterMap = buildParameterMap(options.parameters?.parameters);
 
@@ -636,6 +638,21 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const stacks = stackCollection.stackArtifacts;
     const stackOutputs: { [key: string]: any } = {};
     const outputsFile = options.outputsFile;
+
+    const { buildAsset, publishAsset } = (() => {
+      if (isExecuteChangeSetDeployment(options.deploymentMethod)) {
+        // No-op: assets are already published
+        return {
+          buildAsset: WorkGraph.NOOP,
+          publishAsset: WorkGraph.NOOP,
+        };
+      }
+
+      return {
+        buildAsset: this.createBuildAssetFunction(ioHelper, deployments, options.roleArn),
+        publishAsset: this.createPublishAssetFunction(ioHelper, deployments, options.roleArn, options.forceAssetPublishing),
+      };
+    })();
 
     const deployStack = async (stackNode: StackNode) => {
       const stack = stackNode.stack;
@@ -718,11 +735,16 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       // changes — there is nothing for the user to approve. Outputs, stack ARN,
       // and timings are still emitted via the normal no-op deploy path below.
       if (!prepareResult?.noOp) {
+        // For execute-change-set, describe the existing change set so we can show an accurate diff
+        const diffChangeSet = isExecuteChangeSetDeployment(options.deploymentMethod)
+          ? await deployments.describeChangeSet(stack, options.deploymentMethod.changeSetName)
+          : prepareResult?.changeSet;
+
         const formatter = new DiffFormatter({
           templateInfo: {
             oldTemplate: currentTemplate,
             newTemplate: stack,
-            changeSet: prepareResult?.changeSet,
+            changeSet: diffChangeSet,
           },
         });
 
@@ -924,8 +946,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     await workGraph.doParallel(graphConcurrency, {
       deployStack,
-      buildAsset: this.createBuildAssetFunction(ioHelper, deployments, options.roleArn),
-      publishAsset: this.createPublishAssetFunction(ioHelper, deployments, options.roleArn, options.forceAssetPublishing),
+      buildAsset,
+      publishAsset,
     });
 
     return ret;

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deployment-method.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deployment-method.test.ts
@@ -1,5 +1,6 @@
 import {
   isChangeSetDeployment,
+  isExecuteChangeSetDeployment,
   isExecutingChangeSetDeployment,
   isNonExecutingChangeSetDeployment,
   toExecuteChangeSetDeployment,
@@ -52,6 +53,24 @@ describe('isNonExecutingChangeSetDeployment', () => {
 
   test('false for direct method', () => {
     expect(isNonExecutingChangeSetDeployment({ method: 'direct' })).toBe(false);
+  });
+});
+
+describe('isExecuteChangeSetDeployment', () => {
+  test('true for execute-change-set method', () => {
+    expect(isExecuteChangeSetDeployment({ method: 'execute-change-set', changeSetName: 'my-cs' })).toBe(true);
+  });
+
+  test('false for change-set method', () => {
+    expect(isExecuteChangeSetDeployment({ method: 'change-set' })).toBe(false);
+  });
+
+  test('false for direct method', () => {
+    expect(isExecuteChangeSetDeployment({ method: 'direct' })).toBe(false);
+  });
+
+  test('false for undefined', () => {
+    expect(isExecuteChangeSetDeployment(undefined)).toBe(false);
   });
 });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -285,6 +285,39 @@ test('call CreateStack when method=direct and the stack doesnt exist yet', async
   expect(mockCloudFormationClient).toHaveReceivedCommand(CreateStackCommand);
 });
 
+test('execute-change-set describes and executes an existing change set', async () => {
+  // GIVEN - stack and change set exist
+  givenStackExists();
+  givenChangeSetExists({ ChangeSetName: 'MyChangeSet', Status: ChangeSetStatus.CREATE_COMPLETE });
+
+  // WHEN
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'execute-change-set', changeSetName: 'MyChangeSet' },
+  });
+
+  // THEN - should execute the change set without creating a new one
+  expect(mockCloudFormationClient).toHaveReceivedCommand(ExecuteChangeSetCommand);
+  expect(mockCloudFormationClient).not.toHaveReceivedCommand(CreateChangeSetCommand);
+});
+
+test('execute-change-set throws if change set is not ready', async () => {
+  // GIVEN
+  mockCloudFormationClient.on(DescribeStacksCommand).resolves({
+    Stacks: [{ ...baseResponse }],
+  });
+  mockCloudFormationClient.on(DescribeChangeSetCommand).resolves({
+    Status: 'FAILED',
+    StatusReason: 'some reason',
+  });
+
+  // WHEN/THEN
+  await expect(testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'execute-change-set', changeSetName: 'MyChangeSet' },
+  })).rejects.toThrow('not ready for execution');
+});
+
 test('call UpdateStack when method=direct and the stack exists already', async () => {
   // WHEN
   givenStackExists();

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -409,6 +409,11 @@ be deployed and then executes it. This behavior can be controlled with the
 - `--method=prepare-change-set`: create the change set but don't execute it.
   This is useful if you have external tools that will inspect the change set or
   you have an approval process for change sets.
+- `--method=execute-change-set`: execute a previously created change set. This
+  bypasses change set creation and asset publishing entirely. Requires exactly
+  one stack name. Defaults to the `cdk-deploy-change-set` change set name if
+  `--change-set-name` is not provided. This is useful for two-step deployment
+  workflows where you first review a change set and then execute it.
 - `--method=direct`: do not create a change set but apply the change immediately.
   This is typically a bit faster than creating a change set, but it loses
   the progress information.
@@ -428,8 +433,23 @@ set to make it easier to later execute:
 $ cdk deploy --method=prepare-change-set --change-set-name MyChangeSetName
 ```
 
-For more control over when stack changes are deployed, the CDK can generate a
-CloudFormation change set but not execute it.
+To review a change set before executing it, use a two-step workflow:
+
+```console
+$ # Step 1: Create the change set without executing it
+$ cdk deploy MyStack --method=prepare-change-set
+
+$ # Step 2: Review the change set (e.g., in the AWS Console or via CLI)
+
+$ # Step 3: Execute the change set
+$ cdk deploy MyStack --method=execute-change-set
+```
+
+A custom change set name can be provided with `--change-set-name` in both steps.
+
+When using `--method=execute-change-set`, the options `--force`, `--parameters`,
+`--import-existing-resources`, and `--revert-drift` cannot be used
+since the change set has already been created.
 
 #### Import existing resources
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -31,7 +31,7 @@ import {
 import type { SdkProvider } from '../api/aws-auth';
 import type { BootstrapEnvironmentOptions } from '../api/bootstrap';
 import { Bootstrapper } from '../api/bootstrap';
-import { ExtendedStackSelection, StackCollection } from '../api/cloud-assembly';
+import { ExpandStackSelection, ExtendedStackSelection, StackCollection } from '../api/cloud-assembly';
 import { isChangeSetDeployment, isExecutingChangeSetDeployment, isNonExecutingChangeSetDeployment, toExecuteChangeSetDeployment } from '../api/deploy-private';
 import type { Deployments, SuccessfulDeployStackResult } from '../api/deployments';
 import { mappingsByEnvironment, parseMappingGroups } from '../api/refactor';
@@ -415,6 +415,37 @@ export class CdkToolkit {
       this.ioHost.stackProgress = options.progress;
     }
 
+    // the ioHost uses this internally to determine if a confirmation
+    // is actually needed, so it needs the same value we determine here.
+    const requireApproval = options.requireApproval ?? RequireApproval.BROADENING;
+    this.ioHost.requireDeployApproval = requireApproval;
+
+    // execute-change-set is a new flow that we can just delegate to toolkit-lib
+    if (options.deploymentMethod?.method === 'execute-change-set') {
+      await this.toolkit.deploy(this.props.cloudExecutable, {
+        deploymentMethod: options.deploymentMethod,
+        stacks: {
+          patterns: options.selector.patterns,
+          strategy: StackSelectionStrategy.PATTERN_MUST_MATCH_SINGLE,
+          expand: ExpandStackSelection.NONE,
+        },
+        roleArn: options.roleArn,
+        forceDeployment: options.force,
+        rollback: options.rollback,
+        reuseAssets: options.reuseAssets,
+        concurrency: options.concurrency,
+        traceLogs: options.traceLogs,
+        notificationArns: options.notificationArns,
+        tags: options.tags,
+        outputsFile: options.outputsFile,
+        assetParallelism: options.assetParallelism,
+        assetBuildConcurrency: options.assetBuildConcurrency,
+        assetBuildTime: options.assetBuildTime,
+        parameters: undefined, // parameters are only set during change set creation, so this is explicitly unset because change set already exists
+      });
+      return;
+    }
+
     const startSynthTime = new Date().getTime();
     const stackCollection = await this.selectStacksForDeploy(
       options.selector,
@@ -438,11 +469,6 @@ export class CdkToolkit {
       toolkitStackName: this.toolkitStackName,
       ...options,
     });
-
-    // the ioHost uses this internally to determine if a confirmation
-    // is actually needed, so it needs the same value we determine here.
-    const requireApproval = options.requireApproval ?? RequireApproval.BROADENING;
-    this.ioHost.requireDeployApproval = requireApproval;
 
     const parameterMap = buildParameterMap(options.parameters);
 

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -152,9 +152,9 @@ export async function makeConfig(): Promise<CliConfig> {
           'method': {
             alias: 'm',
             type: 'string',
-            choices: ['direct', 'change-set', 'prepare-change-set'],
+            choices: ['direct', 'change-set', 'prepare-change-set', 'execute-change-set'],
             requiresArg: true,
-            desc: 'How to perform the deployment. Direct is a bit faster but lacks progress information',
+            desc: 'How to perform the deployment. "change-set" (default) creates and executes a change set. "prepare-change-set" creates a change set without executing it. "execute-change-set" executes a previously created change set, bypassing synthesis entirely. "direct" skips change sets for faster deployments but lacks progress information',
           },
           'import-existing-resources': { type: 'boolean', desc: 'Indicates if the stack set imports resources that already exist.', default: false },
           'force': { alias: 'f', type: 'boolean', desc: 'Always deploy stack even if templates are identical', default: false },

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -463,10 +463,11 @@
           "choices": [
             "direct",
             "change-set",
-            "prepare-change-set"
+            "prepare-change-set",
+            "execute-change-set"
           ],
           "requiresArg": true,
-          "desc": "How to perform the deployment. Direct is a bit faster but lacks progress information"
+          "desc": "How to perform the deployment. \"change-set\" (default) creates and executes a change set. \"prepare-change-set\" creates a change set without executing it. \"execute-change-set\" executes a previously created change set, bypassing synthesis entirely. \"direct\" skips change sets for faster deployments but lacks progress information"
         },
         "import-existing-resources": {
           "type": "boolean",

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -696,16 +696,29 @@ function determineDiffMethod(args: any): 'change-set' | 'template' | 'auto' {
 function determineDeploymentMethod(args: any, configuration: Configuration, watch?: boolean): DeploymentMethod {
   let deploymentMethod: ChangeSetDeployment | DirectDeployment | undefined;
   switch (args.method) {
+    case 'execute-change-set':
+      if (!args.STACKS || args.STACKS.length !== 1) {
+        throw new ToolkitError('ExactlyOneStack', '--method=execute-change-set requires exactly one stack');
+      }
+      if (watch || args.watch) {
+        throw new ToolkitError('WatchWithExecuteChangeSet', '--method=execute-change-set cannot be used with watch');
+      }
+      rejectIncompatibleOptions(args, '--method=execute-change-set', {
+        force: '--force',
+        parameters: '--parameters',
+        importExistingResources: '--import-existing-resources',
+        revertDrift: '--revert-drift',
+      });
+      return {
+        method: 'execute-change-set',
+        changeSetName: args.changeSetName ?? 'cdk-deploy-change-set',
+      };
     case 'direct':
-      if (args.changeSetName) {
-        throw new ToolkitError('ChangeSetNameWithDirect', '--change-set-name cannot be used with method=direct');
-      }
-      if (args.importExistingResources) {
-        throw new ToolkitError('ImportWithDirect', '--import-existing-resources cannot be enabled with method=direct');
-      }
-      if (args.revertDrift) {
-        throw new ToolkitError('RevertDriftWithDirect', '--revert-drift cannot be used with method=direct');
-      }
+      rejectIncompatibleOptions(args, '--method=direct', {
+        changeSetName: '--change-set-name',
+        importExistingResources: '--import-existing-resources',
+        revertDrift: '--revert-drift',
+      });
       deploymentMethod = { method: 'direct' };
       break;
     case 'change-set':
@@ -755,6 +768,27 @@ function determineDeploymentMethod(args: any, configuration: Configuration, watc
     default:
     case HotswapMode.FULL_DEPLOYMENT:
       return deploymentMethod;
+  }
+}
+
+/**
+ * Throw if any of the given flags are set, as they are incompatible with the given option.
+ */
+function rejectIncompatibleOptions(args: any, option: string, flags: Record<string, string>) {
+  for (const [key, flag] of Object.entries(flags)) {
+    const value = args[key];
+
+    let isSet = false;
+    if (Array.isArray(value)) {
+      // yargs may default array options to [{}], so only count real values
+      isSet = value.some((v: unknown) => typeof v === 'string' || typeof v === 'number');
+    } else {
+      isSet = !!value;
+    }
+
+    if (isSet) {
+      throw new ToolkitError('IncompatibleOptions', `${flag} cannot be used with ${option}`);
+    }
   }
 }
 

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -490,9 +490,9 @@ export function parseCommandLineArguments(args: Array<string>): any {
           default: undefined,
           alias: 'm',
           type: 'string',
-          choices: ['direct', 'change-set', 'prepare-change-set'],
+          choices: ['direct', 'change-set', 'prepare-change-set', 'execute-change-set'],
           requiresArg: true,
-          desc: 'How to perform the deployment. Direct is a bit faster but lacks progress information',
+          desc: 'How to perform the deployment. "change-set" (default) creates and executes a change set. "prepare-change-set" creates a change set without executing it. "execute-change-set" executes a previously created change set, bypassing synthesis entirely. "direct" skips change sets for faster deployments but lacks progress information',
         })
         .option('import-existing-resources', {
           default: false,

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -792,7 +792,7 @@ export interface DeployOptions {
   readonly changeSetName?: string;
 
   /**
-   * How to perform the deployment. Direct is a bit faster but lacks progress information
+   * How to perform the deployment. "change-set" (default) creates and executes a change set. "prepare-change-set" creates a change set without executing it. "execute-change-set" executes a previously created change set, bypassing synthesis entirely. "direct" skips change sets for faster deployments but lacks progress information
    *
    * aliases: m
    *

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -59,6 +59,7 @@ import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import { Manifest, RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
+import { Toolkit } from '@aws-cdk/toolkit-lib';
 import type { DestroyStackResult } from '@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
 import type { CloudFormationClientResolvedConfig, CreateChangeSetInput, CreateChangeSetOutput, DeleteChangeSetInput, DeleteChangeSetOutput, DescribeChangeSetInput, DescribeChangeSetOutput, ServiceInputTypes, ServiceOutputTypes } from '@aws-sdk/client-cloudformation';
 import { CreateChangeSetCommand, DeleteChangeSetCommand, DescribeChangeSetCommand, DescribeStacksCommand, GetTemplateCommand, StackStatus } from '@aws-sdk/client-cloudformation';
@@ -617,6 +618,39 @@ describe('deploy', () => {
           deploymentMethod: expect.objectContaining({ method: 'change-set' }),
         }),
       );
+    });
+  });
+
+  describe('with method=execute-change-set', () => {
+    test('delegates to toolkit-lib without synthesizing or calling deployStack', async () => {
+      // GIVEN
+      const mockCfnDeployments = instanceMockFrom(Deployments);
+      const toolkitDeploySpy = jest.spyOn(Toolkit.prototype, 'deploy').mockResolvedValue(undefined as any);
+
+      const cdkToolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockCfnDeployments,
+      });
+
+      // WHEN
+      await cdkToolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        deploymentMethod: { method: 'execute-change-set', changeSetName: 'MyCS' },
+      });
+
+      // THEN - delegates to toolkit-lib and bypasses the legacy deployStack path
+      expect(toolkitDeploySpy).toHaveBeenCalledWith(
+        cloudExecutable,
+        expect.objectContaining({
+          deploymentMethod: { method: 'execute-change-set', changeSetName: 'MyCS' },
+          parameters: undefined,
+        }),
+      );
+      expect(mockCfnDeployments.deployStack).not.toHaveBeenCalled();
+      expect(mockCfnDeployments.prepareStack).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/aws-cdk/test/cli/deploy-options.test.ts
+++ b/packages/aws-cdk/test/cli/deploy-options.test.ts
@@ -1,0 +1,66 @@
+import * as cdkToolkitModule from '../../lib/cli/cdk-toolkit';
+import { exec } from '../../lib/cli/cli';
+
+// Prevent actual toolkit operations
+let deploySpy: jest.SpyInstance;
+
+beforeEach(() => {
+  deploySpy = jest.spyOn(cdkToolkitModule.CdkToolkit.prototype, 'deploy').mockResolvedValue();
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('deploy --method=execute-change-set', () => {
+  test('defaults change-set-name to cdk-deploy-change-set', async () => {
+    await exec(['deploy', '--app', 'echo', '--method=execute-change-set', 'MyStack']);
+
+    expect(deploySpy).toHaveBeenCalledWith(expect.objectContaining({
+      deploymentMethod: {
+        method: 'execute-change-set',
+        changeSetName: 'cdk-deploy-change-set',
+      },
+    }));
+  });
+
+  test('requires exactly one stack', async () => {
+    await expect(
+      exec(['deploy', '--app', 'echo', '--method=execute-change-set', '--change-set-name=MyCS', 'Stack1', 'Stack2']),
+    ).rejects.toThrow('--method=execute-change-set requires exactly one stack');
+  });
+
+  test('requires at least one stack', async () => {
+    await expect(
+      exec(['deploy', '--app', 'echo', '--method=execute-change-set', '--change-set-name=MyCS']),
+    ).rejects.toThrow('--method=execute-change-set requires exactly one stack');
+  });
+
+  test('cannot be used with watch', async () => {
+    await expect(
+      exec(['deploy', '--app', 'echo', '--method=execute-change-set', '--change-set-name=MyCS', '--watch', 'MyStack']),
+    ).rejects.toThrow('--method=execute-change-set cannot be used with watch');
+  });
+
+  test.each([
+    ['--force', '--force'],
+    ['--parameters', '--parameters', 'Foo=bar'],
+    ['--import-existing-resources', '--import-existing-resources'],
+    ['--revert-drift', '--revert-drift'],
+  ])('rejects %s', async (_name, ...flags) => {
+    await expect(
+      exec(['deploy', '--app', 'echo', '--method=execute-change-set', '--change-set-name=MyCS', ...flags, 'MyStack']),
+    ).rejects.toThrow('cannot be used with --method=execute-change-set');
+  });
+
+  test('passes through CdkToolkit.deploy with execute-change-set method', async () => {
+    await exec(['deploy', '--app', 'echo', '--method=execute-change-set', '--change-set-name=MyCS', 'MyStack']);
+
+    expect(deploySpy).toHaveBeenCalledWith(expect.objectContaining({
+      deploymentMethod: {
+        method: 'execute-change-set',
+        changeSetName: 'MyCS',
+      },
+    }));
+  });
+});


### PR DESCRIPTION
## Two-step deployment workflows with `--method=execute-change-set`

### Problem

CDK supports creating change sets without executing them via `--method=prepare-change-set`, but there is no way to execute those change sets through CDK afterwards. Users who want a review-then-deploy workflow — common in regulated environments and CI/CD pipelines with manual approval gates — have to drop down to raw CloudFormation API calls or the AWS Console to execute the change set. This breaks the CDK abstraction and loses CDK's progress monitoring, approval prompts, and error handling.

### Use case

Teams that require human review of infrastructure changes before deployment need a complete workflow within CDK:

```console
$ cdk deploy MyStack --method=prepare-change-set
# → Change set created, stack in REVIEW_IN_PROGRESS

# Review in AWS Console, run compliance checks, get approval...

$ cdk deploy MyStack --method=execute-change-set
# → Executes the change set with CDK's progress monitoring
```

This is especially valuable for:
- **Regulated environments** where infrastructure changes require explicit approval before execution
- **CI/CD pipelines** with separate "plan" and "apply" stages (similar to Terraform's workflow)
- **Team workflows** where one person prepares changes and another approves and executes them

### What this PR does

- Adds `--method=execute-change-set` to `cdk deploy`
- Defaults the change set name to `cdk-deploy-change-set` (matching `prepare-change-set`), so the simplest workflow needs no extra flags
- Shows an accurate diff based on the actual change set during the approval prompt
- Rejects options that only apply to change set creation (`--force`, `--parameters`, `--import-existing-resources`, `--revert-drift`) with clear errors
- Requires exactly one stack name
- Exposes `ExecuteChangeSetDeployment` as part of the public `DeploymentMethod` type in `@aws-cdk/toolkit-lib`

---

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license