### PR TITLE
fix: early validation only reports one error

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/diagnosis-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/diagnosis-formatting.ts
@@ -121,11 +121,13 @@ function formatResourceErrors(es: TracedResourceError[]) {
   for (const e of es) {
     const p = locateResourceError(e);
     const lastPart = p.split('/').slice(-1)[0];
-    b.setNodeText(p, [
-      `${lastPart}  ${addendum(' ', e.resourceType, e.logicalId)}`.trim(),
-      ...sideBySide(['🛑'], ' ', wrapText(120, e.message)),
-      ...e.sourceTrace?.creationStackTrace ? sideBySide(['Source Location:'], ' ', e.sourceTrace?.creationStackTrace) : [],
-    ].join('\n'));
+
+    const nodeText = b.nodeText(p);
+    nodeText.header = [`${lastPart}  ${addendum(' ', e.resourceType, e.logicalId)}`.trim()];
+    nodeText.body.push(...sideBySide(['🛑'], ' ', wrapText(120, e.message)));
+    nodeText.footer = e.sourceTrace?.creationStackTrace
+      ? sideBySide(['Source Location:'], ' ', e.sourceTrace?.creationStackTrace)
+      : [];
   }
   return b.render();
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/tree-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/tree-builder.ts
@@ -1,17 +1,17 @@
-import { Tree } from './tree';
+import { Tree, TreeText } from './tree';
 
 export class TreeBuilder {
   private readonly root: TreeBuilderNode;
 
   constructor(private readonly rootText: string) {
     this.root = {
-      tree: new Tree(rootText),
+      tree: new Tree(new TreeText([rootText])),
       children: {},
     };
   }
 
-  public setNodeText(constructPath: string, nodeText: string) {
-    this.obtainNode(constructPath).text = nodeText;
+  public nodeText(constructPath: string): TreeText {
+    return this.obtainNode(constructPath).text;
   }
 
   public render() {
@@ -40,7 +40,7 @@ export class TreeBuilder {
       if (child) {
         cur = child;
       } else {
-        const tree = new Tree(next);
+        const tree = new Tree(new TreeText([next]));
         cur.tree.addChild(tree);
         cur = cur.children[next] = {
           tree,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/tree.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/tree.ts
@@ -1,18 +1,10 @@
 export class Tree {
-  private lines: string[];
+  public text: TreeText;
   private readonly children: Tree[];
 
-  constructor(text: string, children: Tree[] = []) {
-    this.lines = text.split('\n');
+  constructor(text: TreeText, children: Tree[] = []) {
+    this.text = text;
     this.children = [...children];
-  }
-
-  public get text() {
-    return this.lines.join('\n');
-  }
-
-  public set text(text: string) {
-    this.lines = text.split('\n');
   }
 
   public addChild(tree: Tree) {
@@ -20,7 +12,7 @@ export class Tree {
   }
 
   public height(): number {
-    return this.lines.length + sum(this.children.map(c => c.height()));
+    return this.text.lineCount() + sum(this.children.map(c => c.height()));
   }
 
   public render(): string {
@@ -33,7 +25,7 @@ export class Tree {
 
   private _render(): string[] {
     const ret: string[] = [];
-    ret.push(...this.lines);
+    ret.push(...this.text.lines);
     for (let i = 0; i < this.children.length; i++) {
       const isLastChild = i === this.children.length - 1;
 
@@ -55,6 +47,23 @@ export class Tree {
       }
     }
     return ret;
+  }
+}
+
+export class TreeText {
+  constructor(
+    public header: string[] = [],
+    public body: string[] = [],
+    public footer: string[] = [],
+  ) {
+  }
+
+  public get lines() {
+    return [...this.header, ...this.body, ...this.footer];
+  }
+
+  public lineCount(): number {
+    return this.header.length + this.body.length + this.footer.length;
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/fake-aws/fake-cloudformation.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/fake-aws/fake-cloudformation.ts
@@ -120,6 +120,7 @@ interface InMemoryChangeSet {
   description?: string;
   changes: Change[];
   creationTime: Date;
+  changeSetFailureEvents: OperationEvent[];
   earlyValidationErrors: EarlyValidationErrorPrime[];
 }
 
@@ -209,6 +210,11 @@ export class FakeCloudFormation {
    */
   public overrideEarlyValidationErrors?: EarlyValidationErrorPrime[];
 
+  /**
+   * Error events for the next change set operation
+   */
+  public overrideChangeSetErrorEvents?: OperationEvent[];
+
   constructor() {
     this.reset();
   }
@@ -223,6 +229,7 @@ export class FakeCloudFormation {
     this.overrideChangeSetChanges = undefined;
     this.overrideChangeSetStatus = undefined;
     this.overrideEarlyValidationErrors = undefined;
+    this.overrideChangeSetErrorEvents = undefined;
   }
 
   public accessStack(name: string): InMemoryStack {
@@ -231,6 +238,18 @@ export class FakeCloudFormation {
       throw new Error(`No such stack: ${name}`);
     }
     return ret;
+  }
+
+  public accessChangeSet(stackName: string, changeSetName: string): InMemoryChangeSet {
+    const ret = this.stacks.get(stackName);
+    if (!ret) {
+      throw new Error(`No such stack: ${stackName}`);
+    }
+    const cs = ret.changeSets.find((x) => x.name === changeSetName);
+    if (!cs) {
+      throw new Error(`No such stack: ${changeSetName} in stack ${stackName}`);
+    }
+    return cs;
   }
 
   public firstStack(): InMemoryStack {
@@ -452,6 +471,7 @@ export class FakeCloudFormation {
       description: input.Description,
       changes: changes ?? [],
       creationTime: new Date(),
+      changeSetFailureEvents: [],
       earlyValidationErrors: [],
     };
     stack.changeSets.push(cs);
@@ -713,17 +733,20 @@ export class FakeCloudFormation {
 
     const { changeSet: cs } = this.resolveChangeSet(input.ChangeSetName, input.StackName);
 
-    const events: OperationEvent[] = cs.earlyValidationErrors.map((err) => ({
-      EventId: uid(),
-      StackId: cs.stackId,
-      EventType: 'VALIDATION_ERROR',
-      LogicalResourceId: err.logicalId,
-      ResourceType: err.resourceType,
-      ValidationStatusReason: err.validationStatusReason,
-      ValidationPath: err.validationPath,
-      ValidationName: err.validationName ?? 'NAME_CONFLICT_VALIDATION',
-      Timestamp: new Date(),
-    }));
+    const events: OperationEvent[] = [
+      ...cs.changeSetFailureEvents,
+      ...cs.earlyValidationErrors.map((err) => ({
+        EventId: uid(),
+        StackId: cs.stackId,
+        EventType: 'VALIDATION_ERROR' as const,
+        LogicalResourceId: err.logicalId,
+        ResourceType: err.resourceType,
+        ValidationStatusReason: err.validationStatusReason,
+        ValidationPath: err.validationPath,
+        ValidationName: err.validationName ?? 'NAME_CONFLICT_VALIDATION',
+        Timestamp: new Date(),
+      })),
+    ];
 
     return {
       OperationEvents: events,
@@ -843,6 +866,7 @@ export class FakeCloudFormation {
       description: input.Description,
       changes: [],
       creationTime: new Date(),
+      changeSetFailureEvents: [],
       earlyValidationErrors: [],
     };
     stack.changeSets.push(cs);
@@ -871,6 +895,13 @@ export class FakeCloudFormation {
       cs.earlyValidationErrors = this.overrideEarlyValidationErrors;
       this.overrideEarlyValidationErrors = undefined;
       return;
+    }
+    if (this.overrideChangeSetErrorEvents) {
+      cs.status = 'FAILED';
+      cs.statusReason = 'Change set creation failed due to prepared errors';
+      cs.executionStatus = 'UNAVAILABLE';
+      cs.changeSetFailureEvents = this.overrideChangeSetErrorEvents;
+      this.overrideChangeSetErrorEvents = undefined;
     }
 
     // Allow tests to override the computed changes

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/__snapshots__/diagnosis-formatting.test.ts.snap
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/__snapshots__/diagnosis-formatting.test.ts.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`hostMessageFromDiagnosis change set failure with multiple errors for the same resource 1`] = `
+"❌ Stack MyStack:
+Early validation failed for change set my-cs:
+ └─ TestStack
+     └─ BadPolicy  (AWS::IAM::Policy BadPolicy)
+        🛑 Required property [PolicyDocument] not found (at /Resources/BadPolicy/Properties)
+        🛑 Required property [PolicyName] not found (at /Resources/BadPolicy/Properties)"
+`;
+
 exports[`hostMessageFromDiagnosis change set failure with resource errors 1`] = `
 {
   "code": "CDK_TOOLKIT_E9500",

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/diagnosis-formatting.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/diagnosis-formatting.test.ts
@@ -69,6 +69,47 @@ describe('hostMessageFromDiagnosis', () => {
     expect(redactTime(msg)).toMatchSnapshot();
   });
 
+  test('change set failure with multiple errors for the same resource', () => {
+    const diagnosis = {
+      type: 'problem',
+      detectedBy: {
+        type: 'early-validation',
+        changeSetName: 'my-cs',
+      },
+      problems: [
+        {
+          errorCode: 'PROPERTY_VALIDATION_VALIDATION_ERROR',
+          logicalId: 'BadPolicy',
+          message: 'Required property [PolicyDocument] not found (at /Resources/BadPolicy/Properties)',
+          parentStackLogicalIds: [],
+          physicalId: undefined,
+          resourceType: 'AWS::IAM::Policy',
+          sourceTrace: undefined,
+          stackArn: '',
+          topLevelStackHierarchicalId: 'TestStack',
+        },
+        {
+          errorCode: 'PROPERTY_VALIDATION_VALIDATION_ERROR',
+          logicalId: 'BadPolicy',
+          message: 'Required property [PolicyName] not found (at /Resources/BadPolicy/Properties)',
+          parentStackLogicalIds: [],
+          physicalId: undefined,
+          resourceType: 'AWS::IAM::Policy',
+          sourceTrace: undefined,
+          stackArn: '',
+          topLevelStackHierarchicalId: 'TestStack',
+        },
+      ],
+    } satisfies StackDiagnosis;
+
+    // THEN
+    const msg = hostMessageFromDiagnosis(diagnosedStack('MyStack', diagnosis));
+    // Want to see both errors represented in the output
+    expect(msg.message).toMatchSnapshot();
+    expect(msg.message).toContain('[PolicyDocument]');
+    expect(msg.message).toContain('[PolicyName]');
+  });
+
   test('change set failure without resource errors', () => {
     const msg = hostMessageFromDiagnosis(diagnosedStack('MyStack', {
       type: 'problem',

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
@@ -1,8 +1,7 @@
 import {
   ChangeSetStatus,
-  DescribeEventsCommand,
 } from '@aws-sdk/client-cloudformation';
-import type { DiagnosedStack, DiagnoseResult, StackDiagnosis } from '../../../lib/actions/diagnose';
+import type { StackDiagnosis } from '../../../lib/actions/diagnose';
 import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
 import type { ISourceTracer } from '../../../lib/api/source-tracing/private/source-tracing';
 import type { SourceTrace } from '../../../lib/api/source-tracing/types';

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
@@ -1,7 +1,8 @@
 import {
   ChangeSetStatus,
+  DescribeEventsCommand,
 } from '@aws-sdk/client-cloudformation';
-import type { StackDiagnosis } from '../../../lib/actions/diagnose';
+import type { DiagnosedStack, DiagnoseResult, StackDiagnosis } from '../../../lib/actions/diagnose';
 import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
 import type { ISourceTracer } from '../../../lib/api/source-tracing/private/source-tracing';
 import type { SourceTrace } from '../../../lib/api/source-tracing/types';
@@ -335,6 +336,91 @@ describe('CloudFormationStackDiagnoser', () => {
         type: 'problem',
         detectedBy: { type: 'change-set' },
       });
+    });
+
+    test('multiple problems from DescribeEvents are all returned', async () => {
+      fakeCfn.createStackSync({
+        StackName: 'MyStack',
+      });
+      fakeCfn.createChangeSetSync({
+        StackName: 'MyStack',
+        ChangeSetName: 'my-cs',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: 'AWS::EarlyValidation failed',
+      });
+      fakeCfn.accessChangeSet('MyStack', 'my-cs').changeSetFailureEvents = [
+        {
+          EventId: '4a71cc61-289f-40dc-90ab-933a93bbbf63',
+          StackId: 'arn:aws:cloudformation:eu-west-1:111111111111:stack/MyStack/9bca3980-37f6-11f1-9b72-0230792d700d',
+          OperationId: '345a3ffd-e545-437c-b32f-f71647308416',
+          OperationType: 'CREATE_CHANGESET',
+          EventType: 'VALIDATION_ERROR',
+          LogicalResourceId: 'BadPolicy',
+          PhysicalResourceId: '',
+          ResourceType: 'AWS::IAM::Policy',
+          Timestamp: new Date(),
+          ValidationFailureMode: 'FAIL',
+          ValidationName: 'PROPERTY_VALIDATION',
+          ValidationStatus: 'FAILED',
+          ValidationStatusReason: 'Required property [PolicyDocument] not found',
+          ValidationPath: '/Resources/BadPolicy/Properties',
+        },
+        {
+          EventId: '3f399b2a-6fed-4652-a682-9a8a30816f02',
+          StackId: 'arn:aws:cloudformation:eu-west-1:111111111111:stack/MyStack/9bca3980-37f6-11f1-9b72-0230792d700d',
+          OperationId: '345a3ffd-e545-437c-b32f-f71647308416',
+          OperationType: 'CREATE_CHANGESET',
+          EventType: 'VALIDATION_ERROR',
+          LogicalResourceId: 'BadPolicy',
+          PhysicalResourceId: '',
+          ResourceType: 'AWS::IAM::Policy',
+          Timestamp: new Date(),
+          ValidationFailureMode: 'FAIL',
+          ValidationName: 'PROPERTY_VALIDATION',
+          ValidationStatus: 'FAILED',
+          ValidationStatusReason: 'Required property [PolicyName] not found',
+          ValidationPath: '/Resources/BadPolicy/Properties',
+        },
+      ];
+
+      const result = await makeDiagnoser().diagnoseChangeSet({
+        ChangeSetName: 'my-cs',
+        StackName: 'MyStack',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: 'AWS::EarlyValidation failed',
+      });
+
+      expect(result).toMatchObject({
+        type: 'problem',
+        detectedBy: {
+          type: 'early-validation',
+          changeSetName: 'my-cs',
+        },
+        problems: [
+          {
+            errorCode: 'PROPERTY_VALIDATION_VALIDATION_ERROR',
+            logicalId: 'BadPolicy',
+            message: 'Required property [PolicyDocument] not found (at /Resources/BadPolicy/Properties)',
+            parentStackLogicalIds: [],
+            physicalId: undefined,
+            resourceType: 'AWS::IAM::Policy',
+            sourceTrace: undefined,
+            stackArn: '',
+            topLevelStackHierarchicalId: 'TestStack',
+          },
+          {
+            errorCode: 'PROPERTY_VALIDATION_VALIDATION_ERROR',
+            logicalId: 'BadPolicy',
+            message: 'Required property [PolicyName] not found (at /Resources/BadPolicy/Properties)',
+            parentStackLogicalIds: [],
+            physicalId: undefined,
+            resourceType: 'AWS::IAM::Policy',
+            sourceTrace: undefined,
+            stackArn: '',
+            topLevelStackHierarchicalId: 'TestStack',
+          },
+        ],
+      } satisfies StackDiagnosis);
     });
   });
 


### PR DESCRIPTION
If there are multiple Early Validation errors for the same resource, only one of them is reported (the last one that happens to be written to the CloudFormation falure events history).

This PR makes it so all errors for the same resource are reported together. New output:

```
Stack MyStack:
Early validation failed for change set my-cs:
 └─ TestStack
     └─ BadPolicy  (AWS::IAM::Policy BadPolicy)
        🛑 Required property [PolicyDocument] not found (at /Resources/BadPolicy/Properties)
        🛑 Required property [PolicyName] not found (at /Resources/BadPolicy/Properties)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
