### PR TITLE
fix: add integ tests to verify issues around dependency bundling

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -48,6 +48,9 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     await shell.shell(['npm', 'install', '--save-dev', 'ts-node@^10']);
 
     await shell.shell(['npm', 'install']); // Older versions of npm require this to be a separate step from the one above
+
+    await shell.shell(['npm', 'ci']); // this will fail if we have bundled dependencies that introduce version conflicts
+
     await shell.shell(['npx', 'tsc', '--version']);
     await shell.shell(['npm', 'prune']);
     await shell.shell(['npm', 'ls']); // this will fail if we have unmet peer dependencies

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -39,7 +39,6 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     await shell.shell(['npm', '--version']);
 
     await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'app', '--generate-only']);
-    await shell.shell(['npm', 'ci']); // this will fail if we have bundled dependencies that introduce version conflicts
 
     // Necessary because recent versions of ts-jest require TypeScript>=4.3 but we
     // still want to test with older versions as well.

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -11,6 +11,8 @@ import { typescriptVersionsSync, typescriptVersionsYoungerThanDaysSync } from '.
 
     await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', template]);
 
+    await shell.shell(['npm', 'ci']); // this will fail if we have bundled dependencies that introduce version conflicts
+
     await shell.shell(['npm', 'prune']);
     await shell.shell(['npm', 'ls']); // this will fail if we have unmet peer dependencies
     await shell.shell(['npm', 'run', 'build']);
@@ -37,6 +39,7 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     await shell.shell(['npm', '--version']);
 
     await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'app', '--generate-only']);
+    await shell.shell(['npm', 'ci']); // this will fail if we have bundled dependencies that introduce version conflicts
 
     // Necessary because recent versions of ts-jest require TypeScript>=4.3 but we
     // still want to test with older versions as well.
@@ -48,8 +51,6 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     await shell.shell(['npm', 'install', '--save-dev', 'ts-node@^10']);
 
     await shell.shell(['npm', 'install']); // Older versions of npm require this to be a separate step from the one above
-
-    await shell.shell(['npm', 'ci']); // this will fail if we have bundled dependencies that introduce version conflicts
 
     await shell.shell(['npx', 'tsc', '--version']);
     await shell.shell(['npm', 'prune']);

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/use-lib-as-bundled-dependency.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/use-lib-as-bundled-dependency.integtest.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs/promises';
+import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '../../lib';
+
+// Sometimes, due to our own use of bundled dependencies, NPM will fail if a customer declares
+// aws-cdk-lib as a bundled dependency. Test whether that still works.
+integTest('using aws-cdk-lib as a bundled dependency', withTemporaryDirectory(withPackages(async (context) => {
+  const shell = ShellHelper.fromContext(context);
+  await context.cli.makeCliAvailable();
+
+  await shell.shell(['npm', 'init', '-y']);
+
+  const packageJson = JSON.parse(await fs.readFile('package.json', 'utf-8'));
+
+  packageJson.dependencies = {
+    ...packageJson.dependencies,
+    'aws-cdk-lib': context.library.requestedVersion(),
+  };
+  packageJson.bundleDependencies = ['aws-cdk-lib'];
+
+  await fs.writeFile('package.json', JSON.stringify(packageJson, undefined, 2), 'utf-8');
+
+  await shell.shell(['npm', 'install']);
+})));


### PR DESCRIPTION
To go along with https://github.com/aws/aws-cdk/pull/37943.

The new tests are going to fail until `aws-cdk-lib` with that patch has been released.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
