### PR TITLE
fix(cli-integ): increase timeout for typescript init app/sample-app tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -17,7 +17,7 @@ import { typescriptVersionsSync, typescriptVersionsYoungerThanDaysSync } from '.
     await shell.shell(['npm', 'run', 'test']);
 
     await shell.shell(['cdk', 'synth']);
-  })));
+  })), 300_000);
 });
 
 // Same as https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#support-window


### PR DESCRIPTION
## Summary
- Increases the test timeout for `typescript init app` and `typescript init sample-app` integration tests from the default 60s to 5 minutes (300,000ms)
- These tests run npm install, build, test, and synth which can exceed the default timeout
- We are seeing these tests timeout in the pipeline

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

