### PR TITLE
fix(toolkit-lib): deploy does not report nested stack errors

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-nested-stacks-with-fn-join-export.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-nested-stacks-with-fn-join-export.integtest.ts
@@ -3,9 +3,8 @@ import { integTest, withSpecificFixture } from '../../../lib';
 integTest(
   'deploy nested stacks with Fn::Join export names',
   withSpecificFixture('nested-stack-with-fn-join-export', async (fixture) => {
-    // This should succeed. With IncludeNestedStacks:true, CloudFormation
-    // incorrectly reports duplicate export names when multiple nested stacks
-    // use Fn::Join with the same runtime reference to build export names.
+    // This should succeed. IncludeNestedStacks:true is now set and CloudFormation
+    // correctly handles Fn::Join export names in nested stacks (server-side fix).
     await fixture.cdkDeploy('nested-stacks-fn-join-export', { captureStderr: false });
   }),
 );

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-unnecessary-updates-for-nested-stacks.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-skips-unnecessary-updates-for-nested-stacks.integtest.ts
@@ -4,23 +4,26 @@ import { integTest, withDefaultFixture } from '../../../lib';
 integTest(
   'deploy skips unnecessary updates for nested stacks',
   withDefaultFixture(async (fixture) => {
-    // Deploy a stack with a nested stack. CFN will always report nested
-    // stacks as changed, even when nothing actually changed. With the
-    // two-phase change set flow, this means every deploy creates and
-    // executes a new change set.
+    // Deploy a stack with nested stacks. With IncludeNestedStacks, CloudFormation
+    // can accurately detect whether nested stacks have actual changes, rather than
+    // always reporting them as needing an update.
     const stackArn = await fixture.cdkDeploy('with-nested-stack', { captureStderr: false });
+    const changeSet1 = await getLatestChangeSet();
 
-    // Deploy the same stack again — CFN always reports nested stack
-    // resources as changed, so the deploy goes through successfully
-    // without any actual resource changes.
+    // Deploy the same stack again, there should be no new change set created
     await fixture.cdkDeploy('with-nested-stack');
     const changeSet2 = await getLatestChangeSet();
-    expect(changeSet2.StackStatus).toEqual('UPDATE_COMPLETE');
+    expect(changeSet2.ChangeSetId).toEqual(changeSet1.ChangeSetId);
 
-    // Deploy the stack again with --force
-    await fixture.cdkDeploy('with-nested-stack', { options: ['--force'] });
+    // Deploy the stack again with --force. CloudFormation creates a changeset but
+    // accurately reports no changes (including in nested stacks), so the changeset
+    // is not executed and the stack's ChangeSetId remains the same.
+    const forceOutput = await fixture.cdk(
+      fixture.cdkDeployCommandLine('with-nested-stack', { options: ['--force'] }),
+    );
+    expect(forceOutput).toContain('CloudFormation reported that the deployment would not make any changes');
     const changeSet3 = await getLatestChangeSet();
-    expect(changeSet3.ChangeSetId).not.toEqual(changeSet2.ChangeSetId);
+    expect(changeSet3.ChangeSetId).toEqual(changeSet2.ChangeSetId);
 
     // Deploy the stack again with tags, expected to create a new changeset
     // even though the resources didn't change.

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/nested-stack-helpers.ts
@@ -137,15 +137,6 @@ function isCdkManagedNestedStack(stackResource: any): stackResource is NestedSta
   );
 }
 
-/**
- * Returns true if the given template contains any `AWS::CloudFormation::Stack` resources.
- */
-export function templateContainsNestedStacks(template: any): boolean {
-  return Object.values(template?.Resources ?? {}).some(
-    (resource: any) => resource.Type === 'AWS::CloudFormation::Stack',
-  );
-}
-
 export interface NestedStackTemplates {
   readonly physicalName: string | undefined;
   readonly deployedTemplate: Template;

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -16,7 +16,7 @@ import { DeploymentError, ToolkitError } from '../../toolkit/toolkit-error';
 import { changeSetNameFromArn, stackNameFromArn } from '../../util/cloudformation';
 import type { ICloudFormationClient, SdkProvider } from '../aws-auth/private';
 import type { Template, TemplateBodyParameter, TemplateParameter } from '../cloudformation';
-import { CloudFormationStack, makeBodyParameter, templateContainsNestedStacks } from '../cloudformation';
+import { CloudFormationStack, makeBodyParameter } from '../cloudformation';
 import { throwDeploymentErrorFromDiagnosis } from '../diagnosing/diagnosis-formatting';
 import { CloudFormationStackDiagnoser } from '../diagnosing/stack-diagnoser';
 import type { TargetEnvironment } from '../environment';
@@ -214,7 +214,7 @@ export async function createDiffChangeSet(
     const env = await options.deployments.envs.accessStackForMutableStackOperations(options.stack);
     return await uploadBodyParameterAndCreateChangeSet(ioHelper, env, {
       ...options,
-      includeNestedStacks: templateContainsNestedStacks(options.stack.template),
+      includeNestedStacks: true,
     });
   } catch (e: any) {
     // This function is currently only used by diff so these messages are diff-specific
@@ -334,7 +334,7 @@ export async function uploadStackTemplateAssets(stack: cxapi.CloudFormationStack
   }
 }
 
-export async function createChangeSetAndCleanup(
+async function createChangeSetAndCleanup(
   ioHelper: IoHelper,
   options: CreateChangeSetOptions,
 ): Promise<DescribeChangeSetCommandOutput> {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -538,11 +538,7 @@ class FullCloudFormationDeployment {
       ClientToken: `create${this.uuid}`,
       ImportExistingResources: importExistingResources,
       DeploymentMode: revertDrift ? 'REVERT_DRIFT' : undefined,
-
-      // This is necessary to trigger early validation on nested stacks as well
-      // TODO: We currently have a test explicitly checking that this is NOT set to true, but on the other
-      // hand for 'cdk diff' we DO turn it on. Investigate later.
-      // IncludeNestedStacks: true,
+      IncludeNestedStacks: (this.options.resourcesToImport || revertDrift) ? undefined : true,
       ...this.commonPrepareOptions(),
     });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -1,4 +1,3 @@
-import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import {
   ContinueUpdateRollbackCommand,
   DescribeStackEventsCommand,
@@ -7,16 +6,11 @@ import {
   RollbackStackCommand,
   type StackResourceSummary,
   StackStatus,
-  DescribeChangeSetCommand,
-  ChangeSetStatus,
-  CreateChangeSetCommand,
 } from '@aws-sdk/client-cloudformation';
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import { CloudFormationStack } from '../../../lib/api/cloudformation';
 import { Deployments } from '../../../lib/api/deployments';
-import * as cfnApi from '../../../lib/api/deployments/cfn-api';
 import { deployStack } from '../../../lib/api/deployments/deploy-stack';
-import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
 import { ToolkitInfo } from '../../../lib/api/toolkit-info';
 import { testStack } from '../../_helpers/assembly';
 import {
@@ -1191,49 +1185,6 @@ describe('stackExists', () => {
     expect(mockForEnvironment).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({
       assumeRoleArn: expectedRoleArn,
     }));
-  });
-});
-
-test('tags are passed along to create change set', async () => {
-  mockCloudFormationClient.on(CreateChangeSetCommand).resolves({
-    Id: 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/foo/uuid',
-    StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/test-stack/uuid',
-  });
-  mockCloudFormationClient.on(DescribeChangeSetCommand).resolves({
-    Status: ChangeSetStatus.CREATE_COMPLETE,
-  });
-
-  const stack: any = {};
-  stack.tags = { SomeKey: 'SomeValue' };
-  for (const methodName of Object.getOwnPropertyNames(cxapi.CloudFormationStackArtifact.prototype)) {
-    stack[methodName] = jest.fn();
-  }
-
-  await cfnApi.createChangeSetAndCleanup(
-    ioHelper,
-    {
-      stack: stack,
-      cfn: sdk.cloudFormation(),
-      changeSetName: 'foo',
-      willExecute: false,
-      exists: true,
-      uuid: '142DF82A-8ED8-4944-8EEB-A5BAE141F13F',
-      bodyParameter: {},
-      parameters: {},
-      diagnoser: new CloudFormationStackDiagnoser({
-        sdk,
-        sourceTracer: {
-          traceResource: () => Promise.resolve(undefined),
-          traceStack: () => Promise.resolve(undefined),
-        },
-        ioHelper,
-        topLevelStackHierarchicalId: stack.hierarchicalId,
-      }),
-    },
-  );
-
-  expect(mockCloudFormationClient).toHaveReceivedCommandWith(CreateChangeSetCommand, {
-    Tags: [{ Key: 'SomeKey', Value: 'SomeValue' }],
   });
 });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -780,7 +780,9 @@ test('deploy not skipped if template did not change but tags changed', async () 
   });
 
   // THEN
-  expect(mockCloudFormationClient).toHaveReceivedCommand(CreateChangeSetCommand);
+  expect(mockCloudFormationClient).toHaveReceivedCommandWith(CreateChangeSetCommand, {
+    Tags: [{ Key: 'Key', Value: 'NewValue' }],
+  });
   expect(mockCloudFormationClient).toHaveReceivedCommand(ExecuteChangeSetCommand);
   expect(mockCloudFormationClient).toHaveReceivedCommand(DescribeChangeSetCommand);
   expect(mockCloudFormationClient).toHaveReceivedCommandWith(DescribeStacksCommand, {
@@ -1311,6 +1313,8 @@ describe('revert-drift', () => {
       ...expect.anything,
       DeploymentMode: 'REVERT_DRIFT',
     });
+    const calls = mockCloudFormationClient.commandCalls(CreateChangeSetCommand);
+    expect(calls[0].args[0].input.IncludeNestedStacks).toBeUndefined();
   });
 });
 
