### PR TITLE
fix: bootstrap fails if bucket, ECR repo already exist

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-re-bootstrap-after-stack-deletion.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/bootstrap/cdk-bootstrap-can-re-bootstrap-after-stack-deletion.integtest.ts
@@ -1,0 +1,21 @@
+import { integTest, withoutBootstrap } from '../../../lib';
+
+integTest('bootstrap can re-bootstrap after stack deletion', withoutBootstrap(async (fixture) => {
+  const bootstrapStackName = fixture.bootstrapStackName;
+
+  // Bootstrap the environment
+  await fixture.cdkBootstrapModern({
+    toolkitStackName: bootstrapStackName,
+    cfnExecutionPolicy: 'arn:aws:iam::aws:policy/AdministratorAccess',
+  });
+
+  // Delete the bootstrap stack (resources like the S3 bucket will be retained)
+  await fixture.aws.deleteStacks(bootstrapStackName);
+
+  // Re-bootstrap should succeed because importExistingResources is enabled,
+  // allowing the change set to import the retained resources back into the stack.
+  await fixture.cdkBootstrapModern({
+    toolkitStackName: bootstrapStackName,
+    cfnExecutionPolicy: 'arn:aws:iam::aws:policy/AdministratorAccess',
+  });
+}));

--- a/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/bootstrap-props.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/bootstrap-props.ts
@@ -58,6 +58,14 @@ export interface BootstrapEnvironmentOptions {
    * @default true
    */
   usePreviousParameters?: boolean;
+
+  /**
+   * Whether to import existing resources into the stack instead of failing
+   * when they already exist.
+   *
+   * @default true
+   */
+  readonly importExistingResources?: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
@@ -142,7 +142,11 @@ export class BootstrapStack {
         forceDeployment: options.forceDeployment,
         roleArn: options.roleArn,
         tags: options.tags,
-        deploymentMethod: { method: 'change-set', execute: options.execute },
+        deploymentMethod: {
+          method: 'change-set',
+          execute: options.execute,
+          importExistingResources: options.importExistingResources ?? true,
+        },
         parameters,
         usePreviousParameters: options.usePreviousParameters ?? true,
         // Obviously we can't need a bootstrap stack to deploy a bootstrap stack

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -102,6 +102,7 @@ export async function makeConfig(): Promise<CliConfig> {
           'toolkit-stack-name': { type: 'string', desc: 'The name of the CDK toolkit stack to create', requiresArg: true },
           'template': { type: 'string', requiresArg: true, desc: 'Use the template from the given file instead of the built-in one (use --show-template to obtain an example)' },
           'previous-parameters': { type: 'boolean', default: true, desc: 'Use previous values for existing parameters (you must specify all parameters on every deployment if this is disabled)' },
+          'import-existing-resources': { type: 'boolean', desc: 'Whether to import existing resources into the bootstrap stack instead of failing if they already exist', default: true },
         },
       },
       'gc': {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -306,6 +306,11 @@
           "type": "boolean",
           "default": true,
           "desc": "Use previous values for existing parameters (you must specify all parameters on every deployment if this is disabled)"
+        },
+        "import-existing-resources": {
+          "type": "boolean",
+          "desc": "Whether to import existing resources into the bootstrap stack instead of failing if they already exist",
+          "default": true
         }
       }
     },

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -385,6 +385,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
           tags: configuration.settings.get(['tags']),
           terminationProtection: args.terminationProtection,
           usePreviousParameters: args['previous-parameters'],
+          importExistingResources: args.importExistingResources,
           parameters: {
             bucketName: configuration.settings.get(['toolkitBucket', 'bucketName']),
             kmsKeyId: configuration.settings.get(['toolkitBucket', 'kmsKeyId']),

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -82,6 +82,7 @@ export function convertYargsToUserInput(args: any): UserInput {
         toolkitStackName: args.toolkitStackName,
         template: args.template,
         previousParameters: args.previousParameters,
+        importExistingResources: args.importExistingResources,
         ENVIRONMENTS: args.ENVIRONMENTS,
       };
       break;
@@ -412,6 +413,7 @@ export function convertConfigToUserInput(config: any): UserInput {
     toolkitStackName: config.bootstrap?.toolkitStackName,
     template: config.bootstrap?.template,
     previousParameters: config.bootstrap?.previousParameters,
+    importExistingResources: config.bootstrap?.importExistingResources,
   };
   const gcOptions = {
     action: config.gc?.action,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -335,6 +335,11 @@ export function parseCommandLineArguments(args: Array<string>): any {
           default: true,
           type: 'boolean',
           desc: 'Use previous values for existing parameters (you must specify all parameters on every deployment if this is disabled)',
+        })
+        .option('import-existing-resources', {
+          default: true,
+          type: 'boolean',
+          desc: 'Whether to import existing resources into the bootstrap stack instead of failing if they already exist',
         }),
     )
     .command(

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -593,6 +593,13 @@ export interface BootstrapOptions {
   readonly previousParameters?: boolean;
 
   /**
+   * Whether to import existing resources into the bootstrap stack instead of failing if they already exist
+   *
+   * @default - true
+   */
+  readonly importExistingResources?: boolean;
+
+  /**
    * Positional argument for bootstrap
    */
   readonly ENVIRONMENTS?: Array<string>;


### PR DESCRIPTION
If a bootstrap stack is deleted, for safety it leaves behind the S3 Bucket and ECR repository used for storing assets. This will interfere with re-bootstrapping.

Fortunately CloudFormation has an option to automatically adopt hard-named resources into a new stack, so we turn that on by default for bootstrapping. This will get rid of those errors.

The chances this will interfere with normal operation is minimal, but on the off chance it does this behavior can be switched off with a `--no-import-existing-resources` flag.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
