### PR TITLE
fix(cli): show DELETE_FAILED events as skipped during stack updates

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -661,6 +661,7 @@ class FullCloudFormationDeployment {
       ioHelper: this.ioHelper,
       changeSetCreationTime: startTime,
       envResources: this.options.envResources,
+      isStackUpdate: this.update,
     });
     await monitor.start();
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -69,6 +69,13 @@ export interface StackActivityMonitorProps {
    * @default - Bootstrap version is not reported in error messages
    */
   readonly envResources?: EnvironmentResources;
+
+  /**
+   * Whether this deployment is an update to an existing stack (as opposed to a creation).
+   *
+   * @default false
+   */
+  readonly isStackUpdate?: boolean;
 }
 
 /**
@@ -112,6 +119,7 @@ export class StackActivityMonitor {
   private readonly stack: CloudFormationStackArtifact;
   private readonly cfn: ICloudFormationClient;
   private readonly envResources?: EnvironmentResources;
+  private readonly isStackUpdate: boolean;
 
   constructor({
     cfn,
@@ -122,12 +130,14 @@ export class StackActivityMonitor {
     changeSetCreationTime,
     pollingInterval = 2_000,
     envResources,
+    isStackUpdate = false,
   }: StackActivityMonitorProps) {
     this.ioHelper = ioHelper;
     this.stack = stack;
     this.stackDisplayName = stackNameFromArn(stackArn);
     this.cfn = cfn;
     this.envResources = envResources;
+    this.isStackUpdate = isStackUpdate;
 
     this.progressMonitor = new StackProgressMonitor(resourcesTotal);
     this.pollingInterval = pollingInterval;
@@ -151,6 +161,7 @@ export class StackActivityMonitor {
       stack: this.stack,
       stackName: this.stackDisplayName,
       resourcesTotal: this.progressMonitor.total,
+      isStackUpdate: this.isStackUpdate,
     }));
     this.scheduleNextTick();
     return this;

--- a/packages/@aws-cdk/toolkit-lib/lib/payloads/stack-activity.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/payloads/stack-activity.ts
@@ -31,6 +31,13 @@ export interface StackMonitoringControlEvent {
    * Only use for informational purposes and handle the case when it's unavailable.
    */
   readonly resourcesTotal?: number;
