### PR TITLE
fix: DescribeEvents is only used for Early Validation errors

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/changeset-error-fetcher.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/changeset-error-fetcher.ts
@@ -4,10 +4,9 @@ import type { EnvironmentResources } from '../environment';
 import type { IoHelper } from '../io/private/io-helper';
 
 /**
- * A ValidationReporter that checks for early validation errors right after
- * creating the change set.
+ * Uses `DescribeEvents` to get the detailed reasons for why a changeset failed to create, if available.
  */
-export class EarlyValidationReporter {
+export class ChangeSetResourceErrorFetcher {
   constructor(private readonly sdk: SDK, private readonly envResources?: EnvironmentResources) {
   }
 
@@ -15,6 +14,9 @@ export class EarlyValidationReporter {
    * Fetch the details and return them as a string.
    *
    * If the details could not be fetched, log that as a warning using the IoHelper.
+   *
+   * (This method will only ever be used for early validation, so we are not generalizing
+   * the error message in here).
    */
   public async fetchDetailsString(changeSetName: string, stackName: string, ioHelper: IoHelper): Promise<string> {
     const summary = `Early validation failed for stack '${stackName}' (ChangeSet '${changeSetName}')`;
@@ -39,7 +41,7 @@ export class EarlyValidationReporter {
   /**
    * Fetch the details and return them in structured form.
    */
-  public async fetchDetailsStructured(changeSetName: string, stackName: string): Promise<EarlyValidationCheckResult> {
+  public async fetchDetailsStructured(changeSetName: string, stackName: string): Promise<ChangeSetErrorCheckResult> {
     let operationEvents: OperationEvent[] = [];
     try {
       operationEvents = await this.getFailedEvents(stackName, changeSetName);
@@ -52,7 +54,7 @@ export class EarlyValidationReporter {
 
       return {
         type: 'could-not-check',
-        message: `Could not retrieve additional details about early validation errors (${error}). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}.`,
+        message: `Could not retrieve additional details about change set creation errors (${error}). Make sure you have permissions to call the DescribeEvents API, or re-bootstrap your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. Bootstrap toolkit stack version 30 or later is needed; current version: ${currentVersion ?? 'unknown'}.`,
       };
     }
 
@@ -66,7 +68,7 @@ export class EarlyValidationReporter {
         validationName: ev.ValidationName ?? '',
         documentPath: ev.ValidationPath ?? '',
         resourceType: ev.ResourceType,
-      } satisfies EarlyValidationError)),
+      } satisfies ChangeSetResourceError)),
     };
   }
 
@@ -81,11 +83,11 @@ export class EarlyValidationReporter {
   }
 }
 
-export type EarlyValidationCheckResult =
+export type ChangeSetErrorCheckResult =
   | { type: 'could-not-check'; message: string }
-  | { type: 'resource-errors'; errors: EarlyValidationError[] };
+  | { type: 'resource-errors'; errors: ChangeSetResourceError[] };
 
