### PR TITLE
fix: integ test sometimes fails and sometimes succeeds

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/diagnose-app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/diagnose-app/app.js
@@ -28,7 +28,10 @@ class DeployFailStack extends cdk.Stack {
 
     new cdk.CfnResource(this, 'BadPolicy', {
       type: 'AWS::IAM::Policy',
-      // Missing required PolicyDocument property — will fail during deployment
+      properties: {
+        PolicyName: 'SomePolicy',
+        // Missing required PolicyDocument property — will fail during deployment
+      },
     });
   }
 }


### PR DESCRIPTION
We create a "bad policy" to test change set creation failures and their reporting.

In this case, we create an `AWS::IAM::Policy` without both a `PolicyName` and a `PolicyDocument`.

It looks like the failure that CloudFormation reports is nondeterministic: sometimes it complains about the missing Name, and sometimes about the missing Document. But our test expects it to complain about the Document, so if it complains about the Name our test fails.

Fix by adding a Name, so that it can only complain about a Document.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