@@ -1506,17 +1510,26 @@ describe('change set returned with execute:false', () => {
   });
 });
 
-test('does not pass IncludeNestedStacks even for stacks with nested stacks', async () => {
-  // Regression test: IncludeNestedStacks causes CloudFormation to report false
-  // "duplicate Export names" errors when nested stacks use intrinsic functions
-  // (like Fn::Join) in export names.
+test('passes IncludeNestedStacks to get nested stack error reporting', async () => {
   await testDeployStack({
     ...standardDeployStackArguments(FAKE_STACK_WITH_NESTED_STACK),
   });
 
   const calls = mockCloudFormationClient.commandCalls(CreateChangeSetCommand);
   expect(calls.length).toBeGreaterThan(0);
-  expect(calls[0].args[0].input).not.toHaveProperty('IncludeNestedStacks');
+  expect(calls[0].args[0].input).toHaveProperty('IncludeNestedStacks', true);
+});
+
+test('does not pass IncludeNestedStacks for import changesets', async () => {
+  givenStackExists({ StackName: 'withnestedstack' });
+  await testDeployStack({
+    ...standardDeployStackArguments(FAKE_STACK_WITH_NESTED_STACK),
+    resourcesToImport: [{ ResourceType: 'AWS::S3::Bucket', LogicalResourceId: 'Bucket', ResourceIdentifier: { BucketName: 'my-bucket' } }],
+  });
+
+  const calls = mockCloudFormationClient.commandCalls(CreateChangeSetCommand);
+  expect(calls.length).toBeGreaterThan(0);
+  expect(calls[0].args[0].input.IncludeNestedStacks).toBeUndefined();
 });
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diff/diff.test.ts
@@ -1,6 +1,5 @@
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as chalk from 'chalk';
-import { templateContainsNestedStacks } from '../../../lib/api/cloudformation/nested-stack-helpers';
 import { DiffFormatter } from '../../../lib/api/diff/diff-formatter';
 
 function stripAnsi(s: string): string {
@@ -759,29 +758,3 @@ describe('duplicate logical ids in nested stacks', () => {
   });
 });
 
-describe('templateContainsNestedStacks', () => {
-  test('returns true when template has AWS::CloudFormation::Stack resources', () => {
-    expect(templateContainsNestedStacks({
-      Resources: {
-        Nested: { Type: 'AWS::CloudFormation::Stack', Properties: { TemplateURL: 'https://url' } },
-        Bucket: { Type: 'AWS::S3::Bucket' },
-      },
-    })).toBe(true);
-  });
-
-  test('returns false when template has no nested stacks', () => {
-    expect(templateContainsNestedStacks({
-      Resources: {
-        Bucket: { Type: 'AWS::S3::Bucket' },
-      },
-    })).toBe(false);
-  });
-
-  test('returns false for empty template', () => {
-    expect(templateContainsNestedStacks({})).toBe(false);
-  });
-
-  test('returns false for template with no Resources', () => {
-    expect(templateContainsNestedStacks({ Parameters: {} })).toBe(false);
-  });
-});


### PR DESCRIPTION
Fixes #635

Re-enables `IncludeNestedStacks: true` on the deploy changeset creation path. This was originally added in #1292 but reverted in #1307 due to a CloudFormation server-side bug where intrinsic functions (like `Fn::Join`) in export names caused false "duplicate Export names" errors. That server-side issue has now been resolved.

With `IncludeNestedStacks` enabled, CloudFormation validates nested stack templates together during changeset creation. This means deployment errors in nested stacks are properly reported to the user, instead of the generic "The following resource(s) failed to create" message. It also allows CloudFormation to accurately detect "no changes" for nested stacks, avoiding unnecessary changeset executions.

The diff changeset path is simplified to always pass `includeNestedStacks: true` unconditionally (previously it was conditional on `templateContainsNestedStacks`). The `createChangeSetAndCleanup` function is un-exported since it was only exported for testing — the test is moved up a layer to test through the deploy flow instead.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
