### PR TITLE
chore(cli-integ): increase test timeout for SAM integration tests

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
@@ -7,7 +7,12 @@ import type { ShellOptions } from './shell';
 import { rimraf } from './shell';
 import type { AwsContext } from './with-aws';
 import { withAws } from './with-aws';
-import { cloneDirectory, installNpmPackages, TestFixture, DEFAULT_TEST_TIMEOUT_S } from './with-cdk-app';
+import {
+  cloneDirectory,
+  installNpmPackages,
+  TestFixture,
+  EXTENDED_TEST_TIMEOUT_S,
+} from './with-cdk-app';
 import { withTimeout } from './with-timeout';
 
 export interface ActionOutput {
@@ -101,7 +106,7 @@ function errorCausedByGoPkg(error: string) {
  * SAM Integration test fixture for CDK - SAM integration test cases
  */
 export function withSamIntegrationFixture(block: (context: SamIntegrationTestFixture) => Promise<void>) {
-  return withAws(withTimeout(DEFAULT_TEST_TIMEOUT_S, withSamIntegrationCdkApp(block)));
+  return withAws(withTimeout(EXTENDED_TEST_TIMEOUT_S, withSamIntegrationCdkApp(block)));
 }
 
 export class SamIntegrationTestFixture extends TestFixture {


### PR DESCRIPTION
The SAM integ test synthesizes a stack with a bunch of assets. Specifically, a Python Lambda function and a Nodejs Lambda function, and some other stuff. Up to 2.254.0, it managed to pull the docker images for both runtimes, but just barely. It timed out immediately after. On retry, since these images were already cached, it would go on to pull the rest.

In 2.255.0, `bedrockagentcore` was graduated, increasing the size of aws-cdk-lib by 1.3 MB. The larger package makes npm install slightly slower during the SAM test's first attempt, preventing the nodejs16.x Docker image from being built before the 20-minute per-test timeout. On retry, this image must be pulled and built from scratch (~14.6 min extra), pushing the total build time past the credential lifetime. This triggers a cascade where ALL concurrent tests fail simultaneously with `SignatureDoesNotMatch`.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
