### PR TITLE
fix(yarn-cling): omit Berry resolution from shrinkwrap resolved field

### DIFF
--- a/packages/@aws-cdk/yarn-cling/lib/index.ts
+++ b/packages/@aws-cdk/yarn-cling/lib/index.ts
@@ -81,7 +81,9 @@ function convertBerryToClassicLock(parsed: Record<string, any>): YarnLock {
 
     const resolved: ResolvedYarnPackage = {
       version: entry.version,
-      ...(entry.resolution && { resolved: entry.resolution }),
+      // NOTE: Do NOT include entry.resolution here. Berry resolutions look like
+      // "p-try@npm:2.2.0" which npm misparses as a package name, causing 404s.
+      // npm works fine with just version + integrity.
       ...(entry.checksum && { integrity: entry.checksum }),
       ...(entry.dependencies && {
         dependencies: Object.fromEntries(

--- a/packages/@aws-cdk/yarn-cling/test/cling.test.ts
+++ b/packages/@aws-cdk/yarn-cling/test/cling.test.ts
@@ -107,12 +107,10 @@ test('generate lock for berry fixture directory', async () => {
         requires: {
           'aws-cdk-lib': '^2.3.4',
         },
-        resolved: 'aws-cdk@npm:1.2.999',
         version: '1.2.999',
       },
       'aws-cdk-lib': {
         integrity: '10-pineapple',
-        resolved: 'aws-cdk-lib@npm:2.3.999',
         version: '2.3.999',
       },
     },
@@ -137,7 +135,6 @@ test('parseBerryLockfile converts berry format to classic YarnLock', () => {
   expect(result.type).toBe('success');
   expect(result.object['foo@^1.0.0']).toEqual({
     version: '1.2.3',
-    resolved: 'foo@npm:1.2.3',
     integrity: '10-abc123',
   });
 });


### PR DESCRIPTION
All CLI integration test canaries are failing with `npm error 404 Not Found - GET https://registry.npmjs.org/2.2.0`.

The `convertBerryToClassicLock` function (introduced in #1319) copies Yarn Berry's `resolution` field directly into the `npm-shrinkwrap.json` `resolved` field. Berry resolutions look like `p-try@npm:2.2.0`, but npm expects a tarball URL like `https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz`. npm misparses the Berry format and tries to look up bare version numbers as package names on the registry, resulting in 404s.

`@aws-cdk-testing/cli-integ@3.29.1` (before Berry support) installs fine. `@3.29.2` (first release with Berry support) fails.

The fix omits the `resolved` field for Berry-sourced entries. npm resolves packages fine using just `version` + `integrity`. Source of truth - https://docs.npmjs.com/cli/v6/configuring-npm/package-locks

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
