### PR TITLE
feat(cli): show diff and prompt for deploy on non-addition changes

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -6,7 +6,6 @@ import type { ResourceIdentifierSummary, ResourceToImport } from '@aws-sdk/clien
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import type { DeploymentMethod } from '../../actions/deploy';
-import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { Deployments } from '../deployments';
 import { assertIsSuccessfulDeployStackResult } from '../deployments';
 import { IO, type IoHelper } from '../io/private';
@@ -238,15 +237,9 @@ export class ResourceImporter {
     const nonAdditions = resourceChanges.filter(([_, dif]) => !dif.isAddition);
     const additions = resourceChanges.filter(([_, dif]) => dif.isAddition);
 
-    if (nonAdditions.length) {
+    if (nonAdditions.length && allowNonAdditions) {
       const offendingResources = nonAdditions.map(([logId, _]) => this.describeResource(logId));
-
-      if (allowNonAdditions) {
-        await this.ioHelper.defaults.warn(`Ignoring updated/deleted resources (--force): ${offendingResources.join(', ')}`);
-      } else {
-        throw new ToolkitError('ImportNonAdditionChanges', 'No resource updates or deletes are allowed on import operation. Make sure to resolve pending changes ' +
-          `to existing resources, before attempting an import. Updated/deleted resources: ${offendingResources.join(', ')} (--force to override)`);
-      }
+      await this.ioHelper.defaults.warn(`Ignoring updated/deleted resources (--force): ${offendingResources.join(', ')}`);
     }
 
     // Resources in the new template, that are not present in the current template, are a potential import candidates
@@ -257,6 +250,8 @@ export class ResourceImporter {
         resourceDefinition: addDefaultDeletionPolicy(this.stack.template?.Resources?.[logicalId] ?? {}),
       })),
       hasNonAdditions: nonAdditions.length > 0,
+      nonAdditionNames: nonAdditions.map(([logId, _]) => this.describeResource(logId)),
+      diff,
     };
   }
 
@@ -505,6 +500,8 @@ function addDefaultDeletionPolicy(resource: any): any {
 export interface DiscoverImportableResourcesResult {
   readonly additions: ImportableResource[];
   readonly hasNonAdditions: boolean;
+  readonly nonAdditionNames: string[];
+  readonly diff: cfnDiff.TemplateDiff;
 }
 
 export function removeNonImportResources(stack:cxapi.CloudFormationStackArtifact) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -6,6 +6,7 @@ import type { ResourceIdentifierSummary, ResourceToImport } from '@aws-sdk/clien
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import type { DeploymentMethod } from '../../actions/deploy';
+import { DiffFormatter } from '../diff';
 import type { Deployments } from '../deployments';
 import { assertIsSuccessfulDeployStackResult } from '../deployments';
 import { IO, type IoHelper } from '../io/private';
@@ -251,7 +252,12 @@ export class ResourceImporter {
       })),
       hasNonAdditions: nonAdditions.length > 0,
       nonAdditionNames: nonAdditions.map(([logId, _]) => this.describeResource(logId)),
-      diff,
+      diffFormatter: new DiffFormatter({
+        templateInfo: {
+          oldTemplate: currentTemplate,
+          newTemplate: this.stack,
+        },
+      }),
     };
   }
 
@@ -501,7 +507,7 @@ export interface DiscoverImportableResourcesResult {
   readonly additions: ImportableResource[];
   readonly hasNonAdditions: boolean;
   readonly nonAdditionNames: string[];
-  readonly diff: cfnDiff.TemplateDiff;
+  readonly diffFormatter: DiffFormatter;
 }
 
 export function removeNonImportResources(stack:cxapi.CloudFormationStackArtifact) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -6,9 +6,9 @@ import type { ResourceIdentifierSummary, ResourceToImport } from '@aws-sdk/clien
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import type { DeploymentMethod } from '../../actions/deploy';
-import { DiffFormatter } from '../diff';
 import type { Deployments } from '../deployments';
 import { assertIsSuccessfulDeployStackResult } from '../deployments';
