### PR TITLE
fix: empty diff with only hidden CDK metadata changes requests approval from user without explanation

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
@@ -14,8 +14,9 @@ integTest(
       },
     });
 
-    // Assert there are no changes
+    // Assert no visible changes, but hint indicates hidden metadata changes
     expect(diff).toContain('There were no differences');
+    expect(diff).toContain('CDK metadata changes were hidden, run cdk diff --strict to show');
   }),
 );
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff-doesnt-show-resource-metadata-changes.integtest.ts
@@ -14,9 +14,8 @@ integTest(
       },
     });
 
-    // Assert no visible changes, but hint indicates hidden metadata changes
+    // Assert there are no changes
     expect(diff).toContain('There were no differences');
-    expect(diff).toContain('CDK metadata changes were hidden, run cdk diff --strict to show');
   }),
 );
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diff/diff-formatter.ts
@@ -276,9 +276,11 @@ export class DiffFormatter {
 
       // filter out 'AWS::CDK::Metadata' resources from the template
       // filter out 'CheckBootstrapVersion' rules from the template
+      const diffWasNonEmpty = !activeDiff.isEmpty;
       if (!options.strict) {
         obscureDiff(activeDiff);
       }
+      const metadataWasFiltered = diffWasNonEmpty && activeDiff.isEmpty;
 
       if (!activeDiff.isEmpty) {
         numStacksWithChanges++;
@@ -289,7 +291,8 @@ export class DiffFormatter {
           ...logicalIdMap,
         }, options.contextLines);
       } else if (!options.quiet) {
-        stream.write(chalk.green('There were no differences\n'));
+        const hint = metadataWasFiltered ? chalk.grey(' (CDK metadata changes were hidden, run cdk diff --strict to show)') : '';
+        stream.write(`${chalk.green('There were no differences')}${hint}\n`);
       }
 
       if (filteredChangesCount > 0) {

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -40,6 +40,61 @@ describe('formatStackDiff', () => {
     } as any;
   });
 
+  test('shows metadata hint when only CDK metadata changes are present', () => {
+    // GIVEN
+    const oldTemplate = {
+      Resources: {
+        CDKMetadata: {
+          Type: 'AWS::CDK::Metadata',
+          Properties: { Analytics: 'v2:deflate64:oldvalue' },
+        },
+      },
+    };
+    const newTemplateWithMetadata = {
+      ...mockNewTemplate,
+      template: {
+        Resources: {
+          CDKMetadata: {
+            Type: 'AWS::CDK::Metadata',
+            Properties: { Analytics: 'v2:deflate64:newvalue' },
+          },
+        },
+      },
+    } as any;
+
+    // WHEN
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate,
+        newTemplate: newTemplateWithMetadata,
+      },
+    });
+    const result = formatter.formatStackDiff();
+
+    // THEN
+    expect(result.numStacksWithChanges).toBe(0);
+    const sanitizedDiff = stripAnsi(result.formattedDiff!).trim();
+    expect(sanitizedDiff).toContain('There were no differences');
+    expect(sanitizedDiff).toContain('CDK metadata changes were hidden, run cdk diff --strict to show');
+  });
+
+  test('does not show metadata hint when templates are identical', () => {
+    // WHEN
+    const formatter = new DiffFormatter({
+      templateInfo: {
+        oldTemplate: mockNewTemplate.template,
+        newTemplate: mockNewTemplate,
+      },
+    });
+    const result = formatter.formatStackDiff();
+
+    // THEN
+    expect(result.numStacksWithChanges).toBe(0);
+    const sanitizedDiff = stripAnsi(result.formattedDiff!).trim();
+    expect(sanitizedDiff).toContain('There were no differences');
+    expect(sanitizedDiff).not.toContain('CDK metadata');
+  });
+
   test('returns no differences when templates are identical', () => {
     // WHEN
     const formatter = new DiffFormatter({


### PR DESCRIPTION
## Context

When deploying with the changeset method, it's possible for the changeset to be non-empty (not a CloudFormation no-op) while the diff presented to the user shows nothing. This happens when the only template differences are `AWS::CDK::Metadata` resources or `CheckBootstrapVersion` rules — both of which are filtered by `obscureDiff()` unless `cdk diff --strict` is passed.

The user sees a blank "There were no differences" message, then is prompted to approve the deployment with no explanation of why; very confusing.

## Changes

In `DiffFormatter.formatStackDiffHelper()`, capture whether the diff was non-empty before `obscureDiff()` runs. If `obscureDiff()` filtered everything away, append a grey hint to the "no differences" message:

> There were no differences *(CDK metadata changes were hidden, run cdk diff --strict to show)*

This applies everywhere `formatStackDiff()` is called: `cdk diff`, the deploy approval prompt, and `cdk import`.

## Consequences

Users will have a clear signal explaining why the diff appears empty and how to see the full picture. The `--strict` flag is specific to `cdk diff` and already exists to show these changes; this change makes users aware of it when it's relevant.

---
_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license._