### PR TITLE
fix(toolkit-lib): remove IncludeNestedStacks from deploy path

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -31,7 +31,7 @@ import { DeploymentError, DeploymentErrorCodes, ToolkitError } from '../../toolk
 import { formatErrorMessage } from '../../util';
 import type { SDK, SdkProvider, ICloudFormationClient } from '../aws-auth/private';
 import type { TemplateBodyParameter } from '../cloudformation';
-import { makeBodyParameter, CfnEvaluationException, CloudFormationStack, templateContainsNestedStacks } from '../cloudformation';
+import { makeBodyParameter, CfnEvaluationException, CloudFormationStack } from '../cloudformation';
 import type { EnvironmentResources, StringWithoutPlaceholders } from '../environment';
 import { EnvironmentResourcesRegistry } from '../environment';
 import { HotswapPropertyOverrides, ICON, createHotswapPropertyOverrides } from '../hotswap/common';
@@ -470,7 +470,6 @@ class FullCloudFormationDeployment {
       Description: `CDK Changeset for execution ${this.uuid}`,
       ClientToken: `create${this.uuid}`,
       ImportExistingResources: importExistingResources,
-      IncludeNestedStacks: templateContainsNestedStacks(this.stackArtifact.template),
       DeploymentMode: revertDrift ? 'REVERT_DRIFT' : undefined,
       ...this.commonPrepareOptions(),
     });


### PR DESCRIPTION
## Summary

- Reverts the deploy-path portion of #1292, which added `IncludeNestedStacks: true` to the `CreateChangeSet` API call during deployments
- When multiple nested stacks use intrinsic functions (e.g. `Fn::Join`) in their export names, CloudFormation cannot resolve these at changeset validation time and replaces them with identical placeholder strings (`{{IntrinsicFunction://Fn::Join}}`), causing a false "duplicate Export names" error
- The diff path retains `IncludeNestedStacks` as intended by the original feature

## Test

- [ ] Deploy a stack with nested stacks that use `Fn::Join` in export names — should no longer fail with duplicate export error
- [ ] `cdk diff` with nested stacks still uses changeset-based diff (diff path unchanged)
- [ ] Existing integration tests pass