+import { DiffFormatter } from '../diff';
 import { IO, type IoHelper } from '../io/private';
 import type { Tag } from '../tags';
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
@@ -94,7 +94,7 @@ test('discovers importable resources', async () => {
   ]);
 });
 
-test('by default, its an error if there are non-addition changes in the template', async () => {
+test('non-addition changes are reported but do not throw', async () => {
   givenCurrentStack(STACK_WITH_QUEUE.stackName, {
     Resources: {
       SomethingThatDisappeared: {
@@ -104,10 +104,12 @@ test('by default, its an error if there are non-addition changes in the template
   });
 
   const importer = new ResourceImporter(STACK_WITH_QUEUE, props);
-  await expect(importer.discoverImportableResources()).rejects.toThrow(/No resource updates or deletes/);
-
-  // But the error can be silenced
-  await expect(importer.discoverImportableResources(true)).resolves.toBeTruthy();
+  const result = await importer.discoverImportableResources();
+  expect(result.hasNonAdditions).toBe(true);
+  expect(result.nonAdditionNames).toContain('SomethingThatDisappeared');
+  expect(result.additions).toEqual([
+    expect.objectContaining({ logicalId: 'MyQueue' }),
+  ]);
 });
 
 test('asks human for resource identifiers', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
@@ -110,6 +110,7 @@ test('non-addition changes are reported but do not throw', async () => {
   expect(result.additions).toEqual([
     expect.objectContaining({ logicalId: 'MyQueue' }),
   ]);
+  expect(result.diffFormatter).toBeDefined();
 });
 
 test('asks human for resource identifiers', async () => {

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import { format } from 'util';
 import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
-import { formatDifferences } from '@aws-cdk/cloudformation-diff';
 import type { ConfirmationRequest, DeploymentMethod, PublishAssetsOptions, ToolkitAction, ToolkitOptions } from '@aws-cdk/toolkit-lib';
 import { PermissionChangeType, Toolkit, ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
@@ -1004,24 +1003,15 @@ export class CdkToolkit {
       deployments: this.props.deployments,
       ioHelper: asIoHelper(this.ioHost, 'import'),
     });
-    const { additions, hasNonAdditions, diff } = await resourceImporter.discoverImportableResources(options.force);
+    const { additions, hasNonAdditions, diffFormatter } = await resourceImporter.discoverImportableResources(options.force);
 
     // If there are non-addition changes (e.g. after orphan, hardcoded refs differ from Fn::GetAtt),
     // warn the user and ask for confirmation unless --force was given.
     if (hasNonAdditions && !options.force) {
       const ioHelper = this.ioHost.asIoHelper();
-      await ioHelper.defaults.info(
-        `The following resources have pending updates that will be reconciled with a ${chalk.blueBright('cdk deploy')} after import:`,
-      );
-      const stream = new (await import('stream')).PassThrough();
-      let diffOutput = '';
-      stream.on('data', (chunk: Buffer) => {
-        diffOutput += chunk.toString();
-      });
-      formatDifferences(stream, diff);
-      stream.end();
-      await ioHelper.defaults.info(diffOutput);
-      const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('Perform import?', { motivation: 'Import will proceed with drift remaining' }));
+      const { formattedDiff } = diffFormatter.formatStackDiff();
+      await ioHelper.defaults.info(formattedDiff);
+      const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('Perform import?', { motivation: 'Confirm import with pending drift' }));
       if (!confirmed) {
         await ioHelper.defaults.info('Import cancelled.');
         return;
@@ -1076,14 +1066,14 @@ export class CdkToolkit {
       );
     } else if (hasNonAdditions) {
       // After orphan→import, the deployed template still has hardcoded values that differ from
-      // the synth'd template's Fn::GetAtt/Ref intrinsics. A deploy reconciles this drift.
+      // the synth'd template's Fn::GetAtt/Ref intrinsics. A deploy updates the template to match the CDK app.
       if (options.force) {
         await this.ioHost.asIoHelper().defaults.info(
-          `Import complete. Run a ${chalk.blueBright('cdk deploy')} to reconcile any remaining drift.`,
+          `Import complete. Run ${chalk.blueBright('cdk deploy')} to update the stack to match your CDK app.`,
         );
       } else {
         const deployNow = await this.ioHost.asIoHelper().requestResponse(
-          IO.CDK_TOOLKIT_I7010.req(`Finish with a ${chalk.blueBright('cdk deploy')} now?`, { motivation: 'Reconcile remaining drift after import' }),
+          IO.CDK_TOOLKIT_I7010.req(`Finish with a ${chalk.blueBright('cdk deploy')} now?`, { motivation: 'Update stack to match CDK app after import' }),
         );
         if (deployNow) {
           await this.deploy({
@@ -1094,7 +1084,7 @@ export class CdkToolkit {
           });
         } else {
           await this.ioHost.asIoHelper().defaults.info(
-            `Import complete. Remember to run ${chalk.blueBright('cdk deploy')} to reconcile remaining drift.`,
+            `Import complete. Remember to run ${chalk.blueBright('cdk deploy')} to update the stack to match your CDK app.`,
           );
         }
       }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1015,7 +1015,9 @@ export class CdkToolkit {
       );
       const stream = new (await import('stream')).PassThrough();
       let diffOutput = '';
-      stream.on('data', (chunk: Buffer) => { diffOutput += chunk.toString(); });
+      stream.on('data', (chunk: Buffer) => {
+        diffOutput += chunk.toString();
+      });
       formatDifferences(stream, diff);
       stream.end();
       await ioHelper.defaults.info(diffOutput);

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1009,6 +1009,9 @@ export class CdkToolkit {
     // warn the user and ask for confirmation unless --force was given.
     if (hasNonAdditions && !options.force) {
       const ioHelper = this.ioHost.asIoHelper();
+      await ioHelper.defaults.info(
+        `The following resources have pending updates that will be reconciled with a ${chalk.blueBright('cdk deploy')} after import:`,
+      );
       const { formattedDiff } = diffFormatter.formatStackDiff();
       await ioHelper.defaults.info(formattedDiff);
       const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('Perform import?', { motivation: 'Confirm import with pending drift' }));

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { format } from 'util';
 import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
+import { formatDifferences } from '@aws-cdk/cloudformation-diff';
 import type { ConfirmationRequest, DeploymentMethod, PublishAssetsOptions, ToolkitAction, ToolkitOptions } from '@aws-cdk/toolkit-lib';
 import { PermissionChangeType, Toolkit, ToolkitError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
@@ -1003,7 +1004,28 @@ export class CdkToolkit {
       deployments: this.props.deployments,
       ioHelper: asIoHelper(this.ioHost, 'import'),
     });
-    const { additions, hasNonAdditions } = await resourceImporter.discoverImportableResources(options.force);
+    const { additions, hasNonAdditions, diff } = await resourceImporter.discoverImportableResources(options.force);
+
+    // If there are non-addition changes (e.g. after orphan, hardcoded refs differ from Fn::GetAtt),
+    // warn the user and ask for confirmation unless --force was given.
+    if (hasNonAdditions && !options.force) {
+      const ioHelper = this.ioHost.asIoHelper();
+      await ioHelper.defaults.info(
+        `The following resources have pending updates that will be reconciled with a ${chalk.blueBright('cdk deploy')} after import:`,
+      );
+      const stream = new (await import('stream')).PassThrough();
+      let diffOutput = '';
+      stream.on('data', (chunk: Buffer) => { diffOutput += chunk.toString(); });
+      formatDifferences(stream, diff);
+      stream.end();
+      await ioHelper.defaults.info(diffOutput);
+      const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('Perform import?', { motivation: 'Import will proceed with drift remaining' }));
+      if (!confirmed) {
+        await ioHelper.defaults.info('Import cancelled.');
+        return;
+      }
+    }
+
     if (additions.length === 0) {
       await this.ioHost.asIoHelper().defaults.warn(
         '%s: no new resources compared to the currently deployed stack, skipping import.',
@@ -1046,22 +1068,41 @@ export class CdkToolkit {
     });
 
     // Notify user of next steps
-    await this.ioHost.asIoHelper().defaults.info(
-      `Import operation complete. We recommend you run a ${chalk.blueBright('drift detection')} operation ` +
-      'to confirm your CDK app resource definitions are up-to-date. Read more here: ' +
-      chalk.underline.blueBright(
-        'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/detect-drift-stack.html',
-      ),
-    );
     if (actualImport.importResources.length < additions.length) {
-      await this.ioHost.asIoHelper().defaults.info('');
       await this.ioHost.asIoHelper().defaults.warn(
         `Some resources were skipped. Run another ${chalk.blueBright('cdk import')} or a ${chalk.blueBright('cdk deploy')} to bring the stack up-to-date with your CDK app definition.`,
       );
     } else if (hasNonAdditions) {
-      await this.ioHost.asIoHelper().defaults.info('');
-      await this.ioHost.asIoHelper().defaults.warn(
-        `Your app has pending updates or deletes excluded from this import operation. Run a ${chalk.blueBright('cdk deploy')} to bring the stack up-to-date with your CDK app definition.`,
+      // After orphan→import, the deployed template still has hardcoded values that differ from
+      // the synth'd template's Fn::GetAtt/Ref intrinsics. A deploy reconciles this drift.
+      if (options.force) {
+        await this.ioHost.asIoHelper().defaults.info(
+          `Import complete. Run a ${chalk.blueBright('cdk deploy')} to reconcile any remaining drift.`,
+        );
+      } else {
+        const deployNow = await this.ioHost.asIoHelper().requestResponse(
+          IO.CDK_TOOLKIT_I7010.req(`Finish with a ${chalk.blueBright('cdk deploy')} now?`, { motivation: 'Reconcile remaining drift after import' }),
+        );
+        if (deployNow) {
+          await this.deploy({
+            selector: options.selector,
+            toolkitStackName: options.toolkitStackName,
+            roleArn: options.roleArn,
+            deploymentMethod: options.deploymentMethod,
+          });
+        } else {
+          await this.ioHost.asIoHelper().defaults.info(
+            `Import complete. Remember to run ${chalk.blueBright('cdk deploy')} to reconcile remaining drift.`,
+          );
+        }
+      }
+    } else {
+      await this.ioHost.asIoHelper().defaults.info(
+        `Import operation complete. We recommend you run a ${chalk.blueBright('drift detection')} operation ` +
+        'to confirm your CDK app resource definitions are up-to-date. Read more here: ' +
+        chalk.underline.blueBright(
+          'https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/detect-drift-stack.html',
+        ),
       );
     }
   }


### PR DESCRIPTION
Currently, `cdk import` throws an error when it detects non-addition changes (updates/deletes) to existing resources, requiring `--force` to override. This is a poor experience for the `orphan → import` migration workflow, where hardcoded string literals in the deployed template naturally differ from the `Fn::GetAtt`/`Ref` intrinsics in the synth'd template.

Changes:
- `cdk import` no longer throws on non-addition changes. Instead it shows the projected diff and prompts the user to confirm.
- After a successful import with non-addition changes, prompts "*Finish with a cdk deploy now?*" to reconcile remaining drift.
- `--force` still works, skips the prompt and prints a reminder to deploy.

User-facing flow (e.g. `Table` v1 → `TableV2` migration):
1. `cdk orphan --path MyStack/MyTable` : detaches table, hardcodes refs
2. Edit code: `Table` → `TableV2`
3. `cdk import` : shows diff of hardcoded → intrinsic ref changes, asks to confirm, imports, then offers to deploy

No `--force` required. No manual `cdk deploy` step to remember.

Backwards compatible: If there are no non-addition changes, behavior is identical to before.

### Checklist
- [x] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
