### PR TITLE
refactor: use projen primitives for custom workflow definitions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -17,10 +17,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - name: Set up Node
-        uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          package-manager-cache: false
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Reset coverage thresholds

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -45,16 +45,16 @@ jobs:
           git remote add upstream https://github.com/aws/aws-cdk-cli.git
           git fetch upstream 'refs/tags/*:refs/tags/*'
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
-          cache: npm
+          package-manager-cache: false
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Bump to realistic versions
         env:
           TESTING_CANDIDATE: "true"
-        run: yarn workspaces run bump
+        run: npx projen run bump
       - name: build
         env:
           RELEASE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1046,9 +1046,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          package-manager-cache: false
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Download build artifacts
@@ -1069,7 +1071,7 @@ jobs:
         env:
           PUBLISHING_ROLE_ARN: ${{ vars.PUBLISHING_ROLE_ARN }}
           TARGET_BUCKETS: ${{ vars.TARGET_BUCKETS }}
-        run: npx tsx projenrc/publish-to-adc.task.ts
+        run: npx projen publish-to-adc
   record_timestamp:
     name: "aws-cdk: Record publishing timestamp"
     needs: release

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -126,6 +126,14 @@
       "name": "post-upgrade",
       "description": "Runs after upgrading dependencies"
     },
+    "publish-to-adc": {
+      "name": "publish-to-adc",
+      "steps": [
+        {
+          "exec": "tsx projenrc/publish-to-adc.task.ts"
+        }
+      ]
+    },
     "release": {
       "name": "release",
       "description": "Prepare a release from all monorepo packages",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "git-secrets-scan": "npx projen git-secrets-scan",
     "package": "npx projen package",
     "post-upgrade": "npx projen post-upgrade",
+    "publish-to-adc": "npx projen publish-to-adc",
     "release": "npx projen release",
     "run": "npx projen run",
     "test": "npx projen test",

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -12,6 +12,10 @@ export class AdcPublishing extends Component {
       this.project.tasks.tryFind(taskName)?.exec('tsx projenrc/build-standalone-zip.task.ts');
     }
 
+    const publishToAdcTask = this.project_.tasks.tryFind('publish-to-adc') ?? this.project_.addTask('publish-to-adc', {
+      exec: 'tsx projenrc/publish-to-adc.task.ts',
+    });
+
     const releaseWf = this.project_.github?.tryFindWorkflow('release');
     if (!releaseWf) {
       throw new Error('Could not find release workflow');
@@ -40,16 +44,7 @@ export class AdcPublishing extends Component {
       if: '${{ needs.release.outputs.latest_commit == github.sha }}',
       steps: [
         github.WorkflowSteps.checkout(),
-        {
-          uses: 'actions/setup-node@v4',
-          with: {
-            'node-version': 'lts/*',
-          },
-        },
-        {
-          name: 'Install dependencies',
-          run: 'yarn install --check-files --frozen-lockfile',
-        },
+        ...this.project_.renderWorkflowSetup(),
         {
           name: 'Download build artifacts',
           uses: 'actions/download-artifact@v4',
@@ -76,7 +71,7 @@ export class AdcPublishing extends Component {
             PUBLISHING_ROLE_ARN: '${{ vars.PUBLISHING_ROLE_ARN }}',
             TARGET_BUCKETS: '${{ vars.TARGET_BUCKETS }}',
           },
-          run: 'npx tsx projenrc/publish-to-adc.task.ts',
+          run: this.project_.runTaskCommand(publishToAdcTask),
         },
       ],
     });

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -239,8 +239,11 @@ export class CdkCliIntegTestsWorkflow extends Component {
   private readonly JOB_PREPARE = 'prepare';
   private readonly maxWorkersArg: string = '';
 
+  public readonly project: javascript.NodeProject;
+
   constructor(repo: javascript.NodeProject, private readonly props: CdkCliIntegTestsWorkflowProps) {
     super(repo);
+    this.project = repo;
 
     const buildWorkflow = repo.buildWorkflow;
     this.workflow = repo.github?.addWorkflow('integ')!;
@@ -413,28 +416,17 @@ export class CdkCliIntegTestsWorkflow extends Component {
             'git fetch upstream \'refs/tags/*:refs/tags/*\'',
           ].join('\n'),
         },
-        {
-          name: 'Setup Node.js',
-          uses: 'actions/setup-node@v4',
-          with: {
-            'node-version': 'lts/*',
-            'cache': 'npm',
-          },
-        },
-        {
-          name: 'Install dependencies',
-          run: repo.package.installCommand,
-        },
+        ...this.project.renderWorkflowSetup(),
         {
           name: 'Bump to realistic versions',
-          run: 'yarn workspaces run bump',
+          run: `${this.project.runTaskCommand(this.project.tasks.tryFind('run')!)} bump`,
           env: {
             TESTING_CANDIDATE: 'true',
           },
         },
         {
           name: 'build',
-          run: 'npx projen build',
+          run: this.project.runTaskCommand(this.project.buildTask),
           env: {
             // This is necessary to prevent projen from resetting the version numbers to
             // 0.0.0 during its synthesis.

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -29,17 +29,7 @@ export class CodeCovWorkflow extends Component {
       if: props.restrictToRepos.map(r => `github.repository == '${r}'`).join(' || '),
       steps: [
         github.WorkflowSteps.checkout(),
-        {
-          name: 'Set up Node',
-          uses: 'actions/setup-node@v4',
-          with: {
-            'node-version': 'lts/*',
-          },
-        },
-        {
-          name: 'Install dependencies',
-          run: repo.package.installCommand,
-        },
+        ...repo.renderWorkflowSetup(),
         {
           name: 'Reset coverage thresholds',
           run: 'find . -name "jest.config.json" -type f -exec chmod +w {} \\; -exec node -e "const fs=require(\'fs\'); const file=process.argv[1]; const data=JSON.parse(fs.readFileSync(file)); data.coverageThreshold={ }; fs.writeFileSync(file, JSON.stringify(data, null, 2));" {} \\;',


### PR DESCRIPTION
The custom GitHub workflow definitions in `projenrc/` hardcode Node.js setup steps and shell commands like `yarn workspaces run bump` or `npx tsx projenrc/publish-to-adc.task.ts`. This means that whenever the project's package manager or tooling changes (e.g. migrating from Yarn Classic to Berry), every custom workflow needs to be manually updated to match. Meanwhile, projen-managed workflows already handle this automatically through `renderWorkflowSetup()` and `runTaskCommand()`.

This refactoring replaces the manual step definitions with projen primitives across all three custom workflow files. In `adc-publishing.ts`, the hardcoded `setup-node` and `yarn install` steps are replaced with `renderWorkflowSetup()`, and the direct `npx tsx` invocation is wrapped in a proper `publish-to-adc` projen task that is then called via `runTaskCommand()`. In `cdk-cli-integ-tests.ts`, the same setup replacement is applied, and the hardcoded `yarn workspaces run bump` and `npx projen build` commands are replaced with their `runTaskCommand()` equivalents. In `codecov.ts`, the manual setup steps are similarly replaced with `renderWorkflowSetup()`.

The regenerated workflow YAML files reflect these changes: `actions/setup-node` is updated from v4 to v6, the `package-manager-cache` setting is now explicitly configured, and all task invocations go through `npx projen` instead of direct tool calls. These are all consequences of using the projen primitives rather than manual changes.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
