### PR TITLE
feat(toolkit-lib): surface resource delete failures in DeployResult

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/test-case.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/integ-tests/test-case.ts
@@ -30,6 +30,16 @@ export interface TestOptions {
   readonly hooks?: Hooks;
 
   /**
+   * Whether to allow resources that fail to delete during a stack update.
+   *
+   * When false, the test will fail if CloudFormation skips deleting a resource
+   * during a stack update. When true, only a warning is printed.
+   *
+   * @default false
+   */
+  readonly allowDeleteFailures?: boolean;
+
+  /**
    * Whether or not to include asset hashes in the diff
    * Asset hashes can introduces a lot of unneccessary noise into tests,
    * but there are some cases where asset hashes _should_ be included. For example

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/integ.schema.json
@@ -65,6 +65,11 @@
                     "description": "Additional commands to run at predefined points in the test workflow\n\ne.g. { postDeploy: ['yarn', 'test'] } (Default - no hooks)",
                     "$ref": "#/definitions/Hooks"
                 },
+                "allowDeleteFailures": {
+                    "description": "Whether to allow resources that fail to delete during a stack update.\n\nWhen false, the test will fail if CloudFormation skips deleting a resource\nduring a stack update. When true, only a warning is printed.",
+                    "default": false,
+                    "type": "boolean"
+                },
                 "diffAssets": {
                     "description": "Whether or not to include asset hashes in the diff\nAsset hashes can introduces a lot of unneccessary noise into tests,\nbut there are some cases where asset hashes _should_ be included. For example\nany tests involving custom resources or bundling",
                     "default": false,

--- a/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/schema/version.json
@@ -1,5 +1,5 @@
 {
-  "schemaHash": "cf2452236640f556f1b81778515335af1c6bbdb54c7ef12dad43f8cf6a56ddee",
+  "schemaHash": "095859ad1d3d89d3bc4f9cbe9393d219798972dbd2389287bcc66b49f323cef1",
   "$comment": "Do not hold back the version on additions: jsonschema validation of the manifest by the consumer will trigger errors on unexpected fields.",
-  "revision": 53
+  "revision": 54
 }

--- a/packages/@aws-cdk/integ-runner/lib/cli.ts
+++ b/packages/@aws-cdk/integ-runner/lib/cli.ts
@@ -56,6 +56,7 @@ export function parseCliArgs(args: string[] = []) {
     .option('ca-bundle-path', { type: 'string', desc: 'Path to CA certificate to use when validating HTTPS requests. Will read from AWS_CA_BUNDLE environment variable if not specified', requiresArg: true })
     .option('unstable', { type: 'array', desc: `Opt-in to using unstable features. By using these flags you acknowledge that scope and API of unstable features may change without notice. Specify multiple times for each unstable feature you want to opt-in to. ${availableFeaturesDescription()}`, nargs: 1, default: [] })
     .option('role-arn', { type: 'string', desc: 'ARN of the IAM role for CloudFormation to assume during deploy/destroy', requiresArg: true })
+    .option('allow-delete-failures', { type: 'boolean', default: false, desc: 'Do not fail the test when resources fail to delete during a stack update' })
     .strict()
     .parse(args);
 
@@ -121,6 +122,7 @@ export function parseCliArgs(args: string[] = []) {
     proxy: argv.proxy as (string | undefined),
     caBundlePath: argv['ca-bundle-path'] as (string | undefined),
     roleArn: argv['role-arn'] as (string | undefined),
+    allowDeleteFailures: argv['allow-delete-failures'] as boolean,
   };
 }
 
@@ -203,6 +205,7 @@ async function run(options: ReturnType<typeof parseCliArgs>) {
         proxy: options.proxy,
         caBundlePath: options.caBundlePath,
         roleArn: options.roleArn,
+        allowDeleteFailures: options.allowDeleteFailures,
       });
       testsSucceeded = success;
 

--- a/packages/@aws-cdk/integ-runner/lib/engines/cdk-interface.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/cdk-interface.ts
@@ -1,5 +1,5 @@
 import type { DefaultCdkOptions, DestroyOptions as BaseDestroyOptions, DeployOptions as BaseDeployOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
-import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
+import type { DeploymentMethod, ResourceDeleteFailure } from '@aws-cdk/toolkit-lib';
 
 /**
  * Events emitted during watch mode
@@ -107,6 +107,17 @@ export interface CxOptions extends DefaultCdkOptions {
  * This interface defines the contract for CDK operations that can be
  * performed by different engine implementations.
  */
+/**
+ * Result of a deploy operation
+ */
+export interface CdkDeployResult {
+  /**
+   * Resources that CloudFormation failed to delete during a stack update.
+   * These resources are no longer managed by CloudFormation but still exist.
+   */
+  readonly deleteFailures: ResourceDeleteFailure[];
+}
+
 export interface ICdk {
   /**
    * cdk synth
@@ -121,7 +132,7 @@ export interface ICdk {
   /**
    * cdk deploy
    */
-  deploy(options: DeployOptions): Promise<void>;
+  deploy(options: DeployOptions): Promise<CdkDeployResult>;
 
   /**
    * cdk destroy

--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -5,7 +5,7 @@ import type { ICloudAssemblySource, IIoHost, IoMessage, IoRequest, IReadableClou
 import { BaseCredentials, ExpandStackSelection, MemoryContext, NonInteractiveIoHost, StackSelectionStrategy, Toolkit } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
-import type { CxOptions, DeployOptions, DestroyOptions, ICdk, ListOptions, SynthOptions, WatchEvents, WatchOptions } from './cdk-interface';
+import type { CdkDeployResult, CxOptions, DeployOptions, DestroyOptions, ICdk, ListOptions, SynthOptions, WatchEvents, WatchOptions } from './cdk-interface';
 import { ProxyAgentProvider } from './proxy-agent';
 
 export interface ToolkitLibEngineOptions {
@@ -198,10 +198,10 @@ export class ToolkitLibRunnerEngine implements ICdk {
   /**
    * Deploys the CDK app
    */
-  public async deploy(options: DeployOptions) {
+  public async deploy(options: DeployOptions): Promise<CdkDeployResult> {
     const toolkit = this.getOrCreateToolkit(options);
     const cx = await this.cx(options);
-    await toolkit.deploy(cx, {
+    const result = await toolkit.deploy(cx, {
       roleArn: options.roleArn,
       traceLogs: options.traceLogs,
       stacks: this.stackSelector(options),
@@ -210,6 +210,9 @@ export class ToolkitLibRunnerEngine implements ICdk {
       },
       outputsFile: options.outputsFile ? path.join(this.options.workingDirectory, options.outputsFile) : undefined,
     });
+    return {
+      deleteFailures: result.stacks.flatMap(s => s.deleteFailures),
+    };
   }
 
   /**

--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -94,6 +94,16 @@ export interface RunOptions extends CommonOptions {
    * @default - use the bootstrap cfn-exec role
    */
   readonly roleArn?: string;
+
+  /**
+   * Whether to allow resources that fail to delete during a stack update.
+   *
+   * When false, the test will fail if CloudFormation skips deleting a resource
+   * during a stack update. When true, only a warning is printed.
+   *
+   * @default false
+   */
+  readonly allowDeleteFailures?: boolean;
 }
 
 /**
@@ -249,6 +259,7 @@ export class IntegTestRunner extends IntegRunner {
     const clean = options.clean ?? true;
     const updateWorkflowEnabled = (options.updateWorkflow ?? true)
       && (actualTestCase.stackUpdateWorkflow ?? true);
+    const allowDeleteFailures = actualTestCase.allowDeleteFailures ?? options.allowDeleteFailures ?? false;
     const enableForVerbosityLevel = (needed = 1) => {
       const verbosity = options.verbosity ?? 0;
       return (verbosity >= needed) ? true : undefined;
@@ -267,6 +278,7 @@ export class IntegTestRunner extends IntegRunner {
           },
           updateWorkflowEnabled,
           options.testCaseName,
+          allowDeleteFailures,
         );
       }
 
@@ -478,6 +490,7 @@ export class IntegTestRunner extends IntegRunner {
     deployArgs: cdk.DeployOptions,
     updateWorkflowEnabled: boolean,
     testCaseName: string,
+    allowDeleteFailures: boolean,
   ): Promise<AssertionResults | undefined> {
     const actualTestCase = (await this.actualTestSuite()).testSuite[testCaseName];
     try {
@@ -510,7 +523,8 @@ export class IntegTestRunner extends IntegRunner {
         });
       }
       // now deploy the "actual" test.
-      await this.cdk.deploy({
+      // This is the stack update if the update workflow ran above.
+      const actualDeployResult = await this.cdk.deploy({
         ...deployArgs,
         lookups: (await this.actualTestSuite()).enableLookups,
         stacks: [
@@ -521,6 +535,20 @@ export class IntegTestRunner extends IntegRunner {
         context: this.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
         app: this.cdkApp,
       });
+
+      if (actualDeployResult.deleteFailures.length > 0) {
+        const details = actualDeployResult.deleteFailures
+          .map(f => `  - ${f.logicalResourceId} (${f.resourceType}): ${f.reason}`)
+          .join('\n');
+        const message =
+          `${actualDeployResult.deleteFailures.length} resource(s) failed to delete during stack update:\n${details}\n` +
+          'These resources are no longer managed by CloudFormation but still exist and may incur charges.';
+        if (allowDeleteFailures) {
+          logger.warning(message);
+        } else {
+          throw new Error(message);
+        }
+      }
 
       // If there are any assertions
       // deploy the assertion stack as well

--- a/packages/@aws-cdk/integ-runner/lib/workers/common.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/common.ts
@@ -189,6 +189,16 @@ export interface IntegTestOptions {
    * @default - use the bootstrap cfn-exec role
    */
   readonly roleArn?: string;
+
+  /**
+   * Whether to allow resources that fail to delete during a stack update.
+   *
+   * When false, the test will fail if CloudFormation skips deleting a resource
+   * during a stack update. When true, only a warning is printed.
+   *
+   * @default false
+   */
+  readonly allowDeleteFailures?: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
@@ -53,6 +53,7 @@ export async function integTestWorker(request: IntegTestBatchRequest): Promise<I
             updateWorkflow: request.updateWorkflow,
             verbosity,
             roleArn: request.roleArn,
+            allowDeleteFailures: request.allowDeleteFailures,
           });
           if (results && Object.values(results).some(result => result.status === 'fail')) {
             failures.push(testInfo);

--- a/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/engines/toolkit-lib.test.ts
@@ -26,7 +26,7 @@ describe('ToolkitLibRunnerEngine', () => {
       synth: jest.fn(),
       fromCdkApp: jest.fn(),
       list: jest.fn(),
-      deploy: jest.fn(),
+      deploy: jest.fn().mockResolvedValue({ stacks: [] }),
       watch: jest.fn(),
       destroy: jest.fn(),
     } as any;

--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import type { DestroyOptions } from '@aws-cdk/cloud-assembly-schema/lib/integ-tests';
-import type { DeployOptions, ICdk, ListOptions, SynthOptions } from '../lib/engines/cdk-interface';
+import type { CdkDeployResult, DeployOptions, ICdk, ListOptions, SynthOptions } from '../lib/engines/cdk-interface';
 import { IntegSnapshotRunner, IntegTest } from '../lib/runner';
 import type { DestructiveChange, Diagnostic } from '../lib/workers';
 
@@ -29,7 +29,7 @@ export interface MockCdkProviderOptions {
 }
 
 export interface MockCdkMocks {
-  deploy?: jest.MockedFn<(options: DeployOptions) => Promise<void>>;
+  deploy?: jest.MockedFn<(options: DeployOptions) => Promise<CdkDeployResult>>;
   watch?: jest.MockedFn<(options: DeployOptions) => Promise<void>>;
   synth?: jest.MockedFn<(options: SynthOptions) => Promise<void>>;
   destroy?: jest.MockedFn<(options: DestroyOptions) => Promise<void>>;
@@ -42,7 +42,7 @@ export class MockCdkProvider {
 
   constructor(_options: MockCdkProviderOptions) {
     this.cdk = {
-      deploy: jest.fn().mockImplementation(),
+      deploy: jest.fn().mockResolvedValue({ deleteFailures: [] }),
       watch: jest.fn().mockImplementation(),
       synth: jest.fn().mockImplementation(),
       destroy: jest.fn().mockImplementation(),
@@ -52,7 +52,7 @@ export class MockCdkProvider {
   }
 
   public mockDeploy(mock?: MockCdkMocks['deploy']) {
-    this.mocks.deploy = mock ?? jest.fn().mockImplementation();
+    this.mocks.deploy = mock ?? jest.fn().mockResolvedValue({ deleteFailures: [] });
     this.cdk.deploy = this.mocks.deploy;
   }
   public mockWatch(mock?: MockCdkMocks['watch']) {

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -691,6 +691,63 @@ describe('IntegTest runIntegTests', () => {
     }));
     expect(fs.readJSONSync).toHaveBeenCalledWith(fullOutputsPath);
   });
+
+  test('fails when deploy returns deleteFailures', async () => {
+    // GIVEN
+    cdkMock.mockDeploy(jest.fn().mockResolvedValue({
+      deleteFailures: [
+        {
+          logicalResourceId: 'MyBucket',
+          physicalResourceId: 'my-bucket-12345',
+          resourceType: 'AWS::S3::Bucket',
+          reason: 'The bucket is not empty',
+        },
+      ],
+    }));
+
+    const integTest = new IntegTestRunner({
+      cdk: cdkMock.cdk,
+      region: 'eu-west-1',
+      test: new IntegTest({
+        fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
+        discoveryRoot: 'test/test-data',
+      }),
+    });
+
+    // THEN
+    await expect(integTest.runIntegTestCase({
+      testCaseName: 'xxxxx.test-with-snapshot',
+    })).rejects.toThrow(/1 resource\(s\) failed to delete during stack update/);
+  });
+
+  test('does not fail when deploy returns deleteFailures with allowDeleteFailures', async () => {
+    // GIVEN
+    cdkMock.mockDeploy(jest.fn().mockResolvedValue({
+      deleteFailures: [
+        {
+          logicalResourceId: 'MyBucket',
+          physicalResourceId: 'my-bucket-12345',
+          resourceType: 'AWS::S3::Bucket',
+          reason: 'The bucket is not empty',
+        },
+      ],
+    }));
+
+    const integTest = new IntegTestRunner({
+      cdk: cdkMock.cdk,
+      region: 'eu-west-1',
+      test: new IntegTest({
+        fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
+        discoveryRoot: 'test/test-data',
+      }),
+    });
+
+    // THEN - does not throw
+    await integTest.runIntegTestCase({
+      testCaseName: 'xxxxx.test-with-snapshot',
+      allowDeleteFailures: true,
+    });
+  });
 });
 
 describe('IntegTest watchIntegTest', () => {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/bootstrap/deploy-bootstrap.ts
@@ -85,6 +85,7 @@ export class BootstrapStack {
         noOp: true,
         outputs: {},
         stackArn: this.currentToolkitInfo.bootstrapStack.stackId,
+        deleteFailures: [],
       } satisfies SuccessfulDeployStackResult;
 
       // Validate that the bootstrap stack we're trying to replace is from the same variant as the one we're trying to deploy

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -278,6 +278,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       noOp: true,
       outputs: cloudFormationStack.outputs,
       stackArn: cloudFormationStack.stackId,
+      deleteFailures: [],
     };
   } else {
     await ioHelper.defaults.debug(`${deployName}: deploying...`);
@@ -351,6 +352,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
         noOp: true,
         stackArn: cloudFormationStack.stackId,
         outputs: cloudFormationStack.outputs,
+        deleteFailures: [],
       };
     }
   }
@@ -461,6 +463,7 @@ class FullCloudFormationDeployment {
         noOp: true,
         outputs: this.cloudFormationStack.outputs,
         stackArn: changeSetDescription.StackId!,
+        deleteFailures: [],
       };
     }
 
@@ -475,6 +478,7 @@ class FullCloudFormationDeployment {
         outputs: this.cloudFormationStack.outputs,
         stackArn: changeSetDescription.StackId!,
         changeSet: changeSetDescription,
+        deleteFailures: [],
       };
     }
 