-export interface EarlyValidationError {
+export interface ChangeSetResourceError {
   readonly logicalId: string;
   readonly physicalId?: string;
   readonly message: string;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
@@ -1,8 +1,8 @@
 import type { ChangeSetSummary, Stack } from '@aws-sdk/client-cloudformation';
 import { ChangeSetStatus, ChangeType } from '@aws-sdk/client-cloudformation';
-import type { EarlyValidationError } from './early-validation';
-import { EarlyValidationReporter } from './early-validation';
-import type { StackDiagnosis, TracedResourceError } from '../../actions/diagnose';
+import type { ChangeSetResourceError } from './changeset-error-fetcher';
+import { ChangeSetResourceErrorFetcher } from './changeset-error-fetcher';
+import type { StackDiagnosis, StackProblemSource, TracedResourceError } from '../../actions/diagnose';
 import type { ICloudFormationClient, SDK } from '../aws-auth/sdk';
 import type { EnvironmentResources } from '../environment';
 import type { IoHelper } from '../io/private/io-helper';
@@ -160,38 +160,23 @@ export class CloudFormationStackDiagnoser {
       return { type: 'no-problem' };
     }
 
+    // We report early validation errors differently than generic changeset errors. Mostly
+    // for historical reasons.
     const isEarlyValidationError = changeSet.StatusReason?.includes('AWS::EarlyValidation');
     if (isEarlyValidationError) {
-      const ev = await new EarlyValidationReporter(this.props.sdk, this.props.envResources)
-        .fetchDetailsStructured(changeSet.ChangeSetName!, changeSet.StackName!);
-      switch (ev.type) {
-        case 'could-not-check':
-          // Emit the warning here and otherwise just return an empty error block
-          await this.props.ioHelper.defaults.warn(ev.message);
-          return {
-            type: 'problem',
-            detectedBy: {
-              type: 'early-validation',
-              changeSetName: changeSet.ChangeSetName ?? '',
-            },
-            problems: [],
-          };
-        case 'resource-errors':
-          return {
-            type: 'problem',
-            detectedBy: {
-              type: 'early-validation',
-              changeSetName: changeSet.ChangeSetName ?? '',
-            },
-            problems: await this.addErrorTraces(ev.errors.map((e) => resourceErrorFromEarlyValidationError(changeSet.StackId ?? '', this.parentStackLogicalIds, e))),
-          };
-      }
+      return this._reportChangeSetFailureFromEvents(changeSet, {
+        type: 'early-validation',
+        changeSetName: changeSet.ChangeSetName ?? '',
+      });
     }
 
+    // We will recurse into nested change sets if necessary.
     if (changeSet.StatusReason?.includes('Nested change set')) {
       return this._diagnoseNestedChangeSetFailure(changeSet);
     }
 
+    // We special-case failed automatic imports. We know all the meat of the error details are in the
+    // status reason, and nowhere else. We parse it specifically.
     const failedAutoErrors = this._tryDetectFailedAutoImport(changeSet);
     if (failedAutoErrors) {
       return {
@@ -204,6 +189,41 @@ export class CloudFormationStackDiagnoser {
         },
         problems: await this.addErrorTraces(failedAutoErrors),
       };
+    }
+
+    // Otherwise, a generic change set creation error where `DescribeEvents`
+    // might or might not give additional information.
+    return this._reportChangeSetFailureFromEvents(changeSet, {
+      type: 'change-set',
+      changeSetStatus: changeSet.Status ?? '',
+      changeSetName: changeSet.ChangeSetName ?? '',
+      statusReason: changeSet.StatusReason ?? '',
+    });
+  }
+
+  /**
+   * Try to read the resource-specific reasons for a changeset failure from `DescribeEvents`.
+   *
+   * If we couldn't read the events or there are 0 errors returned by that API, return a generic
+   * error.
+   */
+  private async _reportChangeSetFailureFromEvents(changeSet: ChangeSetSummary, detectedBy: StackProblemSource): Promise<StackDiagnosis> {
+    const ev = await new ChangeSetResourceErrorFetcher(this.props.sdk, this.props.envResources)
+      .fetchDetailsStructured(changeSet.ChangeSetName!, changeSet.StackName!);
+
+    // If we have errors to return, return them
+    if (ev.type === 'resource-errors' && ev.errors.length > 0) {
+      return {
+        type: 'problem',
+        detectedBy,
+        problems: await this.addErrorTraces(ev.errors.map((e) => resourceErrorFromEarlyValidationError(changeSet.StackId ?? '', this.parentStackLogicalIds, e))),
+      };
+    }
+
+    // Otherwise, we will return a generic changeset error message. If there was a problem
+    // checking, we log that for good measure but the result is the same.
+    if (ev.type === 'could-not-check') {
+      await this.props.ioHelper.defaults.warn(ev.message);
     }
 
     return this._nonSpecificChangeSetError(changeSet);
@@ -377,7 +397,7 @@ export function changeSetHasNoChanges(description: ChangeSetSummary) {
   );
 }
 
-function resourceErrorFromEarlyValidationError(stackId: string, parentStackLogicalIds: string[], ev: EarlyValidationError): ResourceError {
+function resourceErrorFromEarlyValidationError(stackId: string, parentStackLogicalIds: string[], ev: ChangeSetResourceError): ResourceError {
   return {
     logicalId: ev.logicalId,
     physicalId: ev.physicalId,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
@@ -226,7 +226,7 @@ export class CloudFormationStackDiagnoser {
       await this.props.ioHelper.defaults.warn(ev.message);
     }
 
-    return this._nonSpecificChangeSetError(changeSet);
+    return this._nonSpecificChangeSetError(changeSet, detectedBy);
   }
 
   private async addErrorTraces(errs: readonly ResourceError[]): Promise<TracedResourceError[]> {
@@ -250,15 +250,10 @@ export class CloudFormationStackDiagnoser {
    *
    * We can't point to a specific resource.
    */
-  private async _nonSpecificChangeSetError(changeSet: ChangeSetSummary): Promise<StackDiagnosis> {
+  private async _nonSpecificChangeSetError(changeSet: ChangeSetSummary, detectedBy: StackProblemSource): Promise<StackDiagnosis> {
     return {
       type: 'problem',
-      detectedBy: {
-        type: 'change-set',
-        changeSetName: changeSet.ChangeSetName ?? '',
-        changeSetStatus: changeSet.Status ?? '',
-        statusReason: changeSet.StatusReason ?? '',
-      },
+      detectedBy,
       problems: [
         await this.addErrorTrace({
           // It's about a stack
@@ -280,7 +275,12 @@ export class CloudFormationStackDiagnoser {
     const nested = await this._findFailedNestedStack(changeSet);
     if (!nested) {
       // That's weird. Let's return the change set's status reason as a non-specific error
-      return this._nonSpecificChangeSetError(changeSet);
+      return this._nonSpecificChangeSetError(changeSet, {
+        type: 'change-set',
+        changeSetName: changeSet.ChangeSetName ?? '',
+        changeSetStatus: changeSet.Status ?? '',
+        statusReason: changeSet.StatusReason ?? '',
+      });
     }
 
     const nestedCs = await this.cfn.describeChangeSet({

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -830,6 +830,22 @@ test('deployStack warns when it cannot get the events in case of early validatio
   ).rejects.toThrow('Early validation failed for change set cdk-deploy-change-set');
 });
 
+test('even if ChangeSet error does not match pattern, DescribeEvents is called', async () => {
+  mockCloudFormationClient.on(DescribeChangeSetCommand).resolvesOnce({
+    ChangeSetName: 'cdk-deploy-change-set',
+    Status: ChangeSetStatus.FAILED,
+    StatusReason: 'Something somewhere went wrong, cannot be more specific than that.',
+  });
+
+  await expect(
+    testDeployStack({
+      ...standardDeployStackArguments(),
+    }),
+  ).rejects.toThrow();
+
+  expect(mockCloudFormationClient).toHaveReceivedCommand(DescribeEventsCommand);
+});
+
 test('deploy not skipped if template did not change but one tag removed', async () => {
   // GIVEN
   givenStackExists({

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
@@ -1,4 +1,4 @@
-import { EarlyValidationReporter } from '../../../lib/api/diagnosing/early-validation';
+import { ChangeSetResourceErrorFetcher } from '../../../lib/api/diagnosing/changeset-error-fetcher';
 import type { IoHelper } from '../../../lib/api/io/private/io-helper';
 
 const ioHelperMock = () => ({ defaults: { warn: jest.fn() } }) as any as IoHelper;
@@ -12,7 +12,7 @@ it('returns details when there are failed validation events', async () => {
     }),
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 30 }) };
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const reporter = new ChangeSetResourceErrorFetcher(sdkMock as any, envResourcesMock as any);
 
   await expect(reporter.fetchDetailsString('test-change-set', 'test-stack', ioHelperMock())).resolves.toEqual(
     "Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set'):\n  - Resource already exists (at Resources/MyResource)",
@@ -26,7 +26,7 @@ it('returns a summary when there are no failed validation events', async () => {
     }),
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 30 }) };
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const reporter = new ChangeSetResourceErrorFetcher(sdkMock as any, envResourcesMock as any);
 
   await expect(reporter.fetchDetailsString('test-change-set', 'test-stack', ioHelperMock())).resolves.toEqual(
     "Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set')",
@@ -41,7 +41,7 @@ it('logs a warning and returns the plain summary when DescribeEvents API call fa
   };
   const envResourcesMock = { lookupToolkit: jest.fn().mockResolvedValue({ version: 29 }) };
   const ioHelper = ioHelperMock();
-  const reporter = new EarlyValidationReporter(sdkMock as any, envResourcesMock as any);
+  const reporter = new ChangeSetResourceErrorFetcher(sdkMock as any, envResourcesMock as any);
 
   const result = await reporter.fetchDetailsString('test-change-set', 'test-stack', ioHelper);
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/early-validation.test.ts
@@ -48,7 +48,7 @@ it('logs a warning and returns the plain summary when DescribeEvents API call fa
   expect(result).toEqual("Early validation failed for stack 'test-stack' (ChangeSet 'test-change-set')");
   expect(ioHelper.defaults.warn).toHaveBeenCalledTimes(1);
   expect(ioHelper.defaults.warn).toHaveBeenCalledWith(
-    'Could not retrieve additional details about early validation errors (Error: AccessDenied). ' +
+    'Could not retrieve additional details about change set creation errors (Error: AccessDenied). ' +
     "Make sure you have permissions to call the DescribeEvents API, or re-bootstrap your environment by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. " +
     'Bootstrap toolkit stack version 30 or later is needed; current version: 29.',
   );


### PR DESCRIPTION
Previously, we only called `DescribeEvents` when we detect that the cause of change set creation errors was "early validation" (via a specific bit of text in the failure status reason).

However, it *could* be that CloudFormation reports multiple resource-specific reasons for change set creation failure using `DescribeEvents`. I don't know whether they do or not (maybe they do for some cases but not others), but it never hurts to try before we fall back to a generic "change set failed" message. 

This PR makes that change. Always call `DescribeEvents({ Failed : true })`, and if we find errors we report them. If we don't we report the generic error.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
