### PR TITLE
chore: use projen primitives for artifact actions in GHA Workflows

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -62,17 +62,17 @@ jobs:
           RELEASE: "true"
         run: yarn projen build
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: build-artifact
           path: packages/**/dist/js/*.tgz
-          overwrite: "true"
-      - name: Upload scripts
-        uses: actions/upload-artifact@v4.4.0
+          overwrite: true
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
         with:
           name: script-artifact
           path: .projen/*.sh
-          overwrite: "true"
+          overwrite: true
           include-hidden-files: true
   integ_cli:
     needs: prepare
@@ -88,13 +88,13 @@ jobs:
       CI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
-      - name: Download scripts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: script-artifact
           path: .projen
@@ -165,11 +165,11 @@ jobs:
       - name: Upload logs
         id: logupload
         if: always()
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
-          overwrite: "true"
+          overwrite: true
       - name: Append artifact URL
         if: always()
         run: |-
@@ -209,13 +209,13 @@ jobs:
       CI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
-      - name: Download scripts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: script-artifact
           path: .projen
@@ -286,11 +286,11 @@ jobs:
       - name: Upload logs
         id: logupload
         if: always()
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
-          overwrite: "true"
+          overwrite: true
       - name: Append artifact URL
         if: always()
         run: |-
@@ -320,13 +320,13 @@ jobs:
       CI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
-      - name: Download scripts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: script-artifact
           path: .projen
@@ -397,11 +397,11 @@ jobs:
       - name: Upload logs
         id: logupload
         if: always()
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
-          overwrite: "true"
+          overwrite: true
       - name: Append artifact URL
         if: always()
         run: |-
@@ -428,13 +428,13 @@ jobs:
       CI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
-      - name: Download scripts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: script-artifact
           path: .projen
@@ -505,11 +505,11 @@ jobs:
       - name: Upload logs
         id: logupload
         if: always()
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
-          overwrite: "true"
+          overwrite: true
       - name: Append artifact URL
         if: always()
         run: |-
@@ -550,13 +550,13 @@ jobs:
       CI: "true"
     if: github.event_name != 'merge_group' && !contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: build-artifact
           path: packages
-      - name: Download scripts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: script-artifact
           path: .projen
@@ -627,11 +627,11 @@ jobs:
       - name: Upload logs
         id: logupload
         if: always()
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ steps.artifactid.outputs.slug }}
           path: logs/
-          overwrite: "true"
+          overwrite: true
       - name: Append artifact URL
         if: always()
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,7 +218,7 @@ jobs:
           overwrite: true
       - name: "standalone: Upload artifact"
         if: ${{ steps.git_remote.outputs.latest_commit == github.sha }}
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v7
         with:
           name: standalone_build-artifact
           path: dist/standalone
@@ -1222,8 +1222,8 @@ jobs:
           package-manager-cache: false
       - name: Install dependencies
         run: yarn install --immutable
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: standalone_build-artifact
           path: dist/standalone
@@ -1251,8 +1251,8 @@ jobs:
     environment: releasing
     if: ${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: aws-cdk_build-artifact
           path: dist
@@ -1281,8 +1281,8 @@ jobs:
     environment: releasing
     if: ${{ !inputs.dry_run }}
     steps:
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
+      - name: Download artifact
+        uses: actions/download-artifact@v8
         with:
           name: aws-cdk-toolkit-lib_build-artifact
           path: dist

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -22,14 +22,15 @@ export class AdcPublishing extends Component {
     }
 
     (releaseWf.getJob('release') as github.workflows.Job).steps.push({
+      ...github.WorkflowSteps.uploadArtifact({
+        with: {
+          name: 'standalone_build-artifact',
+          path: 'dist/standalone',
+          overwrite: true,
+        },
+      }),
       name: 'standalone: Upload artifact',
       if: '${{ steps.git_remote.outputs.latest_commit == github.sha }}',
-      uses: 'actions/upload-artifact@v4.4.0',
-      with: {
-        name: 'standalone_build-artifact',
-        path: 'dist/standalone',
-        overwrite: true,
-      },
     });
 
     releaseWf.addJob('standalone_release_adc', {
@@ -45,14 +46,12 @@ export class AdcPublishing extends Component {
       steps: [
         github.WorkflowSteps.checkout(),
         ...this.project_.renderWorkflowSetup(),
-        {
-          name: 'Download build artifacts',
-          uses: 'actions/download-artifact@v4',
+        github.WorkflowSteps.downloadArtifact({
           with: {
             name: 'standalone_build-artifact',
             path: 'dist/standalone',
           },
-        },
+        }),
         {
           name: 'Authenticate Via OIDC Role',
           id: 'creds',

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -17,22 +17,18 @@ const NOT_FLAGGED_EXPR = "!contains(github.event.pull_request.labels.*.name, 'pr
  */
 function downloadArtifactsSteps(): github.workflows.JobStep[] {
   return [
-    {
-      name: 'Download build artifacts',
-      uses: 'actions/download-artifact@v4',
+    github.WorkflowSteps.downloadArtifact({
       with: {
         name: 'build-artifact',
         path: 'packages',
       },
-    },
-    {
-      name: 'Download scripts',
-      uses: 'actions/download-artifact@v4',
+    }),
+    github.WorkflowSteps.downloadArtifact({
       with: {
         name: 'script-artifact',
         path: '.projen',
       },
-    },
+    }),
   ];
 }
 
