### PR TITLE
fix(toolkit-lib): cdk gc hangs when BackgroundStackRefresh.stop() races an in-flight refresh

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/stack-refresh.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/stack-refresh.ts
@@ -147,6 +147,7 @@ export class BackgroundStackRefresh {
   private timeout?: NodeJS.Timeout;
   private lastRefreshTime: number;
   private queuedPromises: Array<(value: unknown) => void> = [];
+  private stopped = false;
 
   constructor(private readonly props: BackgroundStackRefreshProps) {
     this.lastRefreshTime = Date.now();
@@ -168,6 +169,13 @@ export class BackgroundStackRefresh {
       qualifier: this.props.qualifier,
     });
     this.justRefreshedStacks();
+
+    // If stop() was called while the awaited refreshStacks() above was in flight, do not
+    // reinstall a timer — clearTimeout() in stop() could not cancel the already-executing
+    // refresh() call, and scheduling a new one here would pin the event loop forever.
+    if (this.stopped) {
+      return;
+    }
 
     // If the last invocation of refreshStacks takes <5 minutes, the next invocation starts 5 minutes after the last one started.
     // If the last invocation of refreshStacks takes >5 minutes, the next invocation starts immediately.
@@ -203,6 +211,7 @@ export class BackgroundStackRefresh {
   }
 
   public stop() {
+    this.stopped = true;
     clearTimeout(this.timeout);
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
@@ -1008,6 +1008,37 @@ describe('BackgroundStackRefresh', () => {
 
     await expect(waitPromise).rejects.toThrow('refreshStacks took too long; the background thread likely threw an error');
   });
+
+  test('stop() prevents rescheduling even if called during an in-flight refresh', async () => {
+    // Make listStacks return a promise we control, so refresh() stays in flight
+    // while stop() is called.
+    let resolveListStacks: (value: any) => void = () => {
+    };
+    cfnClient.on(ListStacksCommand).callsFake(() => new Promise((resolve) => {
+      resolveListStacks = resolve;
+    }));
+
+    void backgroundRefresh.start();
+
+    // Fire the initial 5-minute timer; refresh() begins and suspends awaiting listStacks.
+    await jest.runOnlyPendingTimersAsync();
+
+    // Caller decides to stop while refresh() is mid-await.
+    setTimeoutSpy.mockClear();
+    backgroundRefresh.stop();
+
+    // Complete the in-flight refresh(). Without the stopped-flag guard, refresh()
+    // would reinstall a setTimeout here and pin the event loop indefinitely.
+    resolveListStacks({ StackSummaries: [] });
+    // Drain microtasks thoroughly so the in-flight refresh() fully unwinds.
+    for (let i = 0; i < 50; i++) {
+      await Promise.resolve();
+    }
+    await jest.advanceTimersByTimeAsync(0);
+
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+    expect(jest.getTimerCount()).toBe(0);
+  });
 });
 
 describe('ProgressPrinter', () => {


### PR DESCRIPTION
### Issue # (if applicable)

Fixes aws/aws-cdk-cli#1385

### Reason for this change

`cdk gc` hangs silently after completing its work on any run whose total duration exceeds ~5 minutes. The process never exits; CI pipelines hit step timeouts and users have to SIGKILL.

Root cause is in `BackgroundStackRefresh`: `refresh()` unconditionally reschedules itself via `setTimeout` on every completion, and `stop()` only calls `clearTimeout` on the tracked timer. If `stop()` fires while an awaited `refreshStacks()` is in flight, the `clearTimeout` call has no effect on the already-executing `refresh()` (the timer that launched it was consumed when it fired). When the in-flight `refresh()` finally resolves, it installs a fresh `setTimeout` that `stop()` has already passed over. That timer pins the Node event loop indefinitely, and re-fires every 5 minutes forever.

This also explains the previously reported stuck-at-NN.NN% / silent-hang patterns — see aws/aws-cdk#33441 and the unmerged-but-insufficient fix in aws/aws-cdk#33466 (which added a redundant `clearTimeout` inside `refresh()` but did not prevent the reschedule from winning the race with `stop()`).

### Description of changes

- Add a `stopped` flag on `BackgroundStackRefresh`. `stop()` sets it; `refresh()` checks it after `refreshStacks()` resolves and returns without rescheduling if `stop()` has been called. This closes the race without changing any other behavior.
- Add a regression test that drives a controllable `listStacks` mock to keep `refresh()` in flight, calls `stop()` during the await, resolves the mock, and asserts that no new `setTimeout` is installed. The test fails on the unpatched code and passes with the fix.

No public API changes, no behaviour change on the happy path.

### Describe any new or updated permissions being added

None.

### Description of how you validated changes

- New unit test `stop() prevents rescheduling even if called during an in-flight refresh` — passes with the fix, fails without it (verified by reverting just the library-side change and re-running).
- All existing `BackgroundStackRefresh` tests still pass (6 passed, 0 failed in `garbage-collection.test.ts` within the `BackgroundStackRefresh` describe block).

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk/blob/main/docs/DESIGN_GUIDELINES.md)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

