### PR TITLE
fix: Node 18 no longer supported

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -303,7 +303,6 @@ jobs:
           - toolkit-lib-integ-tests
         node:
           - lts/*
-          - 18.17.0
           - "20"
           - "22"
           - "24"
@@ -520,8 +519,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - suite: init-typescript-app
-            node: 18.17.0
           - suite: init-typescript-app
             node: "20"
           - suite: init-typescript-app

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -405,7 +405,7 @@ function genericCdkProps(props: GenericProps = {}) {
       jestConfig: sharedJestConfig(),
       preserveDefaultReporters: false,
     },
-    minNodeVersion: '16.0.0',
+    minNodeVersion: '20',
     prettierOptions: {
       settings: {
         printWidth: 120,
@@ -613,7 +613,7 @@ const yarnCling = configureProject(
     srcdir: 'lib',
     deps: ['@yarnpkg/parsers', 'semver'],
     devDeps: ['@types/semver', 'fast-check'],
-    minNodeVersion: '18',
+    minNodeVersion: '20',
     tsconfig: {
       compilerOptions: {
         ...defaultTsOptions,
@@ -646,7 +646,7 @@ const yargsGen = configureProject(
     srcdir: 'lib',
     deps: ['@cdklabs/typewriter', 'prettier@^2.8', 'lodash.clonedeep'],
     devDeps: ['@types/semver', '@types/yarnpkg__lockfile', '@types/lodash.clonedeep', '@types/prettier@^2'],
-    minNodeVersion: '17.0.0', // Necessary for 'structuredClone'
+    minNodeVersion: '20', // Necessary for 'structuredClone'
     tsconfig: {
       compilerOptions: {
         ...defaultTsOptions,
@@ -1733,8 +1733,6 @@ new CdkCliIntegTestsWorkflow(repo, {
     pool: '${{ vars.CDK_INTEG_ATMOSPHERE_POOL }}',
   },
   additionalNodeVersionsToTest: [
-    // 18.18 introduces `Symbol.dispose`, and we need to make sure that we work on older versions as well
-    '18.17.0',
     '20', '22', '24',
   ],
 });

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -254,7 +254,7 @@
           "exec": "yarn install --no-immutable"
         },
         {
-          "exec": "yarn up -R aws-cdk-lib"
+          "exec": "yarn up aws-cdk-lib"
         },
         {
           "exec": "yarn projen"

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -254,7 +254,7 @@
           "exec": "yarn install --no-immutable"
         },
         {
-          "exec": "yarn up aws-cdk-lib"
+          "exec": "yarn up -R aws-cdk-lib"
         },
         {
           "exec": "yarn projen"


### PR DESCRIPTION
Newer versions of `npm` don't support Node 18 anymore, so dependency upgrades are going to fail the test suite on old Node version.

[CDK has already advertised we won't support Node 18 anymore either ](https://aws.amazon.com/blogs/devops/announcing-the-end-of-support-for-node-js-18-x-in-aws-cdk/), so we can safely remove Node 18 support.



---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
