### PR TITLE
chore(toolkit-lib): recommend to use drift aware change sets when deploying to Cloudformation after hotswapping

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -343,7 +343,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       deploymentMethod = deploymentMethod.fallback;
     } else {
       await ioHelper.defaults.info(format(
-        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`
+        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`,
       ));
       return {
         type: 'did-deploy-stack',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -320,6 +320,11 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       );
 
       if (hotswapDeploymentResult) {
+        if (deploymentMethod.fallback) {
+          await ioHelper.defaults.info(
+            `Your next CloudFormation deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`,
+          );
+        }
         return hotswapDeploymentResult;
       }
 
@@ -342,9 +347,6 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
       deploymentMethod = deploymentMethod.fallback;
     } else {
-      await ioHelper.defaults.info(format(
-        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`,
-      ));
       return {
         type: 'did-deploy-stack',
         noOp: true,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -343,7 +343,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       deploymentMethod = deploymentMethod.fallback;
     } else {
       await ioHelper.defaults.info(format(
-        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift you introduced while hotswapping.`
+        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`
       ));
       return {
         type: 'did-deploy-stack',

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -320,11 +320,9 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       );
 
       if (hotswapDeploymentResult) {
-        if (deploymentMethod.fallback) {
-          await ioHelper.defaults.info(
-            `Your next CloudFormation deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping.`,
-          );
-        }
+        await ioHelper.defaults.info(
+          `Your next non-hotswap deployment with ${stackEnv.name} should include '--revert-drift' to resolve the drift that was introduced while hotswapping.`,
+        );
         return hotswapDeploymentResult;
       }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -342,6 +342,9 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
       deploymentMethod = deploymentMethod.fallback;
     } else {
+      await ioHelper.defaults.info(format(
+        `Your next regular deployment with ${stackEnv.name} should use 'cdk deploy --revert-drift' to resolve the drift you introduced while hotswapping.`
+      ));
       return {
         type: 'did-deploy-stack',
         noOp: true,

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -240,6 +240,24 @@ test('correctly passes SSM parameters when hotswapping', async () => {
   );
 });
 
+test('prints revert-drift recommendation on successful hotswap deployment with fallback', async () => {
+  givenStackExists();
+  (tryHotswapDeployment as jest.Mock).mockResolvedValue({
+    type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {},
+  });
+
+  // WHEN
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
+  });
+
+  // THEN
+  expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+    message: expect.stringMatching(/should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping/),
+  }));
+});
+
 describe('hotswap template cache', () => {
   test('writeHotswapTemplateCache is called on a successful hotswap deployment', async () => {
     // GIVEN

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -240,7 +240,7 @@ test('correctly passes SSM parameters when hotswapping', async () => {
   );
 });
 
-test('prints revert-drift recommendation on successful hotswap deployment with fallback', async () => {
+test('prints revert-drift recommendation on successful hotswap deployment', async () => {
   givenStackExists();
   (tryHotswapDeployment as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {},
@@ -249,12 +249,12 @@ test('prints revert-drift recommendation on successful hotswap deployment with f
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
+    deploymentMethod: { method: 'hotswap' },
   });
 
   // THEN
   expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
-    message: expect.stringMatching(/should use 'cdk deploy --revert-drift' to resolve the drift that was introduced while hotswapping/),
+    message: expect.stringMatching(/should include '--revert-drift' to resolve the drift that was introduced while hotswapping/),
   }));
 });
 


### PR DESCRIPTION
Drift aware change sets take into account current resource state when making a changeset and will not make changes if the new template and the resource state align, otherwise will prefer changes from the new template. 
When recovering from hotswap deployments, drift aware changesets will do a better job of getting your Cloudformation state and your current resource state back into sync than a regular Cloudformation deployment (using changesets or update stack) would. Adds a message in the CLI that recommends to use drift aware changesets when deploying to Cloudformation after performing hotswap deployments. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
