### PR TITLE
chore: make builds faster by using NX build cache in workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ name: build
 on:
   pull_request: {}
   workflow_dispatch: {}
+  push:
+    branches:
+      - main
   merge_group: {}
 jobs:
   build:
@@ -14,13 +17,20 @@ jobs:
       self_mutation_happened: ${{ steps.self_mutation.outputs.self_mutation_happened }}
     env:
       CI: "true"
-      NX_SKIP_NX_CACHE: "true"
+      NX_SKIP_NX_CACHE: ${{ github.ref == 'refs/heads/main' || github.event_name == 'merge_group' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Restore NX cache
+        if: ${{ !(github.ref == 'refs/heads/main' || github.event_name == 'merge_group') }}
+        uses: actions/cache/restore@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ github.sha }}
+          restore-keys: nx-
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js
@@ -56,3 +66,9 @@ jobs:
           echo "::error::Files were changed during build (see build log). If this was triggered from a fork, you will need to update your branch."
           cat repo.patch
           exit 1
+      - name: Save NX cache
+        if: ${{ !(github.event_name == 'merge_group') && always() }}
+        uses: actions/cache/save@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ github.sha }}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -13,10 +13,19 @@ jobs:
     runs-on: aws-cdk_ubuntu-latest_4-core
     permissions:
       id-token: write
+    env:
+      NX_SKIP_NX_CACHE: ${{ github.ref == 'refs/heads/main' || github.event_name == 'merge_group' }}
     if: github.repository == 'aws/aws-cdk-cli'
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - name: Restore NX cache
+        if: ${{ !(github.ref == 'refs/heads/main' || github.event_name == 'merge_group') }}
+        uses: actions/cache/restore@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ github.sha }}
+          restore-keys: nx-
       - name: Enable corepack
         run: corepack enable
       - name: Setup Node.js

--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -33,6 +33,7 @@ jobs:
       DEBUG: "true"
       TESTING_CDK: "1"
       NO_UNIT_TESTS: "1"
+      NX_SKIP_NX_CACHE: ${{ github.ref == 'refs/heads/main' || github.event_name == 'merge_group' }}
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
       - name: Checkout
@@ -40,6 +41,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Restore NX cache
+        if: ${{ !(github.ref == 'refs/heads/main' || github.event_name == 'merge_group') }}
+        uses: actions/cache/restore@v5
+        with:
+          path: .nx/cache
+          key: nx-${{ github.sha }}
+          restore-keys: nx-
       - name: Fetch tags from origin repo
         run: |-
           git remote add upstream https://github.com/aws/aws-cdk-cli.git

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -12,6 +12,7 @@ import { IssueLabeler } from './projenrc/issue-labeler';
 import { IssueRegressionLabeler } from './projenrc/issue-regression-labeler';
 import { JsiiBuild } from './projenrc/jsii';
 import { LargePrChecker } from './projenrc/large-pr-checker';
+import { NX_CACHE_ENV, nxCacheSteps } from './projenrc/nx-cache';
 import { PrLabeler } from './projenrc/pr-labeler';
 import { RecordPublishingTimestamp } from './projenrc/record-publishing-timestamp';
 import { DocType, S3DocsPublishing } from './projenrc/s3-docs-publishing';
@@ -336,6 +337,17 @@ const repoProject = new yarn.Monorepo({
     ],
   },
 });
