### PR TITLE
chore: add corepack enable to JSII packaging publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -317,6 +319,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -365,6 +369,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -407,6 +413,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -449,6 +457,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/projenrc/jsii.ts
+++ b/projenrc/jsii.ts
@@ -487,7 +487,13 @@ export class JsiiBuild extends pj.Component {
 
     // Generic bootstrapping for all target languages
     bootstrapSteps.push(...(this.tsProject as any).workflowBootstrapSteps);
-    if (this.tsProject.package.packageManager === NodePackageManager.PNPM) {
+    if (this.tsProject.package.packageManager === NodePackageManager.YARN_BERRY
+      || this.tsProject.package.packageManager === NodePackageManager.YARN2) {
+      bootstrapSteps.push({
+        name: 'Enable corepack',
+        run: 'corepack enable',
+      });
+    } else if (this.tsProject.package.packageManager === NodePackageManager.PNPM) {
       bootstrapSteps.push({
         name: 'Setup pnpm',
         uses: 'pnpm/action-setup@v3',


### PR DESCRIPTION
Fixes the release workflow failure where downstream per-package publish jobs (maven, pypi, nuget, golang) fail with:
`error This project's package.json defines "packageManager": "yarn@4.13.0".`

 However the current global version of Yarn is 1.22.22.

### Problem

The main `release` job has a `corepack enable` step (added automatically by Projen's `NodeProject` for Yarn Berry). However, the JSII packaging publish jobs are generated by custom code in `projenrc/jsii.ts`. The `pacmakForLanguage` method builds its own `bootstrapSteps` and handles pnpm and bun setup, but had no equivalent for Yarn Berry. When those jobs check out `.repo` and run `yarn install --immutable`, they hit the runner's global Yarn 1.x instead of the Corepack-managed Yarn 4.13.0.

### Fix

Added a `corepack enable` bootstrap step for `YARN_BERRY` / `YARN2` package managers in `pacmakForLanguage()`, matching the existing pattern for pnpm and bun. After regeneration, `release.yml` now has `corepack enable` in all affected publish jobs.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

