### PR TITLE
chore: upgrade-aws-cdk-lib workflow fails with `command not found: projen`

### DIFF
--- a/.github/workflows/upgrade-aws-cdk-lib_aws-cdk.yml
+++ b/.github/workflows/upgrade-aws-cdk-lib_aws-cdk.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --immutable
       - name: Upgrade dependencies
-        run: yarn projen upgrade-aws-cdk-lib
+        run: yarn run upgrade-aws-cdk-lib
         working-directory: ./packages/aws-cdk
       - name: Find mutations
         id: create_patch

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1774,6 +1774,17 @@ repoProject.github?.tryFindWorkflow('pull-request-lint')?.file?.patch(
   ].filter(s => s && !disallowed.has(s)).sort().join('\n')),
 );
 
+// Fix: `yarn projen upgrade-aws-cdk-lib` fails in sub-packages because the
+// `projen` binary is hoisted to the root node_modules/.bin and not available
+// on PATH when running from a workspace sub-directory. Use `yarn run` instead,
+// which properly resolves package scripts through Yarn's workspace resolution.
+repoProject.github?.tryFindWorkflow('upgrade-aws-cdk-lib_aws-cdk')?.file?.patch(
+  pj.JsonPatch.replace(
+    '/jobs/upgrade/steps/4/run',
+    'yarn run upgrade-aws-cdk-lib',
+  ),
+);
+
 // enforce same node types everywhere
 [repo, ...repo.subprojects].forEach(p => p.addDevDeps('@types/node@^20'));
 


### PR DESCRIPTION
The `upgrade-aws-cdk-lib_aws-cdk` workflow fails with `command not found: projen` (exit code 127).

This pr is an extension of #1368 , which added `projen` as a devDependency to all workspace packages. This does not resolve the issue because `nodeLinker: node-modules` still hoists the binary to the root.

### Fix
Patch the generated workflow to use `yarn run upgrade-aws-cdk-lib`, which resolves the script through Yarn's script execution context where PATH is correctly configured.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version: N/A