### PR TITLE
fix(cli-integ): release on every commit

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1556,6 +1556,15 @@ const cliInteg = configureProject(
     // integ tests.
     majorVersion: 3,
 
+    // For our integ tests we can just release anything, doesn't matter if it
+    // is a dependency update or something else. In fact we often incorrectly
+    // label changes updates as 'chore' and then our canaries start failing
+    // because we didn't release the integ tests package.
+    //
+    // Cannot be set to `ReleasableCommits.everyCommit()` because that would
+    // actually include very commit in the monorepo.
+    releasableCommits: pj.ReleasableCommits.exec('git log --no-merges --oneline $LATEST_TAG..HEAD -- .'),
+
     srcdir: '.',
     libdir: '.',
     deps: [

--- a/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/tasks.json
@@ -33,7 +33,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts neverMajor maybeRc",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- .",
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -- .",
         "MAJOR": "3"
       },
       "steps": [
@@ -202,7 +202,7 @@
         "VERSIONRCOPTIONS": "{\"path\":\".\"}",
         "BUMP_PACKAGE": "commit-and-tag-version@^12",
         "NEXT_VERSION_COMMAND": "tsx ../../../projenrc/next-version.ts neverMajor maybeRc",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep \"^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+\" -- ."
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -- ."
       },
       "steps": [
         {


### PR DESCRIPTION
The cli-integ package previously only considered commits matching the conventional commits pattern (`feat`/`fix`) as releasable. This meant that dependency updates and other changes incorrectly labeled as `chore` would not trigger a release of the integ tests package, causing canary failures downstream.

This change relaxes the filter to release on every commit that touches the cli-integ package directory. We can't use `ReleasableCommits.everyCommit()` because that would include every commit in the monorepo regardless of which package it touches.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
