### PR TITLE
feat: synth daemon

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/connect.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/connect.ts
@@ -1,0 +1,160 @@
+import * as net from 'net';
+import { ClientMessage, DaemonMessage, PROTOCOL_VERSION } from '../protocol';
+import { LineParser } from './line-parser';
+import { socketPathForProject } from './socket-path';
+
+export interface DaemonConnection {
+  readonly messages: AsyncIterable<DaemonMessage>;
+  send(msg: ClientMessage): void;
+  close(): void;
+}
+
+export async function connectToDaemon(projectDir: string): Promise<DaemonConnection> {
+  const socketPath = socketPathForProject(projectDir);
+  const socket = await connectSocket(socketPath);
+
+  const { accepted, leftover } = await performHandshake(socket);
+  if (!accepted) {
+    socket.destroy();
+    throw new Error('Daemon rejected handshake: protocol version mismatch');
+  }
+
+  return createConnection(socket, leftover);
+}
+
+async function connectSocket(socketPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(socketPath, () => resolve(socket));
+    socket.on('error', reject);
+  });
+}
+
+interface HandshakeResult {
+  accepted: boolean;
+  leftover: string;
+}
+
+const HANDSHAKE_TIMEOUT_MS = 5000;
+
+async function performHandshake(socket: net.Socket): Promise<HandshakeResult> {
+  socket.write(JSON.stringify({ type: 'handshake', version: PROTOCOL_VERSION }) + '\n');
+
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error('Handshake timed out'));
+    }, HANDSHAKE_TIMEOUT_MS);
+
+    const cleanup = () => {
+      clearTimeout(timer);
+      socket.removeListener('data', onData);
+      socket.removeListener('error', onError);
+    };
+
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex !== -1) {
+        cleanup();
+        const line = buffer.slice(0, newlineIndex);
+        const leftover = buffer.slice(newlineIndex + 1);
+        let msg: DaemonMessage;
+        try {
+          msg = JSON.parse(line) as DaemonMessage;
+        } catch {
+          reject(new Error('Invalid JSON in handshake response'));
+          return;
+        }
+        if (msg.type === 'handshakeAck') {
+          resolve({ accepted: msg.accepted, leftover });
+        } else {
+          reject(new Error(`Expected handshakeAck, got ${msg.type}`));
+        }
+      }
+    };
+    const onError = (err: Error) => {
+      cleanup();
+      reject(err);
+    };
+    socket.on('data', onData);
+    socket.on('error', onError);
+  });
+}
+
+function createConnection(socket: net.Socket, leftover: string): DaemonConnection {
+  return {
+    messages: createMessageIterable(socket, leftover),
+    send(msg: ClientMessage): void {
+      if (!socket.destroyed) {
+        socket.write(JSON.stringify(msg) + '\n');
+      }
+    },
+    close(): void {
+      socket.destroy();
+    },
+  };
+}
+
+function createMessageIterable(socket: net.Socket, leftover: string): AsyncIterable<DaemonMessage> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterableIterator<DaemonMessage> {
+      const parser = new LineParser<DaemonMessage>();
+      const queue: DaemonMessage[] = [];
+      let resolve: ((value: IteratorResult<DaemonMessage>) => void) | undefined;
+      let done = false;
+
+      const enqueue = (messages: DaemonMessage[]) => {
+        for (const msg of messages) {
+          if (resolve) {
+            const r = resolve;
+            resolve = undefined;
+            r({ value: msg, done: false });
+          } else {
+            queue.push(msg);
+          }
+        }
+      };
+
+      // Process any data that arrived during handshake
+      if (leftover.length > 0) {
+        enqueue(parser.feed(leftover));
+      }
+
+      socket.on('data', (data) => {
+        enqueue(parser.feed(data.toString()));
+      });
+
+      socket.on('close', () => {
+        done = true;
+        if (resolve) {
+          const r = resolve;
+          resolve = undefined;
+          r({ value: undefined as never, done: true });
+        }
+      });
+
+      socket.on('error', () => {
+        done = true;
+        if (resolve) {
+          const r = resolve;
+          resolve = undefined;
+          r({ value: undefined as never, done: true });
+        }
+      });
+
+      return {
+        next(): Promise<IteratorResult<DaemonMessage>> {
+          if (queue.length > 0) {
+            return Promise.resolve({ value: queue.shift()!, done: false });
+          }
+          if (done) {
+            return Promise.resolve({ value: undefined as never, done: true });
+          }
+          return new Promise((r) => { resolve = r; });
+        },
+        [Symbol.asyncIterator]() { return this; },
+      };
+    },
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/entry.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/entry.ts
@@ -1,0 +1,47 @@
+import { DaemonServer } from './server';
+import { socketPathForProject, logPathForProject } from './socket-path';
+
+function main() {
+  const projectDir = parseProjectDir();
+  const socketPath = socketPathForProject(projectDir);
+  const logFile = logPathForProject(projectDir);
+
+  const server = new DaemonServer({
+    socketPath,
+    projectDir,
+    logFile,
+    onSynth: stubSynth,
+  });
+
+  const shutdown = () => void server.stop();
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  server.start().then(
+    () => {
+      // eslint-disable-next-line no-console
+      console.log(`Daemon started: pid=${process.pid} socket=${socketPath}`);
+    },
+    (err) => {
+      // eslint-disable-next-line no-console
+      console.error('Daemon failed to start:', err);
+      process.exit(1);
+    },
+  );
+}
+
+function parseProjectDir(): string {
+  const args = process.argv.slice(2);
+  const idx = args.indexOf('--project-dir');
+  if (idx === -1 || idx + 1 >= args.length) {
+    // eslint-disable-next-line no-console
+    console.error('Usage: entry.js --project-dir <path>');
+    process.exit(1);
+  }
+  return args[idx + 1];
+}
+
+async function stubSynth(_triggerFile: string): Promise<void> {
+}
+
+main();

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/info-file.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/info-file.ts
@@ -1,0 +1,23 @@
+import * as fs from 'fs';
+import { DaemonInfo } from '../protocol';
+
+export function writeDaemonInfo(infoPath: string, info: DaemonInfo): void {
+  fs.writeFileSync(infoPath, JSON.stringify(info) + '\n', 'utf-8');
+}
+
+export function readDaemonInfo(infoPath: string): DaemonInfo | undefined {
+  try {
+    const content = fs.readFileSync(infoPath, 'utf-8');
+    return JSON.parse(content) as DaemonInfo;
+  } catch {
+    return undefined;
+  }
+}
+
+export function removeDaemonInfo(infoPath: string): void {
+  try {
+    fs.unlinkSync(infoPath);
+  } catch {
+    // Already removed or never existed
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/line-parser.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/line-parser.ts
@@ -1,0 +1,33 @@
+/**
+ * Accumulates raw data chunks and yields complete JSON-parsed lines.
+ */
+export class LineParser<T> {
+  private buffer = '';
+
+  public feed(chunk: string): T[] {
+    this.buffer += chunk;
+    const results: T[] = [];
+    let newlineIndex: number;
+    while ((newlineIndex = this.buffer.indexOf('\n')) !== -1) {
+      const line = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        try {
+          results.push(JSON.parse(line) as T);
+        } catch {
+          // Malformed line — discard
+        }
+      }
+    }
+    return results;
+  }
+
+  public prepend(data: string): void {
+    this.buffer = data + this.buffer;
+  }
+
+  /** Returns any unprocessed data remaining in the buffer */
+  public get remainder(): string {
+    return this.buffer;
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/server.ts
@@ -1,0 +1,247 @@
+import * as net from 'net';
+import * as fs from 'fs';
+import {
+  ClientMessage,
+  DaemonMessage,
+  PROTOCOL_VERSION,
+} from '../protocol';
+import { SynthLatch } from './state-machine';
+import { LineParser } from './line-parser';
+import { writeDaemonInfo, removeDaemonInfo } from './info-file';
+import { infoPathForProject } from './socket-path';
+
+const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+const DEFAULT_SYNTH_TIMEOUT_MS = 5 * 60 * 1000;
+
+export interface DaemonServerOptions {
+  readonly socketPath: string;
+  readonly projectDir: string;
+  readonly logFile: string;
+  readonly onSynth: (triggerFile: string) => Promise<void>;
+  readonly idleTimeoutMs?: number;
+  readonly synthTimeoutMs?: number;
+}
+
+export class DaemonServer {
+  private readonly socketPath: string;
+  private readonly projectDir: string;
+  private readonly logFile: string;
+  private readonly onSynth: (triggerFile: string) => Promise<void>;
+  private readonly idleTimeoutMs: number;
+  private readonly synthTimeoutMs: number;
+  private readonly latch = new SynthLatch();
+  private readonly connections = new Set<net.Socket>();
+  private readonly subscribers = new Set<net.Socket>();
+  private server: net.Server | undefined;
+  private idleTimer: ReturnType<typeof setTimeout> | undefined;
+  private synthTimer: ReturnType<typeof setTimeout> | undefined;
+  private pendingTriggerFile: string | undefined;
+  private shuttingDown = false;
+
+  constructor(options: DaemonServerOptions) {
+    this.socketPath = options.socketPath;
+    this.projectDir = options.projectDir;
+    this.logFile = options.logFile;
+    this.onSynth = options.onSynth;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_IDLE_TIMEOUT_MS;
+    this.synthTimeoutMs = options.synthTimeoutMs ?? DEFAULT_SYNTH_TIMEOUT_MS;
+  }
+
+  public async start(): Promise<void> {
+    this.server = net.createServer((socket) => this.handleConnection(socket));
+
+    await new Promise<void>((resolve, reject) => {
+      this.server!.on('error', reject);
+      this.server!.listen(this.socketPath, () => {
+        this.server!.removeListener('error', reject);
+        resolve();
+      });
+    });
+
+    writeDaemonInfo(infoPathForProject(this.projectDir), {
+      pid: process.pid,
+      socketPath: this.socketPath,
+      version: PROTOCOL_VERSION,
+      startedAt: Date.now(),
+      logFile: this.logFile,
+    });
+
+    this.resetIdleTimer();
+  }
+
+  public async stop(): Promise<void> {
+    if (this.shuttingDown) return;
+    this.shuttingDown = true;
+
+    this.clearIdleTimer();
+    if (this.synthTimer !== undefined) {
+      clearTimeout(this.synthTimer);
+      this.synthTimer = undefined;
+    }
+    this.broadcast({ type: 'shuttingDown', reason: 'shutdown requested' });
+
+    for (const socket of this.connections) {
+      socket.destroy();
+    }
+    this.connections.clear();
+    this.subscribers.clear();
+
+    await new Promise<void>((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+      this.server.close(() => resolve());
+    });
+
+    this.cleanup();
+  }
+
+  private handleConnection(socket: net.Socket): void {
+    const parser = new LineParser<ClientMessage>();
+    this.connections.add(socket);
+
+    socket.on('data', (data) => {
+      const messages = parser.feed(data.toString());
+      for (const msg of messages) {
+        this.handleMessage(socket, msg);
+      }
+    });
+
+    socket.on('close', () => {
+      this.removeConnection(socket);
+    });
+
+    socket.on('error', () => {
+      this.removeConnection(socket);
+    });
+  }
+
+  private removeConnection(socket: net.Socket): void {
+    this.connections.delete(socket);
+    const wasSubscriber = this.subscribers.delete(socket);
+    if (wasSubscriber && this.subscribers.size === 0) {
+      this.resetIdleTimer();
+    }
+  }
+
+  private handleMessage(socket: net.Socket, msg: ClientMessage): void {
+    switch (msg.type) {
+      case 'handshake':
+        this.handleHandshake(socket, msg.version);
+        break;
+      case 'subscribe':
+        this.handleSubscribe(socket);
+        break;
+      case 'requestSynth':
+        this.handleRequestSynth(msg.triggerFile);
+        break;
+      case 'shutdown':
+        void this.stop();
+        break;
+    }
+  }
+
+  private handleHandshake(socket: net.Socket, clientVersion: string): void {
+    const accepted = clientVersion === PROTOCOL_VERSION;
+    this.send(socket, {
+      type: 'handshakeAck',
+      version: PROTOCOL_VERSION,
+      accepted,
+    });
+
+    if (!accepted) {
+      void this.stop();
+    }
+  }
+
+  private handleSubscribe(socket: net.Socket): void {
+    this.subscribers.add(socket);
+    this.clearIdleTimer();
+  }
+
+  private handleRequestSynth(triggerFile: string): void {
+    const { shouldStartSynth } = this.latch.requestSynth();
+    if (shouldStartSynth) {
+      this.runSynth(triggerFile);
+    } else {
+      this.pendingTriggerFile = triggerFile;
+    }
+  }
+
+  private runSynth(triggerFile: string): void {
+    this.synthTimer = setTimeout(() => {
+      this.onSynthSettled(new Error(`Synth timed out after ${this.synthTimeoutMs}ms`));
+    }, this.synthTimeoutMs);
+
+    Promise.resolve()
+      .then(() => this.onSynth(triggerFile))
+      .then(
+        () => this.onSynthSettled(undefined),
+        (err) => this.onSynthSettled(err),
+      );
+  }
+
+  private onSynthSettled(error: unknown): void {
+    if (this.latch.state === 'idle') return; // guard: already settled (e.g. timeout after completion)
+
+    if (this.synthTimer !== undefined) {
+      clearTimeout(this.synthTimer);
+      this.synthTimer = undefined;
+    }
+
+    const timestamp = Date.now();
+
+    if (error === undefined) {
+      this.broadcast({ type: 'synthComplete', timestamp });
+    } else {
+      const message = error instanceof Error ? error.message : String(error);
+      this.broadcast({ type: 'synthFailed', error: message, timestamp });
+    }
+
+    const { shouldStartSynth } = this.latch.synthComplete();
+    if (shouldStartSynth) {
+      this.runSynth(this.pendingTriggerFile ?? '');
+      this.pendingTriggerFile = undefined;
+    } else if (this.subscribers.size === 0) {
+      this.resetIdleTimer();
+    }
+  }
+
+  private broadcast(msg: DaemonMessage): void {
+    for (const socket of this.subscribers) {
+      this.send(socket, msg);
+    }
+  }
+
+  private send(socket: net.Socket, msg: DaemonMessage): void {
+    if (!socket.destroyed) {
+      socket.write(JSON.stringify(msg) + '\n');
+    }
+  }
+
+  private resetIdleTimer(): void {
+    this.clearIdleTimer();
+    if (this.subscribers.size === 0 && !this.shuttingDown && this.latch.state === 'idle') {
+      this.idleTimer = setTimeout(() => {
+        void this.stop();
+      }, this.idleTimeoutMs);
+    }
+  }
+
+  private clearIdleTimer(): void {
+    if (this.idleTimer !== undefined) {
+      clearTimeout(this.idleTimer);
+      this.idleTimer = undefined;
+    }
+  }
+
+  private cleanup(): void {
+    removeDaemonInfo(infoPathForProject(this.projectDir));
+    try {
+      fs.unlinkSync(this.socketPath);
+    } catch {
+      // Socket may already be removed
+    }
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/socket-path.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/socket-path.ts
@@ -1,0 +1,26 @@
+import * as crypto from 'crypto';
+import * as os from 'os';
+import * as path from 'path';
+
+const SOCKET_PREFIX = 'cdk-synth-';
+const HASH_LENGTH = 12;
+
+function hashForProject(projectDir: string): string {
+  return crypto.createHash('sha256').update(projectDir).digest('hex').slice(0, HASH_LENGTH);
+}
+
+export function socketPathForProject(projectDir: string): string {
+  return path.join(os.tmpdir(), `${SOCKET_PREFIX}${hashForProject(projectDir)}.sock`);
+}
+
+export function lockPathForProject(projectDir: string): string {
+  return socketPathForProject(projectDir) + '.lock';
+}
+
+export function infoPathForProject(projectDir: string): string {
+  return socketPathForProject(projectDir) + '.info';
+}
+
+export function logPathForProject(projectDir: string): string {
+  return socketPathForProject(projectDir) + '.log';
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/spawn.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/spawn.ts
@@ -1,0 +1,173 @@
+import * as fs from 'fs';
+import * as child_process from 'child_process';
+import * as path from 'path';
+import { connectToDaemon, DaemonConnection } from './connect';
+import { readDaemonInfo, removeDaemonInfo } from './info-file';
+import {
+  socketPathForProject,
+  lockPathForProject,
+  infoPathForProject,
+  logPathForProject,
+} from './socket-path';
+
+const SPAWN_POLL_INTERVAL_MS = 10;
+const SPAWN_TIMEOUT_MS = 5000;
+
+export interface EnsureDaemonOptions {
+  readonly projectDir: string;
+}
+
+/**
+ * Ensures a daemon is running for the given project directory
+ * and returns a connected client.
+ *
+ * Uses an exclusive lock file to prevent concurrent spawns.
+ * If a daemon is already running, connects to it directly.
+ */
+export async function ensureDaemon(options: EnsureDaemonOptions): Promise<DaemonConnection> {
+  const { projectDir } = options;
+
+  // daemon already running
+  try {
+    return await connectToDaemon(projectDir);
+  } catch {
+    // Connection failed, need to spawn or clean up
+  }
+
+  const lockPath = lockPathForProject(projectDir);
+  const lockFd = acquireLock(lockPath);
+
+  try {
+    // Re-check after acquiring lock (another process may have won the race)
+    try {
+      return await connectToDaemon(projectDir);
+    } catch {
+      // Still not running, so we need to spawn
+    }
+
+    await cleanupStaleState(projectDir);
+    await spawnDaemon(projectDir);
+    return await connectToDaemon(projectDir);
+  } finally {
+    releaseLock(lockFd, lockPath);
+  }
+}
+
+function acquireLock(lockPath: string): number {
+  try {
+    const fd = fs.openSync(lockPath, 'wx');
+    fs.writeSync(fd, String(process.pid));
+    return fd;
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      const stalePid = readLockPid(lockPath);
+      if (stalePid === undefined || !isProcessAlive(stalePid)) {
+        // PID is unreadable/garbage OR process is dead → stale lock
+        try {
+          fs.unlinkSync(lockPath);
+          const fd = fs.openSync(lockPath, 'wx');
+          fs.writeSync(fd, String(process.pid));
+          return fd;
+        } catch {
+          throw new Error('Another process is spawning the daemon');
+        }
+      }
+      throw new Error('Another process is spawning the daemon');
+    }
+    throw err;
+  }
+}
+
+function releaseLock(fd: number, lockPath: string): void {
+  fs.closeSync(fd);
+  try {
+    fs.unlinkSync(lockPath);
+  } catch {
+    // Best effort, safe because aquireLock guarantees we don't keep lock indefinitely
+  }
+}
+
+function readLockPid(lockPath: string): number | undefined {
+  try {
+    const content = fs.readFileSync(lockPath, 'utf-8').trim();
+    const pid = parseInt(content, 10);
+    return isNaN(pid) ? undefined : pid;
+  } catch {
+    return undefined;
+  }
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function cleanupStaleState(projectDir: string): Promise<void> {
+  const socketPath = socketPathForProject(projectDir);
+  const infoPath = infoPathForProject(projectDir);
+
+  const info = readDaemonInfo(infoPath);
+  if (info && isProcessAlive(info.pid)) {
+    try { process.kill(info.pid, 'SIGTERM'); } catch {}
+    await waitForProcessExit(info.pid, 2000);
+  }
+
+  removeDaemonInfo(infoPath);
+  try { fs.unlinkSync(socketPath); } catch {}
+}
+
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await sleep(50);
+  }
+}
+
+async function spawnDaemon(projectDir: string): Promise<void> {
+  const entryPath = path.resolve(__dirname, 'entry.js');
+  const logPath = logPathForProject(projectDir);
+  const logFd = fs.openSync(logPath, 'a');
+
+  const child = child_process.spawn(
+    process.execPath,
+    [entryPath, '--project-dir', projectDir],
+    {
+      detached: true,
+      stdio: ['ignore', logFd, logFd],
+    },
+  );
+  child.unref();
+  fs.closeSync(logFd);
+
+  await waitForSocket(projectDir);
+}
+
+async function waitForSocket(projectDir: string): Promise<void> {
+  const socketPath = socketPathForProject(projectDir);
+  const deadline = Date.now() + SPAWN_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    if (fs.existsSync(socketPath)) {
+      // Socket file exists — try to connect to verify it's listening
+      try {
+        const conn = await connectToDaemon(projectDir);
+        conn.close();
+        return;
+      } catch {
+        // Not ready yet
+      }
+    }
+    await sleep(SPAWN_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Daemon failed to start within ${SPAWN_TIMEOUT_MS}ms`);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/daemon/state-machine.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/daemon/state-machine.ts
@@ -1,0 +1,40 @@
+export type SynthState = 'idle' | 'synthesizing' | 'queued';
+
+export interface TransitionResult {
+  readonly newState: SynthState;
+  readonly shouldStartSynth: boolean;
+}
+
+export class SynthLatch {
+  private _state: SynthState = 'idle';
+
+  public get state(): SynthState {
+    return this._state;
+  }
+
+  public requestSynth(): TransitionResult {
+    switch (this._state) {
+      case 'idle':
+        this._state = 'synthesizing';
+        return { newState: 'synthesizing', shouldStartSynth: true };
+      case 'synthesizing':
+        this._state = 'queued';
+        return { newState: 'queued', shouldStartSynth: false };
+      case 'queued':
+        return { newState: 'queued', shouldStartSynth: false };
+    }
+  }
+
+  public synthComplete(): TransitionResult {
+    switch (this._state) {
+      case 'idle':
+        return { newState: 'idle', shouldStartSynth: false };
+      case 'synthesizing':
+        this._state = 'idle';
+        return { newState: 'idle', shouldStartSynth: false };
+      case 'queued':
+        this._state = 'synthesizing';
+        return { newState: 'synthesizing', shouldStartSynth: true };
+    }
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/index.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/index.ts
@@ -1,1 +1,33 @@
-export const VERSION = '0.0.0';
+export { PROTOCOL_VERSION } from './protocol';
+export type {
+  ClientMessage,
+  DaemonInfo,
+  DaemonMessage,
+  HandshakeAckMessage,
+  HandshakeMessage,
+  RequestSynthMessage,
+  ShutdownMessage,
+  ShuttingDownMessage,
+  SubscribeMessage,
+  SynthCompleteMessage,
+  SynthFailedMessage,
+} from './protocol';
+
+export { SynthLatch } from './daemon/state-machine';
+export type { SynthState, TransitionResult } from './daemon/state-machine';
+
+export {
+  socketPathForProject,
+  lockPathForProject,
+  infoPathForProject,
+  logPathForProject,
+} from './daemon/socket-path';
+
+export { DaemonServer } from './daemon/server';
+export type { DaemonServerOptions } from './daemon/server';
+
+export { connectToDaemon } from './daemon/connect';
+export type { DaemonConnection } from './daemon/connect';
+
+export { ensureDaemon } from './daemon/spawn';
+export type { EnsureDaemonOptions } from './daemon/spawn';

--- a/packages/@aws-cdk/cdk-explorer/lib/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/protocol.ts
@@ -1,0 +1,86 @@
+/**
+ * Wire protocol for the CDK synth daemon.
+ *
+ * Transport: Unix domain socket (macOS/Linux), named pipe (Windows).
+ * Framing: newline-delimited JSON — each message is JSON.stringify(msg) + '\n'.
+ */
+
+// ---------------------------------------------------------------------------
+// Client to Daemon messages
+// ---------------------------------------------------------------------------
+
+export interface RequestSynthMessage {
+  readonly type: 'requestSynth';
+  readonly triggerFile: string;
+}
+
+export interface SubscribeMessage {
+  readonly type: 'subscribe';
+}
+
+export interface HandshakeMessage {
+  readonly type: 'handshake';
+  readonly version: string;
+}
+
+export interface ShutdownMessage {
+  readonly type: 'shutdown';
+}
+
+export type ClientMessage =
+  | RequestSynthMessage
+  | SubscribeMessage
+  | HandshakeMessage
+  | ShutdownMessage;
+
+// ---------------------------------------------------------------------------
+// Daemon to Client messages
+// ---------------------------------------------------------------------------
+
+export interface SynthCompleteMessage {
+  readonly type: 'synthComplete';
+  readonly timestamp: number;
+}
+
+export interface SynthFailedMessage {
+  readonly type: 'synthFailed';
+  readonly error: string;
+  readonly timestamp: number;
+}
+
+export interface HandshakeAckMessage {
+  readonly type: 'handshakeAck';
+  readonly version: string;
+  readonly accepted: boolean;
+}
+
+export interface ShuttingDownMessage {
+  readonly type: 'shuttingDown';
+  readonly reason: string;
+}
+
+export type DaemonMessage =
+  | SynthCompleteMessage
+  | SynthFailedMessage
+  | HandshakeAckMessage
+  | ShuttingDownMessage;
+
+// ---------------------------------------------------------------------------
+// Info file — written by daemon at startup, read by clients for PID detection
+// ---------------------------------------------------------------------------
+
+export interface DaemonInfo {
+  readonly pid: number;
+  readonly socketPath: string;
+  readonly version: string;
+  readonly startedAt: number;
+  readonly logFile: string;
+}
+
+// ---------------------------------------------------------------------------
+// Protocol version — manually bumped when the wire protocol changes.
+// Used for daemon version handshake: if client and daemon versions differ,
+// the daemon shuts down so a new one matching the client can be spawned.
+// ---------------------------------------------------------------------------
+
+export const PROTOCOL_VERSION = '1';

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/connect.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/connect.test.ts
@@ -1,0 +1,136 @@
+import { DaemonServer } from '../../lib/daemon/server';
+import { connectToDaemon, DaemonConnection } from '../../lib/daemon/connect';
+import { socketPathForProject } from '../../lib/daemon/socket-path';
+
+const TEST_PROJECT = `/tmp/cdk-connect-test-${process.pid}`;
+
+describe('connectToDaemon', () => {
+  let server: DaemonServer;
+  let connection: DaemonConnection | undefined;
+
+  afterEach(async () => {
+    if (connection) {
+      connection.close();
+      connection = undefined;
+    }
+    if (server) {
+      await server.stop();
+    }
+  });
+
+  function startServer(options?: { onSynth?: (t: string) => Promise<void> }) {
+    const socketPath = socketPathForProject(TEST_PROJECT);
+    server = new DaemonServer({
+      socketPath,
+      projectDir: TEST_PROJECT,
+      logFile: socketPath + '.log',
+      onSynth: options?.onSynth ?? (() => Promise.resolve()),
+      idleTimeoutMs: 60_000,
+    });
+    return server.start();
+  }
+
+  test('connects and completes handshake', async () => {
+    await startServer();
+    connection = await connectToDaemon(TEST_PROJECT);
+    expect(connection).toBeDefined();
+    expect(connection.send).toBeInstanceOf(Function);
+    expect(connection.close).toBeInstanceOf(Function);
+  });
+
+  test('receives messages via async iterable', async () => {
+    await startServer({ onSynth: () => Promise.resolve() });
+    connection = await connectToDaemon(TEST_PROJECT);
+
+    connection.send({ type: 'subscribe' });
+    connection.send({ type: 'requestSynth', triggerFile: 'test.ts' });
+
+    const iterator = connection.messages[Symbol.asyncIterator]();
+    const result = await iterator.next();
+    expect(result.done).toBe(false);
+    expect(result.value.type).toBe('synthComplete');
+  });
+
+  test('iterable ends when server closes connection', async () => {
+    await startServer();
+    connection = await connectToDaemon(TEST_PROJECT);
+
+    connection.send({ type: 'subscribe' });
+
+    const iterator = connection.messages[Symbol.asyncIterator]();
+
+    // Stop the server — should close connections
+    await server.stop();
+
+    const result = await iterator.next();
+    expect(result.done).toBe(true);
+  });
+
+  test('throws on version mismatch', async () => {
+    await startServer();
+
+    // Monkey-patch PROTOCOL_VERSION for this test is tricky,
+    // so instead we verify that connecting to a healthy server works.
+    // The version mismatch path is tested via the server test suite.
+    // Here we verify the error message format when connection fails entirely.
+    const badProject = '/tmp/no-daemon-here-' + Date.now();
+    await expect(connectToDaemon(badProject)).rejects.toThrow();
+  });
+
+  test('send after close does not throw', async () => {
+    await startServer();
+    connection = await connectToDaemon(TEST_PROJECT);
+
+    connection.close();
+    // Should not throw
+    connection.send({ type: 'subscribe' });
+  });
+
+  test('receives synthFailed messages', async () => {
+    await startServer({ onSynth: () => Promise.reject(new Error('oops')) });
+    connection = await connectToDaemon(TEST_PROJECT);
+
+    connection.send({ type: 'subscribe' });
+    connection.send({ type: 'requestSynth', triggerFile: 'fail.ts' });
+
+    const iterator = connection.messages[Symbol.asyncIterator]();
+    const result = await iterator.next();
+    expect(result.done).toBe(false);
+    expect(result.value.type).toBe('synthFailed');
+  });
+
+  test('multiple messages arrive in order', async () => {
+    let synthCount = 0;
+    let resolvers: Array<() => void> = [];
+
+    await startServer({
+      onSynth: () => new Promise<void>((resolve) => {
+        synthCount++;
+        resolvers.push(resolve);
+      }),
+    });
+    connection = await connectToDaemon(TEST_PROJECT);
+
+    connection.send({ type: 'subscribe' });
+    connection.send({ type: 'requestSynth', triggerFile: 'a.ts' });
+
+    // Wait for synth to start
+    await new Promise((r) => setTimeout(r, 20));
+    expect(synthCount).toBe(1);
+
+    // Queue another
+    connection.send({ type: 'requestSynth', triggerFile: 'b.ts' });
+
+    // Complete first
+    resolvers[0]();
+    const iterator = connection.messages[Symbol.asyncIterator]();
+    const first = await iterator.next();
+    expect(first.value.type).toBe('synthComplete');
+
+    // Wait for queued to start and complete
+    await new Promise((r) => setTimeout(r, 20));
+    resolvers[1]();
+    const second = await iterator.next();
+    expect(second.value.type).toBe('synthComplete');
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/line-parser.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/line-parser.test.ts
@@ -1,0 +1,40 @@
+import { LineParser } from '../../lib/daemon/line-parser';
+
+describe('LineParser', () => {
+  test('parses complete lines', () => {
+    const parser = new LineParser<{ value: number }>();
+    const results = parser.feed('{"value":1}\n{"value":2}\n');
+    expect(results).toEqual([{ value: 1 }, { value: 2 }]);
+  });
+
+  test('buffers partial lines across feeds', () => {
+    const parser = new LineParser<{ value: number }>();
+    expect(parser.feed('{"val')).toEqual([]);
+    expect(parser.feed('ue":42}\n')).toEqual([{ value: 42 }]);
+  });
+
+  test('discards malformed JSON lines', () => {
+    const parser = new LineParser<{ value: number }>();
+    const results = parser.feed('not-json\n{"value":1}\n');
+    expect(results).toEqual([{ value: 1 }]);
+  });
+
+  test('skips empty lines', () => {
+    const parser = new LineParser<{ value: number }>();
+    const results = parser.feed('\n\n{"value":1}\n\n');
+    expect(results).toEqual([{ value: 1 }]);
+  });
+
+  test('prepend injects data before buffer', () => {
+    const parser = new LineParser<{ value: number }>();
+    parser.prepend('{"value":1}\n{"val');
+    const results = parser.feed('ue":2}\n');
+    expect(results).toEqual([{ value: 1 }, { value: 2 }]);
+  });
+
+  test('remainder returns unparsed data', () => {
+    const parser = new LineParser<{ value: number }>();
+    parser.feed('{"value":1}\npartial');
+    expect(parser.remainder).toBe('partial');
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/server.test.ts
@@ -1,0 +1,350 @@
+import * as net from 'net';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { DaemonServer } from '../../lib/daemon/server';
+import { PROTOCOL_VERSION, DaemonMessage, ClientMessage } from '../../lib/protocol';
+import { infoPathForProject } from '../../lib/daemon/socket-path';
+
+function uniqueSocketPath(): string {
+  return path.join(os.tmpdir(), `cdk-test-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+}
+
+function connectToSocket(socketPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(socketPath, () => resolve(socket));
+    socket.on('error', reject);
+  });
+}
+
+function sendMessage(socket: net.Socket, msg: ClientMessage): void {
+  socket.write(JSON.stringify(msg) + '\n');
+}
+
+function readMessages(socket: net.Socket): Promise<DaemonMessage[]> {
+  return new Promise((resolve) => {
+    const messages: DaemonMessage[] = [];
+    let buffer = '';
+
+    socket.on('data', (data) => {
+      buffer += data.toString();
+      let newlineIndex: number;
+      while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        buffer = buffer.slice(newlineIndex + 1);
+        if (line.length > 0) {
+          messages.push(JSON.parse(line) as DaemonMessage);
+        }
+      }
+    });
+
+    socket.on('close', () => resolve(messages));
+  });
+}
+
+function waitForMessage(socket: net.Socket): Promise<DaemonMessage> {
+  return new Promise((resolve) => {
+    let buffer = '';
+    const onData = (data: Buffer) => {
+      buffer += data.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex);
+        socket.removeListener('data', onData);
+        resolve(JSON.parse(line) as DaemonMessage);
+      }
+    };
+    socket.on('data', onData);
+  });
+}
+
+describe('DaemonServer', () => {
+  let server: DaemonServer;
+  let socketPath: string;
+  const projectDir = '/tmp/test-project';
+
+  beforeEach(() => {
+    socketPath = uniqueSocketPath();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+    }
+    try { fs.unlinkSync(socketPath); } catch {}
+  });
+
+  function createServer(options?: { onSynth?: (t: string) => Promise<void>; idleTimeoutMs?: number }) {
+    server = new DaemonServer({
+      socketPath,
+      projectDir,
+      logFile: socketPath + '.log',
+      onSynth: options?.onSynth ?? (() => Promise.resolve()),
+      idleTimeoutMs: options?.idleTimeoutMs,
+    });
+    return server;
+  }
+
+  test('starts and accepts connections', async () => {
+    createServer();
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    expect(socket.destroyed).toBe(false);
+    socket.destroy();
+  });
+
+  test('writes info file on start', async () => {
+    createServer();
+    await server.start();
+
+    const infoPath = infoPathForProject(projectDir);
+    const content = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+    expect(content.pid).toBe(process.pid);
+    expect(content.socketPath).toBe(socketPath);
+    expect(content.version).toBe(PROTOCOL_VERSION);
+  });
+
+  test('removes info file and socket on stop', async () => {
+    createServer();
+    await server.start();
+
+    const infoPath = infoPathForProject(projectDir);
+    expect(fs.existsSync(infoPath)).toBe(true);
+
+    await server.stop();
+    expect(fs.existsSync(infoPath)).toBe(false);
+    expect(fs.existsSync(socketPath)).toBe(false);
+  });
+
+  test('handshake with matching version is accepted', async () => {
+    createServer();
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+
+    const response = await waitForMessage(socket);
+    expect(response).toEqual({
+      type: 'handshakeAck',
+      version: PROTOCOL_VERSION,
+      accepted: true,
+    });
+    socket.destroy();
+  });
+
+  test('handshake with mismatched version is rejected and triggers shutdown', async () => {
+    createServer();
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    const messages = readMessages(socket);
+    sendMessage(socket, { type: 'handshake', version: 'wrong-version' });
+
+    const received = await messages;
+    expect(received[0]).toEqual({
+      type: 'handshakeAck',
+      version: PROTOCOL_VERSION,
+      accepted: false,
+    });
+  });
+
+  test('subscribe registers client for broadcasts', async () => {
+    let synthResolve: () => void;
+    const synthPromise = new Promise<void>((resolve) => { synthResolve = resolve; });
+    createServer({ onSynth: () => { synthResolve(); return synthPromise; } });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+
+    sendMessage(socket, { type: 'subscribe' });
+    sendMessage(socket, { type: 'requestSynth', triggerFile: 'test.ts' });
+
+    // Resolve the synth
+    synthResolve!();
+    const msg = await waitForMessage(socket);
+    expect(msg.type).toBe('synthComplete');
+    socket.destroy();
+  });
+
+  test('synth failure broadcasts synthFailed', async () => {
+    createServer({ onSynth: () => Promise.reject(new Error('boom')) });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+
+    sendMessage(socket, { type: 'subscribe' });
+    sendMessage(socket, { type: 'requestSynth', triggerFile: 'test.ts' });
+
+    const msg = await waitForMessage(socket);
+    expect(msg.type).toBe('synthFailed');
+    socket.destroy();
+  });
+
+  test('queued synth runs after current completes', async () => {
+    let synthCount = 0;
+    let resolvers: Array<() => void> = [];
+
+    createServer({
+      onSynth: () => new Promise<void>((resolve) => {
+        synthCount++;
+        resolvers.push(resolve);
+      }),
+    });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+    sendMessage(socket, { type: 'subscribe' });
+
+    // First request starts synth
+    sendMessage(socket, { type: 'requestSynth', triggerFile: 'a.ts' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(synthCount).toBe(1);
+
+    // Second request while first is running → queued
+    sendMessage(socket, { type: 'requestSynth', triggerFile: 'b.ts' });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(synthCount).toBe(1);
+
+    // Complete first synth → queued one runs
+    resolvers[0]();
+    await waitForMessage(socket); // synthComplete for first
+    await new Promise((r) => setTimeout(r, 20));
+    expect(synthCount).toBe(2);
+
+    resolvers[1]();
+    const msg = await waitForMessage(socket); // synthComplete for second
+    expect(msg.type).toBe('synthComplete');
+    socket.destroy();
+  });
+
+  test('multiple subscribers all receive broadcasts', async () => {
+    let synthResolve: () => void;
+    const synthPromise = new Promise<void>((resolve) => { synthResolve = resolve; });
+    createServer({ onSynth: () => synthPromise });
+    await server.start();
+
+    const socket1 = await connectToSocket(socketPath);
+    const socket2 = await connectToSocket(socketPath);
+
+    sendMessage(socket1, { type: 'handshake', version: PROTOCOL_VERSION });
+    sendMessage(socket2, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket1);
+    await waitForMessage(socket2);
+
+    sendMessage(socket1, { type: 'subscribe' });
+    sendMessage(socket2, { type: 'subscribe' });
+
+    // Give the event loop time to process subscribes
+    await new Promise((r) => setTimeout(r, 20));
+
+    sendMessage(socket1, { type: 'requestSynth', triggerFile: 'x.ts' });
+
+    // Give time for requestSynth to be processed, then resolve
+    await new Promise((r) => setTimeout(r, 20));
+    synthResolve!();
+
+    const msg1 = await waitForMessage(socket1);
+    const msg2 = await waitForMessage(socket2);
+    expect(msg1.type).toBe('synthComplete');
+    expect(msg2.type).toBe('synthComplete');
+
+    socket1.destroy();
+    socket2.destroy();
+  });
+
+  test('idle timeout triggers shutdown when no subscribers', async () => {
+    createServer({ idleTimeoutMs: 50 });
+    await server.start();
+
+    // Server should shut down after 50ms with no subscribers
+    await new Promise((r) => setTimeout(r, 100));
+    expect(fs.existsSync(socketPath)).toBe(false);
+  });
+
+  test('subscription cancels idle timeout', async () => {
+    createServer({ idleTimeoutMs: 50 });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+    sendMessage(socket, { type: 'subscribe' });
+
+    // Wait longer than timeout
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Server should still be running
+    expect(fs.existsSync(socketPath)).toBe(true);
+    socket.destroy();
+  });
+
+  test('shutdown message stops server', async () => {
+    createServer();
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+    sendMessage(socket, { type: 'subscribe' });
+
+    const messages = readMessages(socket);
+    sendMessage(socket, { type: 'shutdown' });
+
+    const received = await messages;
+    expect(received.some((m) => m.type === 'shuttingDown')).toBe(true);
+  });
+
+  test('synth timeout broadcasts synthFailed', async () => {
+    // onSynth that never resolves
+    server = new DaemonServer({
+      socketPath,
+      projectDir,
+      logFile: socketPath + '.log',
+      onSynth: () => new Promise(() => {}),
+      idleTimeoutMs: 60_000,
+      synthTimeoutMs: 50,
+    });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+    sendMessage(socket, { type: 'subscribe' });
+    sendMessage(socket, { type: 'requestSynth', triggerFile: 'hang.ts' });
+
+    const msg = await waitForMessage(socket);
+    expect(msg.type).toBe('synthFailed');
+    if (msg.type === 'synthFailed') {
+      expect(msg.error).toContain('timed out');
+    }
+    socket.destroy();
+  });
+
+  test('idle timer starts after subscriber socket errors out', async () => {
+    createServer({ idleTimeoutMs: 50 });
+    await server.start();
+
+    const socket = await connectToSocket(socketPath);
+    sendMessage(socket, { type: 'handshake', version: PROTOCOL_VERSION });
+    await waitForMessage(socket);
+    sendMessage(socket, { type: 'subscribe' });
+
+    // Wait to confirm server stays alive with subscriber
+    await new Promise((r) => setTimeout(r, 80));
+    expect(fs.existsSync(socketPath)).toBe(true);
+
+    // Simulate abrupt disconnect
+    socket.destroy();
+
+    // Idle timer should fire and shut down
+    await new Promise((r) => setTimeout(r, 100));
+    expect(fs.existsSync(socketPath)).toBe(false);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/socket-path.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/socket-path.test.ts
@@ -1,0 +1,59 @@
+import * as os from 'os';
+import * as path from 'path';
+import {
+  socketPathForProject,
+  lockPathForProject,
+  infoPathForProject,
+  logPathForProject,
+} from '../../lib/daemon/socket-path';
+
+describe('socket-path', () => {
+  test('produces a path in the temp directory', () => {
+    const result = socketPathForProject('/home/user/my-cdk-app');
+    expect(result.startsWith(os.tmpdir())).toBe(true);
+  });
+
+  test('socket path has .sock extension', () => {
+    const result = socketPathForProject('/project');
+    expect(result).toMatch(/\.sock$/);
+  });
+
+  test('lock path appends .lock to socket path', () => {
+    const project = '/home/user/app';
+    expect(lockPathForProject(project)).toBe(socketPathForProject(project) + '.lock');
+  });
+
+  test('info path appends .info to socket path', () => {
+    const project = '/home/user/app';
+    expect(infoPathForProject(project)).toBe(socketPathForProject(project) + '.info');
+  });
+
+  test('log path appends .log to socket path', () => {
+    const project = '/home/user/app';
+    expect(logPathForProject(project)).toBe(socketPathForProject(project) + '.log');
+  });
+
+  test('same project always produces the same path', () => {
+    const dir = '/home/user/my-cdk-app';
+    expect(socketPathForProject(dir)).toBe(socketPathForProject(dir));
+  });
+
+  test('different projects produce different paths', () => {
+    const a = socketPathForProject('/project-a');
+    const b = socketPathForProject('/project-b');
+    expect(a).not.toBe(b);
+  });
+
+  test('path contains cdk-synth- prefix', () => {
+    const result = socketPathForProject('/anything');
+    const basename = path.basename(result);
+    expect(basename).toMatch(/^cdk-synth-/);
+  });
+
+  test('hash portion is 12 hex characters', () => {
+    const result = socketPathForProject('/test');
+    const basename = path.basename(result, '.sock');
+    const hash = basename.replace('cdk-synth-', '');
+    expect(hash).toMatch(/^[0-9a-f]{12}$/);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/spawn.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/spawn.test.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+import { ensureDaemon } from '../../lib/daemon/spawn';
+import { DaemonConnection } from '../../lib/daemon/connect';
+import {
+  socketPathForProject,
+  infoPathForProject,
+  logPathForProject,
+} from '../../lib/daemon/socket-path';
+
+const TEST_PROJECT = `/tmp/cdk-spawn-test-${process.pid}-${Date.now()}`;
+
+describe('ensureDaemon', () => {
+  let connections: DaemonConnection[] = [];
+
+  afterEach(async () => {
+    for (const conn of connections) {
+      conn.send({ type: 'shutdown' });
+      conn.close();
+    }
+    connections = [];
+
+    // Wait for cleanup
+    await new Promise((r) => setTimeout(r, 200));
+
+    // Clean up any leftover files
+    const socketPath = socketPathForProject(TEST_PROJECT);
+    for (const p of [socketPath, socketPath + '.lock', socketPath + '.info', socketPath + '.log']) {
+      try { fs.unlinkSync(p); } catch {}
+    }
+  });
+
+  test('spawns daemon and returns connected client', async () => {
+    const conn = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn);
+
+    expect(conn).toBeDefined();
+    expect(conn.send).toBeInstanceOf(Function);
+    expect(conn.close).toBeInstanceOf(Function);
+  }, 10_000);
+
+  test('creates info file with daemon metadata', async () => {
+    const conn = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn);
+
+    const infoPath = infoPathForProject(TEST_PROJECT);
+    const info = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+    expect(info.pid).toBeGreaterThan(0);
+    expect(info.socketPath).toBe(socketPathForProject(TEST_PROJECT));
+    expect(info.version).toBe('1');
+  }, 10_000);
+
+  test('creates log file', async () => {
+    const conn = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn);
+
+    const logPath = logPathForProject(TEST_PROJECT);
+    expect(fs.existsSync(logPath)).toBe(true);
+  }, 10_000);
+
+  test('second call reuses existing daemon (singleton)', async () => {
+    const conn1 = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn1);
+
+    const infoPath = infoPathForProject(TEST_PROJECT);
+    const pid1 = JSON.parse(fs.readFileSync(infoPath, 'utf-8')).pid;
+
+    const conn2 = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn2);
+
+    const pid2 = JSON.parse(fs.readFileSync(infoPath, 'utf-8')).pid;
+    expect(pid2).toBe(pid1);
+  }, 10_000);
+
+  test('can exchange messages with spawned daemon', async () => {
+    const conn = await ensureDaemon({ projectDir: TEST_PROJECT });
+    connections.push(conn);
+
+    conn.send({ type: 'subscribe' });
+    conn.send({ type: 'requestSynth', triggerFile: 'test.ts' });
+
+    const iterator = conn.messages[Symbol.asyncIterator]();
+    const result = await iterator.next();
+    expect(result.done).toBe(false);
+    expect(result.value.type).toBe('synthComplete');
+  }, 10_000);
+});

--- a/packages/@aws-cdk/cdk-explorer/test/daemon/state-machine.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/daemon/state-machine.test.ts
@@ -1,0 +1,71 @@
+import { SynthLatch } from '../../lib/daemon/state-machine';
+
+describe('SynthLatch', () => {
+  let latch: SynthLatch;
+
+  beforeEach(() => {
+    latch = new SynthLatch();
+  });
+
+  test('starts in idle state', () => {
+    expect(latch.state).toBe('idle');
+  });
+
+  test('idle + requestSynth → synthesizing, shouldStartSynth', () => {
+    const result = latch.requestSynth();
+    expect(result).toEqual({ newState: 'synthesizing', shouldStartSynth: true });
+    expect(latch.state).toBe('synthesizing');
+  });
+
+  test('synthesizing + requestSynth → queued, no synth', () => {
+    latch.requestSynth();
+    const result = latch.requestSynth();
+    expect(result).toEqual({ newState: 'queued', shouldStartSynth: false });
+    expect(latch.state).toBe('queued');
+  });
+
+  test('queued + requestSynth → queued, no synth (idempotent)', () => {
+    latch.requestSynth();
+    latch.requestSynth();
+    const result = latch.requestSynth();
+    expect(result).toEqual({ newState: 'queued', shouldStartSynth: false });
+    expect(latch.state).toBe('queued');
+  });
+
+  test('synthesizing + synthComplete → idle, no synth', () => {
+    latch.requestSynth();
+    const result = latch.synthComplete();
+    expect(result).toEqual({ newState: 'idle', shouldStartSynth: false });
+    expect(latch.state).toBe('idle');
+  });
+
+  test('queued + synthComplete → synthesizing, shouldStartSynth', () => {
+    latch.requestSynth();
+    latch.requestSynth();
+    const result = latch.synthComplete();
+    expect(result).toEqual({ newState: 'synthesizing', shouldStartSynth: true });
+    expect(latch.state).toBe('synthesizing');
+  });
+
+  test('idle + synthComplete → idle, no synth (no-op)', () => {
+    const result = latch.synthComplete();
+    expect(result).toEqual({ newState: 'idle', shouldStartSynth: false });
+    expect(latch.state).toBe('idle');
+  });
+
+  test('full cycle: request → complete → request → request → complete → complete', () => {
+    expect(latch.requestSynth().shouldStartSynth).toBe(true);
+    expect(latch.synthComplete().shouldStartSynth).toBe(false);
+    expect(latch.state).toBe('idle');
+
+    expect(latch.requestSynth().shouldStartSynth).toBe(true);
+    expect(latch.requestSynth().shouldStartSynth).toBe(false);
+    expect(latch.state).toBe('queued');
+
+    expect(latch.synthComplete().shouldStartSynth).toBe(true);
+    expect(latch.state).toBe('synthesizing');
+
+    expect(latch.synthComplete().shouldStartSynth).toBe(false);
+    expect(latch.state).toBe('idle');
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/index.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/index.test.ts
@@ -1,5 +1,15 @@
-import { VERSION } from '../lib';
+import { PROTOCOL_VERSION, SynthLatch, socketPathForProject } from '../lib';
 
-test('package loads', () => {
-  expect(VERSION).toBe('0.0.0');
+test('package exports protocol version', () => {
+  expect(typeof PROTOCOL_VERSION).toBe('string');
+  expect(PROTOCOL_VERSION.length).toBeGreaterThan(0);
+});
+
+test('package exports SynthLatch', () => {
+  const latch = new SynthLatch();
+  expect(latch.state).toBe('idle');
+});
+
+test('package exports socket path utilities', () => {
+  expect(socketPathForProject('/test')).toContain('cdk-synth-');
 });


### PR DESCRIPTION
Implementation for long-running daemon which manages synth request from LSP servers, with connection and cleanup logic and associated tests

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
