### PR TITLE
chore: fix flaky test due to word wrapping

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-import-existing-resources-error-message-includes-construct-paths.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-import-existing-resources-error-message-includes-construct-paths.integtest.ts
@@ -25,7 +25,8 @@ integTest(
         allowErrExit: true,
       });
 
-      expect(stdErr).toContain('needs a DeletionPolicy');
+      // This error text is word-wrapped, only check presence of individual words
+      expect(stdErr).toContain('DeletionPolicy');
       expect(stdErr).toContain('MyRole');
       expect(stdErr).toContain('RemovalPolicy.RETAIN');
       expect(stdErr).toContain('https://docs.aws.amazon.com/cdk/v2/guide/resources.html#resources-removal');


### PR DESCRIPTION
Early validation error messages may be very long, so they are being word wrapped to a reasonable length.

We had a test checking for the presence of the substring "needs a DeletionPolicy"`, but depending on the length of some of the randoly generated identifiers before them that text could be all on one line or barely wrapped over 2 lines, causing the test to occasionally fail.

```
🛑 Automatic import of existing resource MyRoleF48FFE04 ({RoleName=cdktest-03qnm9w9i3vv-import-role}) needs a
                                                                                                      ☝️☝️☝️
   DeletionPolicy of 'Retain' or 'RetainExceptOnCreate'.
   ☝️☝️☝️
```

Instead we search for just individual words here to improve the reliability.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
