### PR TITLE
fix: security changes in nested stacks are not shown for `cdk diff --security-only`

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/nested-stack-with-iam/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/nested-stack-with-iam/app.js
@@ -1,0 +1,38 @@
+const { Stack, App } = require('aws-cdk-lib/core');
+const { NestedStack } = require('aws-cdk-lib/aws-cloudformation');
+const iam = require('aws-cdk-lib/aws-iam');
+const sns = require('aws-cdk-lib/aws-sns');
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+if (!stackPrefix) {
+  throw new Error('the STACK_NAME_PREFIX environment variable is required');
+}
+
+class IamNestedStack extends NestedStack {
+  constructor(scope, id) {
+    super(scope, id);
+    new iam.Role(this, 'NestedRole', {
+      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+    });
+  }
+}
+
+class NoSecurityNestedStack extends NestedStack {
+  constructor(scope, id) {
+    super(scope, id);
+    new sns.Topic(this, 'Topic');
+  }
+}
+
+class ParentStack extends Stack {
+  constructor(scope, id) {
+    super(scope, id);
+    new IamNestedStack(this, 'IamNested');
+    new NoSecurityNestedStack(this, 'NoSecurityNested');
+    new IamNestedStack(this, 'AnotherIamNested');
+  }
+}
+
+const app = new App();
+new ParentStack(app, `${stackPrefix}-nested-iam`);
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/nested-stack-with-iam/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/nested-stack-with-iam/cdk.json
@@ -1,0 +1,7 @@
+{
+  "app": "node app.js",
+  "versionReporting": false,
+  "context": {
+    "aws-cdk:enableDiffNoFail": "true"
+  }
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-detects-security-changes-in-nested-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---security-only-detects-security-changes-in-nested-stacks.integtest.ts
@@ -1,0 +1,21 @@
+import { integTest, withSpecificFixture } from '../../../lib';
+
+integTest(
+  'cdk diff --security-only detects security changes in nested stacks',
+  withSpecificFixture('nested-stack-with-iam', async (fixture) => {
+    const stackName = fixture.fullStackName('nested-iam');
+
+    const diff = await fixture.cdk(['diff', '--security-only', stackName]);
+
+    // Two nested stacks have IAM roles
+    expect(diff).toContain('sts:AssumeRole');
+    expect(diff).toContain('lambda.amazonaws.com');
+    expect(diff).toContain('Number of stacks with differences: 2');
+
+    // The nested stack without security changes should say so on the next line
+    const lines = diff.split('\n');
+    const noSecIdx = lines.findIndex(l => l.includes('NoSecurityNested'));
+    expect(noSecIdx).toBeGreaterThanOrEqual(0);
+    expect(lines[noSecIdx + 1]).toContain('There were no security-related changes');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as fs from 'fs-extra';
 import { LazyListStackResources, type ListStackResources } from './evaluate-cloudformation-template';
 import { CloudFormationStack, type Template } from './stack-helpers';
@@ -143,6 +144,11 @@ export interface NestedStackTemplates {
   readonly nestedStackTemplates: {
     [nestedStackLogicalId: string]: NestedStackTemplates;
   };
+  /**
+   * The changeset for this nested stack, if available.
+   * Populated when the root changeset was created with `IncludeNestedStacks`.
+   */
+  readonly changeSet?: DescribeChangeSetCommandOutput;
 }
 
 interface StackTemplates {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
@@ -6,12 +6,13 @@ import {
   formatSecurityChanges,
   fullDiff,
   mangleLikeCloudFormation,
+  type DescribeChangeSetOutput,
   type ResourceDifference,
   type TemplateDiff,
 } from '@aws-cdk/cloudformation-diff';
 import * as chalk from 'chalk';
 import { PermissionChangeType } from '../../payloads';
-import type { NestedStackTemplates } from '../cloudformation';
+import type { NestedStackTemplates, Template } from '../cloudformation';
 import { StringWriteStream } from '../streams';
 
 /**
@@ -28,6 +29,11 @@ interface FormatSecurityDiffOutput {
    * The IoHost will use this to decide whether or not to print.
    */
   readonly permissionChangeType: PermissionChangeType;
+
+  /**
+   * Number of stacks with security changes
+   */
+  readonly numStacksWithChanges: number;
 }
 
 /**
@@ -86,6 +92,18 @@ interface ReusableStackDiffOptions extends FormatStackDiffOptions {
 }
 
 /**
+ * Properties specific to formatting the security diff
+ */
+interface FormatSecurityDiffOptions {
+  /**
+   * silences stack names and 'no changes' messages for stacks without security changes
+   *
+   * @default false
+   */
+  readonly quiet?: boolean;
+}
+
+/**
  * Information on a template's old/new state
  * that is used for diff.
  */
@@ -93,7 +111,7 @@ export interface TemplateInfo {
   /**
    * The old/existing template
    */
-  readonly oldTemplate: any;
+  readonly oldTemplate: Template;
 
   /**
    * The new template
@@ -106,7 +124,7 @@ export interface TemplateInfo {
    *
    * @default undefined
    */
-  readonly changeSet?: any;
+  readonly changeSet?: DescribeChangeSetOutput;
 
   /**
    * Whether or not there are any imported resources
@@ -137,51 +155,47 @@ export interface TemplateInfo {
  * Class for formatting the diff output
  */
 export class DiffFormatter {
-  private readonly oldTemplate: any;
-  private readonly newTemplate: cxapi.CloudFormationStackArtifact;
+  private readonly templateInfo: TemplateInfo;
   private readonly stackName: string;
-  private readonly changeSet?: any;
-  private readonly nestedStacks: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined;
   private readonly isImport: boolean;
   private readonly mappings: Record<string, string>;
 
   /**
-   * Stores the TemplateDiffs that get calculated in this DiffFormatter,
-   * indexed by the stack name.
+   * Cache of computed TemplateDiffs, indexed by stack name.
    */
-  private _diffs: { [name: string]: TemplateDiff } = {};
+  private readonly cache = new Map<string, TemplateDiff>();
 
   constructor(props: DiffFormatterProps) {
-    this.oldTemplate = props.templateInfo.oldTemplate;
-    this.newTemplate = props.templateInfo.newTemplate;
+    this.templateInfo = props.templateInfo;
     this.stackName = props.templateInfo.newTemplate.displayName ?? props.templateInfo.newTemplate.stackName;
-    this.changeSet = props.templateInfo.changeSet;
-    this.nestedStacks = props.templateInfo.nestedStacks;
     this.isImport = props.templateInfo.isImport ?? false;
     this.mappings = props.templateInfo.mappings ?? {};
   }
 
   public get diffs() {
-    return this._diffs;
+    return Object.fromEntries(this.cache);
   }
 
   /**
-   * Get or creates the diff of a stack.
-   * If it creates the diff, it stores the result in a map for
-   * easier retrieval later.
+   * Compute the diff for a single stack. Results are cached by stack name.
+   *
+   * @param stackName - The name to cache the diff under
+   * @param oldTemplate - The deployed template
+   * @param newTemplate - The new/generated template (read from the artifact)
+   * @param changeSet - The CloudFormation changeset for this specific stack, if available
+   * @param mappings - Resource move mappings
    */
-  private diff(stackName?: string, oldTemplate?: any, mappings: Record<string, string> = {}) {
-    const realStackName = stackName ?? this.stackName;
+  private computeDiff(
+    stackName: string,
+    oldTemplate: Template,
+    newTemplate: Template,
+    changeSet: DescribeChangeSetOutput | undefined,
+    mappings: Record<string, string>,
+  ): TemplateDiff {
+    if (!this.cache.has(stackName)) {
+      const templateDiff = fullDiff(oldTemplate, newTemplate, changeSet, this.isImport);
 
-    if (!this._diffs[realStackName]) {
-      const templateDiff = fullDiff(
-        oldTemplate ?? this.oldTemplate,
-        this.newTemplate.template,
-        this.changeSet,
-        this.isImport,
-      );
-
-      const setMove = (change: ResourceDifference, direction: 'from' | 'to', location?: string)=> {
+      const setMove = (change: ResourceDifference, direction: 'from' | 'to', location?: string) => {
         if (location != null) {
           const [sourceStackName, sourceLogicalId] = location.split('.');
           change.move = {
@@ -193,7 +207,7 @@ export class DiffFormatter {
       };
 
       templateDiff.resources.forEachDifference((id, change) => {
-        const location = `${realStackName}.${id}`;
+        const location = `${stackName}.${id}`;
         if (change.isAddition && Object.values(mappings).includes(location)) {
           setMove(change, 'from', Object.keys(mappings).find(k => mappings[k] === location));
         } else if (change.isRemoval && Object.keys(mappings).includes(location)) {
@@ -201,60 +215,44 @@ export class DiffFormatter {
         }
       });
 
-      this._diffs[realStackName] = templateDiff;
+      this.cache.set(stackName, templateDiff);
     }
-    return this._diffs[realStackName];
+    return this.cache.get(stackName)!;
   }
 
   /**
-   * Return whether the diff has security-impacting changes that need confirmation.
-   *
-   * If no stackName is given, then the root stack name is used.
-   */
-  private permissionType(): PermissionChangeType {
-    const diff = this.diff();
-
-    if (diff.permissionsBroadened) {
-      return PermissionChangeType.BROADENING;
-    } else if (diff.permissionsAnyChanges) {
-      return PermissionChangeType.NON_BROADENING;
-    } else {
-      return PermissionChangeType.NONE;
-    }
-  }
-
-  /**
-   * Format the stack diff
+   * Format the stack diff, including all nested stacks.
    */
   public formatStackDiff(options: FormatStackDiffOptions = {}): FormatStackDiffOutput {
-    return this.formatStackDiffHelper(
-      this.oldTemplate,
-      this.stackName,
-      this.nestedStacks,
-      options,
-      this.mappings,
-    );
+    return this.formatStackDiffHelper({
+      oldTemplate: this.templateInfo.oldTemplate,
+      newTemplate: this.templateInfo.newTemplate.template,
+      stackName: this.stackName,
+      nestedStacks: this.templateInfo.nestedStacks,
+      changeSet: this.templateInfo.changeSet,
+      mappings: this.mappings,
+      logicalIdMap: buildLogicalToPathMap(this.templateInfo.newTemplate),
+    }, options);
   }
 
-  private formatStackDiffHelper(
-    oldTemplate: any,
-    stackName: string,
-    nestedStackTemplates: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined,
-    options: ReusableStackDiffOptions,
-    mappings: Record<string, string> = {},
-  ) {
-    let diff = this.diff(stackName, oldTemplate, mappings);
+  private formatStackDiffHelper(params: {
+    oldTemplate: Template;
+    newTemplate: Template;
+    stackName: string;
+    nestedStacks: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined;
+    changeSet: DescribeChangeSetOutput | undefined;
+    mappings: Record<string, string>;
+    logicalIdMap: Record<string, string>;
+  }, options: ReusableStackDiffOptions = {}): FormatStackDiffOutput {
+    const { oldTemplate, newTemplate, stackName, nestedStacks, changeSet, mappings, logicalIdMap } = params;
 
-    // The stack diff is formatted via `Formatter`, which takes in a stream
-    // and sends its output directly to that stream. To facilitate use of the
-    // global CliIoHost, we create our own stream to capture the output of
-    // `Formatter` and return the output as a string for the consumer of
-    // `formatStackDiff` to decide what to do with it.
+    const diff = this.computeDiff(stackName, oldTemplate, newTemplate, changeSet, mappings);
+
     const stream = new StringWriteStream();
-
     let numStacksWithChanges = 0;
     let formattedDiff = '';
     let filteredChangesCount = 0;
+
     try {
       // must output the stack name if there are differences, even if quiet
       if (stackName && (!options.quiet || !diff.isEmpty)) {
@@ -266,28 +264,29 @@ export class DiffFormatter {
       }
 
       // detect and filter out mangled characters from the diff
+      let activeDiff = diff;
       if (diff.differenceCount && !options.strict) {
-        const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(this.newTemplate.template)));
-        const mangledDiff = fullDiff(oldTemplate, mangledNewTemplate, this.changeSet);
+        const mangledNewTemplate = JSON.parse(mangleLikeCloudFormation(JSON.stringify(newTemplate)));
+        const mangledDiff = fullDiff(oldTemplate, mangledNewTemplate, changeSet);
         filteredChangesCount = Math.max(0, diff.differenceCount - mangledDiff.differenceCount);
         if (filteredChangesCount > 0) {
-          diff = mangledDiff;
+          activeDiff = mangledDiff;
         }
       }
 
       // filter out 'AWS::CDK::Metadata' resources from the template
       // filter out 'CheckBootstrapVersion' rules from the template
       if (!options.strict) {
-        obscureDiff(diff);
+        obscureDiff(activeDiff);
       }
 
-      if (!diff.isEmpty) {
+      if (!activeDiff.isEmpty) {
         numStacksWithChanges++;
 
-        // formatDifferences updates the stream with the formatted stack diff
-        formatDifferences(stream, diff, {
-          ...logicalIdMapFromTemplate(this.oldTemplate),
-          ...buildLogicalToPathMap(this.newTemplate),
+        formatDifferences(stream, activeDiff, {
+          ...logicalIdMapFromTemplate(oldTemplate),
+          ...logicalIdMapFromTemplate(newTemplate),
+          ...logicalIdMap,
         }, options.contextLines);
       } else if (!options.quiet) {
         stream.write(chalk.green('There were no differences\n'));
@@ -297,60 +296,109 @@ export class DiffFormatter {
         stream.write(chalk.yellow(`Omitted ${filteredChangesCount} changes because they are likely mangled non-ASCII characters. Use --strict to print them.\n`));
       }
     } finally {
-      // store the stream containing a formatted stack diff
       formattedDiff = stream.toString();
       stream.end();
     }
 
-    for (const nestedStackLogicalId of Object.keys(nestedStackTemplates ?? {})) {
-      if (!nestedStackTemplates) {
-        break;
-      }
-      const nestedStack = nestedStackTemplates[nestedStackLogicalId];
-
-      (this.newTemplate as any)._template = nestedStack.generatedTemplate;
-      const nextDiff = this.formatStackDiffHelper(
-        nestedStack.deployedTemplate,
-        nestedStack.physicalName ?? nestedStackLogicalId,
-        nestedStack.nestedStackTemplates,
-        options,
-        this.mappings,
-      );
+    // Recurse into nested stacks
+    for (const [logicalId, nestedStack] of Object.entries(nestedStacks ?? {})) {
+      const nextDiff = this.formatStackDiffHelper({
+        oldTemplate: nestedStack.deployedTemplate,
+        newTemplate: nestedStack.generatedTemplate,
+        stackName: nestedStack.physicalName ?? logicalId,
+        nestedStacks: nestedStack.nestedStackTemplates,
+        changeSet: nestedStack.changeSet,
+        mappings,
+        logicalIdMap: {},
+      }, options);
       numStacksWithChanges += nextDiff.numStacksWithChanges;
       formattedDiff += nextDiff.formattedDiff;
     }
 
-    return {
-      numStacksWithChanges,
-      formattedDiff,
-    };
+    return { numStacksWithChanges, formattedDiff };
   }
 
   /**
-   * Format the security diff
+   * Format the security diff, including all nested stacks.
    */
-  public formatSecurityDiff(): FormatSecurityDiffOutput {
-    const diff = this.diff();
+  public formatSecurityDiff(options: FormatSecurityDiffOptions = {}): FormatSecurityDiffOutput {
+    const { formattedDiff, permissionChangeType, numStacksWithChanges } = this.formatSecurityDiffHelper({
+      oldTemplate: this.templateInfo.oldTemplate,
+      newTemplate: this.templateInfo.newTemplate.template,
+      stackName: this.stackName,
+      nestedStacks: this.templateInfo.nestedStacks,
+      changeSet: this.templateInfo.changeSet,
+      logicalIdMap: buildLogicalToPathMap(this.templateInfo.newTemplate),
+    }, options);
 
-    // The security diff is formatted via `Formatter`, which takes in a stream
-    // and sends its output directly to that stream. To faciliate use of the
-    // global CliIoHost, we create our own stream to capture the output of
-    // `Formatter` and return the output as a string for the consumer of
-    // `formatSecurityDiff` to decide what to do with it.
+    return { formattedDiff, permissionChangeType, numStacksWithChanges };
+  }
+
+  private formatSecurityDiffHelper(params: {
+    oldTemplate: Template;
+    newTemplate: Template;
+    stackName: string;
+    nestedStacks: { [nestedStackLogicalId: string]: NestedStackTemplates } | undefined;
+    changeSet: DescribeChangeSetOutput | undefined;
+    logicalIdMap?: Record<string, string>;
+  }, options: FormatSecurityDiffOptions = {}): FormatSecurityDiffOutput {
+    const { oldTemplate, newTemplate, stackName, nestedStacks, changeSet, logicalIdMap } = params;
+
+    const diff = this.computeDiff(stackName, oldTemplate, newTemplate, changeSet, this.mappings);
+    const permissionChangeType = permissionTypeFromDiff(diff);
+
     const stream = new StringWriteStream();
-
-    stream.write(format(`Stack ${chalk.bold(this.stackName)}\n`));
+    if (!options.quiet || permissionChangeType !== PermissionChangeType.NONE) {
+      stream.write(format(`Stack ${chalk.bold(stackName)}\n`));
+    }
 
     try {
-      // formatSecurityChanges updates the stream with the formatted security diff
-      formatSecurityChanges(stream, diff, buildLogicalToPathMap(this.newTemplate));
+      formatSecurityChanges(stream, diff, {
+        ...logicalIdMapFromTemplate(newTemplate),
+        ...logicalIdMap,
+      });
     } finally {
       stream.end();
     }
-    // store the stream containing a formatted stack diff
-    const formattedDiff = stream.toString();
-    return { formattedDiff, permissionChangeType: this.permissionType() };
+
+    let formattedDiff = stream.toString();
+    if (!options.quiet && permissionChangeType === PermissionChangeType.NONE) {
+      formattedDiff += chalk.green('There were no security-related changes (limitations: https://github.com/aws/aws-cdk/issues/1299)\n');
+    }
+    let numStacksWithChanges = permissionChangeType !== PermissionChangeType.NONE ? 1 : 0;
+    let escalatedPermissionType = permissionChangeType;
+
+    // Recurse into nested stacks
+    for (const [logicalId, nestedStack] of Object.entries(nestedStacks ?? {})) {
+      const nestedResult = this.formatSecurityDiffHelper({
+        oldTemplate: nestedStack.deployedTemplate,
+        newTemplate: nestedStack.generatedTemplate,
+        stackName: nestedStack.physicalName ?? logicalId,
+        nestedStacks: nestedStack.nestedStackTemplates,
+        changeSet: nestedStack.changeSet,
+      }, options);
+      formattedDiff += nestedResult.formattedDiff ? '\n' + nestedResult.formattedDiff : '';
+      numStacksWithChanges += nestedResult.numStacksWithChanges;
+      // Escalate: if any nested stack broadens permissions, the whole thing broadens
+      if (nestedResult.permissionChangeType === PermissionChangeType.BROADENING) {
+        escalatedPermissionType = PermissionChangeType.BROADENING;
+      } else if (nestedResult.permissionChangeType === PermissionChangeType.NON_BROADENING
+        && escalatedPermissionType === PermissionChangeType.NONE) {
+        escalatedPermissionType = PermissionChangeType.NON_BROADENING;
+      }
+    }
+
+    return { formattedDiff, permissionChangeType: escalatedPermissionType, numStacksWithChanges };
   }
+}
+
+function permissionTypeFromDiff(diff: TemplateDiff): PermissionChangeType {
+  if (diff.permissionsBroadened) {
+    return PermissionChangeType.BROADENING;
+  } else if (diff.permissionsAnyChanges) {
+    return PermissionChangeType.NON_BROADENING;
+  }
+  return PermissionChangeType.NONE;
 }
 
 function buildLogicalToPathMap(stack: cxapi.CloudFormationStackArtifact) {
@@ -361,11 +409,11 @@ function buildLogicalToPathMap(stack: cxapi.CloudFormationStackArtifact) {
   return map;
 }
 
-function logicalIdMapFromTemplate(template: any) {
+function logicalIdMapFromTemplate(template: Template) {
   const ret: Record<string, string> = {};
 
-  for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
-    const path = (resource as any)?.Metadata?.['aws:cdk:path'];
+  for (const [logicalId, resource] of Object.entries((template.Resources ?? {}) as Record<string, any>)) {
+    const path = resource?.Metadata?.['aws:cdk:path'];
     if (path) {
       ret[logicalId] = path;
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/diff.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/diff.ts
@@ -46,6 +46,12 @@ export interface StackDiff extends SingleStack {
   readonly numStacksWithChanges: number;
 
   /**
+   * Total number of stacks that have security-related changes.
+   * Can be higher than `1` if the stack has nested stacks.
+   */
+  readonly numStacksWithSecurityChanges: number;
+
+  /**
    * Structural diff of the stack
    * Can include more than a single diff if the stack has nested stacks.
    */
@@ -70,6 +76,10 @@ export interface DiffResult extends Duration {
    * Total number of stacks that have changes
    */
   readonly numStacksWithChanges: number;
+  /**
+   * Total number of stacks that have security-related changes
+   */
+  readonly numStacksWithSecurityChanges: number;
   /**
    * Structural diff of all selected stacks
    */

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -373,6 +373,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const contextLines = options.contextLines || 3;
 
     let diffs = 0;
+    let securityDiffs = 0;
 
     const templateInfos = await prepareDiff(diffSpan.asHelper, stacks, deployments, await this.sdkProvider('diff'), options);
     const templateDiffs: { [name: string]: TemplateDiff } = {};
@@ -392,11 +393,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
       // Stack Diff
       diffs += stackDiff.numStacksWithChanges;
+      securityDiffs += securityDiff.numStacksWithChanges;
       appendObject(templateDiffs, formatter.diffs);
       await diffSpan.notify(IO.CDK_TOOLKIT_I4002.msg(stackDiff.formattedDiff, {
         stack: templateInfo.newTemplate,
         diffs: formatter.diffs,
         numStacksWithChanges: stackDiff.numStacksWithChanges,
+        numStacksWithSecurityChanges: securityDiff.numStacksWithChanges,
         permissionChanges: securityDiff.permissionChangeType,
         formattedDiff: {
           diff: stackDiff.formattedDiff,
@@ -407,6 +410,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     await diffSpan.end(`✨ Number of stacks with differences: ${diffs}`, {
       numStacksWithChanges: diffs,
+      numStacksWithSecurityChanges: securityDiffs,
       diffs: templateDiffs,
     });
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -271,6 +271,97 @@ describe('diff', () => {
     }));
   });
 
+  test('security diff detects changes in nested stacks', async () => {
+    // GIVEN - mock nested stacks with IAM
+    jest.spyOn(deployments.Deployments.prototype, 'readCurrentTemplateWithNestedStacks').mockResolvedValue({
+      deployedRootTemplate: {
+        Resources: {
+          IamChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+          IamChild2: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+          NoSecChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+        },
+      },
+      nestedStacks: {
+        IamChild: {
+          deployedTemplate: {},
+          generatedTemplate: {
+            Resources: {
+              Role: {
+                Type: 'AWS::IAM::Role',
+                Properties: {
+                  AssumeRolePolicyDocument: {
+                    Statement: [{ Effect: 'Allow', Principal: { Service: 'lambda.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+                  },
+                },
+              },
+            },
+          },
+          physicalName: 'IamChild',
+          nestedStackTemplates: {},
+        },
+        IamChild2: {
+          deployedTemplate: {},
+          generatedTemplate: {
+            Resources: {
+              Role: {
+                Type: 'AWS::IAM::Role',
+                Properties: {
+                  AssumeRolePolicyDocument: {
+                    Statement: [{ Effect: 'Allow', Principal: { Service: 'ec2.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+                  },
+                },
+              },
+            },
+          },
+          physicalName: 'IamChild2',
+          nestedStackTemplates: {},
+        },
+        NoSecChild: {
+          deployedTemplate: {},
+          generatedTemplate: {
+            Resources: { Topic: { Type: 'AWS::SNS::Topic' } },
+          },
+          physicalName: 'NoSecChild',
+          nestedStackTemplates: {},
+        },
+      },
+    });
+
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-bucket');
+    await toolkit.diff(cx, {
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+      method: DiffMethod.TemplateOnly({ compareAgainstProcessedTemplate: true }),
+    });
+
+    // THEN - security diff should contain nested stack IAM changes
+    expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'diff',
+      level: 'warn',
+      message: expect.stringContaining('This deployment will make potentially sensitive changes'),
+    }));
+    expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'diff',
+      level: 'result',
+      code: 'CDK_TOOLKIT_I4002',
+      data: expect.objectContaining({
+        formattedDiff: expect.objectContaining({
+          security: expect.stringContaining('sts:AssumeRole'),
+        }),
+      }),
+    }));
+
+    // Verify security change count is reported
+    expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'diff',
+      level: 'result',
+      code: 'CDK_TOOLKIT_I4002',
+      data: expect.objectContaining({
+        numStacksWithSecurityChanges: 2,
+      }),
+    }));
+  });
+
   test('TemplateOnly diff method does not try to find changeSet', async () => {
     // WHEN
     const cx = await builderFixture(toolkit, 'stack-with-bucket');

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -2,6 +2,17 @@ import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as chalk from 'chalk';
 import { DiffFormatter } from '../../../lib/api/diff/diff-formatter';
 
+function stripAnsi(s: string): string {
+  return s.replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, '');
+}
+
+function expectLineAfter(output: string, marker: string, expected: string) {
+  const lines = stripAnsi(output).split('\n');
+  const idx = lines.findIndex(l => l.includes(marker));
+  expect(idx).toBeGreaterThanOrEqual(0);
+  expect(lines[idx + 1]).toContain(expected);
+}
+
 describe('formatStackDiff', () => {
   let mockNewTemplate: cxapi.CloudFormationStackArtifact;
 
@@ -115,8 +126,7 @@ describe('formatStackDiff', () => {
     );
   });
 
-  test('handles nested stack templates', () => {
-    // GIVEN
+  test('nested stacks without changes are not counted', () => {
     const nestedStacks = {
       NestedStack1: {
         deployedTemplate: {},
@@ -133,7 +143,6 @@ describe('formatStackDiff', () => {
       },
     };
 
-    // WHEN
     const formatter = new DiffFormatter({
       templateInfo: {
         oldTemplate: {},
@@ -143,11 +152,170 @@ describe('formatStackDiff', () => {
     });
     const result = formatter.formatStackDiff();
 
-    // THEN
-    expect(result.numStacksWithChanges).toBe(3);
+    // Only root stack has changes (Func resource), nested stacks have no diff
+    expect(result.numStacksWithChanges).toBe(1);
     expect(result.formattedDiff).toContain(`Stack ${chalk.bold('test-stack')}`);
     expect(result.formattedDiff).toContain(`Stack ${chalk.bold('nested-stack-1')}`);
     expect(result.formattedDiff).toContain(`Stack ${chalk.bold('nested-stack-2')}`);
+  });
+
+  test('nested stacks with changes are counted', () => {
+    const rootTemplate = {
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    let _template = rootTemplate;
+    const mockArtifact = {
+      get template() {
+        return _template;
+      },
+      set _template(v: any) {
+        _template = v;
+      },
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const nestedStacks = {
+      Nested: {
+        deployedTemplate: {
+          Resources: { Topic: { Type: 'AWS::SNS::Topic', Properties: { DisplayName: 'old' } } },
+        },
+        generatedTemplate: {
+          Resources: { Topic: { Type: 'AWS::SNS::Topic', Properties: { DisplayName: 'new' } } },
+        },
+        physicalName: 'nested-stack-1',
+        nestedStackTemplates: {
+          DeeplyNested: {
+            deployedTemplate: {
+              Resources: { Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'old-q' } } },
+            },
+            generatedTemplate: {
+              Resources: { Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'new-q' } } },
+            },
+            physicalName: 'nested-stack-2',
+            nestedStackTemplates: {},
+          },
+        },
+      },
+    };
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks,
+      },
+    });
+    const result = formatter.formatStackDiff();
+
+    expect(result.numStacksWithChanges).toBe(2);
+    expect(result.formattedDiff).toContain(`Stack ${chalk.bold('nested-stack-1')}`);
+    expect(result.formattedDiff).toContain('AWS::SNS::Topic');
+    expect(result.formattedDiff).toContain(`Stack ${chalk.bold('nested-stack-2')}`);
+    expect(result.formattedDiff).toContain('AWS::SQS::Queue');
+  });
+
+  test('passes per-nested-stack changeset to fullDiff', () => {
+    const nestedChangeSet = { Changes: [], $metadata: {} };
+
+    const rootTemplate = {
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    let _template = rootTemplate;
+    const mockArtifact = {
+      get template() {
+        return _template;
+      },
+      set _template(v: any) {
+        _template = v;
+      },
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const deployed = {
+      Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'old/path' } } },
+    };
+    const generated = {
+      Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'new/path' } } },
+    };
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks: {
+          Nested: {
+            deployedTemplate: deployed,
+            generatedTemplate: generated,
+            physicalName: 'nested-stack-1',
+            nestedStackTemplates: {},
+            changeSet: nestedChangeSet,
+          },
+        },
+      },
+    });
+    formatter.formatStackDiff();
+
+    const nestedDiff = formatter.diffs['nested-stack-1'];
+    expect(nestedDiff).toBeDefined();
+    expect(nestedDiff.differenceCount).toBe(0);
+  });
+
+  test('nested stack without changeset reports template-based differences', () => {
+    const rootTemplate = {
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    let _template = rootTemplate;
+    const mockArtifact = {
+      get template() {
+        return _template;
+      },
+      set _template(v: any) {
+        _template = v;
+      },
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const deployed = {
+      Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'old/path' } } },
+    };
+    const generated = {
+      Resources: { Res: { Type: 'AWS::SNS::Topic', Metadata: { 'aws:cdk:path': 'new/path' } } },
+    };
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks: {
+          Nested: {
+            deployedTemplate: deployed,
+            generatedTemplate: generated,
+            physicalName: 'nested-stack-1',
+            nestedStackTemplates: {},
+          },
+        },
+      },
+    });
+    formatter.formatStackDiff();
+
+    const nestedDiff = formatter.diffs['nested-stack-1'];
+    expect(nestedDiff).toBeDefined();
+    expect(nestedDiff.differenceCount).toBeGreaterThan(0);
   });
 });
 
@@ -227,6 +395,112 @@ describe('formatSecurityDiff', () => {
       '└───┴──────────┴──────────────────────────────────────────────────────────────────┘\n' +
       '(NOTE: There may be security-related changes not in this list. See https://github.com/aws/aws-cdk/issues/1299)',
     );
+  });
+
+  test('detects broadening security changes in nested stacks and counts correctly', () => {
+    const rootTemplate = {
+      Resources: {
+        Nested1: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+        Nested2: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    const mockArtifact = {
+      template: rootTemplate,
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const nestedIamTemplate = {
+      Resources: {
+        NestedRole: {
+          Type: 'AWS::IAM::Role',
+          Properties: {
+            AssumeRolePolicyDocument: {
+              Version: '2012-10-17',
+              Statement: [{
+                Effect: 'Allow',
+                Principal: { Service: 'ec2.amazonaws.com' },
+                Action: 'sts:AssumeRole',
+              }],
+            },
+          },
+        },
+      },
+    };
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks: {
+          Nested1: {
+            deployedTemplate: {},
+            generatedTemplate: nestedIamTemplate,
+            physicalName: 'nested-security-1',
+            nestedStackTemplates: {},
+          },
+          Nested2: {
+            deployedTemplate: {},
+            generatedTemplate: nestedIamTemplate,
+            physicalName: 'nested-security-2',
+            nestedStackTemplates: {},
+          },
+        },
+      },
+    });
+    const result = formatter.formatSecurityDiff();
+
+    expect(result.permissionChangeType).toEqual('broadening');
+    expect(result.numStacksWithChanges).toBe(2);
+    const sanitized = stripAnsi(result.formattedDiff);
+    expect(sanitized).toContain('sts:AssumeRole');
+    expect(sanitized).toContain('ec2.amazonaws.com');
+
+    // Root stack has no security changes — message should follow its header
+    expectLineAfter(result.formattedDiff, 'Stack root-stack', 'There were no security-related changes');
+
+    // Both nested stacks with IAM should be listed
+    expect(sanitized).toContain('Stack nested-security-1');
+    expect(sanitized).toContain('Stack nested-security-2');
+  });
+
+  test('stacks without security changes show no-changes message', () => {
+    const rootTemplate = {
+      Resources: {
+        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
+      },
+    };
+
+    const mockArtifact = {
+      template: rootTemplate,
+      templateFile: 'template.json',
+      stackName: 'root-stack',
+      findMetadataByType: () => [],
+    } as any;
+
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: rootTemplate,
+        newTemplate: mockArtifact,
+        nestedStacks: {
+          Nested: {
+            deployedTemplate: {},
+            generatedTemplate: { Resources: { Bucket: { Type: 'AWS::S3::Bucket' } } },
+            physicalName: 'no-security-stack',
+            nestedStackTemplates: {},
+          },
+        },
+      },
+    });
+    const result = formatter.formatSecurityDiff();
+
+    expect(result.permissionChangeType).toEqual('none');
+    expect(result.numStacksWithChanges).toBe(0);
+
+    // No-changes message should follow the nested stack header
+    expectLineAfter(result.formattedDiff, 'Stack no-security-stack', 'There were no security-related changes');
   });
 });
 
@@ -369,4 +643,3 @@ describe('mangled character filtering', () => {
     expect(sanitized).toContain('Omitted');
   });
 });
-

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -276,12 +276,12 @@ export class CdkToolkit {
       });
 
       if (options.securityOnly) {
-        const securityDiff = formatter.formatSecurityDiff();
+        const securityDiff = formatter.formatSecurityDiff({ quiet });
         // Warn, count, and display the diff only if the reported changes are broadening permissions
         if (securityDiff.permissionChangeType === PermissionChangeType.BROADENING) {
           await this.ioHost.asIoHelper().defaults.warn('This deployment will make potentially sensitive changes according to your current security approval level.\nPlease confirm you intend to make the following modifications:\n');
           await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
-          diffs += 1;
+          diffs += securityDiff.numStacksWithChanges;
         }
       } else {
         const diff = formatter.formatStackDiff({
@@ -335,12 +335,12 @@ export class CdkToolkit {
         });
 
         if (options.securityOnly) {
-          const securityDiff = formatter.formatSecurityDiff();
+          const securityDiff = formatter.formatSecurityDiff({ quiet });
           // Warn, count, and display the diff only if the reported changes are broadening permissions
           if (securityDiff.permissionChangeType === PermissionChangeType.BROADENING) {
             await this.ioHost.asIoHelper().defaults.warn('This deployment will make potentially sensitive changes according to your current security approval level.\nPlease confirm you intend to make the following modifications:\n');
             await this.ioHost.asIoHelper().defaults.info(securityDiff.formattedDiff);
-            diffs += 1;
+            diffs += securityDiff.numStacksWithChanges;
           }
         } else {
           const diff = formatter.formatStackDiff({

--- a/packages/aws-cdk/test/commands/diff.test.ts
+++ b/packages/aws-cdk/test/commands/diff.test.ts
@@ -1280,6 +1280,154 @@ Resources
     expect(plainTextOutput).not.toContain('Stack UnChangedChild');
     expect(exitCode).toBe(0);
   });
+
+  test('diff --security-only counts nested stacks with security changes', async () => {
+    // Override to return nested stacks with IAM
+    cloudFormation.readCurrentTemplateWithNestedStacks.mockImplementation(
+      (stackArtifact: CloudFormationStackArtifact) => {
+        stackArtifact.template.Resources = {
+          IamChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+          IamChild2: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+          NoSecChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+        };
+        return Promise.resolve({
+          deployedRootTemplate: {
+            Resources: {
+              IamChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+              IamChild2: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+              NoSecChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+            },
+          },
+          nestedStacks: {
+            IamChild: {
+              deployedTemplate: {},
+              generatedTemplate: {
+                Resources: {
+                  Role: {
+                    Type: 'AWS::IAM::Role',
+                    Properties: {
+                      AssumeRolePolicyDocument: {
+                        Statement: [{ Effect: 'Allow', Principal: { Service: 'lambda.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+                      },
+                    },
+                  },
+                },
+              },
+              physicalName: 'IamChild',
+              nestedStackTemplates: {},
+            },
+            IamChild2: {
+              deployedTemplate: {},
+              generatedTemplate: {
+                Resources: {
+                  Role: {
+                    Type: 'AWS::IAM::Role',
+                    Properties: {
+                      AssumeRolePolicyDocument: {
+                        Statement: [{ Effect: 'Allow', Principal: { Service: 'ec2.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+                      },
+                    },
+                  },
+                },
+              },
+              physicalName: 'IamChild2',
+              nestedStackTemplates: {},
+            },
+            NoSecChild: {
+              deployedTemplate: {},
+              generatedTemplate: {
+                Resources: { Topic: { Type: 'AWS::SNS::Topic' } },
+              },
+              physicalName: 'NoSecChild',
+              nestedStackTemplates: {},
+            },
+          },
+        });
+      },
+    );
+
+    // WHEN
+    const exitCode = await toolkit.diff({
+      stackNames: ['Parent'],
+      securityOnly: true,
+      method: 'template',
+    });
+
+    // THEN
+    const plainTextOutput = output();
+    expect(plainTextOutput).toContain('sts:AssumeRole');
+    expect(notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      message: expect.stringContaining('✨  Number of stacks with differences: 2'),
+    }));
+
+    // NoSecChild should show no-changes message
+    const lines = plainTextOutput.split('\n');
+    const noSecIdx = lines.findIndex(l => l.includes('Stack NoSecChild'));
+    expect(noSecIdx).toBeGreaterThanOrEqual(0);
+    expect(lines[noSecIdx + 1]).toContain('There were no security-related changes');
+
+    expect(exitCode).toBe(0);
+  });
+
+  test('diff --security-only --quiet suppresses stacks without security changes', async () => {
+    cloudFormation.readCurrentTemplateWithNestedStacks.mockImplementation(
+      (stackArtifact: CloudFormationStackArtifact) => {
+        stackArtifact.template.Resources = {
+          IamChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+          NoSecChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+        };
+        return Promise.resolve({
+          deployedRootTemplate: {
+            Resources: {
+              IamChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+              NoSecChild: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'url' } },
+            },
+          },
+          nestedStacks: {
+            IamChild: {
+              deployedTemplate: {},
+              generatedTemplate: {
+                Resources: {
+                  Role: {
+                    Type: 'AWS::IAM::Role',
+                    Properties: {
+                      AssumeRolePolicyDocument: {
+                        Statement: [{ Effect: 'Allow', Principal: { Service: 'lambda.amazonaws.com' }, Action: 'sts:AssumeRole' }],
+                      },
+                    },
+                  },
+                },
+              },
+              physicalName: 'IamChild',
+              nestedStackTemplates: {},
+            },
+            NoSecChild: {
+              deployedTemplate: {},
+              generatedTemplate: {
+                Resources: { Topic: { Type: 'AWS::SNS::Topic' } },
+              },
+              physicalName: 'NoSecChild',
+              nestedStackTemplates: {},
+            },
+          },
+        });
+      },
+    );
+
+    const exitCode = await toolkit.diff({
+      stackNames: ['Parent'],
+      securityOnly: true,
+      quiet: true,
+      method: 'template',
+    });
+
+    const plainTextOutput = output();
+    expect(plainTextOutput).toContain('sts:AssumeRole');
+    expect(plainTextOutput).not.toContain('Stack NoSecChild');
+    expect(plainTextOutput).not.toContain('There were no security-related changes');
+    expect(plainTextOutput).not.toContain('Stack Parent');
+    expect(exitCode).toBe(0);
+  });
 });
 
 describe('--strict', () => {


### PR DESCRIPTION
Fixes https://github.com/aws/aws-cdk/issues/30187

`cdk diff --security-only` now displays security changes in nested stacks. Previously only the root stack was evaluated, silently ignoring IAM and policy changes at deeper nesting levels.

Additionally:
- Stacks without security changes explicitly say so, linking to known limitations
- `--quiet` suppresses output for stacks without security changes
- `numStacksWithSecurityChanges` is exposed in `StackDiff` and `DiffResult` payloads

### Before 

<img width="462" height="69" alt="image" src="https://github.com/user-attachments/assets/7e10f56a-83da-4d5b-9fc8-d35735b43b9a" />

### After

with `--quiet`

<img width="1200" height="533" alt="image" src="https://github.com/user-attachments/assets/a705f0f6-b969-4fa2-ba20-4be0767cc9cf" />

without `--quiet`

<img width="1198" height="670" alt="image" src="https://github.com/user-attachments/assets/dbd466af-d438-4087-9845-2fe2b2584e5d" />


---

The core issue was that `formatSecurityDiff` never recursed into nested stacks, unlike `formatStackDiff` which already did. The old code also mutated `this.newTemplate._template` during nested stack iteration, making it impossible to share recursion logic between the two paths. The refactored `computeDiff()` takes explicit parameters, enabling both paths to recurse cleanly without side effects.

The `NestedStackTemplates` interface now carries an optional `changeSet` field so that per-nested-stack change set data from CloudFormation can be threaded through to `fullDiff`. `@aws-cdk/cloudformation-diff` is build quite lenient here: it will use a change set when provided, otherwise compare the templates directly. This is a forward-looking change to support a future PR; right now it's unused and nothing has changed.

The stack count (`Number of stacks with differences`) in `--security-only` mode previously hardcoded `+= 1` per root stack. It now uses the actual `numStacksWithChanges` returned by the recursive security diff, correctly reflecting how many stacks (including nested) have security-impacting changes.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
