### PR TITLE
feat(toolkit-lib): honor per-notice dynamicValues separator

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/filter.ts
@@ -3,7 +3,7 @@ import { languageDisplayName } from '../../util/guess-language';
 import type { IoHelper } from '../io/private';
 import type { ConstructTreeNode } from '../tree';
 import { loadTreeFromDir } from '../tree';
-import type { BootstrappedEnvironment, Component, Notice } from './types';
+import type { BootstrappedEnvironment, Component, DynamicValueSpec, Notice } from './types';
 
 /**
  * Normalizes the given components structure into DNF form
@@ -165,7 +165,7 @@ export class NoticesFilter {
         // For every clause in the filter we matched one or more components
         if (matched.every(xs => xs.length > 0)) {
           const ret = new FilteredNotice(notice);
-          this.addDynamicValues(matched.flatMap(x => x), ret);
+          this.addDynamicValues(matched.flatMap(x => x), ret, notice.dynamicValues);
           return [ret];
         }
       }
@@ -188,9 +188,13 @@ export class NoticesFilter {
    * Adds dynamic values from the given ActualComponents
    *
    * If there are multiple components with the same dynamic name, they are joined
-   * by a comma.
+   * by the separator declared in `specs[name].separator`, defaulting to `','`.
    */
-  private addDynamicValues(comps: ActualComponent[], notice: FilteredNotice) {
+  private addDynamicValues(
+    comps: ActualComponent[],
+    notice: FilteredNotice,
+    specs?: Record<string, DynamicValueSpec>,
+  ) {
     const dynamicValues: Record<string, string[]> = {};
     for (const comp of comps) {
       if (comp.dynamicName) {
@@ -199,7 +203,7 @@ export class NoticesFilter {
       }
     }
     for (const [key, values] of Object.entries(dynamicValues)) {
-      notice.addDynamicValue(key, values.join(','));
+      notice.addDynamicValue(key, values.join(specs?.[key]?.separator ?? ','));
     }
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/notices/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/notices/types.ts
@@ -30,6 +30,28 @@ export interface Notice {
   componentsV2?: Array<Component | Component[]>;
   schemaVersion: string;
   severity?: string;
+
+  /**
+   * Per-placeholder rendering options, keyed by the dynamic name used in
+   * `{resolve:NAME}` placeholders within `overview`. Unknown fields on the
+   * spec object MUST be ignored, so new capabilities can be added later
+   * without breaking older CLIs.
+   *
+   * @default - no overrides; placeholders render with default settings (separator ',')
+   */
+  dynamicValues?: Record<string, DynamicValueSpec>;
+}
+
+/**
+ * Rendering options for a single dynamic value placeholder.
+ */
+export interface DynamicValueSpec {
+  /**
+   * Separator used to join multiple values for the same dynamic name.
+   *
+   * @default ","
+   */
+  readonly separator?: string;
 }
 
 export interface NoticeDataSource {

--- a/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/notices.test.ts
@@ -427,6 +427,27 @@ describe(NoticesFilter, () => {
       expect((await filtered).map((f) => f.format()).join('\n')).toContain('env1,env2');
     });
 
+    test('honors dynamicValues.separator override', async () => {
+      const outDir = path.join(fixtures, 'built-with-2_12_0');
+      const cliVersion = '1.0.0';
+
+      const notice: Notice = {
+        ...BASIC_BOOTSTRAP_NOTICE,
+        dynamicValues: { ENVIRONMENTS: { separator: ' ' } },
+      };
+
+      const filtered = await noticesFilter.filter({
+        data: [notice],
+        cliVersion,
+        outDir,
+        bootstrappedEnvironments: [
+          { bootstrapStackVersion: 22, environment: { account: 'account', region: 'region1', name: 'env1' } },
+          { bootstrapStackVersion: 22, environment: { account: 'account', region: 'region2', name: 'env2' } },
+        ],
+      });
+      expect(filtered.map((f) => f.format()).join('\n')).toContain('env1 env2');
+    });
+
     test('ignores invalid bootstrap versions', async () => {
       // doesn't matter for this test because our data only has bootstrap notices
       const outDir = path.join(fixtures, 'built-with-2_12_0');


### PR DESCRIPTION
Fixes aws/aws-cdk#31963

Notices that render `{resolve:NAME}` placeholders join multiple matched values with a hardcoded comma. That works for prose but breaks placeholders that appear inside an executable command, most visibly the rebootstrap notice which currently suggests `cdk bootstrap aws://acct/r1,aws://acct/r2` — not a valid command.

Changing the hardcoded separator in the toolkit would silently alter output for every existing notice that relies on commas in prose. This PR takes the safer notice-side route instead: each notice may carry an optional `dynamicValues` map keyed by placeholder name, where each entry is a `DynamicValueSpec` object. Today the spec only carries `separator`, but keeping the value as an object means future options (`prefix`, `suffix`, `limit`, ...) can be added purely additively without another protocol change — and older CLIs that don't recognise those fields will simply ignore them.

`addDynamicValues` now reads `specs[name]?.separator ?? ','`, so notices that don't set the field behave exactly as before. Paired with the corresponding notices-repo change, the rebootstrap notice will ship `{ ENVIRONMENTS: { separator: " " } }` and new CLIs will render a runnable command. Older CLIs that don't understand the field continue to print the current comma-joined output, so existing users don't regress either way.

Companion change: cdklabs/aws-cdk-notices#TBD

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
