### PR TITLE
fix: remove `uuid` dependency in favor of `node:crypto`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -928,7 +928,6 @@ const toolkitLib = configureProject(
       'semver',
       'split2',
       'fast-glob',
-      'uuid',
       'wrap-ansi@^7', // Last non-ESM version
       'yaml@^1',
     ],
@@ -1263,7 +1262,6 @@ const cli = configureProject(
       'proxy-agent',
       'semver',
       'strip-ansi@^6',
-      'uuid',
       'wrap-ansi@^7', // Last non-ESM version
       'yaml@^1',
       'yargs@^15',

--- a/packages/@aws-cdk/cdk-assets-lib/test/private/docker-credentials.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/private/docker-credentials.test.ts
@@ -1,6 +1,6 @@
-import * as crypto from 'crypto';
-import * as os from 'os';
-import * as path from 'path';
+import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { GetAuthorizationTokenCommand } from '@aws-sdk/client-ecr';
 import { GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
 import type { IAws } from '../../lib/aws';
@@ -51,7 +51,7 @@ describe('cdkCredentialsConfigFile', () => {
 describe('cdkCredentialsConfig', () => {
   let credsFile: string;
   beforeEach(() => {
-    credsFile = `/tmp/foo/bar/does/not/exist/config${crypto.randomUUID()}.json`;
+    credsFile = `/tmp/foo/bar/does/not/exist/config${randomUUID()}.json`;
     process.env.CDK_DOCKER_CREDS_FILE = mockfs.path(credsFile);
   });
 

--- a/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
@@ -27835,10 +27835,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
-** uuid@11.1.1 - https://www.npmjs.com/package/uuid/v/11.1.1 | MIT
-
-----------------
-
 ** workerpool@6.5.1 - https://www.npmjs.com/package/workerpool/v/6.5.1 | Apache-2.0
 Apache License
                            Version 2.0, January 2004

--- a/packages/@aws-cdk/toolkit-lib/.projen/deps.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/deps.json
@@ -385,10 +385,6 @@
       "type": "runtime"
     },
     {
-      "name": "uuid",
-      "type": "runtime"
-    },
-    {
       "name": "wrap-ansi",
       "version": "^7",
       "type": "runtime"

--- a/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
+++ b/packages/@aws-cdk/toolkit-lib/.projen/tasks.json
@@ -55,7 +55,7 @@
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/util-stream,@types/jest,@types/jest-when,@types/picomatch,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-when,license-checker,nx,projen,ts-jest,tsx,archiver,cdk-from-cfn,fast-deep-equal,fast-glob,picomatch,semver,split2,uuid"
+          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@aws-cdk/aws-service-spec,@cdklabs/eslint-plugin,@jest/environment,@jest/globals,@jest/types,@microsoft/api-extractor,@smithy/util-stream,@types/jest,@types/jest-when,@types/picomatch,@types/split2,aws-cdk-lib,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-when,license-checker,nx,projen,ts-jest,tsx,archiver,cdk-from-cfn,fast-deep-equal,fast-glob,picomatch,semver,split2"
         }
       ]
     },

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/diff/private/helpers.ts
@@ -1,7 +1,7 @@
+import { randomUUID } from 'node:crypto';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import * as fs from 'fs-extra';
-import * as uuid from 'uuid';
 import type { ChangeSetDiffOptions, DiffOptions, LocalFileDiffOptions } from '..';
 import { DiffMethod } from '..';
 import type { SdkProvider } from '../../../api/aws-auth/private';
@@ -97,7 +97,7 @@ async function cfnDiff(
       parameters: methodOptions.parameters ?? {},
       failOnError: !(methodOptions.fallbackToTemplate ?? true),
       importExistingResources: methodOptions.importExistingResources,
-      uuid: uuid.v4(),
+      uuid: randomUUID(),
       willExecute: false,
     }) : undefined;
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -1,4 +1,5 @@
-import { format } from 'util';
+import { randomUUID } from 'node:crypto';
+import { format } from 'node:util';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import type {
   CreateChangeSetCommandInput,
@@ -9,7 +10,6 @@ import type {
   Tag,
 } from '@aws-sdk/client-cloudformation';
 import * as chalk from 'chalk';
-import * as uuid from 'uuid';
 import { AssetManifestBuilder } from './asset-manifest-builder';
 import { publishAssets } from './asset-publishing';
 import { addMetadataAssetsToManifest } from './assets';
@@ -228,7 +228,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
     await ioHelper.defaults.debug(
       `Found existing stack ${deployName} that had previously failed creation. Deleting it before attempting to re-create it.`,
     );
-    await cfn.deleteStack({ StackName: cloudFormationStack.stackId, ClientRequestToken: uuid.v4() });
+    await cfn.deleteStack({ StackName: cloudFormationStack.stackId, ClientRequestToken: randomUUID() });
     const deletedStack = await waitForStackDelete(cfn, ioHelper, cloudFormationStack.stackId);
     if (deletedStack && deletedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new DeploymentError(
@@ -401,7 +401,7 @@ class FullCloudFormationDeployment {
 
     this.update = cloudFormationStack.exists && cloudFormationStack.stackStatus.name !== 'REVIEW_IN_PROGRESS';
     this.verb = this.update ? 'update' : 'create';
-    this.uuid = uuid.v4();
+    this.uuid = randomUUID();
   }
 
   public async performDeployment(): Promise<DeployStackResult> {
@@ -769,7 +769,7 @@ export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHel
   await monitor.start();
 
   try {
-    await cfn.deleteStack({ StackName: currentStack.stackId, RoleARN: options.roleArn, ClientRequestToken: uuid.v4() });
+    await cfn.deleteStack({ StackName: currentStack.stackId, RoleARN: options.roleArn, ClientRequestToken: randomUUID() });
     const destroyedStack = await waitForStackDelete(cfn, ioHelper, currentStack.stackId);
     if (destroyedStack && destroyedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new DeploymentError(`Failed to destroy ${deployName}: ${destroyedStack.stackStatus}`, 'StackDestroyFailed');

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import * as cdk_assets from '@aws-cdk/cdk-assets-lib';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/span.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/span.ts
@@ -1,11 +1,11 @@
+import { randomUUID } from 'node:crypto';
 import * as util from 'node:util';
-import * as uuid from 'uuid';
+import type { IoDefaultMessages } from './io-default-messages';
 import type { ActionLessMessage, ActionLessRequest, IoHelper } from './io-helper';
 import type * as make from './message-maker';
 import type { Duration } from '../../../payloads/types';
 import { formatTime } from '../../../util';
 import type { IActionAwareIoHost } from '../io-host';
-import type { IoDefaultMessages } from './io-default-messages';
 
 /**
  * These data fields are automatically added by ending a span
@@ -175,7 +175,7 @@ class MessageSpan<S extends object, E extends SpanEnd> implements IMessageSpan<E
   public constructor(ioHelper: IoHelper, definition: SpanDefinition<S, E>, makeHelper: (ioHost: IActionAwareIoHost) => IoHelper) {
     this.definition = definition;
     this.ioHelper = ioHelper;
-    this.spanId = uuid.v4();
+    this.spanId = randomUUID();
     this.startTime = new Date().getTime();
     this.timingMsgTemplate = '\n✨  %s time: %ds\n';
     this.asHelper = makeHelper(this);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/logs-monitor/logs-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/logs-monitor/logs-monitor.ts
@@ -1,7 +1,7 @@
-import * as util from 'util';
+import { randomUUID } from 'node:crypto';
+import * as util from 'node:util';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as chalk from 'chalk';
-import * as uuid from 'uuid';
 import type { CloudWatchLogEvent } from '../../payloads/logs-monitor';
 import { flatten } from '../../util';
 import type { SDK } from '../aws-auth/private';
@@ -75,7 +75,7 @@ export class CloudWatchLogEventMonitor {
    * resume reading/printing events
    */
   public async activate(): Promise<void> {
-    this.monitorId = uuid.v4();
+    this.monitorId = randomUUID();
 
     await this.ioHelper.notify(IO.CDK_TOOLKIT_I5032.msg('Start monitoring log groups', {
       monitor: this.monitorId,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -1,6 +1,6 @@
-import * as util from 'util';
+import { randomUUID } from 'node:crypto';
+import * as util from 'node:util';
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
-import * as uuid from 'uuid';
 import { StackEventPoller, PollRange } from './stack-event-poller';
 import { StackProgressMonitor } from './stack-progress-monitor';
 import type { StackActivity } from '../../payloads/stack-activity';
@@ -145,7 +145,7 @@ export class StackActivityMonitor {
   }
 
   public async start() {
-    this.monitorId = uuid.v4();
+    this.monitorId = randomUUID();
     await this.ioHelper.notify(IO.CDK_TOOLKIT_I5501.msg(`Deploying ${this.stackDisplayName}`, {
       deployment: this.monitorId,
       stack: this.stack,

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -125,7 +125,6 @@
     "picomatch": "^4",
     "semver": "^7.7.4",
     "split2": "^4.2.0",
-    "uuid": "^11.1.1",
     "wrap-ansi": "^7",
     "yaml": "^1"
   },

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/fake-aws/fake-cloudformation.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/fake-aws/fake-cloudformation.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import {
   type ContinueUpdateRollbackCommandInput,
   type ContinueUpdateRollbackCommandOutput,

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/fake-sts.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/fake-sts.ts
@@ -1,6 +1,6 @@
+import { randomUUID } from 'node:crypto';
 import type { Tag } from '@aws-sdk/client-sts';
 import * as nock from 'nock';
-import * as uuid from 'uuid';
 import { formatErrorMessage } from '../../../lib/util';
 
 interface RegisteredIdentity {
@@ -244,7 +244,7 @@ export class FakeSts {
       );
     }
 
-    const freshAccessKey = uuid.v4();
+    const freshAccessKey = randomUUID();
 
     // Register a new "user" (identity) for this access key
     this.registerUser(targetRole.account, freshAccessKey, {

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-provider.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk-provider.test.ts
@@ -12,10 +12,10 @@
  * We therefore cannot mock the STS Client, but instead we intercept network
  * calls and locally fake an STS Endpoint using the `FakeSts` class.
  */
-import * as os from 'os';
+import { randomUUID } from 'node:crypto';
+import * as os from 'node:os';
 import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as fromEnv from '@aws-sdk/credential-provider-env';
-import * as uuid from 'uuid';
 import type { RegisterRoleOptions, RegisterUserOptions } from './fake-sts';
 import { FakeSts } from './fake-sts';
 import type { ConfigurationOptions, CredentialsOptions, SDK } from '../../../lib/api/aws-auth/private';
@@ -65,7 +65,7 @@ beforeEach(() => {
   //
   // - We have a cache from account# -> credentials
   // - We have a cache from access key -> account
-  uid = `(${uuid.v4()})`;
+  uid = `(${randomUUID()})`;
   pluginQueried = false;
 
   ioHost.notifySpy.mockClear();

--- a/packages/aws-cdk/.projen/deps.json
+++ b/packages/aws-cdk/.projen/deps.json
@@ -436,10 +436,6 @@
       "type": "runtime"
     },
     {
-      "name": "uuid",
-      "type": "runtime"
-    },
-    {
       "name": "wrap-ansi",
       "version": "^7",
       "type": "runtime"

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -55,7 +55,7 @@
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/archiver,@types/jest,@types/mockery,@types/picomatch,@types/promptly,@types/semver,@types/sinon,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-mock,license-checker,node-backpack,nx,projen,sinon,ts-jest,ts-mock-imports,ts-node,tsx,archiver,cdk-from-cfn,enquirer,fast-glob,picomatch,promptly,proxy-agent,semver,uuid"
+          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/archiver,@types/jest,@types/mockery,@types/picomatch,@types/promptly,@types/semver,@types/sinon,aws-sdk-client-mock,aws-sdk-client-mock-jest,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-mock,license-checker,node-backpack,nx,projen,sinon,ts-jest,ts-mock-imports,ts-node,tsx,archiver,cdk-from-cfn,enquirer,fast-glob,picomatch,promptly,proxy-agent,semver"
         }
       ]
     },

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -28213,10 +28213,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
-** uuid@11.1.1 - https://www.npmjs.com/package/uuid/v/11.1.1 | MIT
-
-----------------
-
 ** which-module@2.0.1 - https://www.npmjs.com/package/which-module/v/2.0.1 | ISC
 Copyright (c) 2016, Contributors
 

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -1,5 +1,6 @@
-import * as path from 'path';
-import { format } from 'util';
+import { randomUUID } from 'node:crypto';
+import * as path from 'node:path';
+import { format } from 'node:util';
 import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { ConfirmationRequest, DeploymentMethod, DiagnoseOptions, PublishAssetsOptions, ToolkitAction, ToolkitOptions, UnstableFeature } from '@aws-cdk/toolkit-lib';
@@ -8,7 +9,6 @@ import * as chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
 import * as fs from 'fs-extra';
-import * as uuid from 'uuid';
 import { CliIoHost } from './io-host';
 import type { Configuration } from './user-configuration';
 import { PROJECT_CONFIG } from './user-configuration';
@@ -406,7 +406,7 @@ export class CdkToolkit {
 
     return cfnApi.createDiffChangeSet(asIoHelper(this.ioHost, 'diff'), {
       stack,
-      uuid: uuid.v4(),
+      uuid: randomUUID(),
       deployments: this.props.deployments,
       willExecute: false,
       sdkProvider: this.props.sdkProvider,

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from 'crypto';
-import * as fs from 'fs';
-import * as path from 'path';
+import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import type { IoHelper } from '../../api-private';
 import { cdkCacheDir } from '../../util';
 

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import { getOrCreateInstallationId } from './installation-id';
 import { getLibraryVersion } from './library-version';

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -134,7 +134,6 @@
     "proxy-agent": "^6.5.0",
     "semver": "^7.7.4",
     "strip-ansi": "^6",
-    "uuid": "^11.1.1",
     "wrap-ansi": "^7",
     "yaml": "^1",
     "yargs": "^15"

--- a/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
+++ b/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
@@ -7,7 +7,7 @@ const tempDir = path.join(os.tmpdir(), `installation-id-test-${Date.now()}-${Mat
 
 // Mock crypto.randomUUID to return predictable values
 const mockRandomUUID = jest.fn();
-jest.mock('crypto', () => ({
+jest.mock('node:crypto', () => ({
   randomUUID: mockRandomUUID,
 }));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -520,7 +520,6 @@ __metadata:
     ts-jest: "npm:^29.4.9"
     tsx: "npm:^4.21.0"
     typescript: "npm:5.9"
-    uuid: "npm:^11.1.1"
     wrap-ansi: "npm:^7"
     yaml: "npm:^1"
   peerDependencies:
@@ -7588,7 +7587,6 @@ __metadata:
     ts-node: "npm:^10.9.2"
     tsx: "npm:^4.21.0"
     typescript: "npm:5.9"
-    uuid: "npm:^11.1.1"
     wrap-ansi: "npm:^7"
     yaml: "npm:^1"
     yargs: "npm:^15"
@@ -17983,15 +17981,6 @@ __metadata:
   version: 1.0.1
   resolution: "utils-merge@npm:1.0.1"
   checksum: 10c0/02ba649de1b7ca8854bfe20a82f1dfbdda3fb57a22ab4a8972a63a34553cf7aa51bc9081cf7e001b035b88186d23689d69e71b510e610a09a4c66f68aa95b672
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^11.1.1":
-  version: 11.1.1
-  resolution: "uuid@npm:11.1.1"
-  bin:
-    uuid: dist/esm/bin/uuid
-  checksum: 10c0/9e3af58eba872ece5a5e76f4773a94fc78a0ef2c2444c38dbe6b42f41dadf76c01850fd783604f27986f6195e6286aef064d45987d401b2a33127b98ddf7c0c5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `uuid` package is only used for `uuid.v4()` which generates random UUIDs. Node.js has provided `crypto.randomUUID()` as a stable built-in since Node.js 16, and our minimum supported version is 20. This removes an unnecessary third-party dependency.

All `uuid.v4()` calls are replaced with `randomUUID()` from `node:crypto`. Bare module imports (`crypto`, `util`, `os`, `fs`, `path`) are also normalized to use the `node:` protocol for consistency where I came across them.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
