### PR TITLE
fix(cli-integ): suppress Node.js process warnings in ci-output test

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/output/cdk-ci-true-output-to-stdout.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/output/cdk-ci-true-output-to-stdout.integtest.ts
@@ -17,6 +17,9 @@ integTest(
 
         // Make sure we don't warn on use of deprecated APIs (that cannot be redirected)
         JSII_DEPRECATED: 'quiet',
+
+        // Suppress Node.js process warnings (e.g. fs-extra compatibility warnings)
+        NODE_NO_WARNINGS: '1',
       },
       options: ['--no-notices'],
     };


### PR DESCRIPTION
## Summary

The `ci=true output to stdout` integration test asserts that stderr is empty when running CDK commands with `CI=true`. On the current Node.js version in CodeBuild, `fs-extra` emits a compatibility warning (`fs-extra-WARN0003: fs.realpath.native is not a function`) to stderr, causing the test to fail deterministically.

This has been blocking the `cdk-v2-release` pipeline consistently (4 retries, all failed with the same error).

## Fix

Add `NODE_NO_WARNINGS=1` to the test's `modEnv` to suppress Node.js process warnings that are not CDK-related.

## Impact

- Unblocks the v2 release pipeline (2.255.0 release)
- The test already suppresses JSII warnings and notices; this extends suppression to Node.js-level process warnings

## Related

- Pipeline execution: `aefb8be7-e9ff-41bc-a98d-75b6350d3141`
- Ticket: https://t.corp.amazon.com/V2219126169

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license