### PR TITLE
fix(toolkit-lib): improve error message for resources with same path but different content

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/context.ts
@@ -200,12 +200,12 @@ function resourceMoves(
   if (!(ignoreModifications || isomorphic(digestsBefore, digestsAfter))) {
     const message = ['A refactor operation cannot add, remove or update resources. Only resource moves and renames are allowed.'];
 
-    const difference = (a: Record<string, ResourceLocation[]>, b: Record<string, ResourceLocation[]>) => {
-      return Array.from(setDiff(new Set(Object.keys(a)), new Set(Object.keys(b)))).flatMap(k => a[k]!)
-        .map(x => `  - ${x.toPath()}`)
-        .sort()
-        .join('\n');
+    const locationsForDigests = (a: Record<string, ResourceLocation[]>, b: Record<string, ResourceLocation[]>) => {
+      return Array.from(setDiff(new Set(Object.keys(a)), new Set(Object.keys(b)))).flatMap(k => a[k]!);
     };
+
+    const formatList = (locs: ResourceLocation[], icon: string) =>
+      locs.map(x => `  [${icon}] ${x.toPath()}`).sort().join('\n');
 
     const stackNames = (stacks: CloudFormationStack[]) =>
       stacks.length === 0
@@ -215,8 +215,16 @@ function resourceMoves(
           .sort()
           .join(', ');
 
-    const onlyDeployed = difference(digestsBefore, digestsAfter);
-    const onlyLocal = difference(digestsAfter, digestsBefore);
+    const onlyDeployedLocs = locationsForDigests(digestsBefore, digestsAfter);
+    const onlyLocalLocs = locationsForDigests(digestsAfter, digestsBefore);
+
+    const onlyDeployedPaths = new Set(onlyDeployedLocs.map(l => l.toPath()));
+    const onlyLocalPaths = new Set(onlyLocalLocs.map(l => l.toPath()));
+    const differentPaths = new Set(Array.from(onlyDeployedPaths).filter(p => onlyLocalPaths.has(p)));
+
+    const onlyDeployed = formatList(onlyDeployedLocs.filter(l => !differentPaths.has(l.toPath())), '-');
+    const onlyLocal = formatList(onlyLocalLocs.filter(l => !differentPaths.has(l.toPath())), '+');
+    const different = formatList([...onlyDeployedLocs, ...onlyLocalLocs].filter(l => differentPaths.has(l.toPath())), '~');
 
     if (onlyDeployed.length > 0) {
       message.push(`The following resources are present only in the AWS environment:\n${onlyDeployed}`);
@@ -224,6 +232,10 @@ function resourceMoves(
 
     if (onlyLocal.length > 0) {
       message.push(`\nThe following resources are present only in your CDK application:\n${onlyLocal}`);
+    }
+
+    if (different.length > 0) {
+      message.push(`\nThe following resources are different in your CDK application and the AWS environment:\n${different}`);
     }
 
     message.push('');

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/context.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/context.test.ts
@@ -513,6 +513,80 @@ describe('typed mappings', () => {
     ]);
   });
 
+  test('resource update error message lists updated resources separately', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'old value' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'new value' },
+          },
+        },
+      },
+    };
+
+    expect(() => new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    })).toThrow(/The following resources are different in your CDK application and the AWS environment:\n {2}\[~] Foo\.Bucket1/);
+  });
+
+  test('resource update error message does not list updated resources as only-deployed or only-local', () => {
+    const stack1 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'old value' },
+          },
+        },
+      },
+    };
+
+    const stack2 = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: {
+            Type: 'AWS::S3::Bucket',
+            Properties: { Prop: 'new value' },
+          },
+        },
+      },
+    };
+
+    expect(() => new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    })).not.toThrow(/present only in the AWS environment/);
+
+    expect(() => new RefactoringContext({
+      environment,
+      deployedStacks: [stack1],
+      localStacks: [stack2],
+    })).not.toThrow(/present only in your CDK application/);
+  });
+
   test('combines addition, deletion, update, and rename', () => {
     const stack1 = {
       environment,
@@ -561,6 +635,43 @@ describe('typed mappings', () => {
       deployedStacks: [stack1],
       localStacks: [stack2],
     })).toThrow(/A refactor operation cannot add, remove or update resources/);
+  });
+
+  test('error message separates updated, only-deployed, and only-local resources', () => {
+    // Bucket1: updated (same path, different content)
+    // Bucket2: only deployed (removed locally)
+    // Bucket3: only local (added locally)
+    const deployed = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: { Type: 'AWS::S3::Bucket', Properties: { Prop: 'old' } },
+          Bucket2: { Type: 'AWS::S3::Bucket', Properties: { Prop: 'deployed-only' } },
+        },
+      },
+    };
+
+    const local = {
+      environment,
+      stackName: 'Foo',
+      template: {
+        Resources: {
+          Bucket1: { Type: 'AWS::S3::Bucket', Properties: { Prop: 'new' } },
+          Bucket3: { Type: 'AWS::S3::Bucket', Properties: { Prop: 'local-only' } },
+        },
+      },
+    };
+
+    const thrower = () => new RefactoringContext({
+      environment,
+      deployedStacks: [deployed],
+      localStacks: [local],
+    });
+
+    expect(thrower).toThrow(/present only in the AWS environment:\n {2}\[-] Foo\.Bucket2/);
+    expect(thrower).toThrow(/present only in your CDK application:\n {2}\[\+] Foo\.Bucket3/);
+    expect(thrower).toThrow(/different in your CDK application and the AWS environment:\n {2}\[~] Foo\.Bucket1/);
   });
 });
 


### PR DESCRIPTION
When a refactor operation fails due to resource mismatches, the error message now distinguishes between three categories:

- Resources present only in the AWS environment (removed locally)
- Resources present only in the CDK application (added locally)
- Resources that exist at the same path in both but have different content (updated locally)

Previously, updated resources would appear in both the "only deployed" and "only local" lists, which was misleading. They are now reported under a dedicated "different resources" section.

Also adds tests covering the new error message category.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
