### PR TITLE
chore: use frozen lockfile for yarn install in codecov and integ workflows

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: lts/*
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --check-files --frozen-lockfile
       - name: Reset coverage thresholds
         run: find . -name "jest.config.json" -type f -exec chmod +w {} \; -exec node -e "const fs=require('fs'); const file=process.argv[1]; const data=JSON.parse(fs.readFileSync(file)); data.coverageThreshold={ }; fs.writeFileSync(file, JSON.stringify(data, null, 2));" {} \;
       - name: Build and test CLI

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -50,7 +50,7 @@ jobs:
           node-version: lts/*
           cache: npm
       - name: Install dependencies
-        run: yarn install --check-files
+        run: yarn install --check-files --frozen-lockfile
       - name: Bump to realistic versions
         env:
           TESTING_CANDIDATE: "true"

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -423,7 +423,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         },
         {
           name: 'Install dependencies',
-          run: 'yarn install --check-files',
+          run: repo.package.installCommand,
         },
         {
           name: 'Bump to realistic versions',

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -38,7 +38,7 @@ export class CodeCovWorkflow extends Component {
         },
         {
           name: 'Install dependencies',
-          run: 'yarn install',
+          run: repo.package.installCommand,
         },
         {
           name: 'Reset coverage thresholds',


### PR DESCRIPTION
The codecov and integ workflows were missing `--frozen-lockfile` on their `yarn install` steps. Without it, yarn can silently modify the lockfile during CI runs, which defeats the purpose of having a lockfile for reproducible builds.

Instead of hardcoding the corrected command string, this change uses `repo.package.installCommand` from projen's `NodePackage` API. This ensures the install command stays consistent with the rest of the projen-managed workflows and will automatically adapt if the package manager configuration ever changes.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
