### PR TITLE
fix(integ-runner): hangs in proxy environments due to missing proxy configuration

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -319,6 +319,7 @@ const repoProject = new yarn.Monorepo({
 
 repoProject.tryFindObjectFile(`${repoProject.name}.code-workspace`)?.patch(
   pj.JsonPatch.add('/settings/jest.jestCommandLine', 'npx jest'),
+  pj.JsonPatch.add('/settings/js~1ts.tsdk.path', '<root>/node_modules/typescript/lib'),
 );
 
 new AdcPublishing(repoProject);
@@ -1437,6 +1438,7 @@ const integRunner = configureProject(
       'chalk@^4',
       'fs-extra@^9',
       'yargs@^16',
+      'proxy-agent',
       '@aws-cdk/aws-service-spec',
       '@aws-sdk/client-cloudformation',
     ],

--- a/aws-cdk-cli.code-workspace
+++ b/aws-cdk-cli.code-workspace
@@ -49,6 +49,7 @@
     "files.exclude": {
       "packages": true
     },
-    "jest.jestCommandLine": "npx jest"
+    "jest.jestCommandLine": "npx jest",
+    "js/ts.tsdk.path": "<root>/node_modules/typescript/lib"
   }
 }

--- a/packages/@aws-cdk/integ-runner/.projen/deps.json
+++ b/packages/@aws-cdk/integ-runner/.projen/deps.json
@@ -183,6 +183,10 @@
       "type": "runtime"
     },
     {
+      "name": "proxy-agent",
+      "type": "runtime"
+    },
+    {
       "name": "workerpool",
       "version": "^6",
       "type": "runtime"

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -52,7 +52,7 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/fs-extra,@types/jest,@types/yargs,aws-cdk-lib,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,node-backpack,ts-jest,@aws-cdk/aws-service-spec,@aws-sdk/client-cloudformation"
+          "exec": "npx npm-check-updates@18 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/fs-extra,@types/jest,@types/yargs,aws-cdk-lib,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,node-backpack,ts-jest,@aws-cdk/aws-service-spec,@aws-sdk/client-cloudformation,proxy-agent"
         }
       ]
     },

