### PR TITLE
fix(toolkit-lib): `REVIEW_IN_PROGRESS` stacks are failing `cdk diff` with change set

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-can-be-run-twice-on-a-new-stack.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-can-be-run-twice-on-a-new-stack.integtest.ts
@@ -1,0 +1,16 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'cdk diff --method=change-set can be run twice on a new stack',
+  withDefaultFixture(async (fixture) => {
+    const stackName = fixture.fullStackName('test-1');
+
+    // First diff creates a CREATE changeset, leaving the stack in REVIEW_IN_PROGRESS
+    const diff1 = await fixture.cdk(['diff', '--method=change-set', stackName]);
+    expect(diff1).toContain('AWS::SNS::Topic');
+
+    // Second diff should also succeed, not fail with "Stack does not exist" or UPDATE errors
+    const diff2 = await fixture.cdk(['diff', '--method=change-set', stackName]);
+    expect(diff2).toContain('AWS::SNS::Topic');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -248,7 +248,10 @@ async function uploadBodyParameterAndCreateChangeSet(
       env.resources,
     );
     const cfn = env.sdk.cloudFormation();
-    const exists = (await CloudFormationStack.lookup(cfn, options.stack.stackName, false)).exists;
+    const stack = await CloudFormationStack.lookup(cfn, options.stack.stackName, false);
+    // A stack in REVIEW_IN_PROGRESS was created by a previous CREATE changeset
+    // that was never executed. Treat it as non-existent for changeset purposes.
+    const exists = stack.exists && stack.stackStatus.name !== 'REVIEW_IN_PROGRESS';
 
     const executionRoleArn = await env.replacePlaceholders(options.stack.cloudFormationExecutionRoleArn);
     await ioHelper.defaults.info(


### PR DESCRIPTION
When `cdk diff --method=change-set` is run against a stack that doesn't exist yet, CloudFormation creates a `CREATE` changeset to compute the diff. A side effect of this is that the stack is left in `REVIEW_IN_PROGRESS` status — it exists in CloudFormation's view, but has never actually been deployed.

Running `cdk diff --method=change-set` a second time against the same stack would then fail, because the existing code detected the stack as "existing" and attempted to create an `UPDATE` changeset. CloudFormation rejects this because a stack in `REVIEW_IN_PROGRESS` cannot be updated — it was never fully created in the first place.

### Before

<img width="1413" height="178" alt="image" src="https://github.com/user-attachments/assets/a7ac2086-019b-433b-9641-95870d216815" />

(First diff piped to `/dev/null` to shorten output. The green ➜ indicates success.)

### After

<img width="914" height="37" alt="image" src="https://github.com/user-attachments/assets/475b831a-6d3f-454b-a49e-ae4c9a637594" />

(Output piped to `/dev/null` to shorten. The green ➜ indicates success.)

### The fix

The fix is straightforward: when determining whether a stack "exists" for the purpose of choosing between a `CREATE` or `UPDATE` changeset, stacks in `REVIEW_IN_PROGRESS` are now treated as non-existent. This means a fresh `CREATE` changeset is used, which is the correct behavior since the stack has no deployed resources.

This is a common scenario for users who iteratively run `cdk diff` while developing their stacks before the first deploy.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