@@ -632,6 +636,7 @@ class FullCloudFormationDeployment {
             noOp: true,
             outputs: this.cloudFormationStack.outputs,
             stackArn: this.cloudFormationStack.stackId,
+            deleteFailures: [],
           };
         }
         throw err;
@@ -694,6 +699,7 @@ class FullCloudFormationDeployment {
       noOp: false,
       outputs: finalState.outputs,
       stackArn: finalState.stackId,
+      deleteFailures: this.update ? monitor.deleteFailures : [],
     };
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployment-result.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployment-result.ts
@@ -1,5 +1,6 @@
 import type { DescribeChangeSetCommandOutput } from '@aws-sdk/client-cloudformation';
 import { ToolkitError } from '../../toolkit/toolkit-error';
+import type { ResourceDeleteFailure } from '../../toolkit/types';
 
 export type DeployStackResult =
   | SuccessfulDeployStackResult
@@ -19,6 +20,12 @@ export interface SuccessfulDeployStackResult {
    * Populated when using `change-set` deployment method with `execute: false`.
    */
   readonly changeSet?: DescribeChangeSetCommandOutput;
+
+  /**
+   * Resources that CloudFormation failed to delete during the stack update.
+   * Non-empty only for stack updates where CFN skipped deletion failures.
+   */
+  readonly deleteFailures: ResourceDeleteFailure[];
 }
 
 /** The stack is currently in a failpaused state, and needs to be rolled back before the deployment */