--- a/packages/@aws-cdk/integ-runner/README.md
+++ b/packages/@aws-cdk/integ-runner/README.md
@@ -112,6 +112,12 @@ If not, changes cannot be compared across systems and the [update workflow](#upd
   Keep generated snapshots when differences exist in snapshot comparisons.
 - `--max-workers` (default=`16`)
   The max number of workerpool workers to use when running integration tests concurrently.
+- `--proxy`
+  Use the indicated proxy for all AWS API calls. If not specified, proxy settings are auto-detected
+  from `HTTPS_PROXY` / `HTTP_PROXY` environment variables.
+- `--ca-bundle-path`
+  Path to a PEM certificate bundle to use when validating HTTPS requests. If not specified,
+  reads from the `AWS_CA_BUNDLE` environment variable.
 
 Example:
 

--- a/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
@@ -20820,6 +20820,32 @@ Apache License
 
 ----------------
 
+** @tootallnate/quickjs-emscripten@0.23.0 - https://www.npmjs.com/package/@tootallnate/quickjs-emscripten/v/0.23.0 | MIT
+MIT License
+
+quickjs-emscripten copyright (c) 2019 Jake Teton-Landis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** abort-controller@3.0.0 - https://www.npmjs.com/package/abort-controller/v/3.0.0 | MIT
 MIT License
 
@@ -20843,6 +20869,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+
+----------------
+
+** agent-base@7.1.4 - https://www.npmjs.com/package/agent-base/v/7.1.4 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
@@ -20950,6 +21002,31 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** ast-types@0.13.4 - https://www.npmjs.com/package/ast-types/v/0.13.4 | MIT
+Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -21209,6 +21286,29 @@ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH RE
 ----------------
 
 ** balanced-match@1.0.2 - https://www.npmjs.com/package/balanced-match/v/1.0.2 | MIT
+
+----------------
+
+** basic-ftp@5.2.0 - https://www.npmjs.com/package/basic-ftp/v/5.2.0 | MIT
+Copyright (c) 2019 Patrick Juchli
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ----------------
 
@@ -21641,6 +21741,61 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** data-uri-to-buffer@6.0.2 - https://www.npmjs.com/package/data-uri-to-buffer/v/6.0.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** debug@4.4.3 - https://www.npmjs.com/package/debug/v/4.4.3 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2018-2021 Josh Junon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+and associated documentation files (the 'Software'), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
+** degenerator@5.0.1 - https://www.npmjs.com/package/degenerator/v/5.0.1 | MIT
+
+----------------
+
 ** emoji-regex@8.0.0 - https://www.npmjs.com/package/emoji-regex/v/8.0.0 | MIT
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -21676,6 +21831,106 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** escodegen@2.1.0 - https://www.npmjs.com/package/escodegen/v/2.1.0 | BSD-2-Clause
+Copyright (C) 2012 Yusuke Suzuki (twitter: @Constellation) and other contributors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------
+
+** esprima@4.0.1 - https://www.npmjs.com/package/esprima/v/4.0.1 | BSD-2-Clause
+Copyright JS Foundation and other contributors, https://js.foundation/
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------
+
+** estraverse@5.3.0 - https://www.npmjs.com/package/estraverse/v/5.3.0 | BSD-2-Clause
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+----------------
+
+** esutils@2.0.3 - https://www.npmjs.com/package/esutils/v/2.0.3 | BSD-2-Clause
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ----------------
@@ -22085,6 +22340,32 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ----------------
 
+** get-uri@6.0.5 - https://www.npmjs.com/package/get-uri/v/6.0.5 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
 ** glob-parent@5.1.2 - https://www.npmjs.com/package/glob-parent/v/5.1.2 | ISC
 The ISC License
 
@@ -22139,6 +22420,59 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** http-proxy-agent@7.0.2 - https://www.npmjs.com/package/http-proxy-agent/v/7.0.2 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** https-proxy-agent@7.0.6 - https://www.npmjs.com/package/https-proxy-agent/v/7.0.6 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
 ** inherits@2.0.4 - https://www.npmjs.com/package/inherits/v/2.0.4 | ISC
 The ISC License
 
@@ -22156,6 +22490,30 @@ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
 
+
+
+----------------
+
+** ip-address@10.1.0 - https://www.npmjs.com/package/ip-address/v/10.1.0 | MIT
+Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -22448,6 +22806,26 @@ terms above.
 
 ----------------
 
+** lru-cache@7.18.3 - https://www.npmjs.com/package/lru-cache/v/7.18.3 | ISC
+The ISC License
+
+Copyright (c) 2010-2023 Isaac Z. Schlueter and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
 ** merge2@1.4.1 - https://www.npmjs.com/package/merge2/v/1.4.1 | MIT
 The MIT License (MIT)
 
@@ -22546,6 +22924,14 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** ms@2.1.3 - https://www.npmjs.com/package/ms/v/2.1.3 | MIT
+
+----------------
+
+** netmask@2.0.2 - https://www.npmjs.com/package/netmask/v/2.0.2 | MIT
+
+----------------
+
 ** normalize-path@3.0.0 - https://www.npmjs.com/package/normalize-path/v/3.0.0 | MIT
 The MIT License (MIT)
 
@@ -22583,6 +22969,59 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+
+----------------
+
+** pac-proxy-agent@7.2.0 - https://www.npmjs.com/package/pac-proxy-agent/v/7.2.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** pac-resolver@7.0.1 - https://www.npmjs.com/package/pac-resolver/v/7.0.1 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
@@ -22665,6 +23104,57 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** proxy-agent@6.5.0 - https://www.npmjs.com/package/proxy-agent/v/6.5.0 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** proxy-from-env@1.1.0 - https://www.npmjs.com/package/proxy-from-env/v/1.1.0 | MIT
+The MIT License
+
+Copyright (C) 2016-2018 Rob Wu <rob@robwu.nl>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -23165,6 +23655,115 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** smart-buffer@4.2.0 - https://www.npmjs.com/package/smart-buffer/v/4.2.0 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Josh Glazebrook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** socks-proxy-agent@8.0.5 - https://www.npmjs.com/package/socks-proxy-agent/v/8.0.5 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Nathan Rajlich <nathan@tootallnate.net>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** socks@2.8.7 - https://www.npmjs.com/package/socks/v/2.8.7 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013 Josh Glazebrook
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** source-map@0.6.1 - https://www.npmjs.com/package/source-map/v/0.6.1 | BSD-3-Clause
+
+Copyright (c) 2009-2011, Mozilla Foundation and contributors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the names of the Mozilla Foundation nor the names of project
+  contributors may be used to endorse or promote products derived from this
+  software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ----------------

--- a/packages/@aws-cdk/integ-runner/lib/cli.ts
+++ b/packages/@aws-cdk/integ-runner/lib/cli.ts
@@ -52,6 +52,8 @@ export function parseCliArgs(args: string[] = []) {
     })
     .option('app', { type: 'string', default: undefined, desc: 'The custom CLI command that will be used to run the test files. You can include {filePath} to specify where in the command the test file path should be inserted. Example: --app="python3.8 {filePath}".' })
     .option('test-regex', { type: 'array', desc: 'Detect integration test files matching this JavaScript regex pattern. If used multiple times, all files matching any one of the patterns are detected.', default: [] })
