### PR TITLE
fix: misleading error when DescribeEvents permission is missing during early validation

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -513,7 +513,7 @@ class FullCloudFormationDeployment {
     // Fetching all pages if we'll execute, so we can have the correct change count when monitoring.
     const environmentResourcesRegistry = new EnvironmentResourcesRegistry();
     const envResources = environmentResourcesRegistry.for(this.options.resolvedEnvironment, this.options.sdk, this.ioHelper);
-    const validationReporter = new EarlyValidationReporter(this.options.sdk, envResources);
+    const validationReporter = new EarlyValidationReporter(this.options.sdk, envResources, this.ioHelper);
     try {
       return await waitForChangeSet(this.cfn, this.ioHelper, this.stackName, changeSetName, {
         fetchAll: willExecute,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/early-validation.ts
@@ -2,6 +2,7 @@ import type { OperationEvent } from '@aws-sdk/client-cloudformation';
 import type { ValidationReporter } from './cfn-api';
 import type { SDK } from '../aws-auth/sdk';
 import type { EnvironmentResources } from '../environment';
+import type { IoHelper } from '../io/private';
 
 /**
  * A ValidationReporter that checks for early validation errors right after
@@ -10,10 +11,15 @@ import type { EnvironmentResources } from '../environment';
  * it logs a warning instead.
  */
 export class EarlyValidationReporter implements ValidationReporter {
-  constructor(private readonly sdk: SDK, private readonly envResources: EnvironmentResources) {
+  constructor(
+    private readonly sdk: SDK,
+    private readonly envResources: EnvironmentResources,
+    private readonly ioHelper: IoHelper,
+  ) {
   }
 
   public async fetchDetails(changeSetName: string, stackName: string): Promise<string> {
+    const summary = `Early validation failed for stack '${stackName}' (ChangeSet '${changeSetName}')`;
     let operationEvents: OperationEvent[] = [];
     try {
       operationEvents = await this.getFailedEvents(stackName, changeSetName);
@@ -24,13 +30,15 @@ export class EarlyValidationReporter implements ValidationReporter {
       } catch (e) {
       }
 
-      return `The template cannot be deployed because of early validation errors, but retrieving more details about those
-errors failed (${error}). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap
-your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack.
-Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}.`;
+      await this.ioHelper.defaults.warn(
+        `Could not retrieve additional details about early validation errors (${error}). ` +
+        'Make sure you have permissions to call the DescribeEvents API, or re-bootstrap your environment by running \'cdk bootstrap\' to update the Bootstrap CDK Toolkit stack. ' +
+        `Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}.`,
+      );
+      return summary;
     }
 
-    let message = `ChangeSet '${changeSetName}' on stack '${stackName}' failed early validation`;
+    let message = summary;
     if (operationEvents.length > 0) {
       const failures = operationEvents
         .map((event) => `  - ${event.ValidationStatusReason} (at ${event.ValidationPath})`)

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -795,7 +795,7 @@ test('deployStack throws error in case of early validation failures', async () =
     testDeployStack({
       ...standardDeployStackArguments(),
     }),
-  ).rejects.toThrow(`ChangeSet 'cdk-deploy-change-set' on stack 'withouterrors' failed early validation:
+  ).rejects.toThrow(`Early validation failed for stack 'withouterrors' (ChangeSet 'cdk-deploy-change-set'):
   - Resource already exists (at Resources/MyResource)`);
 });
 
@@ -813,10 +813,7 @@ test('deployStack warns when it cannot get the events in case of early validatio
     testDeployStack({
       ...standardDeployStackArguments(),
     }),
-  ).rejects.toThrow(`The template cannot be deployed because of early validation errors, but retrieving more details about those
-errors failed (Error: AccessDenied). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap
-your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack.
-Bootstrap toolkit stack version 30 or later is needed; current version: 0.`);
+  ).rejects.toThrow("Early validation failed for stack 'withouterrors' (ChangeSet 'cdk-deploy-change-set')");
 });
 
 test('deploy not skipped if template did not change but one tag removed', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
@@ -1,5 +1,7 @@
 import { EarlyValidationReporter } from '../../../lib/api/deployments/early-validation';
 
+const ioHelperMock = () => ({ defaults: { warn: jest.fn() } });
+
 it('returns details when there are failed validation events', async () => {
   const sdkMock = {
     cloudFormation: jest.fn().mockReturnValue({
@@ -9,10 +11,10 @@ it('returns details when there are failed validation events', async () => {
     }),
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 30 }) };
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any, ioHelperMock() as any);
 
   await expect(reporter.fetchDetails('test-change-set', 'test-stack')).resolves.toEqual(
-    "ChangeSet 'test-change-set' on stack 'test-stack' failed early validation:\n  - Resource already exists (at Resources/MyResource)\n",
+    "Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set'):\n  - Resource already exists (at Resources/MyResource)\n",
   );
 });
 
@@ -23,25 +25,30 @@ it('returns a summary when there are no failed validation events', async () => {
     }),
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 30 }) };
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any, ioHelperMock() as any);
 
   await expect(reporter.fetchDetails('test-change-set', 'test-stack')).resolves.toEqual(
-    "ChangeSet 'test-change-set' on stack 'test-stack' failed early validation",
+    "Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set')",
   );
 });
 
-it('returns an explanatory message when DescribeEvents API call fails', async () => {
+it('logs a warning and returns the plain summary when DescribeEvents API call fails', async () => {
   const sdkMock = {
     cloudFormation: jest.fn().mockReturnValue({
       paginatedDescribeEvents: jest.fn().mockRejectedValue(new Error('AccessDenied')),
     }),
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 29 }) };
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const ioHelper = ioHelperMock();
+  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any, ioHelper as any);
 
   const result = await reporter.fetchDetails('test-change-set', 'test-stack');
 
-  expect(result).toContain('The template cannot be deployed because of early validation errors');
-  expect(result).toContain('AccessDenied');
-  expect(result).toContain('29');
+  expect(result).toEqual("Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set')");
+  expect(ioHelper.defaults.warn).toHaveBeenCalledTimes(1);
+  expect(ioHelper.defaults.warn).toHaveBeenCalledWith(
+    'Could not retrieve additional details about early validation errors (Error: AccessDenied). ' +
+    "Make sure you have permissions to call the DescribeEvents API, or re-bootstrap your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. " +
+    'Bootstrap toolkit stack version 30 or later is needed; current version: 29.',
+  );
 });


### PR DESCRIPTION
Fixes #1298

When a change set fails early validation, the reporter in `@aws-cdk/toolkit-lib` attempts to enrich the thrown error with per-event details via `DescribeEvents`. If that call fails — most commonly because the deployment role does not have `cloudformation:DescribeEvents` — the reporter previously returned a message starting with "The template cannot be deployed because of early validation errors, but retrieving more details about those errors failed ...". `waitForChangeSet` then threw that text as an `EarlyValidationFailure`, which made the root cause look like a caller-side permissions problem rather than whatever actually triggered the early validation error in CloudFormation. Users running through CDK Pipelines were particularly affected, because the real validation failure was hidden behind language about a missing API permission.

The reporter now takes an `IoHelper` and surfaces the permissions and bootstrap-version guidance as a warning, while the thrown error carries a plain summary: `Early validation failed for stack '<name>' (ChangeSet '<cs>')`. The deployment still hard-fails with `EarlyValidationFailure`, since CloudFormation will not proceed past early validation, but the failure message no longer misattributes the cause. This matches the behavior already documented in the class comment ("If the `DescribeEvents` API call fails [...] it logs a warning instead.").

The summary wording was chosen to line up with the sibling error thrown from the same function in `cfn-api.ts` (`Failed to create ChangeSet <name> on <stack>: ...`): CamelCase `ChangeSet`, quoted identifiers, and the stack as subject with the change set as correlating metadata.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
