### PR TITLE
chore: standalone release jobs are always skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1434,7 +1434,7 @@ jobs:
       contents: write
       id-token: write
     environment: releasing
-    if: ${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}
+    if: ${{ !cancelled() && needs.aws-cdk_release_npm.result == 'success' && !inputs.dry_run }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -1476,7 +1476,7 @@ jobs:
       contents: write
       id-token: write
     environment: releasing
-    if: ${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}
+    if: ${{ !cancelled() && needs.aws-cdk_release_npm.result == 'success' && !inputs.dry_run }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v8
@@ -1506,7 +1506,7 @@ jobs:
       id-token: write
       contents: read
     environment: releasing
-    if: ${{ !inputs.dry_run }}
+    if: ${{ !cancelled() && needs.aws-cdk-toolkit-lib_release_npm.result == 'success' && !inputs.dry_run }}
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v8

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -1,6 +1,7 @@
 import type { Monorepo } from 'cdklabs-projen-project-types/lib/yarn';
 import { Component, github } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
+import { runAfterPublish } from './util';
 
 export class AdcPublishing extends Component {
   constructor(private readonly project_: Monorepo) {
@@ -42,7 +43,7 @@ export class AdcPublishing extends Component {
         contents: JobPermission.WRITE,
         idToken: JobPermission.WRITE,
       },
-      if: '${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}',
+      if: runAfterPublish('aws-cdk_release_npm'),
       steps: [
         github.WorkflowSteps.checkout(),
         ...this.project_.renderWorkflowSetup(),

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -1,6 +1,7 @@
 import type { Monorepo } from 'cdklabs-projen-project-types/lib/yarn';
 import { Component, github } from 'projen';
 import { JobPermission } from 'projen/lib/github/workflows-model';
+import { runAfterPublish } from './util';
 
 /**
  * Record publishing timestamp to SSM
@@ -27,7 +28,7 @@ export class RecordPublishingTimestamp extends Component {
         contents: JobPermission.WRITE,
         idToken: JobPermission.WRITE,
       },
-      if: '${{ needs.release.outputs.latest_commit == github.sha && !inputs.dry_run }}',
+      if: runAfterPublish('aws-cdk_release_npm'),
       steps: [
         github.WorkflowSteps.downloadArtifact({
           with: {

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -1,5 +1,6 @@
 import type { Monorepo, TypeScriptWorkspace } from 'cdklabs-projen-project-types/lib/yarn';
 import { Component, github } from 'projen';
+import { runAfterPublish } from './util';
 
 export enum DocType {
   /**
@@ -76,7 +77,7 @@ export class S3DocsPublishing extends Component {
       environment: 'releasing', // <-- this has the configuration
       needs: [`${safeName}_release_npm`],
       runsOn: ['ubuntu-latest'],
-      if: '${{ !inputs.dry_run }}',
+      if: runAfterPublish(`${safeName}_release_npm`),
       permissions: {
         idToken: github.workflows.JobPermission.WRITE,
         contents: github.workflows.JobPermission.READ,

--- a/projenrc/util.ts
+++ b/projenrc/util.ts
@@ -9,3 +9,14 @@ export class GitHubToken {
 export function stringifyList(list: string[]) {
   return `[${list.join('|')}]`;
 }
+
+/**
+ * Workflow `if` condition for jobs that should run after a package's npm publish job.
+ *
+ * `!cancelled()` opts out of the implicit (transitive) `success()` gate that would
+ * otherwise skip the job whenever any unrelated package in the release graph wasn't
+ * republished. We gate on the direct publish job's result instead.
+ */
+export function runAfterPublish(npmJobId: string): string {
+  return `\${{ !cancelled() && needs.${npmJobId}.result == 'success' && !inputs.dry_run }}`;
+}


### PR DESCRIPTION
The release workflow's three "standalone" jobs — publish the standalone CLI to ADC, record the publishing timestamp in SSM, and publish the toolkit-lib api-extractor model to S3 — were skipped on virtually every release, including releases where `aws-cdk` and `@aws-cdk/toolkit-lib` were actually published. For example, run [26519804668](https://github.com/aws/aws-cdk-cli/actions/runs/26519804668) published both `aws-cdk` and `toolkit-lib` to npm successfully and created their GitHub releases, yet all three standalone jobs skipped.

The cause is GitHub's implicit success gate. When a job's `if` contains no status-check function, GitHub evaluates an implicit `success()` over the job's entire transitive `needs` graph, and a skipped job anywhere upstream makes that gate `false` regardless of what the `if` expression itself says. The package publish jobs survive skipped upstreams only because they use `!cancelled() && !failure()`; the standalone jobs did not. Since almost every release leaves at least one package un-republished — its publish job is skipped because the version was unchanged — the transitive gate was poisoned and the standalone jobs were skipped even though their own publish job succeeded.

The fix adds `!cancelled()` so these jobs opt out of the implicit transitive gate, and gates them explicitly on the result of the direct npm publish job they care about (`needs.<pkg>_release_npm.result == 'success'`). That preserves the original intent — only run once the relevant package has actually been published — without being dragged down by unrelated packages that were not part of this release. The redundant `latest_commit == github.sha` check is dropped because a successful publish of that job already implies it.

The condition is centralized in a new `runAfterPublish` helper in `projenrc/util.ts` so the three jobs share a single definition.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
