### PR TITLE
fix(cli): deploy with no changes skips outputs and stack ARN

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-outputs-file-written-on-no-change-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-outputs-file-written-on-no-change-deploy.integtest.ts
@@ -1,0 +1,28 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'outputs-file is written on initial and no-change deploys',
+  withDefaultFixture(async (fixture) => {
+    const outputsFile = path.join(fixture.integTestDir, 'outputs', 'outputs.json');
+    await fs.mkdir(path.dirname(outputsFile), { recursive: true });
+
+    // First deploy — creates the stack and writes the outputs file
+    await fixture.cdkDeploy('outputs-test-1', { options: ['--outputs-file', outputsFile] });
+    const firstOutputs = JSON.parse(await fs.readFile(outputsFile, 'utf-8'));
+    expect(firstOutputs).toEqual({
+      [`${fixture.stackNamePrefix}-outputs-test-1`]: {
+        TopicName: `${fixture.stackNamePrefix}-outputs-test-1MyTopic`,
+      },
+    });
+
+    // Delete the file so we can assert it gets recreated on the no-change deploy
+    await fs.rm(outputsFile);
+
+    // Second deploy — no changes, outputs file must still be written
+    await fixture.cdkDeploy('outputs-test-1', { options: ['--outputs-file', outputsFile] });
+    const secondOutputs = JSON.parse(await fs.readFile(outputsFile, 'utf-8'));
+    expect(secondOutputs).toEqual(firstOutputs);
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-outputs-shown-on-no-change-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-outputs-shown-on-no-change-deploy.integtest.ts
@@ -1,0 +1,17 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'deploy outputs shown on initial and no-change deploys',
+  withDefaultFixture(async (fixture) => {
+    // First deploy — creates the stack
+    const firstDeploy = await fixture.cdkDeploy('outputs-test-1');
+    expect(firstDeploy).toContain('Outputs:');
+    expect(firstDeploy).toContain('TopicName');
+
+    // Second deploy — no changes, outputs must still be shown
+    const secondDeploy = await fixture.cdkDeploy('outputs-test-1');
+    expect(secondDeploy).toContain('Outputs:');
+    expect(secondDeploy).toContain('TopicName');
+    expect(secondDeploy).toContain('(no changes)');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -714,12 +714,6 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         })
         : undefined;
 
-      // Empty change set — no changes to deploy
-      if (prepareResult?.noOp === true) {
-        await ioHelper.notify(IO.CDK_TOOLKIT_I5900.msg(chalk.green(`\n ✅  ${stack.displayName} (no changes)`), prepareResult));
-        return;
-      }
-
       const formatter = new DiffFormatter({
         templateInfo: {
           oldTemplate: currentTemplate,
@@ -764,7 +758,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
       let deployDuration;
       try {
-        const prepareIsFinal = isNonExecutingChangeSetDeployment(options.deploymentMethod);
+        const prepareIsFinal = prepareResult && (prepareResult.noOp || isNonExecutingChangeSetDeployment(options.deploymentMethod));
         let deployResult: SuccessfulDeployStackResult | undefined = prepareIsFinal ? prepareResult : undefined;
 
         let rollback = options.rollback;

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -194,6 +194,29 @@ IAM Statement Changes
       expect(mockDeployStack).toHaveBeenCalledTimes(0);
     });
 
+    test('noOp deploy still prints outputs, deployment time, and stack ARN', async () => {
+      // GIVEN
+      jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
+        type: 'did-deploy-stack',
+        noOp: true,
+        outputs: { BucketName: 'my-bucket' },
+        stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      });
+      jest.spyOn(deployments.Deployments.prototype, 'cleanupChangeSet').mockResolvedValue();
+
+      // WHEN
+      const cx = await cdkOutFixture(toolkit, 'stack-with-bucket');
+      await toolkit.deploy(cx, {
+        deploymentMethod: { method: 'change-set' },
+      });
+
+      // THEN — outputs, stack ARN, and success message are printed
+      expect(mockDeployStack).toHaveBeenCalledTimes(0);
+      ioHost.expectMessage({ containing: '(no changes)' });
+      ioHost.expectMessage({ containing: 'BucketName' });
+      ioHost.expectMessage({ containing: 'arn:aws:cloudformation:region:account:stack/test-stack' });
+    });
+
     test('non-executing change-set skips deploy loop', async () => {
       // GIVEN
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -555,12 +555,6 @@ export class CdkToolkit {
         })
         : undefined;
 
-      // Empty change set — no changes to deploy
-      if (prepareResult?.noOp === true) {
-        await this.ioHost.asIoHelper().defaults.info(' ✅  %s (no changes)', chalk.bold(stack.displayName));
-        return;
-      }
-
       if (requireApproval !== RequireApproval.NEVER) {
         const currentTemplate = await this.props.deployments.readCurrentTemplate(stack);
         const formatter = new DiffFormatter({
@@ -611,7 +605,7 @@ export class CdkToolkit {
       try {
         // The prepare result is final if the change set was empty (noOp) or
         // the deployment method is non-executing (prepare-change-set).
-        const prepareIsFinal = prepareResult && isNonExecutingChangeSetDeployment(options.deploymentMethod);
+        const prepareIsFinal = prepareResult && (prepareResult.noOp || isNonExecutingChangeSetDeployment(options.deploymentMethod));
         let deployResult: SuccessfulDeployStackResult | undefined = prepareIsFinal ? prepareResult : undefined;
 
         // Start with user config for rollback,

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -425,6 +425,45 @@ describe('deploy', () => {
       expect(messages.some((m: string) => m.includes('Total time'))).toBe(true);
     });
 
+    test('noOp deploy still writes outputs-file', async () => {
+      // GIVEN
+      const mockCfnDeployments = instanceMockFrom(Deployments);
+      mockCfnDeployments.readCurrentTemplate.mockResolvedValue({});
+      mockCfnDeployments.prepareStack.mockResolvedValue({
+        type: 'did-deploy-stack',
+        noOp: true,
+        outputs: { BucketName: 'my-bucket' },
+        stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      });
+
+      const outputsFile = path.join(os.tmpdir(), `cdk-outputs-${Date.now()}.json`);
+      const cdkToolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockCfnDeployments,
+      });
+
+      try {
+        // WHEN
+        await cdkToolkit.deploy({
+          selector: { patterns: ['Test-Stack-A-Display-Name'] },
+          requireApproval: RequireApproval.NEVER,
+          deploymentMethod: { method: 'change-set' },
+          outputsFile,
+        });
+
+        // THEN — outputs file was written with the stack outputs
+        const contents = JSON.parse(fs.readFileSync(outputsFile, 'utf-8'));
+        expect(contents).toEqual({
+          'Test-Stack-A': { BucketName: 'my-bucket' },
+        });
+      } finally {
+        fs.removeSync(outputsFile);
+      }
+    });
+
     test('cleans up change set when approval is rejected', async () => {
       // GIVEN
       const mockCfnDeployments = instanceMockFrom(Deployments);

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -387,6 +387,44 @@ describe('deploy', () => {
       expect(mockCfnDeployments.deployStack).toHaveBeenCalledTimes(1);
     });
 
+    test('noOp deploy still prints outputs, deployment time, and stack ARN', async () => {
+      // GIVEN
+      const mockCfnDeployments = instanceMockFrom(Deployments);
+      mockCfnDeployments.readCurrentTemplate.mockResolvedValue({});
+      mockCfnDeployments.prepareStack.mockResolvedValue({
+        type: 'did-deploy-stack',
+        noOp: true,
+        outputs: { BucketName: 'my-bucket' },
+        stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      });
+
+      const cdkToolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockCfnDeployments,
+      });
+
+      // WHEN
+      await cdkToolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.NEVER,
+        deploymentMethod: { method: 'change-set' },
+      });
+
+      // THEN — no execute call since noOp
+      expect(mockCfnDeployments.deployStack).toHaveBeenCalledTimes(0);
+
+      // AND — outputs, stack ARN, deployment time, and success message are printed
+      const messages = notifySpy.mock.calls.map((c: any) => c[0]?.message).filter(Boolean);
+      expect(messages.some((m: string) => m.includes('(no changes)'))).toBe(true);
+      expect(messages.some((m: string) => m.includes('Deployment time'))).toBe(true);
+      expect(messages.some((m: string) => m.includes('BucketName'))).toBe(true);
+      expect(messages.some((m: string) => m.includes('arn:aws:cloudformation:region:account:stack/test-stack'))).toBe(true);
+      expect(messages.some((m: string) => m.includes('Total time'))).toBe(true);
+    });
+
     test('cleans up change set when approval is rejected', async () => {
       // GIVEN
       const mockCfnDeployments = instanceMockFrom(Deployments);


### PR DESCRIPTION
Fixes #1386
Fixes #1389

Since the two-phase deploy was introduced in #1273, an empty change set returned early from the deploy function before printing outputs, stack ARN, and deployment timings. For stacks without changes, downstream consumers that depend on CloudFormation exports saw nothing after the "(no changes)" line, breaking workflows that assumed outputs are always visible on successful deploys.

The fix lets the no-op result flow through the normal output formatting path by including it in the `prepareIsFinal` check. The existing output, timing, and stack ARN notifications fire as they did before the regression. No additional change set is created because the prepared result is already final — the deploy loop is skipped entirely when `prepareResult.noOp` is true.

The same bug existed in both the CLI and the toolkit-lib deploy implementations, and both are fixed here. It also caused `--outputs-file` to be skipped on no-change deploys, since the file is written in the deploy function's `finally` block that was never reached. Unit tests in each package assert that outputs, deployment time, stack ARN, and the `--outputs-file` are emitted on a no-change deploy. Integration tests redeploy a stack with an output and assert both the stdout outputs and `--outputs-file` are present in both runs.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
