### PR TITLE
chore(cli): feature flags in alphabetical order in `cdk.json` when using `cdk init`

### DIFF
--- a/packages/aws-cdk/lib/commands/init/init.ts
+++ b/packages/aws-cdk/lib/commands/init/init.ts
@@ -1020,5 +1020,7 @@ async function loadInitVersions(): Promise<Versions> {
  */
 export async function currentlyRecommendedAwsCdkLibFlags() {
   const recommendedFlagsFile = path.join(cliRootDir(), 'lib', 'init-templates', '.recommended-feature-flags.json');
-  return JSON.parse(await fs.readFile(recommendedFlagsFile, { encoding: 'utf-8' }));
+  const flags = JSON.parse(await fs.readFile(recommendedFlagsFile, { encoding: 'utf-8' }));
+  const sortedKeys = Object.keys(flags).sort();
+  return Object.fromEntries(sortedKeys.map(k => [k, flags[k]]));
 }


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-cdk/issues/35662

cdk projects generated by `cdk init` do not organize feature flags in alphabetical order in `cdk.json` (unlike running the `cdk flags` command) which can make looking through the list of flags a bit confusing. 
Put the flags in alphabetical order in `cdk.json` when creating a project with `cdk init`. 
Verified manually.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