+    .option('proxy', { type: 'string', desc: 'Use the indicated proxy. Will read from HTTPS_PROXY environment variable if not specified', requiresArg: true })
+    .option('ca-bundle-path', { type: 'string', desc: 'Path to CA certificate to use when validating HTTPS requests. Will read from AWS_CA_BUNDLE environment variable if not specified', requiresArg: true })
     .option('unstable', { type: 'array', desc: `Opt-in to using unstable features. By using these flags you acknowledge that scope and API of unstable features may change without notice. Specify multiple times for each unstable feature you want to opt-in to. ${availableFeaturesDescription()}`, nargs: 1, default: [] })
     .strict()
     .parse(args);
@@ -115,6 +117,8 @@ export function parseCliArgs(args: string[] = []) {
     watch: argv.watch as boolean,
     strict: argv.strict as boolean,
     unstable: arrayFromYargs(argv.unstable) ?? [],
+    proxy: argv.proxy as (string | undefined),
+    caBundlePath: argv['ca-bundle-path'] as (string | undefined),
   };
 }
 
@@ -194,6 +198,8 @@ async function run(options: ReturnType<typeof parseCliArgs>) {
         verbosity: options.verbosity,
         updateWorkflow: options.updateWorkflow,
         watch: options.watch,
+        proxy: options.proxy,
+        caBundlePath: options.caBundlePath,
       });
       testsSucceeded = success;
 
