### PR TITLE
fix: unnecessary 1-second delay on non-EC2 workstations

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -116,12 +116,13 @@ export class AwsCliCompatible {
      */
 
     // Skip the IMDS credential provider if we're not on EC2, to avoid a
-    // 1-2 second timeout on non-EC2 machines. The SDK's remoteProvider
-    // already respects AWS_EC2_METADATA_DISABLED.
-    if (!isEc2Instance() && process.env.AWS_EC2_METADATA_DISABLED === undefined) {
+    // 1-2 second timeout on non-EC2 machines.
+    if (process.env.AWS_EC2_METADATA_DISABLED === undefined && !isEc2Instance()) {
       process.env.AWS_EC2_METADATA_DISABLED = 'true';
     }
 
+    // This chain respects the AWS_EC2_METADATA_DISABLED envvar, which can otherwise
+    // not be easily disabled using a property.
     const nodeProviderChain = fromNodeProviderChain({
       profile: envProfile,
       clientConfig,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/awscli-compatible.ts
@@ -5,6 +5,7 @@ import { createCredentialChain, fromEnv, fromIni, fromNodeProviderChain } from '
 import { MetadataService } from '@aws-sdk/ec2-metadata-service';
 import { loadSharedConfigFiles } from '@smithy/shared-ini-file-loader';
 import type { RequestHandlerSettings } from './base-credentials';
+import { isEc2Instance } from './ec2-detection';
 import { makeCachingProvider } from './provider-caching';
 import type { ISdkLogger } from './sdk-logger';
 import { AuthenticationError } from '../../toolkit/toolkit-error';
@@ -113,6 +114,14 @@ export class AwsCliCompatible {
      *
      * The NodeProviderChain is already cached.
      */
+
+    // Skip the IMDS credential provider if we're not on EC2, to avoid a
+    // 1-2 second timeout on non-EC2 machines. The SDK's remoteProvider
+    // already respects AWS_EC2_METADATA_DISABLED.
+    if (!isEc2Instance() && process.env.AWS_EC2_METADATA_DISABLED === undefined) {
+      process.env.AWS_EC2_METADATA_DISABLED = 'true';
+    }
+
     const nodeProviderChain = fromNodeProviderChain({
       profile: envProfile,
       clientConfig,
@@ -172,6 +181,10 @@ export class AwsCliCompatible {
    * @returns The region for the instance identity
    */
   private async regionFromMetadataService() {
+    if (!isEc2Instance()) {
+      return undefined;
+    }
+
     await this.ioHelper.defaults.debug('Looking up AWS region in the EC2 Instance Metadata Service (IMDS).');
     try {
       const metadataService = new MetadataService({

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/ec2-detection.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/ec2-detection.ts
@@ -24,11 +24,6 @@ export function isEc2Instance(): boolean {
 }
 
 function detectEc2(): boolean {
-  // If the user has explicitly told us about IMDS, respect that
-  if (process.env.AWS_EC2_METADATA_DISABLED !== undefined) {
-    return process.env.AWS_EC2_METADATA_DISABLED === 'false';
-  }
-
   const os = platform();
   try {
     if (os === 'linux') {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/ec2-detection.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/ec2-detection.ts
@@ -1,0 +1,87 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { platform } from 'node:os';
+
+/**
+ * Detect whether we are running on an EC2 instance by inspecting local system
+ * metadata. This avoids the 1-2 second IMDS timeout on non-EC2 machines.
+ *
+ * Detection methods per platform (per AWS docs
+ * https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/identify_ec2_instances.html):
+ * - Linux: check DMI board_asset_tag for an EC2 instance ID, or hypervisor UUID for "ec2" prefix
+ * - Windows: check DMI board_asset_tag via registry
+ * - macOS and other platforms: assumed not EC2
+ *
+ * The result is cached for the lifetime of the process.
+ */
+let cachedIsEc2: boolean | undefined;
+export function isEc2Instance(): boolean {
+  if (cachedIsEc2 !== undefined) {
+    return cachedIsEc2;
+  }
+  cachedIsEc2 = detectEc2();
+  return cachedIsEc2;
+}
+
+function detectEc2(): boolean {
+  // If the user has explicitly told us about IMDS, respect that
+  if (process.env.AWS_EC2_METADATA_DISABLED !== undefined) {
+    return process.env.AWS_EC2_METADATA_DISABLED === 'false';
+  }
+
+  const os = platform();
+  try {
+    if (os === 'linux') {
+      return detectEc2Linux();
+    }
+    if (os === 'win32') {
+      return detectEc2Windows();
+    }
+    // macOS and other platforms: not EC2
+    // (EC2 Mac instances run on dedicated Mac minis with a Linux-based Nitro
+    // hypervisor, but the guest OS sees itself as darwin. In practice these are
+    // extremely rare for CDK CLI usage. If needed, this can be extended.)
+    return false;
+  } catch {
+    // If detection fails, assume EC2. This makes us slightly slower but nothing
+    // will unexpectedly break.
+    return true;
+  }
+}
+
+function detectEc2Linux(): boolean {
+  // Nitro instances expose the instance ID as the board asset tag
+  const boardAssetTag = '/sys/devices/virtual/dmi/id/board_asset_tag';
+  if (existsSync(boardAssetTag)) {
+    const tag = readFileSync(boardAssetTag, 'utf-8').trim();
+    if (tag.startsWith('i-')) {
+      return true;
+    }
+  }
+
+  // Xen (PV) instances expose a UUID starting with "ec2" via the hypervisor
+  const hypervisorUuid = '/sys/hypervisor/uuid';
+  if (existsSync(hypervisorUuid)) {
+    const uuid = readFileSync(hypervisorUuid, 'utf-8').trim().toLowerCase();
+    if (uuid.startsWith('ec2')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function detectEc2Windows(): boolean {
+  // On Windows EC2 instances the board asset tag is an instance ID, readable
+  // from the registry without elevated privileges.
+  const tag = execSync(
+    'reg query "HKLM\\SYSTEM\\HardwareConfig\\Current" /v BaseBoardAssetTag 2>nul',
+    { encoding: 'utf-8', timeout: 500 },
+  ).trim();
+  // Output contains "BaseBoardAssetTag    REG_SZ    i-0abc..."
+  if (/i-[0-9a-f]+/i.test(tag)) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Because we query IMDS for credentials on every startup, which has a 1-second timeout to fail to connect to `169.254.169.254`, we incur a 1 second delay on regular workstations.

Do a check to see whether we are on an EC2 instance, and if not disable the IMDS lookup.

Fixes #627.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
