### PR TITLE
chore: add F5-launchable dev VS Code extension for LSP development

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch CDK LSP (dev extension)",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}/dev-vscode-extension"
+      ],
+      "outFiles": [
+        "${workspaceFolder}/dev-vscode-extension/out/**/*.js",
+        "${workspaceFolder}/packages/@aws-cdk/cdk-explorer/lib/**/*.js"
+      ],
+      "preLaunchTask": "build cdk lsp dev extension"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build cdk lsp dev extension",
+      "detail": "Compiles dev-vscode-extension/ TypeScript so F5 has a fresh out/extension.js to load. Does NOT rebuild the LSP server itself — run 'yarn workspace @aws-cdk/cdk-explorer build' separately when you change LSP source.",
+      "type": "shell",
+      "command": "npm run build",
+      "options": {
+        "cwd": "${workspaceFolder}/dev-vscode-extension"
+      },
+      "problemMatcher": "$tsc",
+      "group": "build"
+    }
+  ]
+}

--- a/dev-vscode-extension/.gitignore
+++ b/dev-vscode-extension/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+package-lock.json

--- a/dev-vscode-extension/README.md
+++ b/dev-vscode-extension/README.md
@@ -1,0 +1,54 @@
+# dev-vscode-extension — DEVELOPMENT ONLY
+
+> **This is NOT the shipping CDK LSP integration.**
+>
+> The CDK LSP ships to VS Code users via the **AWS Toolkit** extension (see RFC).
+> Non-VS-Code editors and AI agents point their LSP client directly at the LSP
+> server entrypoint over stdio (see RFC §"Editor Integration").
+>
+> This folder exists **only** so contributors can press F5 in VS Code and exercise
+> the LSP end-to-end while they're working on it. Do not publish this to the
+> VS Code Marketplace. Do not depend on it from any shipped code path.
+
+## What this folder is
+
+A minimal VS Code extension whose only job is to spawn the local
+`@aws-cdk/cdk-explorer` LSP server (`packages/@aws-cdk/cdk-explorer/lib/lsp/main.js`)
+and connect it to a development VS Code window via stdio.
+
+## How to use
+
+1. Build the LSP server (once after pulling, and after any LSP source change):
+
+   ```bash
+   yarn workspace @aws-cdk/cdk-explorer build
+   ```
+
+2. Install + build this extension:
+
+   ```bash
+   cd dev-vscode-extension
+   npm install
+   npm run build
+   ```
+
+3. Open the **monorepo root** (`aws-cdk-cli/`) in VS Code, then press **F5**.
+
+   VS Code's `extensionHost` debug config opens a second VS Code window with
+   this extension loaded. Errors from `client.start()` go to the
+   "Output" → "CDK LSP" channel of the second window.
+
+4. In the second VS Code window, open a CDK project (TypeScript) and open one
+   of its stack files. The dev extension activates and the LSP attaches.
+
+   The LSP feature surface (diagnostics, CodeLens, etc.) lights up as those
+   features land on `feat/cdk-lsp`. Opening a `.ts` file is enough to trigger
+   activation today.
+
+## Editing loop
+
+- Edit LSP source under `packages/@aws-cdk/cdk-explorer/lib/lsp/` →
+  `yarn workspace @aws-cdk/cdk-explorer compile` → in the second VS Code
+  window, run "Developer: Reload Window" to restart the LSP.
+- Edit this extension's source under `dev-vscode-extension/src/` →
+  `npm run build` → close and re-launch the F5 debug session.

--- a/dev-vscode-extension/package.json
+++ b/dev-vscode-extension/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cdk-lsp-dev",
+  "displayName": "CDK LSP (development only)",
+  "description": "DEVELOPMENT-ONLY VS Code extension. Spawns the local @aws-cdk/cdk-explorer LSP server for F5 debugging. Not the shipping CDK LSP integration — see README.md.",
+  "version": "0.0.0-dev",
+  "publisher": "cdk-dev",
+  "private": true,
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": [
+    "Programming Languages"
+  ],
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onLanguage:typescript"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "watch": "tsc -p tsconfig.json --watch"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "@types/vscode": "^1.85.0",
+    "typescript": "5.9"
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9"
+  }
+}

