### PR TITLE
feat(cloud-assembly-schema): validation report includes suppressed rules

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
@@ -197,6 +197,15 @@ export interface SuppressedViolationJson extends PolicyViolationJson {
    * @default - unknown
    */
   readonly acknowledgedAt?: string;
+
+  /**
+   * Stack trace showing where the acknowledgement was declared.
+   *
+   * A `\n`-delimited string of stack frames.
+   *
+   * @default - no stack trace
+   */
+  readonly acknowledgedStackTrace?: string;
 }
 
 /**

--- a/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
@@ -57,6 +57,17 @@ export interface PluginReportJson {
    * Violations found by this plugin.
    */
   readonly violations: PolicyViolationJson[];
+
+  /**
+   * Violations that were suppressed via acknowledgement.
+   *
+   * These violations matched an acknowledged rule ID and were excluded
+   * from the active violations list. They are retained for audit
+   * trail and reporting purposes.
+   *
+   * @default - no suppressed violations
+   */
+  readonly suppressedViolations?: SuppressedViolationJson[];
 }
 
 /**
@@ -159,6 +170,33 @@ export interface ViolatingConstructJson {
    * @default - No stack traces
    */
   readonly stackTraces?: string[];
+}
+
+/**
+ * A violation that was acknowledged/suppressed and excluded from the
+ * active violation set.
+ */
+export interface SuppressedViolationJson extends PolicyViolationJson {
+  /**
+   * The acknowledgement ID that caused this violation to be suppressed.
+   *
+   * Format: `<plugin-name>::<rule-name>` (spaces replaced with hyphens).
+   */
+  readonly acknowledgedId: string;
+
+  /**
+   * The reason given for the acknowledgement, if provided.
+   *
+   * @default - no reason given
+   */
+  readonly reason?: string;
+
+  /**
+   * The construct path where the acknowledgement was declared.
+   *
+   * @default - unknown
+   */
+  readonly acknowledgedAt?: string;
 }
 
 /**

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/validation-report.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/validation-report.schema.json
@@ -52,6 +52,13 @@
                     "items": {
                         "$ref": "#/definitions/PolicyViolationJson"
                     }
+                },
+                "suppressedViolations": {
+                    "description": "Violations that were suppressed via acknowledgement.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/SuppressedViolationJson"
+                    }
                 }
             },
             "required": ["pluginName", "conclusion", "violations"]
@@ -106,6 +113,59 @@
             "description": "The severity of a policy violation.",
             "type": "string",
             "enum": ["fatal", "error", "warning", "info", "custom"]
+        },
+        "SuppressedViolationJson": {
+            "description": "A violation that was acknowledged/suppressed and excluded from the active violation set.",
+            "type": "object",
+            "properties": {
+                "ruleName": {
+                    "description": "The name of the rule that was violated.",
+                    "type": "string"
+                },
+                "description": {
+                    "description": "A description of the violation.",
+                    "type": "string"
+                },
+                "suggestedFix": {
+                    "description": "How to fix the violation.",
+                    "type": "string"
+                },
+                "severity": {
+                    "description": "The severity of the violation.",
+                    "$ref": "#/definitions/PolicyViolationSeverity"
+                },
+                "customSeverity": {
+                    "description": "If the plugin wants to report using a non-standard severity, put it here.",
+                    "type": "string"
+                },
+                "ruleMetadata": {
+                    "description": "Additional rule-specific metadata.",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "string"
+                    }
+                },
+                "violatingConstructs": {
+                    "description": "Constructs that violated the rule.",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/ViolatingConstructJson"
+                    }
+                },
+                "acknowledgedId": {
+                    "description": "The acknowledgement ID that caused this violation to be suppressed.",
+                    "type": "string"
+                },
+                "reason": {
+                    "description": "The reason given for the acknowledgement, if provided.",
+                    "type": "string"
+                },
+                "acknowledgedAt": {
+                    "description": "The construct path where the acknowledgement was declared.",
+                    "type": "string"
+                }
+            },
+            "required": ["ruleName", "description", "severity", "violatingConstructs", "acknowledgedId"]
         },
         "ViolatingConstructJson": {
             "description": "A construct that violated a policy rule.",

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/validation-report.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/validation-report.schema.json
@@ -163,6 +163,10 @@
                 "acknowledgedAt": {
                     "description": "The construct path where the acknowledgement was declared.",
                     "type": "string"
+                },
+                "acknowledgedStackTrace": {
+                    "description": "Stack trace showing where the acknowledgement was declared.",
+                    "type": "string"
                 }
             },
             "required": ["ruleName", "description", "severity", "violatingConstructs", "acknowledgedId"]

--- a/packages/@aws-cdk/cloud-assembly-schema/test/validation-report.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/test/validation-report.test.ts
@@ -89,6 +89,96 @@ describe('Manifest.loadValidationReport', () => {
     expect(() => Manifest.loadValidationReport(reportPath)).toThrow();
   });
 
+  test('loads a report with suppressed violations', () => {
+    const reportPath = path.join(tmpDir, 'validation-report.json');
+    fs.writeFileSync(reportPath, JSON.stringify({
+      version: '1.0.0',
+      pluginReports: [{
+        pluginName: 'TestPlugin',
+        conclusion: 'success',
+        violations: [],
+        suppressedViolations: [{
+          ruleName: 'no-public-buckets',
+          description: 'S3 Buckets must not be publicly accessible',
+          severity: 'warning',
+          violatingConstructs: [{
+            constructPath: 'MyStack/MyBucket/Resource',
+          }],
+          acknowledgedId: 'TestPlugin::no-public-buckets',
+          reason: 'This bucket is intentionally public for static website hosting',
+          acknowledgedAt: 'MyStack',
+        }],
+      }],
+    }));
+
+    const report = Manifest.loadValidationReport(reportPath);
+
+    expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+    expect(report.pluginReports[0].suppressedViolations![0].ruleName).toBe('no-public-buckets');
+    expect(report.pluginReports[0].suppressedViolations![0].acknowledgedId).toBe('TestPlugin::no-public-buckets');
+    expect(report.pluginReports[0].suppressedViolations![0].reason).toBe('This bucket is intentionally public for static website hosting');
+    expect(report.pluginReports[0].suppressedViolations![0].acknowledgedAt).toBe('MyStack');
+  });
+
+  test('loads a report with suppressed violations without optional fields', () => {
+    const reportPath = path.join(tmpDir, 'validation-report.json');
+    fs.writeFileSync(reportPath, JSON.stringify({
+      version: '1.0.0',
+      pluginReports: [{
+        pluginName: 'TestPlugin',
+        conclusion: 'success',
+        violations: [],
+        suppressedViolations: [{
+          ruleName: 'no-public-buckets',
+          description: 'S3 Buckets must not be publicly accessible',
+          severity: 'warning',
+          violatingConstructs: [{
+            constructPath: 'MyStack/MyBucket/Resource',
+          }],
+          acknowledgedId: 'TestPlugin::no-public-buckets',
+        }],
+      }],
+    }));
+
+    const report = Manifest.loadValidationReport(reportPath);
+
+    expect(report.pluginReports[0].suppressedViolations).toHaveLength(1);
+    expect(report.pluginReports[0].suppressedViolations![0].reason).toBeUndefined();
+    expect(report.pluginReports[0].suppressedViolations![0].acknowledgedAt).toBeUndefined();
+  });
+
+  test('throws on suppressed violation missing acknowledgedId when schema validation is enabled', () => {
+    const prev = process.env.TESTING_CDK;
+    process.env.TESTING_CDK = '1';
+    try {
+      const reportPath = path.join(tmpDir, 'validation-report.json');
+      fs.writeFileSync(reportPath, JSON.stringify({
+        version: '1.0.0',
+        pluginReports: [{
+          pluginName: 'TestPlugin',
+          conclusion: 'success',
+          violations: [],
+          suppressedViolations: [{
+            ruleName: 'no-public-buckets',
+            description: 'S3 Buckets must not be publicly accessible',
+            severity: 'warning',
+            violatingConstructs: [{
+              constructPath: 'MyStack/MyBucket/Resource',
+            }],
+          }],
+        }],
+      }));
+
+      expect(() => Manifest.loadValidationReport(reportPath)).toThrow();
+    } finally {
+      if (prev === undefined) {
+        delete process.env.TESTING_CDK;
+      } else {
+        process.env.TESTING_CDK = prev;
+      }
+    }
+  });
+
   test('throws on invalid severity value', () => {
     const reportPath = path.join(tmpDir, 'validation-report.json');
     fs.writeFileSync(reportPath, JSON.stringify({


### PR DESCRIPTION
Add `suppressedViolations` to `PluginReportJson` so acknowledged violations are retained in the report for audit purposes.

`SuppressedViolationJson` extends `PolicyViolationJson` with `acknowledgedId` (required), `reason`, and `acknowledgedAt`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license