+
+// NX Cache: run the build workflow on main to seed the cache for PR builds.
+repoProject.github?.tryFindWorkflow('build')?.on({ push: { branches: ['main'] } });
+
+// NX Cache: the build workflow's NX_SKIP_NX_CACHE is hardcoded by cdklabs-projen-project-types.
+// Patch it to be conditional and add cache restore/save steps.
+repoProject.github?.tryFindWorkflow('build')?.file?.patch(
+  pj.JsonPatch.replace('/jobs/build/env/NX_SKIP_NX_CACHE', NX_CACHE_ENV.NX_SKIP_NX_CACHE),
+  pj.JsonPatch.add('/jobs/build/steps/1', nxCacheSteps()[0]),
+  pj.JsonPatch.add('/jobs/build/steps/-', nxCacheSteps()[1]),
+);
 
 repoProject.tryFindObjectFile(`${repoProject.name}.code-workspace`)?.patch(
   pj.JsonPatch.add('/settings/jest.jestCommandLine', 'npx jest'),

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -1,6 +1,7 @@
 import { yarn } from 'cdklabs-projen-project-types';
 import type { javascript, Project } from 'projen';
 import { Component, github, TextFile } from 'projen';
+import { NX_CACHE_ENV, nxCacheRestoreStep } from './nx-cache';
 
 /**
  * Amends the test task with special provisions for unit testing.
@@ -388,6 +389,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         DEBUG: 'true',
         TESTING_CDK: '1',
         NO_UNIT_TESTS: '1',
+        ...NX_CACHE_ENV,
       },
       // Don't run again on the merge queue, we already got confirmation that it works and the
       // tests are quite expensive.
@@ -403,6 +405,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
             repository: '${{ github.event.pull_request.head.repo.full_name }}',
           },
         },
+        nxCacheRestoreStep(),
         // We used to fetch tags from the repo using 'checkout', but if it's a fork
         // the tags won't be there, so we have to fetch them from upstream.
         //

--- a/projenrc/codecov.ts
+++ b/projenrc/codecov.ts
@@ -1,6 +1,7 @@
 import { Component, github } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 import type { TypeScriptProject } from 'projen/lib/typescript';
+import { NX_CACHE_ENV, nxCacheRestoreStep } from './nx-cache';
 
 export interface CodeCovWorkflowProps {
   readonly restrictToRepos: string[];
@@ -27,8 +28,10 @@ export class CodeCovWorkflow extends Component {
       runsOn: ['aws-cdk_ubuntu-latest_4-core'],
       permissions: { idToken: JobPermission.WRITE },
       if: props.restrictToRepos.map(r => `github.repository == '${r}'`).join(' || '),
+      env: NX_CACHE_ENV,
       steps: [
         github.WorkflowSteps.checkout(),
+        nxCacheRestoreStep(),
         ...repo.renderWorkflowSetup(),
         {
           name: 'Reset coverage thresholds',

--- a/projenrc/nx-cache.ts
+++ b/projenrc/nx-cache.ts
@@ -1,0 +1,37 @@
+import type { github } from 'projen';
+
+const IS_MERGE_QUEUE = "github.event_name == 'merge_group'";
+const IS_MAIN_OR_MERGE_QUEUE = "github.ref == 'refs/heads/main' || github.event_name == 'merge_group'";
+
+export const NX_CACHE_ENV = {
+  NX_SKIP_NX_CACHE: `\${{ ${IS_MAIN_OR_MERGE_QUEUE} }}`,
+};
+
+export function nxCacheSteps(): github.workflows.JobStep[] {
+  return [nxCacheRestoreStep(), nxCacheSaveStep()];
+}
+
+export function nxCacheRestoreStep(): github.workflows.JobStep {
+  return {
+    name: 'Restore NX cache',
+    if: `\${{ !(${IS_MAIN_OR_MERGE_QUEUE}) }}`,
+    uses: 'actions/cache/restore@v5',
+    with: {
+      'path': '.nx/cache',
+      'key': 'nx-${{ github.sha }}',
+      'restore-keys': 'nx-',
+    },
+  };
+}
+
+function nxCacheSaveStep(): github.workflows.JobStep {
+  return {
+    name: 'Save NX cache',
+    if: `\${{ !(${IS_MERGE_QUEUE}) && always() }}`,
+    uses: 'actions/cache/save@v5',
+    with: {
+      path: '.nx/cache',
+      key: 'nx-${{ github.sha }}',
+    },
+  };
+}


### PR DESCRIPTION
The NX cache was previously always skipped in CI (`NX_SKIP_NX_CACHE: true`), meaning every workflow run rebuilt everything from scratch. This adds `actions/cache@v5` to persist the `.nx/cache` directory across runs for the build, integ, and codecov workflows.

To ensure correctness, the cache is never used on the `main` branch or during merge queue builds. On those runs, `NX_SKIP_NX_CACHE` evaluates to `true` and the cache action is skipped entirely. On pull request builds, the cache is restored from a previous run and saved with the current commit SHA as key.

The shared cache configuration lives in `projenrc/nx-cache.ts` and is used by the codecov and integ workflow projen components directly. For the build workflow, a `JsonPatch` is necessary because `NX_SKIP_NX_CACHE` is hardcoded by `cdklabs-projen-project-types`.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