--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/hotswap-deployments.ts
@@ -146,6 +146,7 @@ export async function tryHotswapDeployment(
       noOp: result.hotswappableChanges.length === 0,
       stackArn: cloudFormationStack.stackId,
       outputs: cloudFormationStack.outputs,
+      deleteFailures: [],
     };
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -154,6 +154,14 @@ export class StackActivityMonitor {
     return this.poller.errors;
   }
 
+  /**
+   * Resources that received DELETE_FAILED during the stack update.
+   * CloudFormation skips these and completes the update anyway.
+   */
+  public get deleteFailures() {
+    return this.poller.deleteFailures;
+  }
+
   public async start() {
     this.monitorId = randomUUID();
     await this.ioHelper.notify(IO.CDK_TOOLKIT_I5501.msg(`Deploying ${this.stackDisplayName}`, {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-event-poller.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-event-poller.ts
@@ -1,6 +1,8 @@
 import type { StackEvent } from '@aws-sdk/client-cloudformation';
+import { ResourceStatus } from '@aws-sdk/client-cloudformation';
 import type { ResourceError } from './resource-errors';
 import { ResourceErrors } from './resource-errors';
+import type { ResourceDeleteFailure } from '../../toolkit/types';
 import { formatErrorMessage, isRootStackEvent } from '../../util';
 import type { ICloudFormationClient } from '../aws-auth/private';
 
@@ -152,6 +154,12 @@ export class StackEventPoller {
    */
   public readonly errors = new ResourceErrors();
 
+  /**
+   * Resources that received DELETE_FAILED during a stack update.
+   * CloudFormation skips these and completes the update anyway.
+   */
+  public readonly deleteFailures: ResourceDeleteFailure[] = [];
+
   private readonly eventIds = new Set<string>();
   private readonly nestedStackPollers: Record<string, StackEventPoller> = {};
 
@@ -194,8 +202,22 @@ export class StackEventPoller {
     this.events.push(...events);
 
     this.errors.update(...events);
+    this.updateDeleteFailures(events);
 
     return events;
+  }
+
+  private updateDeleteFailures(events: ResourceEvent[]) {
+    for (const { event } of events) {
+      if (event.ResourceStatus === ResourceStatus.DELETE_FAILED && event.ResourceType !== 'AWS::CloudFormation::Stack') {
+        this.deleteFailures.push({
+          logicalResourceId: event.LogicalResourceId ?? '',
+          physicalResourceId: event.PhysicalResourceId,
+          resourceType: event.ResourceType ?? '',
+          reason: event.ResourceStatusReason ?? '',
+        });
+      }
+    }
   }
 
   private async doPoll(): Promise<ResourceEvent[]> {

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -994,6 +994,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
           stackArn: deployResult.stackArn,
           outputs: deployResult.outputs,
           hierarchicalId: stack.hierarchicalId,
+          deleteFailures: deployResult.deleteFailures,
         });
       } catch (e: any) {
         // It has to be exactly this string because an integration test tests for

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/types.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/types.ts
@@ -52,6 +52,41 @@ export interface DeployedStack extends PhysicalStack {
    * The outputs of the deployed CloudFormation stack
    */
   readonly outputs: { [key: string]: string };
+
+  /**
+   * Resources that CloudFormation failed to delete during the stack update
+   *
+   * When a resource replacement or removal triggers a delete that fails,
+   * CloudFormation skips the deletion and completes the update anyway. These
+   * resources are no longer managed by CloudFormation but still exist and may
+   * incur charges.
+   */
+  readonly deleteFailures: ResourceDeleteFailure[];
+}
+
+/**
+ * A resource that CloudFormation failed to delete during a stack update
+ */
+export interface ResourceDeleteFailure {
+  /**
+   * The logical ID of the resource in the CloudFormation template
+   */
+  readonly logicalResourceId: string;
+
+  /**
+   * The physical ID of the resource (e.g. an ARN or name)
+   */
+  readonly physicalResourceId?: string;
+
+  /**
+   * The CloudFormation resource type (e.g. AWS::S3::Bucket)
+   */
+  readonly resourceType: string;
+
+  /**
+   * The reason CloudFormation gave for the deletion failure
+   */
+  readonly reason: string;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy-hotswap.test.ts
@@ -9,6 +9,7 @@ let mockDeployStack = jest.fn().mockResolvedValue({
   stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
   outputs: {},
   noOp: false,
+  deleteFailures: [],
 });
 
 jest.mock('../../lib/api/deployments', () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy-trace-logs.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy-trace-logs.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
     stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
     outputs: {},
     noOp: false,
+    deleteFailures: [],
   });
   jest.spyOn(deployments.Deployments.prototype, 'resolveEnvironment').mockResolvedValue({
     account: '11111111',

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -21,6 +21,7 @@ beforeEach(() => {
     stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
     outputs: {},
     noOp: false,
+    deleteFailures: [],
   });
   jest.spyOn(deployments.Deployments.prototype, 'resolveEnvironment').mockResolvedValue({
     account: '11111111',
@@ -130,6 +131,7 @@ IAM Statement Changes
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
         type: 'did-deploy-stack',
         noOp: false,
+        deleteFailures: [],
         outputs: {},
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: DEFAULT_DEPLOY_CHANGE_SET_NAME, $metadata: {} } as any,
@@ -139,6 +141,7 @@ IAM Statement Changes
         .mockResolvedValueOnce({
           type: 'did-deploy-stack',
           noOp: false,
+          deleteFailures: [],
           outputs: {},
           stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
         });
@@ -179,6 +182,7 @@ IAM Statement Changes
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
         type: 'did-deploy-stack',
         noOp: true,
+        deleteFailures: [],
         outputs: {},
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
       });
@@ -199,6 +203,7 @@ IAM Statement Changes
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
         type: 'did-deploy-stack',
         noOp: true,
+        deleteFailures: [],
         outputs: { BucketName: 'my-bucket' },
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
       });
@@ -222,6 +227,7 @@ IAM Statement Changes
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
         type: 'did-deploy-stack',
         noOp: true,
+        deleteFailures: [],
         outputs: {},
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
       });
@@ -246,6 +252,7 @@ IAM Statement Changes
       jest.spyOn(deployments.Deployments.prototype, 'prepareStack').mockResolvedValueOnce({
         type: 'did-deploy-stack',
         noOp: false,
+        deleteFailures: [],
         outputs: {},
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} } as any,
@@ -438,6 +445,7 @@ IAM Statement Changes
             stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
             outputs: {},
             noOp: false,
+            deleteFailures: [],
           } satisfies DeployStackResult;
         } else {
           return {
@@ -467,6 +475,7 @@ IAM Statement Changes
             stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
             outputs: {},
             noOp: false,
+            deleteFailures: [],
           } satisfies DeployStackResult;
         } else {
           return {
@@ -494,6 +503,7 @@ IAM Statement Changes
         OutputKey2: 'OutputValue2',
       },
       noOp: false,
+      deleteFailures: [],
     });
 
     // WHEN