+
+  /**
+   * Whether this deployment is an update to an existing stack (as opposed to a creation).
+   *
+   * @default false
+   */
+  readonly isStackUpdate?: boolean;
 }
 
 export interface StackActivity {

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/base.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/base.ts
@@ -18,6 +18,7 @@ export interface ActivityPrinterProps {
 export abstract class ActivityPrinterBase implements IActivityPrinter {
   protected static readonly TIMESTAMP_WIDTH = 12;
   protected static readonly STATUS_WIDTH = 20;
+  protected static readonly EXPANDED_STATUS_WIDTH = 27;
 
   /**
    * Stream to write to
@@ -40,6 +41,8 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
 
   protected readonly failures = new Array<StackActivity>();
 
+  protected isStackUpdate = false;
+
   protected hookFailureMap = new Map<string, Map<string, string>>();
 
   constructor(protected readonly props: ActivityPrinterProps) {
@@ -54,6 +57,7 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
   public notify(msg: IoMessage<unknown>): void {
     switch (true) {
       case IO.CDK_TOOLKIT_I5501.is(msg):
+        this.isStackUpdate = (msg.data as any)?.isStackUpdate ?? false;
         this.start(msg.data);
         break;
       case IO.CDK_TOOLKIT_I5502.is(msg):
@@ -149,5 +153,14 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
    */
   protected isActivityForTheStack(activity: StackActivity) {
     return activity.event.PhysicalResourceId === activity.event.StackId;
+  }
+
+  /**
+   * During a stack update, DELETE_FAILED events are provisional: CloudFormation
+   * will eventually skip them and complete the update. We display these with
+   * reduced urgency so users don't assume the deployment has failed.
+   */
+  protected isProvisionalFailure(activity: StackActivity): boolean {
+    return this.isStackUpdate && activity.event.ResourceStatus === 'DELETE_FAILED';
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/base.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/base.ts
@@ -17,8 +17,7 @@ export interface ActivityPrinterProps {
 
 export abstract class ActivityPrinterBase implements IActivityPrinter {
   protected static readonly TIMESTAMP_WIDTH = 12;
-  protected static readonly STATUS_WIDTH = 20;
-  protected static readonly EXPANDED_STATUS_WIDTH = 27;
+  protected static readonly STATUS_WIDTH = 23;
 
   /**
    * Stream to write to
@@ -74,6 +73,11 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
 
   public start({ stack }: { stack: CloudFormationStackArtifact }) {
     this.resourceTypeColumnWidth = maxResourceTypeLength(stack.template);
+    this.resourcesInProgress = {};
+    this.stackProgress = undefined;
+    this.rollingBack = false;
+    this.failures.length = 0;
+    this.hookFailureMap.clear();
   }
 
   public activity(activity: StackActivity) {
@@ -156,9 +160,8 @@ export abstract class ActivityPrinterBase implements IActivityPrinter {
   }
 
   /**
-   * During a stack update, DELETE_FAILED events are provisional: CloudFormation
-   * will eventually skip them and complete the update. We display these with
-   * reduced urgency so users don't assume the deployment has failed.
+   * During a stack update, DELETE_FAILED events are skippable: CloudFormation
+   * will eventually skip them and complete the update.
    */
   protected isProvisionalFailure(activity: StackActivity): boolean {
     return this.isStackUpdate && activity.event.ResourceStatus === 'DELETE_FAILED';

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/current.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/current.ts
@@ -49,18 +49,25 @@ export class CurrentActivityPrinter extends ActivityPrinterBase {
     const toPrint: StackActivity[] = [...this.failures, ...Object.values(this.resourcesInProgress)];
     toPrint.sort((a, b) => a.event.Timestamp!.getTime() - b.event.Timestamp!.getTime());
 
+    const statusWidth = toPrint.some((activity) => this.isProvisionalFailure(activity))
+      ? CurrentActivityPrinter.EXPANDED_STATUS_WIDTH
+      : CurrentActivityPrinter.STATUS_WIDTH;
     lines.push(
       ...toPrint.map((res) => {
-        const color = colorFromStatusActivity(res.event.ResourceStatus);
+        const provisional = this.isProvisionalFailure(res);
+        const color = provisional ? chalk.dim : colorFromStatusActivity(res.event.ResourceStatus);
         const resourceName = res.metadata?.constructPath ?? res.event.LogicalResourceId ?? '';
+        const statusText = provisional
+          ? `${(res.event.ResourceStatus || '').slice(0, statusWidth)} (provisional)`
+          : (res.event.ResourceStatus || '').slice(0, statusWidth);
 
         return util.format(
           '%s | %s | %s | %s%s',
           padLeft(CurrentActivityPrinter.TIMESTAMP_WIDTH, new Date(res.event.Timestamp!).toLocaleTimeString()),
-          color(padRight(CurrentActivityPrinter.STATUS_WIDTH, (res.event.ResourceStatus || '').slice(0, CurrentActivityPrinter.STATUS_WIDTH))),
+          color(padRight(statusWidth, statusText)),
           padRight(this.resourceTypeColumnWidth, res.event.ResourceType || ''),
           color(chalk.bold(shorten(40, resourceName))),
-          this.failureReasonOnNextLine(res),
+          provisional ? '' : this.failureReasonOnNextLine(res),
         );
       }),
     );
@@ -71,11 +78,10 @@ export class CurrentActivityPrinter extends ActivityPrinterBase {
   public stop() {
     super.stop();
 
-    // Print failures at the end
+    // Print failures at the end (excluding provisional DELETE_FAILED during updates)
     const lines = new Array<string>();
     for (const failure of this.failures) {
-      // Root stack failures are not interesting
-      if (this.isActivityForTheStack(failure)) {
+      if (this.isActivityForTheStack(failure) || this.isProvisionalFailure(failure)) {
         continue;
       }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/current.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/current.ts
@@ -49,25 +49,22 @@ export class CurrentActivityPrinter extends ActivityPrinterBase {
     const toPrint: StackActivity[] = [...this.failures, ...Object.values(this.resourcesInProgress)];
     toPrint.sort((a, b) => a.event.Timestamp!.getTime() - b.event.Timestamp!.getTime());
 
-    const statusWidth = toPrint.some((activity) => this.isProvisionalFailure(activity))
-      ? CurrentActivityPrinter.EXPANDED_STATUS_WIDTH
-      : CurrentActivityPrinter.STATUS_WIDTH;
     lines.push(
       ...toPrint.map((res) => {
         const provisional = this.isProvisionalFailure(res);
-        const color = provisional ? chalk.dim : colorFromStatusActivity(res.event.ResourceStatus);
+        const color = provisional ? chalk.yellow : colorFromStatusActivity(res.event.ResourceStatus);
         const resourceName = res.metadata?.constructPath ?? res.event.LogicalResourceId ?? '';
         const statusText = provisional
-          ? `${(res.event.ResourceStatus || '').slice(0, statusWidth)} (provisional)`
-          : (res.event.ResourceStatus || '').slice(0, statusWidth);
+          ? `${(res.event.ResourceStatus || '').slice(0, CurrentActivityPrinter.STATUS_WIDTH)} (skipped)`
+          : (res.event.ResourceStatus || '').slice(0, CurrentActivityPrinter.STATUS_WIDTH);
 
         return util.format(
           '%s | %s | %s | %s%s',
           padLeft(CurrentActivityPrinter.TIMESTAMP_WIDTH, new Date(res.event.Timestamp!).toLocaleTimeString()),
-          color(padRight(statusWidth, statusText)),
+          color(padRight(CurrentActivityPrinter.STATUS_WIDTH, statusText)),
           padRight(this.resourceTypeColumnWidth, res.event.ResourceType || ''),
           color(chalk.bold(shorten(40, resourceName))),
-          provisional ? '' : this.failureReasonOnNextLine(res),
+          provisional ? ' (this will take a few minutes to recover)' : this.failureReasonOnNextLine(res),
         );
       }),
     );
@@ -100,6 +97,10 @@ export class CurrentActivityPrinter extends ActivityPrinterBase {
       if (trace) {
         lines.push(chalk.red(`\t${trace.join('\n\t\\_ ')}\n`));
       }
+    }
+
+    if (this.failures.some((f) => this.isProvisionalFailure(f))) {
+      lines.push(chalk.yellow('\n ⚠️  Some resources failed to delete but were skipped. These resources may still exist and could incur charges. Clean them up manually.\n'));
     }
 
     // Display in the same block space, otherwise we're going to have silly empty lines.

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/history.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/history.ts
@@ -28,8 +28,6 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
 
   private readonly printable = new Array<StackActivity>();
 
-  private hasProvisionalFailures = false;
-
   constructor(props: ActivityPrinterProps) {
     super(props);
   }
@@ -52,6 +50,10 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
         this.printOne(failure, false);
       }
     }
+
+    if (this.failures.some((f) => this.isProvisionalFailure(f))) {
+      this.stream.write(chalk.yellow('\n ⚠️  Some resources failed to delete but were skipped. These resources may still exist and could incur charges. Clean them up manually.\n'));
+    }
   }
 
   protected print() {
@@ -66,13 +68,7 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
   private printOne(activity: StackActivity, progress?: boolean) {
     const event = activity.event;
     const provisional = this.isProvisionalFailure(activity);
-    if (provisional) {
-      this.hasProvisionalFailures = true;
-    }
-    const statusWidth = this.hasProvisionalFailures
-      ? HistoryActivityPrinter.EXPANDED_STATUS_WIDTH
-      : HistoryActivityPrinter.STATUS_WIDTH;
-    const color = provisional ? chalk.dim : colorFromStatusResult(event.ResourceStatus);
+    const color = provisional ? chalk.yellow : colorFromStatusResult(event.ResourceStatus);
     let reasonColor = chalk.cyan;
 
     let stackTrace = '';
@@ -91,8 +87,8 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
     const resourceName = metadata ? metadata.constructPath : event.LogicalResourceId || '';
     const logicalId = resourceName !== event.LogicalResourceId ? `(${event.LogicalResourceId}) ` : '';
     const statusText = provisional
-      ? `${(event.ResourceStatus || '').slice(0, statusWidth)} (provisional)`
-      : (event.ResourceStatus || '').slice(0, statusWidth);
+      ? `${(event.ResourceStatus || '').slice(0, HistoryActivityPrinter.STATUS_WIDTH)} (skipped)`
+      : (event.ResourceStatus || '').slice(0, HistoryActivityPrinter.STATUS_WIDTH);
 
     this.stream.write(
       util.format(
@@ -100,11 +96,11 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
         event.StackName,
         progress !== false ? `${activity.progress.formatted} | ` : '',
         new Date(event.Timestamp!).toLocaleTimeString(),
-        color(padRight(statusWidth, statusText)),
+        color(padRight(HistoryActivityPrinter.STATUS_WIDTH, statusText)),
         padRight(this.resourceTypeColumnWidth, event.ResourceType || ''),
         color(chalk.bold(resourceName)),
         logicalId,
-        provisional ? '' : reasonColor(chalk.bold(event.ResourceStatusReason ? event.ResourceStatusReason : '')),
+        provisional ? '(this will take a few minutes to recover)' : reasonColor(chalk.bold(event.ResourceStatusReason ? event.ResourceStatusReason : '')),
         provisional ? '' : reasonColor(stackTrace),
       ),
     );

--- a/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/history.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/activity-printer/history.ts
@@ -28,6 +28,8 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
 
   private readonly printable = new Array<StackActivity>();
 
+  private hasProvisionalFailures = false;
+
   constructor(props: ActivityPrinterProps) {
     super(props);
   }
@@ -40,15 +42,13 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
   public stop() {
     super.stop();
 
-    // Print failures at the end
-    if (this.failures.length > 0) {
+    // Print failures at the end (excluding provisional DELETE_FAILED during updates)
+    const realFailures = this.failures.filter(
+      (f) => !this.isActivityForTheStack(f) && !this.isProvisionalFailure(f),
+    );
+    if (realFailures.length > 0) {
       this.stream.write('\nFailed resources:\n');
-      for (const failure of this.failures) {
-        // Root stack failures are not interesting
-        if (this.isActivityForTheStack(failure)) {
-          continue;
-        }
-
+      for (const failure of realFailures) {
         this.printOne(failure, false);
       }
     }
@@ -65,13 +65,20 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
 
   private printOne(activity: StackActivity, progress?: boolean) {
     const event = activity.event;
-    const color = colorFromStatusResult(event.ResourceStatus);
+    const provisional = this.isProvisionalFailure(activity);
+    if (provisional) {
+      this.hasProvisionalFailures = true;
+    }
+    const statusWidth = this.hasProvisionalFailures
+      ? HistoryActivityPrinter.EXPANDED_STATUS_WIDTH
+      : HistoryActivityPrinter.STATUS_WIDTH;
+    const color = provisional ? chalk.dim : colorFromStatusResult(event.ResourceStatus);
     let reasonColor = chalk.cyan;
 
     let stackTrace = '';
     const metadata = activity.metadata;
 
-    if (event.ResourceStatus && event.ResourceStatus.indexOf('FAILED') !== -1) {
+    if (!provisional && event.ResourceStatus && event.ResourceStatus.indexOf('FAILED') !== -1) {
       if (progress == undefined || progress) {
         event.ResourceStatusReason = event.ResourceStatusReason ? this.failureReason(activity) : '';
       }
@@ -83,6 +90,9 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
 
     const resourceName = metadata ? metadata.constructPath : event.LogicalResourceId || '';
     const logicalId = resourceName !== event.LogicalResourceId ? `(${event.LogicalResourceId}) ` : '';
+    const statusText = provisional
+      ? `${(event.ResourceStatus || '').slice(0, statusWidth)} (provisional)`
+      : (event.ResourceStatus || '').slice(0, statusWidth);
 
     this.stream.write(
       util.format(
@@ -90,12 +100,12 @@ export class HistoryActivityPrinter extends ActivityPrinterBase {
         event.StackName,
         progress !== false ? `${activity.progress.formatted} | ` : '',
         new Date(event.Timestamp!).toLocaleTimeString(),
-        color(padRight(HistoryActivityPrinter.STATUS_WIDTH, (event.ResourceStatus || '').slice(0, HistoryActivityPrinter.STATUS_WIDTH))), // pad left and trim
+        color(padRight(statusWidth, statusText)),
         padRight(this.resourceTypeColumnWidth, event.ResourceType || ''),
         color(chalk.bold(resourceName)),
         logicalId,
-        reasonColor(chalk.bold(event.ResourceStatusReason ? event.ResourceStatusReason : '')),
-        reasonColor(stackTrace),
+        provisional ? '' : reasonColor(chalk.bold(event.ResourceStatusReason ? event.ResourceStatusReason : '')),
+        provisional ? '' : reasonColor(stackTrace),
       ),
     );
 

--- a/packages/@aws-cdk/toolkit-lib/test/activity-monitor/history.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/activity-monitor/history.test.ts
@@ -96,6 +96,88 @@ test('prints "Failed Resources:" list, when at least one deployment fails', () =
   ]);
 });
 
+test('DELETE_FAILED during stack update is shown as provisional in dim, without reason or stack trace', () => {
+  const historyActivityPrinter = new HistoryActivityPrinter({
+    stream: process.stderr,
+  });
+
+  const output = stderr.inspectSync(() => {
+    (historyActivityPrinter as any).isStackUpdate = true;
+    historyActivityPrinter.start({ stack: testStack({ stackName: 'stack-name' }) });
+    historyActivityPrinter.activity({
+      event: {
+        LogicalResourceId: 'MyResource',
+        ResourceStatus: ResourceStatus.DELETE_FAILED,
+        ResourceStatusReason: 'Resource cannot be deleted',
+        Timestamp: new Date(TIMESTAMP),
+        ResourceType: 'AWS::S3::Bucket',
+        StackId: 'stack-id',
+        EventId: '',
+        StackName: 'stack-name',
+      },
+      deployment: 'test',
+      metadata: {
+        constructPath: 'MyConstruct/MyResource',
+        entry: { trace: ['line1', 'line2'] },
+      } as any,
+      progress: {
+        completed: 1,
+        total: 2,
+        formatted: '1/2',
+      },
+    });
+    historyActivityPrinter.stop();
+  });
+
+  // Should show "(provisional)", no reason, no stack trace, no "Failed resources:" section
+  const joined = output.join('\n');
+  expect(joined).toContain('DELETE_FAILED (provisional)');
+  expect(joined).not.toContain('Resource cannot be deleted');
+  expect(joined).not.toContain('line1');
+  expect(joined).not.toContain('line2');
+  expect(joined).not.toContain('Failed resources:');
+});
+
+test('DELETE_FAILED during stack create is shown normally in red with reason and stack trace', () => {
+  const historyActivityPrinter = new HistoryActivityPrinter({
+    stream: process.stderr,
+  });
+
+  const output = stderr.inspectSync(() => {
+    historyActivityPrinter.start({ stack: testStack({ stackName: 'stack-name' }) });
+    historyActivityPrinter.activity({
+      event: {
+        LogicalResourceId: 'MyResource',
+        ResourceStatus: ResourceStatus.DELETE_FAILED,
+        ResourceStatusReason: 'Resource cannot be deleted',
+        Timestamp: new Date(TIMESTAMP),
+        ResourceType: 'AWS::S3::Bucket',
+        StackId: 'stack-id',
+        EventId: '',
+        StackName: 'stack-name',
+      },
+      deployment: 'test',
+      metadata: {
+        constructPath: 'MyConstruct/MyResource',
+        entry: { trace: ['line1', 'line2'] },
+      } as any,
+      progress: {
+        completed: 1,
+        total: 2,
+        formatted: '1/2',
+      },
+    });
+    historyActivityPrinter.stop();
+  });
+
+  // Should show reason, stack trace, and "Failed resources:" recap
+  const joined = output.join('\n');
+  expect(joined).toContain('Resource cannot be deleted');
+  expect(joined).toContain('line1');
+  expect(joined).not.toContain('(provisional)');
+  expect(joined).toContain('Failed resources:');
+});
+
 test('print failed resources because of hook failures', () => {
   const historyActivityPrinter = new HistoryActivityPrinter({
     stream: process.stderr,

--- a/packages/@aws-cdk/toolkit-lib/test/activity-monitor/history.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/activity-monitor/history.test.ts
@@ -40,7 +40,7 @@ test('prints "IN_PROGRESS" ResourceStatus', () => {
   });
 
   expect(output.map(x => x.trim())).toEqual([
-    `stack-name | 0/4 | ${HUMAN_TIME} | ${chalk.reset('CREATE_IN_PROGRESS  ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
+    `stack-name | 0/4 | ${HUMAN_TIME} | ${chalk.reset('CREATE_IN_PROGRESS     ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
   ]);
 });
 
@@ -89,14 +89,14 @@ test('prints "Failed Resources:" list, when at least one deployment fails', () =
   });
 
   expect(output.map(x => x.trim())).toEqual([
-    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.reset('UPDATE_IN_PROGRESS  ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
-    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED       ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))}`,
+    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.reset('UPDATE_IN_PROGRESS     ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
+    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED          ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))}`,
     'Failed resources:',
-    `stack-name | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED       ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))}`,
+    `stack-name | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED          ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))}`,
   ]);
 });
 
-test('DELETE_FAILED during stack update is shown as provisional in dim, without reason or stack trace', () => {
+test('DELETE_FAILED during stack update is shown as skipped in yellow, with recovery note', () => {
   const historyActivityPrinter = new HistoryActivityPrinter({
     stream: process.stderr,
   });
@@ -129,16 +129,18 @@ test('DELETE_FAILED during stack update is shown as provisional in dim, without 
     historyActivityPrinter.stop();
   });
 
-  // Should show "(provisional)", no reason, no stack trace, no "Failed resources:" section
+  // Should show "(skipped)", recovery note, cleanup warning, no reason, no stack trace, no "Failed resources:" section
   const joined = output.join('\n');
-  expect(joined).toContain('DELETE_FAILED (provisional)');
+  expect(joined).toContain('DELETE_FAILED (skipped)');
+  expect(joined).toContain('(this will take a few minutes to recover)');
+  expect(joined).toContain('failed to delete but were skipped');
   expect(joined).not.toContain('Resource cannot be deleted');
   expect(joined).not.toContain('line1');
   expect(joined).not.toContain('line2');
   expect(joined).not.toContain('Failed resources:');
 });
 
-test('DELETE_FAILED during stack create is shown normally in red with reason and stack trace', () => {
+test('DELETE_FAILED during stack create is shown in red with reason and stack trace', () => {
   const historyActivityPrinter = new HistoryActivityPrinter({
     stream: process.stderr,
   });
@@ -174,7 +176,7 @@ test('DELETE_FAILED during stack create is shown normally in red with reason and
   const joined = output.join('\n');
   expect(joined).toContain('Resource cannot be deleted');
   expect(joined).toContain('line1');
-  expect(joined).not.toContain('(provisional)');
+  expect(joined).not.toContain('(skipped)');
   expect(joined).toContain('Failed resources:');
 });
 
@@ -227,9 +229,9 @@ test('print failed resources because of hook failures', () => {
   });
 
   expect(output.map(x => x.trim())).toEqual([
-    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.reset('UPDATE_IN_PROGRESS  ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
-    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED       ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))} ${chalk.red(chalk.bold('The following hook(s) failed: hook1 : stack1 must obey certain rules'))}`,
+    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.reset('UPDATE_IN_PROGRESS     ')} | AWS::CloudFormation::Stack | ${chalk.reset(chalk.bold('stack1'))}`,
+    `stack-name | 0/2 | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED          ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))} ${chalk.red(chalk.bold('The following hook(s) failed: hook1 : stack1 must obey certain rules'))}`,
     'Failed resources:',
-    `stack-name | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED       ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))} ${chalk.red(chalk.bold('The following hook(s) failed: hook1 : stack1 must obey certain rules'))}`,
+    `stack-name | ${HUMAN_TIME} | ${chalk.red('UPDATE_FAILED          ')} | AWS::CloudFormation::Stack | ${chalk.red(chalk.bold('stack1'))} ${chalk.red(chalk.bold('The following hook(s) failed: hook1 : stack1 must obey certain rules'))}`,
   ]);
 });


### PR DESCRIPTION
## Summary

- During a stack update, `DELETE_FAILED` events are now displayed in yellow with a "(skipped)" label instead of alarming red, since CloudFormation will eventually skip these and complete the update anyway.
- Stack traces and error reasons are suppressed for these skipped failures. Instead, a "(this will take a few minutes to recover)" note is shown at the end of the row.
- At the end of the deployment, a warning is printed telling the user that skipped resources may still exist and could incur charges.
- Fixed a pre-existing bug where per-deployment state (failures, rollback status, in-progress resources) was not reset between consecutive stack deployments in the same session, causing status messages and warnings from one stack to bleed into the next.
- During stack creation, the original behavior (red, full error details, stack traces) is preserved unchanged.

## Motivation

When CloudFormation updates a stack and encounters a `DELETE_FAILED` on a resource being replaced, it will retry and ultimately succeed (or the overall update will fail for a different reason). Showing these transient states in red with full stack traces gives users the false impression that their deployment has failed, when in reality it's still in progress.

## Screenshots

### While deployment is in progress

<img width="1647" height="237" alt="update-in-progress" src="https://github.com/user-attachments/assets/99914255-73b1-46f4-89a6-a7bb10e79599" />

### After deployment completes

<img width="1640" height="555" alt="update-complete" src="https://github.com/user-attachments/assets/504f5886-07d1-405f-8401-936891a22737" />

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
