### PR TITLE
fix(toolkit-lib): CLI hangs when CreateChangeSet returns InternalFailure

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -668,7 +668,7 @@ export class SDK {
       region,
       credentials: credProvider,
       requestHandler,
-      retryStrategy: new ConfiguredRetryStrategy(7, (attempt) => 300 * (2 ** attempt)),
+      retryStrategy: new ConfiguredRetryStrategy(7, cappedExponentialBackoff(300, 15_000)),
       customUserAgent: defaultCliUserAgent(),
       logger: logger ? makeSdkLoggerSafeByBindingThis(logger) : undefined,
     };
@@ -740,7 +740,7 @@ export class SDK {
   public cloudFormation(): ICloudFormationClient {
     const client = new CloudFormationClient({
       ...this.config,
-      retryStrategy: new ConfiguredRetryStrategy(11, (attempt: number) => 1000 * (2 ** attempt)),
+      retryStrategy: new ConfiguredRetryStrategy(7, cappedExponentialBackoff(1000, 15_000)),
     });
     return {
       continueUpdateRollback: async (
@@ -1202,4 +1202,23 @@ function makeSdkLoggerSafeByBindingThis(logger: ISdkLogger): ISdkLogger {
     warn: logger.warn.bind(logger),
     error: logger.error.bind(logger),
   };
+}
+
+/**
+ * Build an exponential-backoff delay function whose result is capped at a maximum.
+ *
+ * An uncapped exponential backoff (`base * 2^attempt`) grows without bound as the
+ * number of retries increases. For the retry counts we use on the CloudFormation
+ * client in particular (11 attempts), that means the SDK can spend *tens of
+ * minutes* silently sleeping between retries when the service returns a
+ * retryable error such as `InternalFailure`. To the user that looks like the
+ * CLI has hung. Capping each individual delay at ~15s bounds the total retry
+ * time to a few minutes at worst, while still giving the SDK plenty of
+ * opportunity to ride out transient server problems or throttling.
+ *
+ * @param baseMs - base delay in milliseconds (used in `baseMs * 2^attempt`)
+ * @param capMs - maximum delay in milliseconds; any computed delay larger than this is clamped
+ */
+export function cappedExponentialBackoff(baseMs: number, capMs: number): (attempt: number) => number {
+  return (attempt: number) => Math.min(baseMs * (2 ** attempt), capMs);
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-retry.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-retry.test.ts
@@ -1,0 +1,44 @@
+import { cappedExponentialBackoff } from '../../../lib/api/aws-auth/private';
+
+describe(cappedExponentialBackoff, () => {
+  test('returns exponentially growing delays while below the cap', () => {
+    const backoff = cappedExponentialBackoff(1000, 15_000);
+
+    expect(backoff(1)).toBe(2000);
+    expect(backoff(2)).toBe(4000);
+    expect(backoff(3)).toBe(8000);
+  });
+
+  test('clamps delays to the provided maximum', () => {
+    const backoff = cappedExponentialBackoff(1000, 15_000);
+
+    // Uncapped would be 16_000, 32_000, 1024 * 1000, 2048 * 1000 etc.
+    expect(backoff(4)).toBe(15_000);
+    expect(backoff(5)).toBe(15_000);
+    expect(backoff(10)).toBe(15_000);
+    expect(backoff(20)).toBe(15_000);
+  });
+
+  test('bounds total retry time for the CloudFormation client configuration', () => {
+    // This mirrors the actual production config: 7 retries, 1s base, 15s cap.
+    // Without the cap the total retry time was ~34 minutes, which manifests as
+    // a hang to CLI users when CloudFormation returns InternalFailure.
+    const backoff = cappedExponentialBackoff(1000, 15_000);
+
+    let total = 0;
+    for (let attempt = 1; attempt <= 6; attempt++) {
+      total += backoff(attempt);
+    }
+
+    // 2 + 4 + 8 + 15 + 15 + 15 = 59 seconds
+    expect(total).toBe(59_000);
+    expect(total).toBeLessThan(120_000);
+  });
+
+  test('can produce delays smaller than the base when base is small', () => {
+    const backoff = cappedExponentialBackoff(100, 10_000);
+
+    expect(backoff(0)).toBe(100);
+    expect(backoff(1)).toBe(200);
+  });
+});


### PR DESCRIPTION
Fixes #1483

When `CreateChangeSet` (or any CloudFormation API) returns a retryable error like `InternalFailure`, the AWS SDK retries with exponential backoff. The previous configuration used an uncapped exponential delay (`1000 * 2^attempt`) with 11 max attempts, meaning the total silent retry time could exceed 34 minutes. To the user this looks like the CLI has hung after printing "creating CloudFormation changeset...".

This change introduces a `cappedExponentialBackoff` helper that clamps each individual delay at 15 seconds. Combined with reducing the CloudFormation max attempts from 11 to 7 (matching the default SDK config), the worst-case retry time is now ~59 seconds — still enough to ride out transient failures, but fast enough that users see an actual error message instead of a perceived hang.

The same cap is applied to the default SDK retry strategy. While the improvement on max wait time is insignificant here (worst-case goes from ~38 seconds down to ~34 seconds), we gain consistency and safety for possible future changes.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
