### PR TITLE
fix: Python programs on Windows can't write unicode characters

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/exec.ts
@@ -32,7 +32,12 @@ export async function execInChildProcess(commandAndArgs: string, options: ExecOp
       stdio: ['ignore', 'pipe', 'pipe'],
       detached: false,
       cwd: options.cwd,
-      env: options.env,
+      env: {
+        // On Windwows, Python will default to cp1252 when not connected to a terminal, but we
+        // expect it to be UTF-8 below (to be able to split on lines).
+        PYTHONIOENCODING: 'utf-8',
+        ...options.env,
+      },
 
       // We are using 'shell: true' on purprose. Traditionally we have allowed shell features in
       // this string, so we have to continue to do so into the future. On Windows, this is simply


### PR DESCRIPTION
Because we now connect subprocesses to a pipe, Python on Windows defaults to the cp1252 encoding. This encoding does not contain many unicode characters, and Python programs will crash when trying to write them.

There is an environment variable we can set to override the default encoding for Python programs. Set it to utf-8.

Fixes https://github.com/aws/aws-cdk-cli/issues/1276.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