--- a/dev-vscode-extension/src/extension.ts
+++ b/dev-vscode-extension/src/extension.ts
@@ -1,0 +1,59 @@
+// DEVELOPMENT-ONLY extension. See ../README.md.
+//
+// Spawns the local @aws-cdk/cdk-explorer LSP server (compiled to lib/lsp/main.js)
+// as a child process and connects it as a standard LSP client.
+
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { LanguageClient, TransportKind, type LanguageClientOptions } from 'vscode-languageclient/node';
+
+let client: LanguageClient | undefined;
+
+const LSP_SERVER_RELATIVE = path.join(
+  '..',
+  'packages',
+  '@aws-cdk',
+  'cdk-explorer',
+  'lib',
+  'lsp',
+  'main.js',
+);
+
+export function activate(context: vscode.ExtensionContext): void {
+  const serverModule = context.asAbsolutePath(LSP_SERVER_RELATIVE);
+  const outputChannel = vscode.window.createOutputChannel('CDK LSP');
+  context.subscriptions.push(outputChannel);
+
+  const clientOptions: LanguageClientOptions = {
+    // The LSP currently produces source-linked data only for TypeScript apps.
+    documentSelector: [{ scheme: 'file', language: 'typescript' }],
+    initializationOptions: {
+      applicationDir: vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
+    },
+    outputChannel,
+  };
+
+  // The LSP server (lib/lsp/main.ts) hard-wires stdin/stdout for the connection
+  // streams, matching how `cdk lsp` will be invoked in production. Stdio here
+  // matches that contract exactly.
+  client = new LanguageClient(
+    'cdkLsp',
+    'CDK LSP (development only)',
+    {
+      run: { module: serverModule, transport: TransportKind.stdio },
+      debug: { module: serverModule, transport: TransportKind.stdio },
+    },
+    clientOptions,
+  );
+
+  context.subscriptions.push({ dispose: () => client?.stop() });
+
+  client.start().catch((err) => {
+    outputChannel.appendLine(`CDK LSP failed to start: ${err?.stack ?? err}`);
+    outputChannel.show(true);
+  });
+}
+
+export function deactivate(): Thenable<void> | undefined {
+  return client?.stop();
+}

--- a/dev-vscode-extension/tsconfig.json
+++ b/dev-vscode-extension/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2022",
+    "lib": ["es2022"],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION

Adds a development-only VS Code extension under `dev-vscode-extension/` that lets contributors exercise the CDK LSP end-to-end with `F5`. The extension launches a second VS Code window with the local `@aws-cdk/cdk-explorer` LSP server (`packages/@aws-cdk/cdk-explorer/lib/lsp/main.js`) attached over stdio, so any TypeScript file opened in that window activates the LSP against the workspace folder's `cdk.out/`.

This is **not** the shipping LSP integration. For the production LSP:
- VS Code users get the LSP via the **AWS Toolkit** extension (separate repo).
- Other editors and AI agents (Neovim, Zed, Claude Code, etc.) point their LSP client at the server entrypoint directly.

This folder is purely contributor-facing scaffolding. The README is explicit about that, and the package is private + named `cdk-lsp-dev` to avoid any accidental publish.

## How to use

1. Build the LSP server once: `yarn workspace @aws-cdk/cdk-explorer build`
2. Build the dev extension: `cd dev-vscode-extension && npm install && npm run build`
3. Open `aws-cdk-cli/` in VS Code, press **F5**.
4. In the second VS Code window, open a CDK project's `.ts` file. The LSP attaches.

Today on `feat/cdk-lsp` the LSP only handles `initialize`/`didSave`. As feature commits land (diagnostics, CodeLens, etc.), they appear in the F5 window automatically — no extension changes needed.

## Why a separate folder, not part of `@aws-cdk/cdk-explorer`?

Mixing a VS Code extension manifest into the explorer package would change its `main` entry point, force a `vscode-languageclient` runtime dependency, and add `engines.vscode` constraints — all of which would leak into anything that imports the explorer as a library (the future `cdk lsp` CLI subcommand, the web server, tests). Keeping the dev extension outside the projen-managed package avoids that pollution.
### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
