### PR TITLE
fix: telemetry does not use proxy agent

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -121,7 +121,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   });
 
   try {
-    await ioHost.startTelemetry(argv, configuration.context);
+    await ioHost.startTelemetry(argv, configuration.context, proxyAgent);
   } catch (e: any) {
     await ioHost.asIoHelper().defaults.trace(`Telemetry instantiation failed: ${e.message}`);
   }


### PR DESCRIPTION
We instantiated the proxy agent correctly, but forgot to pass it to the telemetry backend.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
