### PR TITLE
fix: error information is lost

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app-w-synthesis-error/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app-w-synthesis-error/app.js
@@ -1,0 +1,22 @@
+const cdk = require('aws-cdk-lib/core');
+const s3 = require('aws-cdk-lib/aws-s3');
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+if (!stackPrefix) {
+  throw new Error('the STACK_NAME_PREFIX environment variable is required');
+}
+
+class IncorrectBucketNameStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    new s3.Bucket(this, 'Bucket', {
+      bucketName: '&@%$*&@$%',
+    });
+  }
+}
+
+const app = new cdk.App();
+new IncorrectBucketNameStack(app, `${stackPrefix}-incorrect-bucket-name`);
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app-w-synthesis-error/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app-w-synthesis-error/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "node app"
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { integTest, withSpecificFixture } from '../../lib';
+
+integTest(
+  'cdk synth with telemetry and validation error leads to invoke failure',
+  withSpecificFixture('app-w-synthesis-error', async (fixture) => {
+    const telemetryFile = path.join(fixture.integTestDir, `telemetry-${Date.now()}.json`);
+    const output = await fixture.cdk(['synth', `--telemetry-file=${telemetryFile}`], {
+      allowErrExit: true,
+      verboseLevel: 3, // trace mode
+    });
+
+    expect(output).toContain('This is an error');
+
+    // Check the trace that telemetry was executed successfully despite error in synth
+    expect(output).toContain('Telemetry Sent Successfully');
+
+    const json = fs.readJSONSync(telemetryFile);
+    expect(json).toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          state: 'FAILED',
+          eventType: 'SYNTH',
+        }),
+        error: {
+          name: 'synth:InvalidBucketNameValue',
+        },
+      }),
+    ]);
+    fs.unlinkSync(telemetryFile);
+  }),
+);
+

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
@@ -15,8 +15,17 @@ integTest(
     expect(json).toEqual([
       expect.objectContaining({
         event: expect.objectContaining({
-          state: 'FAILED',
           eventType: 'SYNTH',
+          state: 'FAILED',
+        }),
+        error: {
+          name: 'synth:InvalidBucketNameValue',
+        },
+      }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          eventType: 'INVOKE',
+          state: 'FAILED',
         }),
         error: {
           name: 'synth:InvalidBucketNameValue',

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
@@ -6,15 +6,10 @@ integTest(
   'cdk synth with telemetry and validation error leads to invoke failure',
   withSpecificFixture('app-w-synthesis-error', async (fixture) => {
     const telemetryFile = path.join(fixture.integTestDir, `telemetry-${Date.now()}.json`);
-    const output = await fixture.cdk(['synth', `--telemetry-file=${telemetryFile}`], {
+    await fixture.cdk(['synth', `--telemetry-file=${telemetryFile}`], {
       allowErrExit: true,
       verboseLevel: 3, // trace mode
     });
-
-    expect(output).toContain('This is an error');
-
-    // Check the trace that telemetry was executed successfully despite error in synth
-    expect(output).toContain('Telemetry Sent Successfully');
 
     const json = fs.readJSONSync(telemetryFile);
     expect(json).toEqual([

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-synth-telemetry-with-synth-exception.integtest.ts
@@ -29,6 +29,6 @@ integTest(
       }),
     ]);
     fs.unlinkSync(telemetryFile);
-  }),
+  }, { aws: { disableBootstrap: true } }),
 );
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -871,10 +871,9 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       } catch (e: any) {
         // It has to be exactly this string because an integration test tests for
         // "bold(stackname) failed: ResourceNotReady: <error>"
-        throw new ToolkitError(
-          'DeployStackFailed',
-          [`❌  ${chalk.bold(stack.stackName)} failed:`, ...(e.name ? [`${e.name}:`] : []), e.message].join(' '),
-        );
+        const code = ToolkitError.isToolkitError(e) ? e.name : 'DeployStackFailed';
+        const newMessage = [`❌  ${chalk.bold(stack.stackName)} failed:`, ...(e.name ? [`${e.name}:`] : []), e.message].join(' ');
+        throw new ToolkitError(code, newMessage);
       } finally {
         if (options.traceLogs) {
           // deploy calls that originate from watch will come with their own cloudWatchLogMonitor

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -720,10 +720,9 @@ export class CdkToolkit {
       } catch (e: any) {
         // It has to be exactly this string because an integration test tests for
         // "bold(stackname) failed: ResourceNotReady: <error>"
-        const wrappedError = new ToolkitError(
-          'DeployFailed',
-          [`❌  ${chalk.bold(stack.stackName)} failed:`, ...(e.name ? [`${e.name}:`] : []), formatErrorMessage(e)].join(' '),
-        );
+        const code = ToolkitError.isToolkitError(e) ? e.name : 'DeployStackFailed'; // Formerly 'DeployFailed'
+        const newMessage = [`❌  ${chalk.bold(stack.stackName)} failed:`, ...(e.name ? [`${e.name}:`] : []), e.message].join(' ');
+        const wrappedError = new ToolkitError(code, newMessage);
 
         error = {
           name: cdkCliErrorName(wrappedError),


### PR DESCRIPTION
Error code information was attached to a `ToolkitError` that was later on rethrown with a blanket code, losing the error code. Maintain the error code if we have it.

Also add an integ test to confirm we correctly extract synthesis errors from an application that fails with a synthesis exception.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
