### PR TITLE
fix(yarn-cling): omit Berry resolution from shrinkwrap resolved field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,6 +271,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -317,6 +319,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -365,6 +369,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -407,6 +413,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:
@@ -449,6 +457,8 @@ jobs:
       - name: Restore build artifact permissions
         run: cd dist && setfacl --restore=permissions-backup.acl
         continue-on-error: true
+      - name: Enable corepack
+        run: corepack enable
       - name: Checkout
         uses: actions/checkout@v6
         with:

--- a/packages/@aws-cdk/yarn-cling/lib/index.ts
+++ b/packages/@aws-cdk/yarn-cling/lib/index.ts
@@ -81,7 +81,9 @@ function convertBerryToClassicLock(parsed: Record<string, any>): YarnLock {
 
     const resolved: ResolvedYarnPackage = {
       version: entry.version,
-      ...(entry.resolution && { resolved: entry.resolution }),
+      // NOTE: Do NOT include entry.resolution here. Berry resolutions look like
+      // "p-try@npm:2.2.0" which npm misparses as a package name, causing 404s.
+      // npm works fine with just version + integrity.
       ...(entry.checksum && { integrity: entry.checksum }),
       ...(entry.dependencies && {
         dependencies: Object.fromEntries(

--- a/packages/@aws-cdk/yarn-cling/test/cling.test.ts
+++ b/packages/@aws-cdk/yarn-cling/test/cling.test.ts
@@ -107,12 +107,10 @@ test('generate lock for berry fixture directory', async () => {
         requires: {
           'aws-cdk-lib': '^2.3.4',
         },
-        resolved: 'aws-cdk@npm:1.2.999',
         version: '1.2.999',
       },
       'aws-cdk-lib': {
         integrity: '10-pineapple',
-        resolved: 'aws-cdk-lib@npm:2.3.999',
         version: '2.3.999',
       },
     },
@@ -137,7 +135,6 @@ test('parseBerryLockfile converts berry format to classic YarnLock', () => {
   expect(result.type).toBe('success');
   expect(result.object['foo@^1.0.0']).toEqual({
     version: '1.2.3',
-    resolved: 'foo@npm:1.2.3',
     integrity: '10-abc123',
   });
 });

--- a/projenrc/jsii.ts
+++ b/projenrc/jsii.ts
@@ -487,7 +487,13 @@ export class JsiiBuild extends pj.Component {
 
     // Generic bootstrapping for all target languages
     bootstrapSteps.push(...(this.tsProject as any).workflowBootstrapSteps);
-    if (this.tsProject.package.packageManager === NodePackageManager.PNPM) {
+    if (this.tsProject.package.packageManager === NodePackageManager.YARN_BERRY
+      || this.tsProject.package.packageManager === NodePackageManager.YARN2) {
+      bootstrapSteps.push({
+        name: 'Enable corepack',
+        run: 'corepack enable',
+      });
+    } else if (this.tsProject.package.packageManager === NodePackageManager.PNPM) {
       bootstrapSteps.push({
         name: 'Setup pnpm',
         uses: 'pnpm/action-setup@v3',


### PR DESCRIPTION
CLI integration test canaries are failing with:

```
npm error 404 Not Found - GET 
https://registry.npmjs.org/2.2.0 - Not found
```

This happens when the canary runs `npm install @aws-cdk-testing/cli-integ@3.29.2`.
The published package contains an `npm-shrinkwrap.json` with Yarn Berry-format
`resolved` fields that npm cannot parse.

## Root Cause

The `convertBerryToClassicLock` function (introduced in b25e79db) copies Berry's
`resolution` field directly into the shrinkwrap's `resolved` field:

```json
"resolved": "p-try@npm:2.2.0"
```

npm expects a tarball URL:
```
"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz"
```

When npm encounters the Berry format, it misparses it and tries to look up bare version numbers (e.g. 2.2.0) as package names on the registry, resulting in 404s.

Fix
Omit the resolved field for Berry-sourced entries. npm resolves packages fine using just version + integrity.

Verification
@aws-cdk-testing/cli-integ@3.29.1 (pre-Berry support): installs successfully
@aws-cdk-testing/cli-integ@3.29.2 (broken): reproduces the 404 error locally
After this fix: yarn-cling generates a clean shrinkwrap with no Berry-format resolved fields, and npm can install it without errors

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
