### PR TITLE
fix(cli-integ): exclude regions where stack refactoring is not supported

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/regions.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/regions.ts
@@ -33,7 +33,7 @@ const ALL_REGIONS = [
   'ca-west-1',
   'mx-central-1',
 
-  // currently experiencing service distruptions.
+  // currently experiencing service disruptions.
   // 'me-central-1',
   // 'me-south-1',
 ];
@@ -41,3 +41,12 @@ const ALL_REGIONS = [
 export function allBut(exclude: string[]): string[] {
   return Array.from(new Set(ALL_REGIONS.filter((r) => !exclude.includes(r))));
 }
+
+/**
+ * Regions that support CloudFormation Stack Refactoring
+ */
+export const STACK_REFACTORING_REGIONS = allBut([
+  'ap-southeast-5',
+  'ap-southeast-7',
+  'mx-central-1',
+]);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-detect-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-detect-changes.integtest.ts
@@ -1,4 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - dry run - detects refactoring changes and prints the result',
@@ -24,7 +25,7 @@ integTest(
 
     expect(stdErr).toContain('The following resources were moved or renamed:');
     expect(removeColor(stdErr)).toMatch(/│ AWS::SQS::Queue │ .*\/OldName\/Resource │ .*\/NewName\/Resource │/);
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );
 
 function removeColor(str: string): string {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-filter-by-patterns.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-filter-by-patterns.integtest.ts
@@ -1,4 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - dry run - filters stacks by pattern',
@@ -29,5 +30,5 @@ integTest(
 
     const numberOfEnvironments = (stdErr.match(/Resource Type/g) || []).length;
     expect(numberOfEnvironments).toEqual(1);
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-no-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-dry-run-no-changes.integtest.ts
@@ -1,4 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - dry-run - no refactoring changes detected',
@@ -19,5 +20,5 @@ integTest(
     });
 
     expect(stdErr).toContain('Nothing to refactor');
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-large-template.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-large-template.integtest.ts
@@ -1,4 +1,5 @@
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - handles large templates by uploading to S3',
@@ -24,5 +25,5 @@ integTest(
     // CloudFormation may complete the refactoring, while the stack is still in the "UPDATE_IN_PROGRESS" state.
     // Give it a couple of seconds to finish the update.
     await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-move-same-to-different-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-move-same-to-different-stacks.integtest.ts
@@ -1,5 +1,6 @@
 import { DescribeStackResourcesCommand, ListStacksCommand, type StackResource } from '@aws-sdk/client-cloudformation';
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - moves a referenced resource to a different stack',
@@ -46,7 +47,7 @@ integTest(
     // CloudFormation may complete the refactoring, while the stack is still in the "UPDATE_IN_PROGRESS" state.
     // Give it a couple of seconds to finish the update.
     await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );
 
 interface StackInfo {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-no-ambiguities-execution.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-no-ambiguities-execution.integtest.ts
@@ -1,5 +1,6 @@
 import { DescribeStackResourcesCommand, type StackResource } from '@aws-sdk/client-cloudformation';
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - detects refactoring changes and executes the refactor',
@@ -42,7 +43,7 @@ integTest(
     // CloudFormation may complete the refactoring, while the stack is still in the "UPDATE_IN_PROGRESS" state.
     // Give it a couple of seconds to finish the update.
     await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );
 
 export function getStackNameFromArn(stackArn: string): string {

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-with-ambiguities-execution.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/refactor/cdk-refactor-with-ambiguities-execution.integtest.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import type { StackResource } from '@aws-sdk/client-cloudformation';
 import { DescribeStackResourcesCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withSpecificFixture } from '../../../lib';
+import { STACK_REFACTORING_REGIONS } from '../../../lib/regions';
 
 integTest(
   'cdk refactor - detects refactoring changes and executes the refactor, overriding ambiguities',
@@ -68,7 +69,7 @@ integTest(
     // CloudFormation may complete the refactoring, while the stack is still in the "UPDATE_IN_PROGRESS" state.
     // Give it a couple of seconds to finish the update.
     await new Promise((resolve) => setTimeout(resolve, 2000));
-  }),
+  }, { aws: { regions: STACK_REFACTORING_REGIONS } }),
 );
 
 interface StackInfo {


### PR DESCRIPTION
CloudFormation stack refactoring is not available in all AWS regions. The refactor integration tests were failing in regions where `CreateStackRefactor` is not supported (e.g. `mx-central-1`).

This adds a shared `STACK_REFACTORING_REGIONS` constant to `regions.ts` that excludes unsupported regions, and applies it to all 7 refactor integration tests — both `--force` and `--dry-run` variants, since both code paths call the `CreateStackRefactor` API.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