@@ -215,6 +221,8 @@ async function run(options: ReturnType<typeof parseCliArgs>) {
         ...testsToRun[0],
         profile: options.profiles ? options.profiles[0] : undefined,
         region: options.testRegions[0],
+        proxy: options.proxy,
+        caBundlePath: options.caBundlePath,
       });
     }
   } finally {

--- a/packages/@aws-cdk/integ-runner/lib/engines/proxy-agent.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/proxy-agent.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs-extra';
+import { ProxyAgent } from 'proxy-agent';
+
+/**
+ * Options for creating a proxy agent
+ */
+export interface ProxyAgentOptions {
+  /**
+   * Proxy address to use
+   *
+   * @default - ProxyAgent auto-detects from environment variables
+   */
+  readonly proxyAddress?: string;
+
+  /**
+   * A path to a certificate bundle that contains a cert to be trusted.
+   *
+   * @default - reads from AWS_CA_BUNDLE environment variable
+   */
+  readonly caBundlePath?: string;
+}
+
+/**
+ * Cached provider for proxy-aware HTTP agents.
+ *
+ * Reuses the same ProxyAgent instance for identical configurations
+ * to avoid creating multiple agents across engine instances.
+ */
+export class ProxyAgentProvider {
+  /**
+   * Get or create a ProxyAgent for the given options.
+   * Returns a cached instance if one already exists for the same configuration.
+   */
+  public static getOrCreate(options: ProxyAgentOptions = {}): ProxyAgent {
+    const key = JSON.stringify([options.proxyAddress, options.caBundlePath]);
+
+    const cached = ProxyAgentProvider.cache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const getProxyForUrl = options.proxyAddress != null
+      ? () => Promise.resolve(options.proxyAddress!)
+      : undefined;
+
+    const agent = new ProxyAgent({
+      ca: tryReadCaBundle(options.caBundlePath),
+      getProxyForUrl,
+    });
+
+    ProxyAgentProvider.cache.set(key, agent);
+    return agent;
+  }
+
+  /**
+   * Clear the cache. Intended for testing only.
+   */
+  public static clearCache(): void {
+    ProxyAgentProvider.cache.clear();
+  }
+
+  private static readonly cache = new Map<string, ProxyAgent>();
+}
+
+/**
+ * Try to read a CA bundle from the given path, or from the AWS_CA_BUNDLE environment variable.
+ */
+function tryReadCaBundle(bundlePath?: string): string | undefined {
+  const resolvedPath = bundlePath ?? process.env.AWS_CA_BUNDLE ?? process.env.aws_ca_bundle;
+  if (!resolvedPath) {
+    return undefined;
+  }
+  try {
+    return fs.readFileSync(resolvedPath, 'utf-8');
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -6,6 +6,7 @@ import { BaseCredentials, ExpandStackSelection, MemoryContext, NonInteractiveIoH
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import type { CxOptions, DeployOptions, DestroyOptions, ICdk, ListOptions, SynthOptions, WatchEvents, WatchOptions } from './cdk-interface';
+import { ProxyAgentProvider } from './proxy-agent';
 
 export interface ToolkitLibEngineOptions {
   /**
@@ -40,6 +41,40 @@ export interface ToolkitLibEngineOptions {
    * @default - no profile is passed, the default profile is used
    */
   readonly profile?: string;
+
+  /**
+   * Use the indicated proxy
+   *
+   * @default - no proxy, ProxyAgent auto-detects from environment variables
+   */
+  readonly proxy?: string;
+
+  /**
+   * Path to CA certificate to use when validating HTTPS requests
+   *
+   * @default - no additional CA bundle
+   */
+  readonly caBundlePath?: string;
+}
+
+/**
+ * Per-action options that can override the engine defaults.
+ */
+export interface ActionOptions {
+  /**
+   * The AWS profile to use
+   */
+  readonly profile?: string;
+
+  /**
+   * Use the indicated proxy
+   */
+  readonly proxy?: string;
+
+  /**
+   * Path to CA certificate to use when validating HTTPS requests
+   */
+  readonly caBundlePath?: string;
 }
 
 /**
@@ -50,6 +85,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
   private readonly options: ToolkitLibEngineOptions;
   private readonly showOutput: boolean;
   private readonly ioHost: IntegRunnerIoHost;
+  private readonly toolkitCache = new Map<string, Toolkit>();
 
   public constructor(options: ToolkitLibEngineOptions) {
     this.options = options;
@@ -59,7 +95,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
     // don't pass it to the toolkit.
     this.ioHost = new IntegRunnerIoHost();
 
-    this.toolkit = this.createToolkit(options.profile, options.region);
+    this.toolkit = this.getOrCreateToolkit();
 
     // @TODO - these options are currently available on the action calls
     // but toolkit-lib needs them at the constructor level.
@@ -69,9 +105,6 @@ export class ToolkitLibRunnerEngine implements ICdk {
     //  - assemblyFailureAt: options.strict ?? options.ignoreErrors
     // Logging
     //  - options.color
-    // SDK
-    //  - options.proxy
-    //  - options.caBundlePath
 
     // @TODO - similar to the above, but in toolkit-lib these options would go on the IoHost
     //  - options.trace
@@ -80,18 +113,36 @@ export class ToolkitLibRunnerEngine implements ICdk {
   }
 
   /**
-   * Creates a Toolkit instance with the given profile and region.
+   * Get or create a Toolkit instance for the given action options.
+   * Caches instances by their resolved configuration to avoid creating
+   * duplicate Toolkit instances for identical settings.
    */
-  private createToolkit(profile: string | undefined, region: string): Toolkit {
-    return new Toolkit({
+  private getOrCreateToolkit(actionOptions?: ActionOptions): Toolkit {
+    const profile = actionOptions?.profile ?? this.options.profile;
+    const proxy = actionOptions?.proxy ?? this.options.proxy;
+    const caBundlePath = actionOptions?.caBundlePath ?? this.options.caBundlePath;
+    const key = JSON.stringify([profile, proxy, caBundlePath]);
+
+    const cached = this.toolkitCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const toolkit = new Toolkit({
       ioHost: this.showOutput ? this.ioHost : new NoopIoHost(),
       sdkConfig: {
         baseCredentials: BaseCredentials.awsCliCompatible({
           profile,
-          defaultRegion: region,
+          defaultRegion: this.options.region,
         }),
+        httpOptions: {
+          agent: ProxyAgentProvider.getOrCreate({ proxyAddress: proxy, caBundlePath }),
+        },
       },
     });
+
+    this.toolkitCache.set(key, toolkit);
+    return toolkit;
   }
 
   /**
@@ -135,7 +186,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Lists the stacks in the CDK app
    */
   public async list(options: ListOptions): Promise<string[]> {
-    const toolkit = this.createToolkit(options.profile ?? this.options.profile, this.options.region);
+    const toolkit = this.getOrCreateToolkit(options);
     const cx = await this.cx(options);
     const stacks = await toolkit.list(cx, {
       stacks: this.stackSelector(options),
@@ -148,7 +199,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Deploys the CDK app
    */
   public async deploy(options: DeployOptions) {
-    const toolkit = this.createToolkit(options.profile ?? this.options.profile, this.options.region);
+    const toolkit = this.getOrCreateToolkit(options);
     const cx = await this.cx(options);
     await toolkit.deploy(cx, {
       roleArn: options.roleArn,
@@ -165,7 +216,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Watches the CDK app for changes and deploys them automatically
    */
   public async watch(options: WatchOptions, events?: WatchEvents) {
-    const toolkit = this.createToolkit(options.profile ?? this.options.profile, this.options.region);
+    const toolkit = this.getOrCreateToolkit(options);
     const cx = await this.cx(options);
     try {
       const watcher = await toolkit.watch(cx, {
@@ -194,7 +245,7 @@ export class ToolkitLibRunnerEngine implements ICdk {
    * Destroys the CDK app
    */
   public async destroy(options: DestroyOptions) {
-    const toolkit = this.createToolkit(options.profile ?? this.options.profile, this.options.region);
+    const toolkit = this.getOrCreateToolkit(options);
     const cx = await this.cx(options);
 
     await toolkit.destroy(cx, {

--- a/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
@@ -13,5 +13,7 @@ export function makeEngine(options: IntegRunnerOptions): ToolkitLibRunnerEngine 
     env: options.env,
     region: options.region,
     profile: options.profile,
+    proxy: options.proxy,
+    caBundlePath: options.caBundlePath,
   });
 }

--- a/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/runner-base.ts
@@ -67,6 +67,20 @@ export interface IntegRunnerOptions {
    * @default false
    */
   readonly showOutput?: boolean;
+
+  /**
+   * Use the indicated proxy
+   *
+   * @default - no proxy
+   */
+  readonly proxy?: string;
+
+  /**
+   * Path to CA certificate to use when validating HTTPS requests
+   *
+   * @default - no additional CA bundle
+   */
+  readonly caBundlePath?: string;
 }
 
 /**

--- a/packages/@aws-cdk/integ-runner/lib/workers/common.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/common.ts
@@ -168,6 +168,20 @@ export interface IntegTestOptions {
    * @default false
    */
   readonly watch?: boolean;
+
+  /**
+   * Use the indicated proxy
+   *
+   * @default - no proxy
+   */
+  readonly proxy?: string;
+
+  /**
+   * Path to CA certificate to use when validating HTTPS requests
+   *
+   * @default - no additional CA bundle
+   */
+  readonly caBundlePath?: string;
 }
 
 /**

--- a/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
@@ -31,6 +31,8 @@ export async function integTestWorker(request: IntegTestBatchRequest): Promise<I
         test,
         profile: request.profile,
         region: request.region,
+        proxy: request.proxy,
+        caBundlePath: request.caBundlePath,
         env: {
           CDK_DOCKER: process.env.CDK_DOCKER ?? 'docker',
         },
@@ -98,6 +100,8 @@ export async function watchTestWorker(options: IntegWatchOptions): Promise<void>
     test,
     profile: options.profile,
     region: options.region,
+    proxy: options.proxy,
+    caBundlePath: options.caBundlePath,
     env: {
       CDK_DOCKER: process.env.CDK_DOCKER ?? 'docker',
     },

--- a/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
@@ -136,6 +136,8 @@ export async function runIntegrationTestsInParallel(
         dryRun: options.dryRun,
         verbosity: options.verbosity,
         updateWorkflow: options.updateWorkflow,
+        proxy: options.proxy,
+        caBundlePath: options.caBundlePath,
       }], {
         on: printResults,
       });

--- a/packages/@aws-cdk/integ-runner/lib/workers/integ-watch-worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/integ-watch-worker.ts
@@ -6,6 +6,8 @@ export interface IntegWatchOptions extends IntegTestInfo {
   readonly region: string;
   readonly profile?: string;
   readonly verbosity?: number;
+  readonly proxy?: string;
+  readonly caBundlePath?: string;
 }
 export async function watchIntegrationTest(pool: workerpool.WorkerPool, options: IntegWatchOptions): Promise<void> {
   await pool.exec('watchTestWorker', [options], {

--- a/packages/@aws-cdk/integ-runner/package.json
+++ b/packages/@aws-cdk/integ-runner/package.json
@@ -77,6 +77,7 @@
     "chalk": "^4",
     "chokidar": "^4",
     "fs-extra": "^9",
+    "proxy-agent": "^6.5.0",
     "workerpool": "^6",
     "yargs": "^16"
   },

--- a/packages/@aws-cdk/integ-runner/test/cli.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/cli.test.ts
@@ -284,3 +284,36 @@ describe('CLI config file', () => {
     expect(options.maxWorkers).toBe(20);
   });
 });
+
+describe('Proxy options', () => {
+  test('--proxy is parsed', () => {
+    const options = parseCliArgs(['--proxy', 'http://my-proxy:8080']);
+    expect(options.proxy).toBe('http://my-proxy:8080');
+  });
+
+  test('--ca-bundle-path is parsed', () => {
+    const options = parseCliArgs(['--ca-bundle-path', '/path/to/ca.pem']);
+    expect(options.caBundlePath).toBe('/path/to/ca.pem');
+  });
+
+  test('proxy defaults to undefined', () => {
+    const options = parseCliArgs([]);
+    expect(options.proxy).toBeUndefined();
+  });
+
+  test('caBundlePath defaults to undefined', () => {
+    const options = parseCliArgs([]);
+    expect(options.caBundlePath).toBeUndefined();
+  });
+
+  test('proxy is read from config file', () => {
+    const configFile = 'integ.config.json';
+    fs.writeFileSync(configFile, JSON.stringify({ proxy: 'http://config-proxy:3128' }));
+    try {
+      const options = parseCliArgs([]);
+      expect(options.proxy).toBe('http://config-proxy:3128');
+    } finally {
+      fs.unlinkSync(configFile);
+    }
+  });
+});

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
@@ -1,8 +1,17 @@
 /* eslint-disable @typescript-eslint/unbound-method */
+import * as os from 'os';
+import * as path from 'path';
 import { Toolkit, BaseCredentials } from '@aws-cdk/toolkit-lib';
+import * as fs from 'fs-extra';
+import { ProxyAgentProvider } from '../../lib/engines/proxy-agent';
 import { ToolkitLibRunnerEngine } from '../../lib/engines/toolkit-lib';
 
 jest.mock('@aws-cdk/toolkit-lib');
+jest.mock('proxy-agent', () => ({
+  ProxyAgent: jest.fn().mockImplementation((opts: any) => ({
+    _proxyAgentOpts: opts,
+  })),
+}));
 
 const MockedToolkit = Toolkit as jest.MockedClass<typeof Toolkit>;
 const MockedBaseCredentials = BaseCredentials as jest.Mocked<typeof BaseCredentials>;
@@ -339,7 +348,7 @@ describe('ToolkitLibRunnerEngine', () => {
       });
     });
 
-    it('should create a new toolkit even when deploy profile matches constructor profile', async () => {
+    it('should reuse cached toolkit when deploy profile matches constructor profile', async () => {
       MockedBaseCredentials.awsCliCompatible = jest.fn();
 
       const sameProfileEngine = new ToolkitLibRunnerEngine({
@@ -359,8 +368,111 @@ describe('ToolkitLibRunnerEngine', () => {
         profile: 'same-profile',
       });
 
-      // A new Toolkit is always created for deploy, even when profile matches
-      expect(MockedToolkit).toHaveBeenCalledTimes(constructorCallCount + 1);
+      // Toolkit is reused from cache when profile matches
+      expect(MockedToolkit).toHaveBeenCalledTimes(constructorCallCount);
+    });
+  });
+
+  describe('proxy configuration', () => {
+    beforeEach(() => {
+      ProxyAgentProvider.clearCache();
+    });
+
+    it('should pass agent to Toolkit sdkConfig', () => {
+      new ToolkitLibRunnerEngine({
+        workingDirectory: '/test',
+        region: 'us-dummy-1',
+      });
+
+      expect(MockedToolkit).toHaveBeenCalledWith(expect.objectContaining({
+        sdkConfig: expect.objectContaining({
+          httpOptions: expect.objectContaining({
+            agent: expect.any(Object),
+          }),
+        }),
+      }));
+    });
+
+    it('should pass proxy address to ProxyAgentProvider', () => {
+      const spy = jest.spyOn(ProxyAgentProvider, 'getOrCreate');
+
+      new ToolkitLibRunnerEngine({
+        workingDirectory: '/test',
+        region: 'us-dummy-1',
+        proxy: 'http://my-proxy:8080',
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        proxyAddress: 'http://my-proxy:8080',
+        caBundlePath: undefined,
+      });
+    });
+
+    it('should pass caBundlePath to ProxyAgentProvider', () => {
+      const spy = jest.spyOn(ProxyAgentProvider, 'getOrCreate');
+
+      new ToolkitLibRunnerEngine({
+        workingDirectory: '/test',
+        region: 'us-dummy-1',
+        caBundlePath: '/path/to/ca.pem',
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        proxyAddress: undefined,
+        caBundlePath: '/path/to/ca.pem',
+      });
+    });
+
+    it('should reuse cached agent for identical options', () => {
+      const agent1 = ProxyAgentProvider.getOrCreate({ proxyAddress: 'http://proxy:8080' });
+      const agent2 = ProxyAgentProvider.getOrCreate({ proxyAddress: 'http://proxy:8080' });
+
+      expect(agent1).toBe(agent2);
+    });
+
+    it('should create different agents for different options', () => {
+      const agent1 = ProxyAgentProvider.getOrCreate({ proxyAddress: 'http://proxy1:8080' });
+      const agent2 = ProxyAgentProvider.getOrCreate({ proxyAddress: 'http://proxy2:8080' });
+
+      expect(agent1).not.toBe(agent2);
+    });
+
+    it('should read CA bundle from file', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'integ-test-'));
+      const caPath = path.join(tmpDir, 'ca-bundle.pem');
+      fs.writeFileSync(caPath, 'test-ca-cert');
+
+      try {
+        const agent = ProxyAgentProvider.getOrCreate({ caBundlePath: caPath }) as any;
+        expect(agent._proxyAgentOpts.ca).toBe('test-ca-cert');
+      } finally {
+        fs.removeSync(tmpDir);
+      }
+    });
+
+    it('should read CA bundle from AWS_CA_BUNDLE env var', () => {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'integ-test-'));
+      const caPath = path.join(tmpDir, 'env-ca-bundle.pem');
+      fs.writeFileSync(caPath, 'env-ca-cert');
+      const original = process.env.AWS_CA_BUNDLE;
+      process.env.AWS_CA_BUNDLE = caPath;
+
+      try {
+        const agent = ProxyAgentProvider.getOrCreate() as any;
+        expect(agent._proxyAgentOpts.ca).toBe('env-ca-cert');
+      } finally {
+        if (original === undefined) {
+          delete process.env.AWS_CA_BUNDLE;
+        } else {
+          process.env.AWS_CA_BUNDLE = original;
+        }
+        fs.removeSync(tmpDir);
+      }
+    });
+
+    it('should handle non-existent CA bundle path gracefully', () => {
+      const agent = ProxyAgentProvider.getOrCreate({ caBundlePath: '/nonexistent/ca-bundle.pem' }) as any;
+      expect(agent._proxyAgentOpts.ca).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Fixes #1305

`integ-runner` now supports `--proxy` and `--ca-bundle-path` CLI options to configure proxy settings for all AWS API calls. When no `--proxy` flag is given, proxy settings are auto-detected from `HTTPS_PROXY`/`HTTP_PROXY` environment variables. The `--ca-bundle-path` option reads a PEM certificate bundle, falling back to the `AWS_CA_BUNDLE` environment variable. Both options can also be set via `integ.config.json`.

Previously, `ToolkitLibRunnerEngine` did not pass proxy or CA bundle options to the `Toolkit` constructor's `sdkConfig`. The AWS SDK v3's `NodeHttpHandler` creates its own `https.Agent` which bypasses proxy environment variables, so a proxy-aware agent must be explicitly provided. This became a regression when the toolkit-lib engine became the default in #906 and the old CLI engine was removed in #1108. The old engine spawned `cdk` as a child process which handled proxy settings internally. The new engine runs in-process but never wired up the proxy configuration.

The fix uses `proxy-agent` (the same library as the CDK CLI) to create proxy-aware agents that are passed as `sdkConfig.httpOptions.agent` to the Toolkit constructor. Both `ProxyAgent` and `Toolkit` instances are cached by their resolved configuration to avoid creating duplicates across engine instances. Per-action options from `DefaultCdkOptions` can override the engine defaults through a dedicated `ActionOptions` interface.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
