### PR TITLE
feat(toolkit-lib): changeset-based diff for nested stacks

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/assertions.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/assertions.ts
@@ -1,0 +1,43 @@
+/**
+ * Custom Jest matchers for CLI integration tests.
+ */
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Matchers<R> {
+      /**
+       * Assert that the line following a matching line matches the expected pattern.
+       */
+      toHaveNextLineMatching(linePattern: string | RegExp, expected: string | RegExp): R;
+    }
+  }
+}
+
+function matches(line: string, pattern: string | RegExp): boolean {
+  return typeof pattern === 'string' ? line.includes(pattern) : pattern.test(line);
+}
+
+expect.extend({
+  toHaveNextLineMatching(received: string, linePattern: string | RegExp, expected: string | RegExp) {
+    const lines = received.split('\n');
+    const idx = lines.findIndex(l => matches(l, linePattern));
+
+    if (idx < 0) {
+      return {
+        pass: false,
+        message: () => `Expected output to contain a line matching ${linePattern}, but none was found`,
+      };
+    }
+
+    const nextLine = lines[idx + 1] ?? '';
+    const pass = matches(nextLine, expected);
+
+    return {
+      pass,
+      message: () => pass
+        ? `Expected line after ${linePattern} not to match ${expected}, but it did:\n  ${nextLine}`
+        : `Expected line after ${linePattern} to match ${expected}, but got:\n  ${nextLine}`,
+    };
+  },
+});

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-unnecessary-updates-for-nested-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-unnecessary-updates-for-nested-stacks.integtest.ts
@@ -2,11 +2,11 @@ import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
 
 integTest(
-  'fast deploy',
+  'deploy skips unnecessary updates for nested stacks',
   withDefaultFixture(async (fixture) => {
-    // we are using a stack with a nested stack because CFN will always attempt to
-    // update a nested stack, which will allow us to verify that updates are actually
-    // skipped unless --force is specified.
+    // Deploy a stack with nested stacks. With IncludeNestedStacks, CloudFormation
+    // can accurately detect whether nested stacks have actual changes, rather than
+    // always reporting them as needing an update.
     const stackArn = await fixture.cdkDeploy('with-nested-stack', { captureStderr: false });
     const changeSet1 = await getLatestChangeSet();
 
@@ -15,10 +15,15 @@ integTest(
     const changeSet2 = await getLatestChangeSet();
     expect(changeSet2.ChangeSetId).toEqual(changeSet1.ChangeSetId);
 
-    // Deploy the stack again with --force, now we should create a changeset
-    await fixture.cdkDeploy('with-nested-stack', { options: ['--force'] });
+    // Deploy the stack again with --force. CloudFormation creates a changeset but
+    // accurately reports no changes (including in nested stacks), so the changeset
+    // is not executed and the stack's ChangeSetId remains the same.
+    const forceOutput = await fixture.cdk(
+      fixture.cdkDeployCommandLine('with-nested-stack', { options: ['--force'] }),
+    );
+    expect(forceOutput).toContain('CloudFormation reported that the deployment would not make any changes');
     const changeSet3 = await getLatestChangeSet();
-    expect(changeSet3.ChangeSetId).not.toEqual(changeSet2.ChangeSetId);
+    expect(changeSet3.ChangeSetId).toEqual(changeSet2.ChangeSetId);
 
     // Deploy the stack again with tags, expected to create a new changeset
     // even though the resources didn't change.
@@ -36,4 +41,3 @@ integTest(
     }
   }),
 );
-

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-with-doubly-nested-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-with-doubly-nested-stacks.integtest.ts
@@ -1,0 +1,19 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'cdk diff --method=change-set with doubly nested stacks',
+  withDefaultFixture(async (fixture) => {
+    const stackName = fixture.fullStackName('with-doubly-nested-stack');
+
+    // Diff a stack with two levels of nesting
+    const diff = await fixture.cdk(['diff', '--method=change-set', stackName]);
+
+    // Root stack should contain the outer nested stack
+    expect(diff).toContain('AWS::CloudFormation::Stack');
+    // The inner nested stack should contain the SNS topic
+    expect(diff).toContain('AWS::SNS::Topic');
+    // Should use changeset-based diff successfully
+    expect(diff).not.toContain('Could not create a change set');
+    expect(diff).toContain('read-only change set');
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-with-nested-stacks-through-full-lifecycle.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-with-nested-stacks-through-full-lifecycle.integtest.ts
@@ -1,0 +1,36 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'cdk diff --method=change-set with nested stacks through full lifecycle',
+  withDefaultFixture(async (fixture) => {
+    const stackName = fixture.fullStackName('with-nested-stack');
+
+    // 1. Diff a new stack with nested stacks (CREATE change set)
+    const diffNew = await fixture.cdk(['diff', '--method=change-set', stackName]);
+    // Should show the nested stack resource in the root stack
+    expect(diffNew).toContain('AWS::CloudFormation::Stack');
+    // Should show the SNS topic from inside the nested stack
+    expect(diffNew).toContain('AWS::SNS::Topic');
+    // Should use changeset-based diff, not fall back to template diff
+    expect(diffNew).not.toContain('Could not create a change set');
+    expect(diffNew).not.toContain('falling back to template diff');
+    // Should show the changeset info message
+    expect(diffNew).toContain('read-only change set');
+
+    // 2. Deploy the stack
+    await fixture.cdkDeploy('with-nested-stack');
+
+    // 3. Diff after deploy with no changes — should report no differences
+    const diffNoChanges = await fixture.cdk(['diff', '--method=change-set', stackName]);
+    expect(diffNoChanges).toContain('There were no differences');
+    expect(diffNoChanges).not.toContain('Could not create a change set');
+
+    // 4. Destroy the stack
+    await fixture.cdkDestroy('with-nested-stack');
+
+    // 5. Diff again after destroy (CREATE change set for a new stack)
+    const diffAfterDestroy = await fixture.cdk(['diff', '--method=change-set', stackName]);
+    expect(diffAfterDestroy).toContain('AWS::CloudFormation::Stack');
+    expect(diffAfterDestroy).toContain('AWS::SNS::Topic');
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only--method-change-set-detects-security-changes-in-nested-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only--method-change-set-detects-security-changes-in-nested-stacks.integtest.ts
@@ -2,11 +2,11 @@ import { integTest, withSpecificFixture } from '../../../lib';
 import '../../../lib/assertions';
 
 integTest(
-  'cdk diff --security-only detects security changes in nested stacks',
+  'cdk diff --security-only --method=change-set detects security changes in nested stacks',
   withSpecificFixture('nested-stack-with-iam', async (fixture) => {
     const stackName = fixture.fullStackName('nested-iam');
 
-    const diff = await fixture.cdk(['diff', '--security-only', stackName]);
+    const diff = await fixture.cdk(['diff', '--security-only', '--method=change-set', stackName]);
 
     // Two nested stacks have IAM roles
     expect(diff).toContain('sts:AssumeRole');

--- a/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
@@ -991,4 +991,41 @@ describe('method tests', () => {
       expect(queue.isDifferent).toBe(true);
     });
   });
+
+  test('changeset with Add action preserves addition diff', () => {
+    // GIVEN
+    const currentTemplate = {};
+    const newTemplate = {
+      Resources: {
+        NewRole: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [{ Effect: 'Allow', Principal: { Service: 'lambda.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+            },
+          },
+        },
+      },
+    };
+
+    // WHEN - changeset says the resource is being added (no Details for Add actions)
+    const diff = fullDiff(currentTemplate, newTemplate, {
+      Changes: [{
+        Type: 'Resource',
+        ResourceChange: {
+          Action: 'Add',
+          LogicalResourceId: 'NewRole',
+          ResourceType: 'AWS::IAM::Role',
+        },
+      }],
+    });
+
+    // THEN - the resource should still show as an addition, not be filtered out
+    expect(diff.differenceCount).toBe(1);
+    expect(diff.resources.differenceCount).toBe(1);
+    const roleDiff = diff.resources.get('NewRole');
+    expect(roleDiff.isAddition).toBe(true);
+    expect(roleDiff.isDifferent).toBe(true);
+  });
 });

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -1,10 +1,12 @@
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
+import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as fs from 'fs-extra';
 import * as uuid from 'uuid';
 import type { ChangeSetDiffOptions, DiffOptions, LocalFileDiffOptions } from '..';
 import { DiffMethod } from '..';
 import type { SdkProvider } from '../../../api/aws-auth/private';
 import type { StackCollection } from '../../../api/cloud-assembly/stack-collection';
+import type { NestedStackTemplates } from '../../../api/cloudformation';
 import type { Deployments } from '../../../api/deployments';
 import * as cfnApi from '../../../api/deployments/cfn-api';
 import type { TemplateInfo } from '../../../api/diff';
@@ -99,6 +101,12 @@ async function cfnDiff(
       methodOptions.importExistingResources,
     ) : undefined;
 
+    // If the changeset includes nested stacks, describe each nested changeset
+    // and attach it to the corresponding entry in nestedStacks.
+    if (changeSet) {
+      await attachNestedChangeSetData(deployments, stack, changeSet, nestedStacks);
+    }
+
     const mappings = allMappings.find(m =>
       m.environment.region === stack.environment.region && m.environment.account === stack.environment.account,
     )?.mappings ?? {};
@@ -137,6 +145,49 @@ async function changeSetDiff(
     failOnError: !fallBackToTemplate,
     importExistingResources,
   });
+}
+
+/**
+ * Walk the root changeset's Changes looking for nested stack resources
+ * that have their own ChangeSetId. Describe each nested changeset and
+ * attach it to the matching entry in the nestedStacks map.
+ */
+async function attachNestedChangeSetData(
+  deployments: Deployments,
+  stack: cxapi.CloudFormationStackArtifact,
+  rootChangeSet: DescribeChangeSetCommandOutput,
+  nestedStacks: { [logicalId: string]: NestedStackTemplates },
+): Promise<void> {
+  const env = await deployments.envs.accessStackForReadOnlyStackOperations(stack);
+  const cfn = env.sdk.cloudFormation();
+
+  for (const change of rootChangeSet.Changes ?? []) {
+    const rc = change.ResourceChange;
+    if (rc?.ResourceType !== 'AWS::CloudFormation::Stack' || !rc.ChangeSetId || !rc.LogicalResourceId) {
+      continue;
+    }
+
+    const nested = nestedStacks[rc.LogicalResourceId];
+    if (!nested) {
+      continue;
+    }
+
+    const nestedChangeSet = await cfn.describeChangeSet({
+      ChangeSetName: rc.ChangeSetId,
+      StackName: rc.PhysicalResourceId ?? rc.LogicalResourceId,
+    });
+
+    // Replace the entry with one that includes the changeset
+    (nestedStacks as any)[rc.LogicalResourceId] = {
+      ...nested,
+      changeSet: nestedChangeSet,
+    };
+
+    // Recurse into deeper nesting levels
+    if (nestedChangeSet && Object.keys(nested.nestedStackTemplates).length > 0) {
+      await attachNestedChangeSetData(deployments, stack, nestedChangeSet, nested.nestedStackTemplates);
+    }
+  }
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
@@ -137,6 +137,15 @@ function isCdkManagedNestedStack(stackResource: any): stackResource is NestedSta
   );
 }
 
+/**
+ * Returns true if the given template contains any `AWS::CloudFormation::Stack` resources.
+ */
+export function templateContainsNestedStacks(template: any): boolean {
+  return Object.values(template?.Resources ?? {}).some(
+    (resource: any) => resource.Type === 'AWS::CloudFormation::Stack',
+  );
+}
+
 export interface NestedStackTemplates {
   readonly physicalName: string | undefined;
   readonly deployedTemplate: Template;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -17,7 +17,7 @@ import type { Deployments } from './deployments';
 import { DeploymentError, ToolkitError } from '../../toolkit/toolkit-error';
 import type { ICloudFormationClient, SdkProvider } from '../aws-auth/private';
 import type { Template, TemplateBodyParameter, TemplateParameter } from '../cloudformation';
-import { CloudFormationStack, makeBodyParameter } from '../cloudformation';
+import { CloudFormationStack, makeBodyParameter, templateContainsNestedStacks } from '../cloudformation';
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 
@@ -159,6 +159,7 @@ export type PrepareChangeSetOptions = {
   parameters: { [name: string]: string | undefined };
   resourcesToImport?: ResourcesToImport;
   importExistingResources?: boolean;
+  includeNestedStacks?: boolean;
   /**
    * Default behavior is to log AWS CloudFormation errors and move on. Set this property to true to instead
    * fail on errors received by AWS CloudFormation.
@@ -179,6 +180,7 @@ export type CreateChangeSetOptions = {
   parameters: { [name: string]: string | undefined };
   resourcesToImport?: ResourceToImport[];
   importExistingResources?: boolean;
+  includeNestedStacks?: boolean;
   role?: string;
 };
 
@@ -189,21 +191,10 @@ export async function createDiffChangeSet(
   ioHelper: IoHelper,
   options: PrepareChangeSetOptions,
 ): Promise<DescribeChangeSetCommandOutput | undefined> {
-  // `options.stack` has been modified to include any nested stack templates directly inline with its own template, under a special `NestedTemplate` property.
-  // Thus the parent template's Resources section contains the nested template's CDK metadata check, which uses Fn::Equals.
-  // This causes CreateChangeSet to fail with `Template Error: Fn::Equals cannot be partially collapsed`.
-  for (const resource of Object.values(options.stack.template.Resources ?? {})) {
-    if ((resource as any).Type === 'AWS::CloudFormation::Stack') {
-      if (options.failOnError) {
-        throw new ToolkitError('NestedStacksNotSupported', 'Changeset diff is not supported for stacks with nested stacks. Please use \'--method=auto\' to allow falling back to a template diff.');
-      }
-      await ioHelper.defaults.debug('This stack contains one or more nested stacks, falling back to template diff...');
-
-      return undefined;
-    }
-  }
-
-  return uploadBodyParameterAndCreateChangeSet(ioHelper, options);
+  return uploadBodyParameterAndCreateChangeSet(ioHelper, {
+    ...options,
+    includeNestedStacks: templateContainsNestedStacks(options.stack.template),
+  });
 }
 
 /**
@@ -266,6 +257,7 @@ async function uploadBodyParameterAndCreateChangeSet(
       parameters: options.parameters,
       resourcesToImport: options.resourcesToImport,
       importExistingResources: options.importExistingResources,
+      includeNestedStacks: options.includeNestedStacks,
       role: executionRoleArn,
     });
   } catch (e: any) {
@@ -334,6 +326,7 @@ export async function createChangeSet(
     Parameters: stackParams.apiParameters,
     ResourcesToImport: options.resourcesToImport,
     ImportExistingResources: options.importExistingResources,
+    IncludeNestedStacks: options.includeNestedStacks || undefined,
     RoleARN: options.role,
     Tags: toCfnTags(options.stack.tags),
     Capabilities: ['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -31,7 +31,7 @@ import { DeploymentError, DeploymentErrorCodes, ToolkitError } from '../../toolk
 import { formatErrorMessage } from '../../util';
 import type { SDK, SdkProvider, ICloudFormationClient } from '../aws-auth/private';
 import type { TemplateBodyParameter } from '../cloudformation';
-import { makeBodyParameter, CfnEvaluationException, CloudFormationStack } from '../cloudformation';
+import { makeBodyParameter, CfnEvaluationException, CloudFormationStack, templateContainsNestedStacks } from '../cloudformation';
 import type { EnvironmentResources, StringWithoutPlaceholders } from '../environment';
 import { EnvironmentResourcesRegistry } from '../environment';
 import { HotswapPropertyOverrides, ICON, createHotswapPropertyOverrides } from '../hotswap/common';
@@ -470,6 +470,7 @@ class FullCloudFormationDeployment {
       Description: `CDK Changeset for execution ${this.uuid}`,
       ClientToken: `create${this.uuid}`,
       ImportExistingResources: importExistingResources,
+      IncludeNestedStacks: templateContainsNestedStacks(this.stackArtifact.template),
       DeploymentMode: revertDrift ? 'REVERT_DRIFT' : undefined,
       ...this.commonPrepareOptions(),
     });

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -1,5 +1,6 @@
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as chalk from 'chalk';
+import { templateContainsNestedStacks } from '../../../lib/api/cloudformation/nested-stack-helpers';
 import { DiffFormatter } from '../../../lib/api/diff/diff-formatter';
 
 function stripAnsi(s: string): string {
@@ -220,6 +221,8 @@ describe('formatStackDiff', () => {
   });
 
   test('passes per-nested-stack changeset to fullDiff', () => {
+    // A changeset that says the resource has NO property changes filters out
+    // false positives that the template diff would otherwise report.
     const nestedChangeSet = { Changes: [], $metadata: {} };
 
     const rootTemplate = {
@@ -241,6 +244,7 @@ describe('formatStackDiff', () => {
       findMetadataByType: () => [],
     } as any;
 
+    // Template diff sees a metadata change, but the changeset says there are no real changes
     const deployed = {
       Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'old/path' } } },
     };
@@ -265,8 +269,10 @@ describe('formatStackDiff', () => {
     });
     formatter.formatStackDiff();
 
+    // With the changeset (empty Changes), the metadata-only diff is filtered out
     const nestedDiff = formatter.diffs['nested-stack-1'];
     expect(nestedDiff).toBeDefined();
+    // Changeset says no changes — all template differences are filtered as false positives
     expect(nestedDiff.differenceCount).toBe(0);
   });
 
@@ -290,6 +296,7 @@ describe('formatStackDiff', () => {
       findMetadataByType: () => [],
     } as any;
 
+    // Same metadata change, but no changeset to filter it out
     const deployed = {
       Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'old/path' } } },
     };
@@ -307,14 +314,17 @@ describe('formatStackDiff', () => {
             generatedTemplate: generated,
             physicalName: 'nested-stack-1',
             nestedStackTemplates: {},
+            // no changeSet
           },
         },
       },
     });
     formatter.formatStackDiff();
 
+    // Without a changeset, the template diff reports the metadata change as a real difference
     const nestedDiff = formatter.diffs['nested-stack-1'];
     expect(nestedDiff).toBeDefined();
+    // Template-only diff: the resource has a metadata difference
     expect(nestedDiff.differenceCount).toBeGreaterThan(0);
   });
 });
@@ -641,5 +651,32 @@ describe('mangled character filtering', () => {
     expect(sanitized).not.toContain('AWS::CloudFormation::Stack');
     expect(sanitized).toContain('nested-stack');
     expect(sanitized).toContain('Omitted');
+  });
+});
+
+describe('templateContainsNestedStacks', () => {
+  test('returns true when template has AWS::CloudFormation::Stack resources', () => {
+    expect(templateContainsNestedStacks({
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+        Bucket: { Type: 'AWS::S3::Bucket' },
+      },
+    })).toBe(true);
+  });
+
+  test('returns false when template has no nested stacks', () => {
+    expect(templateContainsNestedStacks({
+      Resources: {
+        Bucket: { Type: 'AWS::S3::Bucket' },
+      },
+    })).toBe(false);
+  });
+
+  test('returns false for empty template', () => {
+    expect(templateContainsNestedStacks({})).toBe(false);
+  });
+
+  test('returns false for template with no Resources', () => {
+    expect(templateContainsNestedStacks({ Parameters: {} })).toBe(false);
   });
 });


### PR DESCRIPTION
Closes aws/aws-cdk#28568

Until now, `cdk diff` silently fell back to a template-only diff whenever a stack contained nested stacks. The guard in `createDiffChangeSet` rejected any template with `AWS::CloudFormation::Stack` resources, based on an outdated comment about template inlining causing `Fn::Equals cannot be partially collapsed` errors. That inlining was removed in a prior refactoring, but the guard and its comment were never cleaned up.

### Before

<img width="1063" height="38" alt="image" src="https://github.com/user-attachments/assets/e2317da5-fd51-47bb-afd7-4acfc70de561" />


### After

<img width="1421" height="397" alt="image" src="https://github.com/user-attachments/assets/727019d8-4222-4b43-a644-302bed6625fe" />

<img width="1134" height="385" alt="image" src="https://github.com/user-attachments/assets/622cfd55-2b9d-482a-a8bd-0b995d20ee73" />

<img width="376" height="37" alt="image" src="https://github.com/user-attachments/assets/0a8467d4-5195-47c0-9371-1c36fb209cdf" />


### Details

This change removes the stale guard and instead passes `IncludeNestedStacks: true` to the CloudFormation `CreateChangeSet` API when nested stacks are detected in the template. This applies to both the diff and deploy paths, so deployments also benefit from CloudFormation's native nested changeset support.

For diff specifically, each nested changeset returned by CloudFormation is described and attached to the corresponding entry in the `NestedStackTemplates` structure. The `DiffFormatter` then threads the per-nested-stack changeset data through to `fullDiff`, giving nested stacks the same accurate replacement information that root stacks already had. This builds on the groundwork laid in #1295, which added the `changeSet` field to `NestedStackTemplates` and made both `formatStackDiff` and `formatSecurityDiff` recurse into nested stacks — but left the changeset field deliberately unused.

A `templateContainsNestedStacks` helper is introduced and used in both `createDiffChangeSet` and `FullCloudFormationDeployment` to decide when to set `IncludeNestedStacks`. The helper is intentionally simple — it checks for the presence of `AWS::CloudFormation::Stack` resources in the template's `Resources` section.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
