### PR TITLE
chore: order record_timestamp and standalone jobs after aws-cdk publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1203,7 +1203,9 @@ jobs:
         run: npx -p publib@latest publib-npm
   standalone_release_adc:
     name: "standalone: publish to ADC"
-    needs: release
+    needs:
+      - release
+      - aws-cdk_release_npm
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -1243,7 +1245,9 @@ jobs:
         run: yarn projen publish-to-adc
   record_timestamp:
     name: "aws-cdk: Record publishing timestamp"
-    needs: release
+    needs:
+      - release
+      - aws-cdk_release_npm
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -35,7 +35,7 @@ export class AdcPublishing extends Component {
     releaseWf.addJob('standalone_release_adc', {
       name: 'standalone: publish to ADC',
       environment: 'releasing', // <-- this has the configuration
-      needs: ['release'],
+      needs: ['release', 'aws-cdk_release_npm'],
       runsOn: ['ubuntu-latest'],
       permissions: {
         contents: JobPermission.WRITE,

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -21,7 +21,7 @@ export class RecordPublishingTimestamp extends Component {
     releaseWf.addJob('record_timestamp', {
       name: 'aws-cdk: Record publishing timestamp',
       environment: 'releasing', // <-- this has the configuration
-      needs: ['release'],
+      needs: ['release', 'aws-cdk_release_npm'],
       runsOn: ['ubuntu-latest'],
       permissions: {
         contents: JobPermission.WRITE,


### PR DESCRIPTION
The `record_timestamp` and `standalone_release_adc` jobs in the release workflow were not respecting the topological release order that was recently added. Both jobs only depended on the `release` job, which meant they could execute before `aws-cdk` was actually published to npm. This is incorrect because `record_timestamp` records the publishing timestamp for the CLI, and the standalone artifact is the CLI — both should only run after the CLI has been successfully published.

Both jobs now depend on `aws-cdk_release_npm` to ensure they run in the correct order.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
