### PR TITLE
fix: skip require-approval prompt when change set is empty

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-approval-prompt-on-no-change-deploy.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-approval-prompt-on-no-change-deploy.integtest.ts
@@ -1,0 +1,26 @@
+import { integTest, withDefaultFixture } from '../../../lib';
+
+integTest(
+  'deploy with --require-approval skips the approval prompt on a no-change deploy',
+  withDefaultFixture(async (fixture) => {
+    // First deploy — creates the stack.
+    await fixture.cdkDeploy('test-2');
+
+    // Second deploy — no changes. With --require-approval=any-change and no
+    // --yes, the CLI must *not* prompt for approval: there is nothing for the
+    // user to approve. If the bug regresses, this call will hang waiting for
+    // stdin and the test will time out.
+    const output = await fixture.cdkDeploy('test-2', {
+      options: ['--require-approval=any-change', '--method=change-set'],
+      neverRequireApproval: false,
+      modEnv: {
+        FORCE_COLOR: '0',
+      },
+    });
+
+    // The deploy completed and reported no changes — and, crucially, never
+    // asked the user to confirm "updates" that don't exist.
+    expect(output).toContain('(no changes)');
+    expect(output).not.toContain('Do you wish to deploy these changes');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -714,37 +714,42 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         })
         : undefined;
 
-      const formatter = new DiffFormatter({
-        templateInfo: {
-          oldTemplate: currentTemplate,
-          newTemplate: stack,
-          changeSet: prepareResult?.changeSet,
-        },
-      });
+      // Skip the approval prompt entirely when the prepared change set has no
+      // changes — there is nothing for the user to approve. Outputs, stack ARN,
+      // and timings are still emitted via the normal no-op deploy path below.
+      if (!prepareResult?.noOp) {
+        const formatter = new DiffFormatter({
+          templateInfo: {
+            oldTemplate: currentTemplate,
+            newTemplate: stack,
+            changeSet: prepareResult?.changeSet,
+          },
+        });
 
-      const securityDiff = formatter.formatSecurityDiff();
-      const stackDiff = formatter.formatStackDiff();
+        const securityDiff = formatter.formatSecurityDiff();
+        const stackDiff = formatter.formatStackDiff();
 
-      // Send a request response with the diff as part of the message,
-      // and the template diff as data
-      // (IoHost decides whether to print depending on permissionChangeType)
-      const hasSecurityChanges = securityDiff.permissionChangeType !== PermissionChangeType.NONE;
-      const deployMotivation = hasSecurityChanges
-        ? '"--require-approval" is enabled and stack includes security-sensitive updates.'
-        : '"--require-approval" is enabled and stack includes updates.';
-      const diffOutput = hasSecurityChanges ? securityDiff.formattedDiff : stackDiff.formattedDiff;
-      const deployQuestion = `${diffOutput}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
-      const deployConfirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I5060.req(deployQuestion, {
-        motivation: deployMotivation,
-        concurrency,
-        permissionChangeType: securityDiff.permissionChangeType,
-        templateDiffs: formatter.diffs,
-      }));
-      if (!deployConfirmed) {
-        if (prepareResult?.changeSet?.ChangeSetName) {
-          await deployments.cleanupChangeSet(stack, prepareResult.changeSet.ChangeSetName);
+        // Send a request response with the diff as part of the message,
+        // and the template diff as data
+        // (IoHost decides whether to print depending on permissionChangeType)
+        const hasSecurityChanges = securityDiff.permissionChangeType !== PermissionChangeType.NONE;
+        const deployMotivation = hasSecurityChanges
+          ? '"--require-approval" is enabled and stack includes security-sensitive updates.'
+          : '"--require-approval" is enabled and stack includes updates.';
+        const diffOutput = hasSecurityChanges ? securityDiff.formattedDiff : stackDiff.formattedDiff;
+        const deployQuestion = `${diffOutput}\n\n${deployMotivation}\nDo you wish to deploy these changes`;
+        const deployConfirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I5060.req(deployQuestion, {
+          motivation: deployMotivation,
+          concurrency,
+          permissionChangeType: securityDiff.permissionChangeType,
+          templateDiffs: formatter.diffs,
+        }));
+        if (!deployConfirmed) {
+          if (prepareResult?.changeSet?.ChangeSetName) {
+            await deployments.cleanupChangeSet(stack, prepareResult.changeSet.ChangeSetName);
+          }
+          throw new ToolkitError('DeployAborted', 'Aborted by user');
         }
-        throw new ToolkitError('DeployAborted', 'Aborted by user');
       }
 
       const stackIndex = stacks.indexOf(stack) + 1;

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -217,6 +217,30 @@ IAM Statement Changes
       ioHost.expectMessage({ containing: 'arn:aws:cloudformation:region:account:stack/test-stack' });
     });
 
+    test('noOp deploy skips the require-approval prompt', async () => {
+      // GIVEN
+      jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
+        type: 'did-deploy-stack',
+        noOp: true,
+        outputs: {},
+        stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      });
+      jest.spyOn(deployments.Deployments.prototype, 'cleanupChangeSet').mockResolvedValue();
+
+      // WHEN — stack-with-role would normally trigger the security-sensitive
+      // approval prompt, but a no-op change set means there is nothing for the
+      // user to approve.
+      const cx = await cdkOutFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        deploymentMethod: { method: 'change-set' },
+      });
+
+      // THEN — no CDK_TOOLKIT_I5060 request was issued
+      expect(ioHost.requestSpy).not.toHaveBeenCalledWith(expect.objectContaining({
+        code: 'CDK_TOOLKIT_I5060',
+      }));
+    });
+
     test('non-executing change-set skips deploy loop', async () => {
       // GIVEN
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -555,7 +555,10 @@ export class CdkToolkit {
         })
         : undefined;
 
-      if (requireApproval !== RequireApproval.NEVER) {
+      // Also skip the approval flow when the prepared change set is a no-op —
+      // there is nothing for the user to approve. Outputs, stack ARN, and
+      // timings are still emitted via the normal no-op deploy path below.
+      if (requireApproval !== RequireApproval.NEVER && !prepareResult?.noOp) {
         const currentTemplate = await this.props.deployments.readCurrentTemplate(stack);
         const formatter = new DiffFormatter({
           templateInfo: {

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -425,6 +425,41 @@ describe('deploy', () => {
       expect(messages.some((m: string) => m.includes('Total time'))).toBe(true);
     });
 
+    test('noOp deploy skips the require-approval prompt', async () => {
+      // GIVEN
+      const mockCfnDeployments = instanceMockFrom(Deployments);
+      mockCfnDeployments.readCurrentTemplate.mockResolvedValue({});
+      mockCfnDeployments.prepareStack.mockResolvedValue({
+        type: 'did-deploy-stack',
+        noOp: true,
+        outputs: {},
+        stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      });
+
+      const cdkToolkit = new CdkToolkit({
+        ioHost,
+        cloudExecutable,
+        configuration: cloudExecutable.configuration,
+        sdkProvider: cloudExecutable.sdkProvider,
+        deployments: mockCfnDeployments,
+      });
+
+      requestSpy = jest.spyOn(ioHost, 'requestResponse');
+
+      // WHEN — ANYCHANGE would normally prompt for approval, but a no-op change
+      // set means there is nothing for the user to approve.
+      await cdkToolkit.deploy({
+        selector: { patterns: ['Test-Stack-A-Display-Name'] },
+        requireApproval: RequireApproval.ANYCHANGE,
+        deploymentMethod: { method: 'change-set' },
+      });
+
+      // THEN — no CDK_TOOLKIT_I5060 request was issued
+      expect(requestSpy).not.toHaveBeenCalledWith(expect.objectContaining({
+        code: 'CDK_TOOLKIT_I5060',
+      }));
+    });
+
     test('noOp deploy still writes outputs-file', async () => {
       // GIVEN
       const mockCfnDeployments = instanceMockFrom(Deployments);


### PR DESCRIPTION
Fixes #1401

## Context

When `--require-approval` is enabled and the prepared change set has no changes, the toolkit still asks the user to approve the deploy. The output reads:

```
There were no differences

"--require-approval" is enabled and stack includes updates.
Do you wish to deploy these changes (y/n)?
```

The diff explicitly reports there are no differences, yet the user is prompted to confirm "updates" that don't exist.

The prompt lives in both `@aws-cdk/toolkit-lib`'s `toolkit.ts` deploy loop and the CLI's `cdk-toolkit.ts`. `prepareResult.noOp` is already consulted later (for `prepareIsFinal`) but is not checked before the `CDK_TOOLKIT_I5060` confirmation request.

## Changes

- Guard the `CDK_TOOLKIT_I5060` request in both `@aws-cdk/toolkit-lib` and the CLI's `cdk-toolkit` with `!prepareResult?.noOp`.
- Add a unit test in each package asserting that `CDK_TOOLKIT_I5060` is not issued when `prepareStack` returns `noOp: true`, even with `requireApproval=any-change`.
- Add an integration test that deploys a stack and then redeploys it with `--require-approval=any-change --method=change-set`, asserting the second run completes and the prompt text never appears in the output.

The indent was increased due to the new conditional in the toolkit-lib. Review with whitespace ignored: https://github.com/aws/aws-cdk-cli/pull/1402/changes?w=1

## Consequences

- No-op deploys with `--require-approval` enabled no longer prompt. The user is not asked to approve changes when there are no changes to apply.
- The no-op result continues to flow through the normal output/ARN/timing path introduced in #1387, so the "(no changes)" success message, stack outputs, `--outputs-file`, and stack ARN are still emitted.
- No message registry codes added; the fix is a guard on an existing path.

## Considerations

The original issue also suggests emitting a new `CDK_TOOLKIT_W5023` warn-level notification analogous to `W5021`/`W5022` — for example `"<stack>: stack has no changes."`. I've left this out because the existing `(no changes)` suffix on the `CDK_TOOLKIT_I5900` success message already conveys the same information, and a separate event felt like duplication.

Happy to add a dedicated `W5023` code if you'd like a distinct structured event for tooling to hook into — it's a purely additive change and wouldn't affect the outputs/ARN/timing path. Let me know and I'll extend this PR.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license