@@ -517,6 +527,7 @@ IAM Statement Changes
             OutputKey1: 'OutputValue1',
             OutputKey2: 'OutputValue2',
           },
+          deleteFailures: [],
         },
         {
           stackName: 'Stack2',
@@ -533,6 +544,7 @@ IAM Statement Changes
             OutputKey2: 'OutputValue2',
             // omg
           },
+          deleteFailures: [],
         },
       ],
     });
@@ -548,6 +560,7 @@ IAM Statement Changes
         OutputKey2: 'OutputValue2',
       },
       noOp: false,
+      deleteFailures: [],
     });
 
     // WHEN
@@ -562,6 +575,40 @@ IAM Statement Changes
         }),
       ],
     });
+  });
+
+  test('deploy result includes deleteFailures from the deployment', async () => {
+    // GIVEN
+    mockDeployStack.mockResolvedValue({
+      type: 'did-deploy-stack',
+      stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+      outputs: {},
+      noOp: false,
+      deleteFailures: [
+        {
+          logicalResourceId: 'MyBucket',
+          physicalResourceId: 'my-bucket-12345',
+          resourceType: 'AWS::S3::Bucket',
+          reason: 'The bucket is not empty',
+        },
+      ],
+    });
+
+    // WHEN
+    const cx = await cdkOutFixture(toolkit, 'two-empty-stacks');
+    const result = await toolkit.deploy(cx);
+
+    // THEN
+    for (const stack of result.stacks) {
+      expect(stack.deleteFailures).toEqual([
+        {
+          logicalResourceId: 'MyBucket',
+          physicalResourceId: 'my-bucket-12345',
+          resourceType: 'AWS::S3::Bucket',
+          reason: 'The bucket is not empty',
+        },
+      ]);
+    }
   });
 
   test('action disposes of assembly produced by source', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap2.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap2.test.ts
@@ -73,6 +73,7 @@ describe('Bootstrapping v2', () => {
     mockDeployStack.mockResolvedValue({
       type: 'did-deploy-stack',
       noOp: false,
+      deleteFailures: [],
       outputs: {},
       stackArn: 'arn:stack',
     });
@@ -466,6 +467,7 @@ describe('Bootstrapping v2', () => {
       return Promise.resolve({
         type: 'did-deploy-stack',
         noOp: false,
+        deleteFailures: [],
         outputs: {},
         stackArn: 'arn:stack',
       });
@@ -752,6 +754,7 @@ describe('Bootstrapping v2', () => {
         return Promise.resolve({
           type: 'did-deploy-stack',
           noOp: false,
+          deleteFailures: [],
           outputs: {},
           stackArn: 'arn:stack',
         });

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -93,6 +93,7 @@ test('prepareStack calls deployStack with execute: false and returns successful 
   (deployStack as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack',
     noOp: false,
+    deleteFailures: [],
     outputs: {},
     stackArn: 'arn:stack',
     changeSet: { Status: 'CREATE_COMPLETE' },
@@ -114,6 +115,7 @@ test('prepareStack calls deployStack with execute: false and returns successful 
   expect(result).toEqual(expect.objectContaining({
     type: 'did-deploy-stack',
     noOp: false,
+    deleteFailures: [],
     changeSet: { Status: 'CREATE_COMPLETE' },
   }));
 });

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -243,7 +243,7 @@ test('correctly passes SSM parameters when hotswapping', async () => {
 test('prints revert-drift recommendation on successful hotswap deployment', async () => {
   givenStackExists();
   (tryHotswapDeployment as jest.Mock).mockResolvedValue({
-    type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {},
+    type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {}, deleteFailures: [],
   });
 
   // WHEN
@@ -263,7 +263,7 @@ describe('hotswap template cache', () => {
     // GIVEN
     (tryHotswapDeployment as jest.Mock).mockImplementation(async () => {
       await writeHotswapTemplateCache('assembly-dir', 'withouterrors', {}, {});
-      return { type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {} };
+      return { type: 'did-deploy-stack', noOp: false, stackArn: 'arn:stack', outputs: {}, deleteFailures: [] };
     });
 
     // WHEN

--- a/packages/@aws-cdk/toolkit-lib/test/api/orphan/orphan.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/orphan/orphan.test.ts
@@ -115,7 +115,7 @@ beforeEach(() => {
 
   jest.spyOn(deployments, 'deployStack').mockImplementation(async (opts: any) => {
     deployedTemplates.push(opts.overrideTemplate);
-    return { type: 'did-deploy-stack', noOp: false, outputs: {}, stackArn: 'arn' };
+    return { type: 'did-deploy-stack', noOp: false, outputs: {}, stackArn: 'arn', deleteFailures: [] };
   });
 });
 
@@ -282,7 +282,7 @@ describe('ResourceOrphaner', () => {
       (deployments.deployStack as jest.Mock).mockImplementation(async (opts: any) => {
         callCount++;
         deployedTemplates.push(opts.overrideTemplate);
-        return { type: 'did-deploy-stack', noOp: callCount > 2, outputs: {}, stackArn: 'arn' };
+        return { type: 'did-deploy-stack', noOp: callCount > 2, outputs: {}, stackArn: 'arn', deleteFailures: [] };
       });
 
       const plan = await orphaner.makePlan(STACK, ['MyTable']);

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-event-poller.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-event-poller.test.ts
@@ -121,4 +121,96 @@ describe('poll', () => {
 
     await expect(poller.poll()).rejects.toThrow('Something else went wrong');
   });
+
+  test('collects DELETE_FAILED events into deleteFailures', async () => {
+    const deployTime = Date.now();
+
+    const sdk = new MockSdk();
+    mockCloudFormationClient.on(DescribeStackEventsCommand).resolves({
+      StackEvents: [
+        {
+          Timestamp: new Date(deployTime + 3000),
+          EventId: 'event-3',
+          StackId: 'stack-id',
+          StackName: 'stack',
+          LogicalResourceId: 'MyBucket',
+          PhysicalResourceId: 'my-bucket-12345',
+          ResourceType: 'AWS::S3::Bucket',
+          ResourceStatus: 'DELETE_FAILED',
+          ResourceStatusReason: 'The bucket is not empty',
+        },
+        {
+          Timestamp: new Date(deployTime + 2000),
+          EventId: 'event-2',
+          StackId: 'stack-id',
+          StackName: 'stack',
+          LogicalResourceId: 'MyFunction',
+          ResourceType: 'AWS::Lambda::Function',
+          ResourceStatus: 'DELETE_COMPLETE',
+        },
+        {
+          Timestamp: new Date(deployTime + 1000),
+          EventId: 'event-1',
+          StackId: 'stack-id',
+          StackName: 'stack',
+          LogicalResourceId: 'MyTable',
+          PhysicalResourceId: 'my-table',
+          ResourceType: 'AWS::DynamoDB::Table',
+          ResourceStatus: 'DELETE_FAILED',
+          ResourceStatusReason: 'Table has deletion protection enabled',
+        },
+      ],
+    });
+
+    const poller = new StackEventPoller(sdk.cloudFormation(), {
+      stackArn: 'stack-id',
+      initialPollRange: PollRange.sinceTimestamp(deployTime),
+    });
+
+    await poller.poll();
+
+    expect(poller.deleteFailures).toEqual([
+      {
+        logicalResourceId: 'MyTable',
+        physicalResourceId: 'my-table',
+        resourceType: 'AWS::DynamoDB::Table',
+        reason: 'Table has deletion protection enabled',
+      },
+      {
+        logicalResourceId: 'MyBucket',
+        physicalResourceId: 'my-bucket-12345',
+        resourceType: 'AWS::S3::Bucket',
+        reason: 'The bucket is not empty',
+      },
+    ]);
+  });
+
+  test('does not include AWS::CloudFormation::Stack DELETE_FAILED in deleteFailures', async () => {
+    const deployTime = Date.now();
+
+    const sdk = new MockSdk();
+    mockCloudFormationClient.on(DescribeStackEventsCommand).resolves({
+      StackEvents: [
+        {
+          Timestamp: new Date(deployTime + 1000),
+          EventId: 'event-1',
+          StackId: 'stack-id',
+          StackName: 'stack',
+          LogicalResourceId: 'NestedStack',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'DELETE_FAILED',
+          ResourceStatusReason: 'Nested stack failed',
+        },
+      ],
+    });
+
+    const poller = new StackEventPoller(sdk.cloudFormation(), {
+      stackArn: 'stack-id',
+      initialPollRange: PollRange.sinceTimestamp(deployTime),
+    });
+
+    await poller.poll();
+
+    expect(poller.deleteFailures).toEqual([]);
+  });
 });

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -123,6 +123,7 @@ beforeEach(async () => {
     outputs: {},
     type: 'did-deploy-stack',
     stackArn: 'fake-arn',
+    deleteFailures: [],
   });
 
   cloudExecutable = await MockCloudExecutable.create({
@@ -239,6 +240,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} },
       });
       mockCfnDeployments.deployStack.mockResolvedValue({
@@ -246,6 +248,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -287,6 +290,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} },
       });
       mockCfnDeployments.deployStack.mockResolvedValue({
@@ -294,6 +298,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -335,6 +340,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -370,6 +376,7 @@ describe('deploy', () => {
         noOp: true,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -400,6 +407,7 @@ describe('deploy', () => {
         noOp: true,
         outputs: { BucketName: 'my-bucket' },
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -438,6 +446,7 @@ describe('deploy', () => {
         noOp: true,
         outputs: {},
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+        deleteFailures: [],
       });
 
       const cdkToolkit = new CdkToolkit({
@@ -473,6 +482,7 @@ describe('deploy', () => {
         noOp: true,
         outputs: { BucketName: 'my-bucket' },
         stackArn: 'arn:aws:cloudformation:region:account:stack/test-stack',
+        deleteFailures: [],
       });
 
       const outputsFile = path.join(os.tmpdir(), `cdk-outputs-${Date.now()}.json`);
@@ -512,6 +522,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'my-change-set', $metadata: {} },
       });
 
@@ -548,6 +559,7 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} },
       });
 
@@ -580,12 +592,13 @@ describe('deploy', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stackArn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} },
       });
       // First deploy: needs rollback. Second deploy: succeeds.
       mockCfnDeployments.deployStack
         .mockResolvedValueOnce({ type: 'failpaused-need-rollback-first', status: 'UPDATE_ROLLBACK_FAILED', reason: 'not-norollback' })
-        .mockResolvedValueOnce({ type: 'did-deploy-stack', noOp: false, outputs: {}, stackArn: 'stackArn' });
+        .mockResolvedValueOnce({ type: 'did-deploy-stack', noOp: false, outputs: {}, stackArn: 'stackArn', deleteFailures: [] });
       mockCfnDeployments.rollbackStack.mockResolvedValue({ success: true, stackArn: 'stackArn' });
 
       // Auto-confirm rollback prompt
@@ -677,6 +690,7 @@ describe('deploy', () => {
           noOp: false,
           outputs: {},
           stackArn: 'stackArn',
+          deleteFailures: [],
           stackArtifact: instanceMockFrom(cxapi.CloudFormationStackArtifact),
         }),
       );
@@ -2401,6 +2415,7 @@ describe('rollback', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stack:arn',
+        deleteFailures: [],
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [], ChangeSetName: 'cdk-deploy-change-set', $metadata: {} },
       })
       // Second call: execute-change-set returns the test's expected result
@@ -2411,6 +2426,7 @@ describe('rollback', () => {
         noOp: false,
         outputs: {},
         stackArn: 'stack:arn',
+        deleteFailures: [],
       });
 
     // respond with yes
@@ -2632,6 +2648,7 @@ class FakeCloudFormation extends Deployments {
       noOp: false,
       outputs: { StackName: options.stack.stackName },
       stackArtifact: options.stack,
+      deleteFailures: [],
     });
   }
 

--- a/packages/aws-cdk/test/commands/bootstrap.test.ts
+++ b/packages/aws-cdk/test/commands/bootstrap.test.ts
@@ -14,6 +14,7 @@ describe('cdk bootstrap', () => {
       outputs: {},
       type: 'did-deploy-stack',
       stackArn: 'fake-arn',
+      deleteFailures: [],
     });
 
     await exec(['bootstrap', 'aws://123456789012/us-east-1']);
@@ -31,6 +32,7 @@ describe('cdk bootstrap', () => {
       outputs: {},
       type: 'did-deploy-stack',
       stackArn: 'fake-arn',
+      deleteFailures: [],
     });
 
     await exec(['bootstrap', 'aws://123456789012/us-east-1', '--deny-external-id']);
@@ -52,6 +54,7 @@ describe('cdk bootstrap', () => {
       outputs: {},
       type: 'did-deploy-stack',
       stackArn: 'fake-arn',
+      deleteFailures: [],
     });
 
     await exec(['bootstrap', 'aws://123456789012/us-east-1', '--no-deny-external-id']);

--- a/packages/aws-cdk/test/commands/diff.test.ts
+++ b/packages/aws-cdk/test/commands/diff.test.ts
@@ -393,6 +393,7 @@ describe('imports', () => {
         noOp: true,
         outputs: {},
         stackArn: '',
+        deleteFailures: [],
         stackArtifact: options.stack,
       }),
     );
@@ -517,6 +518,7 @@ describe('non-nested stacks', () => {
         noOp: true,
         outputs: {},
         stackArn: '',
+        deleteFailures: [],
         stackArtifact: options.stack,
       }),
     );
@@ -725,6 +727,7 @@ describe('stack exists checks', () => {
         noOp: true,
         outputs: {},
         stackArn: '',
+        deleteFailures: [],
         stackArtifact: options.stack,
       }),
     );


