### PR TITLE
feat(cli): add hotswap support for QuickSight resources via CCAPI

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
@@ -94,6 +94,13 @@ const RESOURCE_DETECTORS: { [key: string]: HotswapDetector } = {
   'AWS::CloudWatch::Dashboard': isHotswappableCloudControlChange,
   'AWS::StepFunctions::StateMachine': isHotswappableCloudControlChange,
   'AWS::BedrockAgentCore::Runtime': isHotswappableCloudControlChange,
+
+  // QuickSight
+  'AWS::QuickSight::Dashboard': isHotswappableCloudControlChange,
+  'AWS::QuickSight::Analysis': isHotswappableCloudControlChange,
+  'AWS::QuickSight::Template': isHotswappableCloudControlChange,
+  'AWS::QuickSight::DataSet': isHotswappableCloudControlChange,
+  'AWS::QuickSight::DataSource': isHotswappableCloudControlChange,
 };
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/hotswap/cloud-control-hotswap-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/hotswap/cloud-control-hotswap-deployments.test.ts
@@ -432,6 +432,11 @@ describe.each([
   'AWS::CloudWatch::Dashboard',
   'AWS::StepFunctions::StateMachine',
   'AWS::BedrockAgentCore::Runtime',
+  'AWS::QuickSight::Dashboard',
+  'AWS::QuickSight::Analysis',
+  'AWS::QuickSight::Template',
+  'AWS::QuickSight::DataSet',
+  'AWS::QuickSight::DataSource',
 ])('CCAPI sanity check for resources where Primary Identifier matches Physical ID %s', (resourceType) => {
   beforeEach(() => {
     hotswapMockSdkProvider = setup.setupHotswapTests();
@@ -526,6 +531,109 @@ describe.each([
       TypeName: resourceType,
       Identifier: 'res-123|res-123',
       PatchDocument: JSON.stringify([{ op: 'replace', path: '/SomeProp', value: 'new' }]),
+    });
+  });
+});
+
+describe.each([HotswapMode.FALL_BACK, HotswapMode.HOTSWAP_ONLY])('QuickSight hotswap via CCAPI in %p mode', (hotswapMode) => {
+  beforeEach(() => {
+    hotswapMockSdkProvider = setup.setupHotswapTests();
+
+    mockCloudFormationClient.on(DescribeTypeCommand).resolves({
+      Schema: JSON.stringify({
+        primaryIdentifier: ['/properties/AwsAccountId', '/properties/DashboardId'],
+      }),
+    });
+    mockCloudControlClient.on(UpdateResourceCommand).resolves({});
+  });
+
+  test('hotswaps a QuickSight Dashboard Name change', async () => {
+    // GIVEN
+    setup.setCurrentCfnStackTemplate({
+      Resources: {
+        MyDashboard: {
+          Type: 'AWS::QuickSight::Dashboard',
+          Properties: {
+            AwsAccountId: '123456789012',
+            DashboardId: 'my-dashboard',
+            Name: 'Old Dashboard',
+          },
+        },
+      },
+    });
+    setup.pushStackResourceSummaries(
+      setup.stackSummaryOf('MyDashboard', 'AWS::QuickSight::Dashboard', 'my-dashboard'),
+    );
+    const cdkStackArtifact = setup.cdkStackArtifactOf({
+      template: {
+        Resources: {
+          MyDashboard: {
+            Type: 'AWS::QuickSight::Dashboard',
+            Properties: {
+              AwsAccountId: '123456789012',
+              DashboardId: 'my-dashboard',
+              Name: 'New Dashboard',
+            },
+          },
+        },
+      },
+    });
+
+    // WHEN
+    const deployStackResult = await hotswapMockSdkProvider.tryHotswapDeployment(hotswapMode, cdkStackArtifact);
+
+    // THEN
+    expect(deployStackResult).not.toBeUndefined();
+    expect(mockCloudControlClient).toHaveReceivedCommandWith(UpdateResourceCommand, {
+      TypeName: 'AWS::QuickSight::Dashboard',
+      Identifier: 'my-dashboard',
+      PatchDocument: JSON.stringify([{ op: 'replace', path: '/Name', value: 'New Dashboard' }]),
+    });
+  });
+
+  test('hotswaps a QuickSight Dashboard Definition change', async () => {
+    // GIVEN
+    const oldDefinition = { DataSetIdentifierDeclarations: [{ Identifier: 'ds1', DataSetArn: 'arn:old' }] };
+    const newDefinition = { DataSetIdentifierDeclarations: [{ Identifier: 'ds1', DataSetArn: 'arn:new' }] };
+    setup.setCurrentCfnStackTemplate({
+      Resources: {
+        MyDashboard: {
+          Type: 'AWS::QuickSight::Dashboard',
+          Properties: {
+            AwsAccountId: '123456789012',
+            DashboardId: 'my-dashboard',
+            Definition: oldDefinition,
+          },
+        },
+      },
+    });
+    setup.pushStackResourceSummaries(
+      setup.stackSummaryOf('MyDashboard', 'AWS::QuickSight::Dashboard', 'my-dashboard'),
+    );
+    const cdkStackArtifact = setup.cdkStackArtifactOf({
+      template: {
+        Resources: {
+          MyDashboard: {
+            Type: 'AWS::QuickSight::Dashboard',
+            Properties: {
+              AwsAccountId: '123456789012',
+              DashboardId: 'my-dashboard',
+              Definition: newDefinition,
+            },
+          },
+        },
+      },
+    });
+
+    // WHEN
+    const deployStackResult = await hotswapMockSdkProvider.tryHotswapDeployment(hotswapMode, cdkStackArtifact);
+
+    // THEN
+    expect(deployStackResult).not.toBeUndefined();
+    expect(mockCloudControlClient).toHaveReceivedCommandWith(UpdateResourceCommand, {
+      TypeName: 'AWS::QuickSight::Dashboard',
+      Identifier: 'my-dashboard',
+      PatchDocument: JSON.stringify([{ op: 'replace', path: '/Definition', value: newDefinition }]),
     });
   });
 });


### PR DESCRIPTION
## Summary

- Registers five QuickSight resource types with the Cloud Control API hotswap handler
- Enables `cdk deploy --hotswap` for QuickSight Dashboards, Analyses, Templates, DataSets, and DataSources
- Leverages the generic CCAPI infrastructure from #1310 instead of custom SDK integrations

## Motivation

QuickSight resources require frequent updates during development (dashboard definitions, data mappings, visualizations). Hotswap via CCAPI lets developers bypass CloudFormation and update resources directly, cutting iteration time.

This replaces #1055, which used custom per-service QuickSight SDK calls. Per feedback from @rix0rrr, the CCAPI approach is preferred since #1310 landed the generic infrastructure.

## Changes

- `hotswap-deployments.ts`: Add 5 QuickSight resource types to `RESOURCE_DETECTORS` map
- `cloud-control-hotswap-deployments.test.ts`: Add QuickSight types to CCAPI sanity-check suite, plus dedicated tests for Dashboard Name and Definition changes in both `FALL_BACK` and `HOTSWAP_ONLY` modes

## Test plan

- [x] All 50 CCAPI hotswap unit tests pass (5 new sanity checks + 4 QuickSight-specific tests)
- [x] Verify QuickSight Dashboard hotswap with a real CDK app using `cdk deploy --hotswap`

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license