### PR TITLE
fix(cli-integ): no such file or directory: package.json

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/use-lib-as-bundled-dependency.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-lib/use-lib-as-bundled-dependency.integtest.ts
@@ -1,4 +1,5 @@
 import * as fs from 'fs/promises';
+import * as path from 'path';
 import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '../../lib';
 
 // Sometimes, due to our own use of bundled dependencies, NPM will fail if a customer declares
@@ -9,7 +10,8 @@ integTest('using aws-cdk-lib as a bundled dependency', withTemporaryDirectory(wi
 
   await shell.shell(['npm', 'init', '-y']);
 
-  const packageJson = JSON.parse(await fs.readFile('package.json', 'utf-8'));
+  const packageJsonPath = path.join(context.integTestDir, 'package.json');
+  const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf-8'));
 
   packageJson.dependencies = {
     ...packageJson.dependencies,
@@ -17,7 +19,7 @@ integTest('using aws-cdk-lib as a bundled dependency', withTemporaryDirectory(wi
   };
   packageJson.bundleDependencies = ['aws-cdk-lib'];
 
-  await fs.writeFile('package.json', JSON.stringify(packageJson, undefined, 2), 'utf-8');
+  await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, undefined, 2), 'utf-8');
 
   await shell.shell(['npm', 'install']);
 })));


### PR DESCRIPTION
This file was read and written with respect to the *current path*, instead of the temporary test directory. In some environments, this causes the test to fail.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
