### PR TITLE
chore: fix broken integ tests after yarn berry migration

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -57,6 +57,8 @@ jobs:
         env:
           TESTING_CANDIDATE: "true"
         run: yarn projen run bump
+      - name: Update lockfile after version bump
+        run: yarn install --immutable-cache
       - name: build
         env:
           RELEASE: "true"

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -425,6 +425,10 @@ export class CdkCliIntegTestsWorkflow extends Component {
           },
         },
         {
+          name: 'Update lockfile after version bump',
+          run: 'yarn install --immutable-cache',
+        },
+        {
           name: 'build',
           run: this.project.runTaskCommand(this.project.buildTask),
           env: {


### PR DESCRIPTION
Since the Yarn Berry migration, the integ test workflow fails during the build step because the version bump changes workspace package versions, which invalidates the `yarn.lock` file. The initial `yarn install --immutable` correctly ensures a clean lockfile on checkout, but after `yarn projen run bump` modifies the workspace versions, the lockfile is now out of date and subsequent operations fail.

This adds a `yarn install --immutable-cache` step between the bump and build steps. The `--immutable-cache` flag allows the lockfile to be rewritten to reflect the new workspace resolutions, while still preventing any new packages from being downloaded from the npm registry. This gives us the safety guarantee we want (no surprise dependency changes) while accommodating the version bump.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