@@ -433,25 +429,21 @@ export class CdkCliIntegTestsWorkflow extends Component {
             RELEASE: 'true',
           },
         },
-        {
-          name: 'Upload artifact',
-          uses: 'actions/upload-artifact@v4.4.0',
+        github.WorkflowSteps.uploadArtifact({
           with: {
             name: 'build-artifact',
             path: 'packages/**/dist/js/*.tgz',
-            overwrite: 'true',
+            overwrite: true,
           },
-        },
-        {
-          name: 'Upload scripts',
-          uses: 'actions/upload-artifact@v4.4.0',
+        }),
+        github.WorkflowSteps.uploadArtifact({
           with: {
-            'name': 'script-artifact',
-            'path': '.projen/*.sh',
-            'overwrite': 'true',
-            'include-hidden-files': true,
+            name: 'script-artifact',
+            path: '.projen/*.sh',
+            overwrite: true,
+            includeHiddenFiles: true,
           },
-        },
+        }),
       ],
     });
 
@@ -634,15 +626,16 @@ export class CdkCliIntegTestsWorkflow extends Component {
           },
         },
         {
+          ...github.WorkflowSteps.uploadArtifact({
+            with: {
+              name: '${{ steps.artifactid.outputs.slug }}',
+              path: 'logs/',
+              overwrite: true,
+            },
+          }),
           name: 'Upload logs',
           if: 'always()',
-          uses: 'actions/upload-artifact@v4.4.0',
           id: 'logupload',
-          with: {
-            name: '${{ steps.artifactid.outputs.slug }}',
-            path: 'logs/',
-            overwrite: 'true',
-          },
         },
         {
           name: 'Append artifact URL',

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -1,5 +1,5 @@
 import type { Monorepo } from 'cdklabs-projen-project-types/lib/yarn';
-import { Component } from 'projen';
+import { Component, github } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
 
 /**
@@ -29,14 +29,12 @@ export class RecordPublishingTimestamp extends Component {
       },
       if: '${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}',
       steps: [
-        {
-          name: 'Download build artifacts',
-          uses: 'actions/download-artifact@v4',
+        github.WorkflowSteps.downloadArtifact({
           with: {
             name: 'aws-cdk_build-artifact',
             path: 'dist',
           },
-        },
+        }),
         {
           name: 'Read version from build artifacts',
           id: 'aws-cdk-version',

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -82,14 +82,12 @@ export class S3DocsPublishing extends Component {
         contents: github.workflows.JobPermission.READ,
       },
       steps: [
-        {
-          name: 'Download build artifacts',
-          uses: 'actions/download-artifact@v4',
+        github.WorkflowSteps.downloadArtifact({
           with: {
             name: `${safeName}_build-artifact`,
             path: 'dist',
           },
-        },
+        }),
         {
           name: 'Authenticate Via OIDC Role',
           id: 'creds',


### PR DESCRIPTION
Replaces all hardcoded `actions/upload-artifact@v4.4.0` and `actions/download-artifact@v4` references with projen's `WorkflowSteps.uploadArtifact()` and `WorkflowSteps.downloadArtifact()` primitives. This upgrades to v7 and v8 respectively, resolving the Node.js 20 deprecation warnings that were firing on the release and integ workflows.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
