### PR TITLE
fix: update version includes a spurious newline

### DIFF
--- a/packages/aws-cdk/lib/cli/util/npm.ts
+++ b/packages/aws-cdk/lib/cli/util/npm.ts
@@ -20,7 +20,7 @@ export async function execNpmView(currentVersion: string) {
       throw new ToolkitError('NpmViewCurrentFailed', `npm view command for current version failed: ${currentResult.stderr.trim()}`);
     }
 
-    const latestVersion = latestResult.stdout;
+    const latestVersion = latestResult.stdout.trim();
     const currentInfo = JSON.parse(currentResult.stdout);
 
     return {


### PR DESCRIPTION
Our upgrade message has looked like this for a long time:

```
*****************************************************
*** Newer version of CDK is available [2.1120.0
] ***
*** Upgrade recommended (npm install -g aws-cdk)  ***
*****************************************************
```

Time to fix it and get rid of that spurious newline.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
