### PR TITLE
fix(cli): stray quotes in deploy confirmation prompt

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -582,7 +582,7 @@ export class CdkToolkit {
           try {
             await askUserConfirmation(
               this.ioHost,
-              IO.CDK_TOOLKIT_I5060.req(`${motivation}: 'Do you wish to deploy these changes'`, {
+              IO.CDK_TOOLKIT_I5060.req(`${motivation}: Do you wish to deploy these changes?`, {
                 motivation,
                 concurrency,
                 permissionChangeType: securityDiff.permissionChangeType,


### PR DESCRIPTION
The deploy confirmation prompt displayed stray single quotes around the question text and was missing a question mark. This made the prompt look like a code artifact rather than a proper user-facing question.

## Before
`(--require-approval broadening): 'Do you wish to deploy these changes'`

<img width="2150" height="506" alt="image" src="https://github.com/user-attachments/assets/929ad63a-0c43-4782-9e31-a6ad1c7aa907" />


## After
`(--require-approval broadening): Do you wish to deploy these changes?`

<img width="750" height="49" alt="image" src="https://github.com/user-attachments/assets/a81bf656-728b-48d0-9ca6-35afbb9ad4ac" />


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
