### PR TITLE
fix(cli): suppress flags message on stdout during synth in CI mode

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1209,7 +1209,13 @@ export class CdkToolkit {
         await printSerializedObject(this.ioHost.asIoHelper(), obscureTemplate(stacks.firstStack.template), json ?? false);
       }
 
-      await displayFlagsMessage(this.ioHost.asIoHelper(), this.toolkit, this.props.cloudExecutable);
+      // In CI mode, non-error messages go to stdout. When we just printed the
+      // template to stdout, skip the flags message to preserve the contract that
+      // `cdk synth` output is valid YAML. When quiet (no template printed) or
+      // non-CI (flags go to stderr), it's safe to show.
+      if (quiet || !this.ioHost.isCI) {
+        await displayFlagsMessage(this.ioHost.asIoHelper(), this.toolkit, this.props.cloudExecutable);
+      }
       return undefined;
     }
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -2050,6 +2050,32 @@ describe('synth', () => {
     expect(notifySpy.mock.calls.length).toEqual(0);
   });
 
+  test('single stack synth in CI mode does not pollute stdout with flags message', async () => {
+    // GIVEN
+    ioHost.isCI = true;
+    const toolkit = defaultToolkitSetup();
+
+    // WHEN - single stack, quiet=false (template printed to stdout)
+    await toolkit.synth(['Test-Stack-A-Display-Name'], false, false);
+
+    // THEN - only the template result should be emitted, no warn-level flags message
+    const warnMessages = notifySpy.mock.calls.filter(([msg]) => msg.level === 'warn');
+    expect(warnMessages).toEqual([]);
+  });
+
+  test('single stack synth in CI mode with quiet shows flags message', async () => {
+    // GIVEN
+    ioHost.isCI = true;
+    const toolkit = defaultToolkitSetup();
+
+    // WHEN - single stack, quiet=true (no template printed)
+    await toolkit.synth(['Test-Stack-A-Display-Name'], false, true);
+
+    // THEN - flags message is allowed since stdout is not occupied by the template
+    // (it may or may not appear depending on flag state, but it's not suppressed)
+    // We just verify the synth completes without error
+  });
+
   describe('stack with error and flagged for validation', () => {
     beforeEach(async () => {
       cloudExecutable = await MockCloudExecutable.create({


### PR DESCRIPTION
## Problem

In CI mode, the CLI routes all non-error messages to stdout ([source](https://github.com/aws/aws-cdk-cli/blob/main/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts#L411-L424)). When `cdk synth` prints a single stack's template to stdout, the feature flags warning (`N feature flags are not configured...`) also goes to stdout, breaking the contract that `cdk synth` output is valid YAML.

This means `cdk synth > template.yaml` in CI produces an invalid YAML file.

## Solution

Skip the flags message when the template was printed to stdout in CI mode. The condition is `quiet || !isCI`:

| CI | Template printed | Flags message? | Stream |
|----|-----------------|----------------|--------|
| true | yes | ❌ suppressed | — |
| true | no (`--quiet`) | ✅ | stdout |
| false | yes | ✅ | stderr |
| false | no | ✅ | stderr |

The multi-stack path is unaffected (no template goes to stdout there).

## Testing

Added two tests verifying:
1. Single-stack synth in CI mode does not emit warn-level messages
2. Single-stack synth in CI mode with `--quiet` still works

Closes #913

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*