### PR TITLE
fix: progress is wrong for nested stacks

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -294,7 +294,7 @@ export class StackActivityMonitor {
     const pollEvents = await this.poller.poll();
 
     for (const resourceEvent of pollEvents) {
-      this.progressMonitor.process(resourceEvent.event);
+      this.progressMonitor.process(resourceEvent);
 
       // If this is a failed Guard Hook event with an invocation ID, fetch annotations
       if (resourceEvent.event.HookInvocationId) {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-progress-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-progress-monitor.ts
@@ -1,5 +1,5 @@
 import * as util from 'util';
-import type { StackEvent } from '@aws-sdk/client-cloudformation';
+import type { ResourceEvent } from './stack-event-poller';
 import type { StackProgress } from '../../payloads/progress';
 import { padLeft } from '../../util';
 
@@ -84,13 +84,20 @@ export class StackProgressMonitor {
   /**
    * Process as stack event and update the progress state.
    */
-  public process(event: StackEvent): void {
+  public process(resourceEvent: ResourceEvent): void {
+    // Only resources in the root stack (nested stack events do not count towards progress)
+    if (resourceEvent.parentStackLogicalIds.length > 0) {
+      return;
+    }
+
+    const event = resourceEvent.event;
     const status = event.ResourceStatus;
     if (!status || !event.LogicalResourceId) {
       return;
     }
 
     if (status.endsWith('_COMPLETE_CLEANUP_IN_PROGRESS')) {
+      // The stack
       this.resourcesDone++;
     }
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/progress-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/progress-monitor.test.ts
@@ -10,45 +10,57 @@ test('prints 0/4 progress report, when addActivity is called with an "IN_PROGRES
   const stackProgress = new StackProgressMonitor(3);
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.CREATE_IN_PROGRESS,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.CREATE_IN_PROGRESS,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('0/4');
 });
 
-test('prints 1/4 progress report, when addActivity is called with an "UPDATE_COMPLETE" ResourceStatus', () => {
+test.each([
+  [false, 1],
+  [true, 0],
+])(', when addActivity is called with an "UPDATE_COMPLETE" ResourceStatus in nested stack=%p, prints %p/4 progress report', (nested, expectedProgress) => {
   const stackProgress = new StackProgressMonitor(3);
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: nested ? ['NestedStackLogicalId'] : [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
-  expect(stackProgress.formatted).toStrictEqual('1/4');
+  expect(stackProgress.formatted).toStrictEqual(`${expectedProgress}/4`);
 });
 
 test('prints 1/4 progress report, when addActivity is called with an "ROLLBACK_COMPLETE" ResourceStatus', () => {
   const stackProgress = new StackProgressMonitor(3);
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.ROLLBACK_COMPLETE,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.ROLLBACK_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('1/4');
@@ -58,13 +70,16 @@ test('prints 0/4 progress report, when addActivity is called with an "UPDATE_FAI
   const stackProgress = new StackProgressMonitor(3);
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.UPDATE_FAILED,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.UPDATE_FAILED,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('0/4');
@@ -74,13 +89,16 @@ test('prints "  1" progress report, when number of resources is unknown and addA
   const stackProgress = new StackProgressMonitor();
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('  1');
@@ -90,26 +108,33 @@ test('will count backwards when resource is first completed and then rolled back
   const stackProgress = new StackProgressMonitor(3);
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('1/4');
 
   stackProgress.process({
-    LogicalResourceId: 'stack1',
-    ResourceStatus: ResourceStatus.ROLLBACK_COMPLETE,
-    Timestamp: new Date(TIMESTAMP),
-    ResourceType: 'AWS::CloudFormation::Stack',
-    StackId: '',
-    EventId: '',
-    StackName: 'stack-name',
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.ROLLBACK_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
   });
 
   expect(stackProgress.formatted).toStrictEqual('0/4');
 });
+


### PR DESCRIPTION
The CDK CLI prints a `(current)/(total)` progress.

However, the `(total)` counter is based off of the change set of the root stack, while the `(current)` counter is a count of all the stack deployment events that the CLI has seen, which includes events in nested stacks.

Be sure to only increase the progress counter for root stack events.

Pre-emptive FAQ: why not accurately reflect the total amount of changes in all nested stacks? Because we have chosen (and locked in using tests) that we are not creating change sets for nested stacks. So there's no way to predict how many changes there will be in the nested stacks before executing.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
