### PR TITLE
chore: use correct team name for PR reviewer assignment

### DIFF
--- a/.github/workflows/issue-label-assign.yml
+++ b/.github/workflows/issue-label-assign.yml
@@ -11,18 +11,18 @@ on:
       - edited
 jobs:
   Triage-Issues:
-    name: Triage Manager
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    name: Triage Issues
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
     env:
       AREA_PARAMS: '[{"area":"@aws-cdk/cloud-assembly-schema","keywords":["cloud-assembly","schema"],"labels":["@aws-cdk/cloud-assembly-schema"]},{"area":"@aws-cdk/cloudformation-diff","keywords":["diff","cloudformation"],"labels":["@aws-cdk/cloudformation-diff"]},{"area":"@aws-cdk/toolkit-lib","keywords":["toolkit","programmtic toolkit","toolkit-lib"],"labels":["@aws-cdk/toolkit-lib"]},{"area":"aws-cdk","keywords":["aws-cdk","cli","cdk cli","cdk"],"labels":["aws-cdk"]},{"area":"cdk-assets","keywords":["assets","cdk-assets"],"labels":["cdk-assets"]}]'
       AREA_AFFIXES: '{"prefixes":["@aws-cdk/"]}'
-      OSDS_DEVS: '{"assignees":["ashishdhingra","khushail","hunhsieh"]}'
+      OSDS_DEVS: '{"assignees":["hunhsieh"]}'
     steps:
       - name: Triage Manager
-        uses: aws-github-ops/aws-issue-triage-manager@main
+        uses: aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           target: issues
@@ -33,18 +33,18 @@ jobs:
           parameters: ${{ env.AREA_PARAMS }}
           affixes: ${{ env.AREA_AFFIXES }}
   Triage-Pull-Requests:
-    name: Triage Manager
-    runs-on: aws-cdk_ubuntu-latest_4-core
+    name: Triage Pull Requests
+    runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
     environment: automation
     steps:
       - name: Triage Manager
-        uses: aws-github-ops/aws-issue-triage-manager@main
+        uses: aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61
         with:
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           target: pull-requests
-          default-area: '{"reviewers":{"teamReviewers":["aws-cdk-owners"]}}'
+          default-area: '{"reviewers":{"teamReviewers":["aws-cdk-core-team"]}}'
           parameters: '[{"area":"pullrequests","keywords":["pullrequestkeyword"]}]'
           area-is-keyword: true

--- a/projenrc/issue-labeler.ts
+++ b/projenrc/issue-labeler.ts
@@ -5,7 +5,7 @@ import { JobPermission } from 'projen/lib/github/workflows-model';
 import type { TypeScriptProject } from 'projen/lib/typescript';
 import { GitHubToken, stringifyList } from './util';
 
-const OSDS_DEVS = ['ashishdhingra', 'khushail', 'hunhsieh'];
+const OSDS_DEVS = ['hunhsieh'];
 const AREA_AFFIXES = ['@aws-cdk/'];
 const AREA_PARAMS = [
   { area: '@aws-cdk/cloud-assembly-schema', keywords: ['cloud-assembly', 'schema'], labels: ['@aws-cdk/cloud-assembly-schema'] },
@@ -38,19 +38,30 @@ interface TriageManagerOptions {
   credentials?: GithubCredentials;
 }
 
+function triageManagerHumanFriendlyName(target: TriageManagerOptions['target']): string {
+  switch (target) {
+    case 'both':
+      return 'Issues and Pull Requests';
+    case 'issues':
+      return 'Issues';
+    case 'pull-requests':
+      return 'Pull Requests';
+  }
+}
+
 function triageManagerJob(triageManagerOptions: TriageManagerOptions) {
   const credentials = triageManagerOptions.credentials ?? GitHubToken.GITHUB_TOKEN;
-
+  const name = `Triage ${triageManagerHumanFriendlyName(triageManagerOptions.target)}`;
   return {
-    name: 'Triage Manager',
-    runsOn: ['aws-cdk_ubuntu-latest_4-core'],
+    name,
+    runsOn: ['ubuntu-latest'],
     permissions: { issues: JobPermission.WRITE, pullRequests: JobPermission.WRITE },
     environment: credentials.environment,
     steps: [
       ...credentials.setupSteps,
       {
         name: 'Triage Manager',
-        uses: 'aws-github-ops/aws-issue-triage-manager@main',
+        uses: 'aws-github-ops/aws-issue-triage-manager@701b2b0b4ba8c03c587149c37519052c357a2a61',
         with: {
           'github-token': credentials.tokenRef,
           'target': triageManagerOptions.target,
@@ -103,7 +114,7 @@ export class IssueLabeler extends Component {
     this.workflow.addJob('Triage-Pull-Requests', triageManagerJob({
       target: 'pull-requests',
       areaIsKeyword: true,
-      defaultArea: '{"reviewers":{"teamReviewers":["aws-cdk-owners"]}}',
+      defaultArea: '{"reviewers":{"teamReviewers":["aws-cdk-core-team"]}}',
       parameters: '[{"area":"pullrequests","keywords":["pullrequestkeyword"]}]',
       credentials: repo.github?.projenCredentials,
     }));


### PR DESCRIPTION
The issue-label-assign workflow was failing on PRs because it tried to request reviews from the `aws-cdk-owners` team, which is not a collaborator on this repository. Updated to use `aws-cdk-core-team` instead.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