### PR DESCRIPTION
## Motivation

When CloudFormation updates a stack and a resource fails to delete (e.g. a non-empty S3 bucket being replaced), it retries 3 times, then abandons the deletion and marks the update as successful (See the [CloudFormation documentation][1]). The resource is removed from the stack's scope but still exists and may incur charges. Until now, this condition was invisible to programmatic consumers of `toolkit-lib` and to integration tests.

## Changes

- Adds `deleteFailures: ResourceDeleteFailure[]` to `DeployedStack` (public API), exposing resources that CloudFormation failed to delete during a stack update but silently skipped.
- Tracks `DELETE_FAILED` events in `StackEventPoller` during the deployment monitoring phase, and threads them through the internal `SuccessfulDeployStackResult` to the public `DeployResult`.
- In `integ-runner`, the "actual" deploy (the stack update) now checks for delete failures and fails the test by default, making it impossible for integration tests to silently pass when resources leak.
- Adds per-test-case `allowDeleteFailures` option in the integ test manifest (`TestOptions`) and a global `--allow-delete-failures` CLI flag as a fallback for cases where this behavior is expected.

[1]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/troubleshooting.html#troubleshooting-errors-resource-removed-not-deleted

## Screenshots

<img width="1645" height="427" alt="Screenshot 2026-06-01 at 10 58 23" src="https://github.com/user-attachments/assets/ba5c3a70-2301-44f0-9fd2-5657716ee4c9" />


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
