### PR TITLE
fix(cli): resolve command aliases in unknown options check

### DIFF
--- a/packages/aws-cdk/lib/cli/util/check-unknown-options.ts
+++ b/packages/aws-cdk/lib/cli/util/check-unknown-options.ts
@@ -30,6 +30,16 @@ function collectKnownOptions(optionDefs: Record<string, any>): Set<string> {
 /** Pre-computed set of known global options (static, doesn't depend on argv) */
 const globalKnownOptions = collectKnownOptions(config.globalOptions);
 
+/** Reverse mapping from command alias to canonical command name */
+const commandAliasMap = new Map<string, string>();
+for (const [name, def] of Object.entries<any>(config.commands)) {
+  if (def.aliases) {
+    for (const alias of def.aliases) {
+      commandAliasMap.set(alias, name);
+    }
+  }
+}
+
 /** yargs internal keys that are always present in argv */
 const yargsInternals = new Set(['_', '$0', 'help', 'h', 'version']);
 
@@ -43,8 +53,9 @@ const yargsInternals = new Set(['_', '$0', 'help', 'h', 'version']);
  */
 export function findUnknownOptions(argv: any): string[] {
   const command = argv._[0];
+  const canonicalCommand = commandAliasMap.get(command) ?? command;
 
-  const commandDef = config.commands[command];
+  const commandDef = config.commands[canonicalCommand];
   const commandKnownOptions = commandDef?.options
     ? collectKnownOptions(commandDef.options)
     : new Set<string>();

--- a/packages/aws-cdk/lib/cli/util/check-unknown-options.ts
+++ b/packages/aws-cdk/lib/cli/util/check-unknown-options.ts
@@ -60,14 +60,17 @@ export function findUnknownOptions(argv: any): string[] {
     ? collectKnownOptions(commandDef.options)
     : new Set<string>();
 
-  const positionalArg = commandDef?.arg?.name;
+  const positionalArgRaw = commandDef?.arg?.name;
+  const positionalArgs = positionalArgRaw
+    ? new Set([positionalArgRaw, positionalArgRaw.toLowerCase()])
+    : new Set<string>();
 
   const unknown: string[] = [];
   for (const key of Object.keys(argv)) {
     if (argv[key] === undefined) {
       continue;
     }
-    if (yargsInternals.has(key) || key === positionalArg) {
+    if (yargsInternals.has(key) || positionalArgs.has(key)) {
       continue;
     }
     if (globalKnownOptions.has(key) || commandKnownOptions.has(key)) {

--- a/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
+++ b/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
@@ -108,10 +108,10 @@ describe('findUnknownOptions', () => {
 
   test('does not report positional args (both original case and lowercase)', () => {
     const argv = {
-      '_': ['ack'],
-      '$0': 'cdk',
-      'ID': 12345,
-      'id': 12345,
+      _: ['ack'],
+      $0: 'cdk',
+      ID: 12345,
+      id: 12345,
     };
     expect(findUnknownOptions(argv)).toEqual([]);
   });

--- a/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
+++ b/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
@@ -106,6 +106,16 @@ describe('findUnknownOptions', () => {
     expect(findUnknownOptions(argv)).toEqual([]);
   });
 
+  test('does not report positional args (both original case and lowercase)', () => {
+    const argv = {
+      '_': ['ack'],
+      '$0': 'cdk',
+      'ID': 12345,
+      'id': 12345,
+    };
+    expect(findUnknownOptions(argv)).toEqual([]);
+  });
+
   test('resolves synth alias (synthesize -> synth)', () => {
     const argv = {
       _: ['synthesize'],

--- a/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
+++ b/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
@@ -95,13 +95,13 @@ describe('findUnknownOptions', () => {
 
   test('resolves command aliases to canonical names (e.g. ls -> list)', () => {
     const argv = {
-      _: ['ls'],
-      $0: 'cdk',
-      long: true,
-      l: true,
-      showDependencies: false,
+      '_': ['ls'],
+      '$0': 'cdk',
+      'long': true,
+      'l': true,
+      'showDependencies': false,
       'show-dependencies': false,
-      d: false,
+      'd': false,
     };
     expect(findUnknownOptions(argv)).toEqual([]);
   });

--- a/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
+++ b/packages/aws-cdk/test/cli/util/check-unknown-options.test.ts
@@ -93,6 +93,29 @@ describe('findUnknownOptions', () => {
     }
   });
 
+  test('resolves command aliases to canonical names (e.g. ls -> list)', () => {
+    const argv = {
+      _: ['ls'],
+      $0: 'cdk',
+      long: true,
+      l: true,
+      showDependencies: false,
+      'show-dependencies': false,
+      d: false,
+    };
+    expect(findUnknownOptions(argv)).toEqual([]);
+  });
+
+  test('resolves synth alias (synthesize -> synth)', () => {
+    const argv = {
+      _: ['synthesize'],
+      $0: 'cdk',
+      exclusively: true,
+      e: true,
+    };
+    expect(findUnknownOptions(argv)).toEqual([]);
+  });
+
   test('still reports truly unknown options even when CDK_ env vars exist', () => {
     process.env.CDK_INTEG_ATMOSPHERE_POOL = 'test-pool';
     try {


### PR DESCRIPTION
## Summary

- Fixes regression where command aliases (e.g. `cdk ls`, `cdk synthesize`, `cdk ack`, `cdk doc`) incorrectly triggered unknown option warnings for their command-specific flags
- Builds a reverse alias→canonical map at module scope and resolves the command before looking up options in the registry

## Root Cause

`findUnknownOptions` used `argv._[0]` directly as the key into `config.commands`, but `cli-type-registry.json` only stores commands under their canonical names (`list`, `synth`, `acknowledge`, `docs`). When a user invokes via alias (`ls`, `synthesize`, `ack`, `doc`), the lookup returns `undefined` and all command-specific options get flagged as unknown.

Fix for PR: https://github.com/aws/aws-cdk-cli/pull/1514

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license