### PR TITLE
refactor(cli): use the list action from toolkit-lib in the CLI

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/index.ts
@@ -1,5 +1,6 @@
 export * from './io-host-wrappers';
 export * from './io-helper';
+export * from './io-default-messages';
 export * from './level-priority';
 export * from './span';
 export * from './message-maker';

--- a/packages/aws-cdk/lib/api-private.ts
+++ b/packages/aws-cdk/lib/api-private.ts
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-relative-packages */
 export { deployStack } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
-export type { DeployStackOptions as DeployStackApiOptions } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
+export type { DeployStackOptions as DeployStackApiOptions, DestroyStackResult } from '../../@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
 export * as cfnApi from '../../@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api';
 export { createIgnoreMatcher } from '../../@aws-cdk/toolkit-lib/lib/util/glob-matcher';
 export * from '../../@aws-cdk/toolkit-lib/lib/api/io/private';

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -38,7 +38,7 @@ import type { Deployments, SuccessfulDeployStackResult } from '../api/deployment
 import { mappingsByEnvironment, parseMappingGroups } from '../api/refactor';
 import { type Tag } from '../api/tags';
 import { StackActivityProgress } from '../commands/deploy';
-import { listStacks } from '../commands/list-stacks';
+import { formatStackList } from '../commands/list-stacks';
 import type { FromScan, GenerateTemplateOutput } from '../commands/migrate';
 import {
   appendWarningsToReadme,
@@ -958,38 +958,14 @@ export class CdkToolkit {
     selectors: string[],
     options: { long?: boolean; json?: boolean; showDeps?: boolean } = {},
   ): Promise<number> {
-    const stacks = await listStacks(this, {
-      selectors: selectors,
+    this.ioHost.rewriteOnce(IO.CDK_TOOLKIT_I2901, (msg) => formatStackList(msg.data.stacks, options));
+
+    await this.toolkit.list(this.props.cloudExecutable, {
+      stacks: selectors.length > 0
+        ? { patterns: selectors, strategy: StackSelectionStrategy.PATTERN_MATCH, expand: ExpandStackSelection.UPSTREAM }
+        : undefined,
     });
 
-    if (options.long && options.showDeps) {
-      await printSerializedObject(this.ioHost.asIoHelper(), stacks, options.json ?? false);
-      return 0;
-    }
-
-    if (options.showDeps) {
-      const stackDeps = stacks.map(stack => ({
-        id: stack.id,
-        dependencies: stack.dependencies,
-      }));
-      await printSerializedObject(this.ioHost.asIoHelper(), stackDeps, options.json ?? false);
-      return 0;
-    }
-
-    if (options.long) {
-      const long = stacks.map(stack => ({
-        id: stack.id,
-        name: stack.name,
-        environment: stack.environment,
-      }));
-      await printSerializedObject(this.ioHost.asIoHelper(), long, options.json ?? false);
-      return 0;
-    }
-
-    // just print stack IDs
-    for (const stack of stacks) {
-      await this.ioHost.asIoHelper().defaults.result(stack.id);
-    }
     return 0; // exit-code
   }
 

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -3,11 +3,11 @@ import * as util from 'node:util';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import type { HotswapResult, IIoHost, IoMessage, IoMessageCode, IoMessageLevel, IoRequest, ToolkitAction } from '@aws-cdk/toolkit-lib';
-import type { Context } from '@aws-cdk/toolkit-lib/lib/api';
 import * as chalk from 'chalk';
 import * as promptly from 'promptly';
-import type { IoHelper, ActivityPrinterProps, IActivityPrinter } from '../../../lib/api-private';
+import type { IoHelper, ActivityPrinterProps, IActivityPrinter, IoMessageMaker, IoDefaultMessages } from '../../../lib/api-private';
 import { asIoHelper, IO, isMessageRelevantForLevel, CurrentActivityPrinter, HistoryActivityPrinter } from '../../../lib/api-private';
+import type { Context } from '../../api/context';
 import { StackActivityProgress } from '../../commands/deploy';
 import { canCollectTelemetry } from '../telemetry/collect-telemetry';
 import { cdkCliErrorName } from '../telemetry/error';
@@ -104,6 +104,39 @@ export interface CliIoHostProps {
 export type TargetStream = 'stdout' | 'stderr' | 'drop';
 
 /**
+ * The result a message listener may return to influence how a message is handled.
+ *
+ * A listener can only update the message _text_; it cannot change any other
+ * field of the message (such as its `code`), which keeps the code-keyed
+ * listener registry valid.
+ */
+export interface MessageListenerResult {
+  /**
+   * Replace the text that is printed for this message.
+   *
+   * @default - the message text is left unchanged
+   */
+  readonly message?: string;
+
+  /**
+   * Skip the default processing of the message, i.e. do not write it to a stream.
+   *
+   * @default false
+   */
+  readonly preventDefault?: boolean;
+}
+
+/**
+ * A registered message listener. Its return value (if any) may update the
+ * message text and/or prevent the default processing.
+ */
+type MessageListenerFn = (msg: IoMessage<any>) => void | MessageListenerResult;
+interface MessageListener {
+  readonly once: boolean;
+  readonly fn: MessageListenerFn;
+}
+
+/**
  * A simple IO host for the CLI that writes messages to the console.
  */
 export class CliIoHost implements IIoHost {
@@ -175,6 +208,9 @@ export class CliIoHost implements IIoHost {
   private corkedCounter = 0;
   private readonly corkedLoggingBuffer: IoMessage<unknown>[] = [];
 
+  // Message listeners, keyed by message code. See `on`/`once`/`rewrite`/`rewriteOnce`.
+  private readonly messageListeners = new Map<IoMessageCode, MessageListener[]>();
+
   private readonly autoRespond: boolean;
 
   /**
@@ -192,6 +228,10 @@ export class CliIoHost implements IIoHost {
     this.requireDeployApproval = props.requireDeployApproval ?? RequireApproval.BROADENING;
     this.stackProgress = props.stackProgress ?? StackActivityProgress.BAR;
     this.autoRespond = props.autoRespond ?? false;
+
+    // Stack-activity messages are handled by the activity printer rather than
+    // written to a stream. This is wired up as message listeners.
+    this.routeStackActivityToPrinter();
   }
 
   public async startTelemetry(args: any, context: Context, proxyAgent?: Agent) {
@@ -291,7 +331,7 @@ export class CliIoHost implements IIoHost {
     return this._progress;
   }
 
-  public get defaults() {
+  public get defaults(): IoDefaultMessages {
     return this.asIoHelper().defaults;
   }
 
@@ -325,31 +365,137 @@ export class CliIoHost implements IIoHost {
   }
 
   /**
+   * Register a listener that is invoked for every message with the given code.
+   *
+   * The listener may return a `MessageListenerResult` to update the message
+   * text and/or prevent the default processing (writing it to a stream);
+   * returning nothing leaves the message untouched. Returns a function that
+   * removes the listener again.
+   *
+   * @example
+   * const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+   *   myCount += msg.data.stacks.length;
+   * });
+   */
+  public on<T>(code: IoMessageMaker<T>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
+    return this.addMessageListener(code.code, { once: false, fn: listener as MessageListenerFn });
+  }
+
+  /**
+   * Like `on`, but the listener is automatically removed after it has been
+   * invoked once.
+   */
+  public once<T>(code: IoMessageMaker<T>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
+    return this.addMessageListener(code.code, { once: true, fn: listener as MessageListenerFn });
+  }
+
+  /**
+   * Register a formatter that replaces the printed text of messages with the
+   * given code. This lets a caller define _how_ a toolkit message is presented
+   * without the IoHost needing to know about it.
+   *
+   * Syntactic sugar for an `on` listener that returns `{ message }`. Returns a
+   * function that removes the formatter again.
+   *
+   * @example
+   * const dispose = ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) =>
+   *   serializeStructure(msg.data.stacks, true));
+   */
+  public rewrite<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string): () => void {
+    return this.on(code, (msg) => ({ message: formatter(msg) }));
+  }
+
+  /**
+   * Like `rewrite`, but the formatter is automatically removed after it has
+   * been applied once.
+   */
+  public rewriteOnce<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string): () => void {
+    return this.once(code, (msg) => ({ message: formatter(msg) }));
+  }
+
+  /**
+   * Add a listener to the registry and return a function that removes it.
+   */
+  private addMessageListener(code: IoMessageCode, listener: MessageListener): () => void {
+    const listeners = this.messageListeners.get(code) ?? [];
+    listeners.push(listener);
+    this.messageListeners.set(code, listeners);
+
+    return () => {
+      const index = listeners.indexOf(listener);
+      if (index >= 0) {
+        listeners.splice(index, 1);
+      }
+    };
+  }
+
+  /**
+   * Run all registered listeners for a message's code, in registration order.
+   *
+   * A listener may update the message text (which is passed on to subsequent
+   * listeners and the rest of the pipeline) and/or request that the default
+   * processing be skipped. `once` listeners are removed after they have run.
+   *
+   * Returns the (possibly text-updated) message and whether any listener
+   * prevented the default processing.
+   */
+  private applyMessageListeners(msg: IoMessage<unknown>): { message: IoMessage<unknown>; preventDefault: boolean } {
+    let current = msg;
+    let preventDefault = false;
+
+    const listeners = msg.code ? this.messageListeners.get(msg.code) : undefined;
+    if (listeners && listeners.length > 0) {
+      // Iterate over a copy so that `once` listeners can remove themselves safely.
+      for (const listener of [...listeners]) {
+        const result = listener.fn(current);
+
+        if (listener.once) {
+          const index = listeners.indexOf(listener);
+          if (index >= 0) {
+            listeners.splice(index, 1);
+          }
+        }
+
+        if (result) {
+          if (result.message !== undefined) {
+            current = { ...current, message: result.message };
+          }
+          if (result.preventDefault) {
+            preventDefault = true;
+          }
+        }
+      }
+    }
+
+    return { message: current, preventDefault };
+  }
+
+  /**
    * Notifies the host of a message.
    * The caller waits until the notification completes.
    */
   public async notify(msg: IoMessage<unknown>): Promise<void> {
     await this.maybeEmitTelemetry(msg);
 
-    if (this.isStackActivity(msg)) {
-      if (!this.activityPrinter) {
-        this.activityPrinter = this.makeActivityPrinter();
-      }
-      this.activityPrinter.notify(msg);
+    // Run any registered listeners. A listener may update the message text
+    // and/or prevent the default processing (e.g. stack-activity messages are
+    // routed to the activity printer and not written to a stream).
+    const { message, preventDefault } = this.applyMessageListeners(msg);
+    if (preventDefault) {
       return;
     }
 
-    if (!isMessageRelevantForLevel(msg, this.logLevel)) {
+    if (!isMessageRelevantForLevel(message, this.logLevel)) {
       return;
     }
 
     if (this.corkedCounter > 0) {
-      this.corkedLoggingBuffer.push(msg);
+      this.corkedLoggingBuffer.push(message);
       return;
     }
 
-    const output = this.formatMessage(msg);
-    const stream = this.selectStream(msg);
+    const output = this.formatMessage(message);
+    const stream = this.selectStream(message);
     stream?.write(output);
   }
 
@@ -365,14 +511,25 @@ export class CliIoHost implements IIoHost {
   }
 
   /**
-   * Detect stack activity messages so they can be send to the printer.
+   * Route stack-activity messages to the activity printer (progress bar or
+   * event list) rather than writing them to a stream.
+   *
+   * Implemented as listeners that handle the message via the printer and
+   * prevent the default processing, so the rest of the pipeline does not also
+   * emit them. The printer is created lazily on the first stack-activity message.
    */
-  private isStackActivity(msg: IoMessage<unknown>) {
-    return msg.code && [
-      'CDK_TOOLKIT_I5501',
-      'CDK_TOOLKIT_I5502',
-      'CDK_TOOLKIT_I5503',
-    ].includes(msg.code);
+  private routeStackActivityToPrinter() {
+    const route = (msg: IoMessage<unknown>): MessageListenerResult => {
+      if (!this.activityPrinter) {
+        this.activityPrinter = this.makeActivityPrinter();
+      }
+      this.activityPrinter.notify(msg);
+      return { preventDefault: true }; // handled by the printer; don't also write to a stream
+    };
+
+    this.on(IO.CDK_TOOLKIT_I5501, route);
+    this.on(IO.CDK_TOOLKIT_I5502, route);
+    this.on(IO.CDK_TOOLKIT_I5503, route);
   }
 
   /**

--- a/packages/aws-cdk/lib/commands/list-stacks.ts
+++ b/packages/aws-cdk/lib/commands/list-stacks.ts
@@ -1,41 +1,52 @@
 import type { StackDetails } from '@aws-cdk/toolkit-lib';
-import type { CdkToolkit } from '../cli/cdk-toolkit';
-import { DefaultSelection, ExtendedStackSelection } from '../cxapp';
+import { serializeStructure } from '../util';
 
 /**
- * Options for List Stacks
- */
-export interface ListStacksOptions {
-  /**
-   * Stacks to list
-   *
-   * @default - All stacks are listed
-   */
-  readonly selectors: string[];
-}
-
-/**
- * List Stacks
+ * Render the output of `cdk list` for a set of stacks, honoring the output flags.
  *
- * @param toolkit - cdk toolkit
- * @param options - list stacks options
- * @returns StackDetails[]
+ * - `--long --show-dependencies`: the full stack details, serialized.
+ * - `--show-dependencies`: each stack's id and its dependencies, serialized.
+ * - `--long`: each stack's id, name and environment, serialized.
+ * - otherwise: the stack ids, one per line.
+ *
+ * `--json` selects JSON over YAML for the serialized variants (it has no effect
+ * on the plain id listing, matching the historical CLI behavior).
  */
-export async function listStacks(toolkit: CdkToolkit, options: ListStacksOptions): Promise<StackDetails[]> {
-  const assembly = await toolkit.assembly();
+export function formatStackList(
+  stacks: StackDetails[],
+  options: { long?: boolean; json?: boolean; showDeps?: boolean } = {},
+): string {
+  const json = options.json ?? false;
 
-  const stacks = await assembly.selectStacks({
-    patterns: options.selectors,
-  }, {
-    extend: ExtendedStackSelection.Upstream,
-    defaultBehavior: DefaultSelection.AllStacks,
-  });
+  if (options.long && options.showDeps) {
+    // Only a subset of stack information is printed; in particular metadata
+    // (which may be huge) is intentionally excluded.
+    const full = stacks.map(stack => ({
+      id: stack.id,
+      name: stack.name,
+      environment: stack.environment,
+      dependencies: stack.dependencies,
+    }));
+    return serializeStructure(full, json);
+  }
 
-  // we only want to print a subset of information in `cdk list --json`
-  return stacks.withDependencies().map(stack => ({
-    id: stack.id,
-    name: stack.name,
-    environment: stack.environment,
-    dependencies: stack.dependencies,
-  }));
+  if (options.showDeps) {
+    const stackDeps = stacks.map(stack => ({
+      id: stack.id,
+      dependencies: stack.dependencies,
+    }));
+    return serializeStructure(stackDeps, json);
+  }
+
+  if (options.long) {
+    const long = stacks.map(stack => ({
+      id: stack.id,
+      name: stack.name,
+      environment: stack.environment,
+    }));
+    return serializeStructure(long, json);
+  }
+
+  // just the stack ids
+  return stacks.map(stack => stack.id).join('\n');
 }

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -60,7 +60,6 @@ import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import { Manifest, RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
 import { Toolkit } from '@aws-cdk/toolkit-lib';
-import type { DestroyStackResult } from '@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack';
 import type { CloudFormationClientResolvedConfig, CreateChangeSetInput, CreateChangeSetOutput, DeleteChangeSetInput, DeleteChangeSetOutput, DescribeChangeSetInput, DescribeChangeSetOutput, ServiceInputTypes, ServiceOutputTypes } from '@aws-sdk/client-cloudformation';
 import { CreateChangeSetCommand, DeleteChangeSetCommand, DescribeChangeSetCommand, DescribeStacksCommand, GetTemplateCommand, StackStatus } from '@aws-sdk/client-cloudformation';
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
@@ -81,6 +80,7 @@ import {
 } from '../../lib/api/deployments';
 import { Mode } from '../../lib/api/plugin';
 import type { Tag } from '../../lib/api/tags';
+import type { DestroyStackResult } from '../../lib/api-private';
 import { asIoHelper } from '../../lib/api-private';
 import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
 import { CliIoHost } from '../../lib/cli/io-host';
@@ -192,9 +192,20 @@ describe('list', () => {
 
     // THEN
     expect(result).toEqual(0); // Exit code
-    expect(notifySpy).toHaveBeenCalledWith(expectIoMsg('Test-Stack-A-Display-Name', 'result'));
-    expect(notifySpy).toHaveBeenCalledWith(expectIoMsg('Test-Stack-B', 'result'));
-    expect(notifySpy).toHaveBeenCalledWith(expectIoMsg('Test-Stack-A/Test-Stack-C', 'result'));
+
+    // The `list` toolkit action emits a single CDK_TOOLKIT_I2901 result message
+    // carrying the selected stacks; the CLI renders it (see formatStackList).
+    const listMsg = notifySpy.mock.calls
+      .map(call => call[0])
+      .find((m: any) => m.code === 'CDK_TOOLKIT_I2901');
+    if (!listMsg) {
+      throw new Error('expected a CDK_TOOLKIT_I2901 message to be emitted');
+    }
+    expect(listMsg.message.split('\n').sort()).toEqual([
+      'Test-Stack-A-Display-Name',
+      'Test-Stack-A/Test-Stack-C',
+      'Test-Stack-B',
+    ]);
   });
 });
 

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -5,6 +5,7 @@ import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import { Context } from '../../../lib/api/context';
+import { IO } from '../../../lib/api-private';
 import type { IoMessage, IoMessageLevel, IoRequest } from '../../../lib/cli/io-host';
 import { CliIoHost } from '../../../lib/cli/io-host';
 import { CLI_PRIVATE_IO } from '../../../lib/cli/telemetry/messages';
@@ -147,6 +148,205 @@ describe('CliIoHost', () => {
       // THEN
       expect(mockStdout).not.toHaveBeenCalled();
       expect(mockStderr).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('message listeners', () => {
+    const disposers: Array<() => void> = [];
+
+    function track(dispose: () => void) {
+      disposers.push(dispose);
+      return dispose;
+    }
+
+    function listMessage(message = 'Stack-A\nStack-B'): IoMessage<unknown> {
+      return plainMessage({
+        time: new Date(),
+        level: 'result',
+        action: 'list',
+        code: 'CDK_TOOLKIT_I2901',
+        message,
+      });
+    }
+
+    beforeEach(() => {
+      ioHost.isTTY = false;
+    });
+
+    afterEach(() => {
+      // Remove any listeners that did not remove themselves, to avoid leaking
+      // into other tests that share the singleton io host.
+      while (disposers.length > 0) {
+        disposers.pop()!();
+      }
+    });
+
+    test('on() invokes the observer for every matching message without changing output', async () => {
+      const observed: string[] = [];
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      }));
+
+      await ioHost.notify(listMessage('first'));
+      await ioHost.notify(listMessage('second'));
+
+      // observer saw both, output is unchanged
+      expect(observed).toEqual(['first', 'second']);
+      expect(mockStdout).toHaveBeenCalledWith('first\n');
+      expect(mockStdout).toHaveBeenCalledWith('second\n');
+    });
+
+    test('once() invokes the observer only for the first matching message', async () => {
+      const observed: string[] = [];
+      track(ioHost.once(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      }));
+
+      await ioHost.notify(listMessage('first'));
+      await ioHost.notify(listMessage('second'));
+
+      expect(observed).toEqual(['first']);
+    });
+
+    test('rewrite() replaces the printed text for every matching message', async () => {
+      track(ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${msg.message}`));
+
+      await ioHost.notify(listMessage('first'));
+      await ioHost.notify(listMessage('second'));
+
+      expect(mockStdout).toHaveBeenCalledWith('rewritten:first\n');
+      expect(mockStdout).toHaveBeenCalledWith('rewritten:second\n');
+    });
+
+    test('rewriteOnce() replaces the text of only the first matching message', async () => {
+      track(ioHost.rewriteOnce(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${msg.message}`));
+
+      await ioHost.notify(listMessage('first'));
+      await ioHost.notify(listMessage('second'));
+
+      expect(mockStdout).toHaveBeenCalledWith('rewritten:first\n');
+      expect(mockStdout).toHaveBeenCalledWith('second\n');
+    });
+
+    test('the returned dispose function removes the listener', async () => {
+      const observed: string[] = [];
+      const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      });
+
+      await ioHost.notify(listMessage('before'));
+      dispose();
+      await ioHost.notify(listMessage('after'));
+
+      expect(observed).toEqual(['before']);
+    });
+
+    test('listeners only fire for the registered message code', async () => {
+      const observed: string[] = [];
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      }));
+
+      await ioHost.notify(plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: 'CDK_TOOLKIT_I0001',
+        message: 'unrelated',
+      }));
+
+      expect(observed).toEqual([]);
+    });
+
+    test('listeners receive the typed message payload', async () => {
+      let seenIds: string[] = [];
+      track(ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) => {
+        seenIds = msg.data.stacks.map(s => s.id);
+        return seenIds.join(', ');
+      }));
+
+      await ioHost.notify({
+        ...listMessage(),
+        data: { stacks: [{ id: 'Stack-A' }, { id: 'Stack-B' }] as any },
+      });
+
+      expect(seenIds).toEqual(['Stack-A', 'Stack-B']);
+      expect(mockStdout).toHaveBeenCalledWith('Stack-A, Stack-B\n');
+    });
+
+    test('on() updates the printed text when it returns { message }', async () => {
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => ({ message: `updated:${msg.message}` })));
+
+      await ioHost.notify(listMessage('hello'));
+
+      expect(mockStdout).toHaveBeenCalledWith('updated:hello\n');
+    });
+
+    test('on() prevents the default processing when it returns { preventDefault: true }', async () => {
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, () => ({ preventDefault: true })));
+
+      await ioHost.notify(listMessage('suppressed'));
+
+      // default processing skipped: never written to any stream
+      expect(mockStdout).not.toHaveBeenCalled();
+      expect(mockStderr).not.toHaveBeenCalled();
+    });
+
+    test('disposing a listener twice is a no-op', async () => {
+      const observed: string[] = [];
+      const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      });
+
+      dispose();
+      dispose();
+      await ioHost.notify(listMessage('after'));
+
+      expect(observed).toEqual([]);
+    });
+  });
+
+  describe('stack activity routing', () => {
+    function activityMessage(code: string, message = 'raw activity text'): IoMessage<unknown> {
+      return plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'deploy',
+        code: code as any,
+        message,
+      });
+    }
+
+    beforeEach(() => {
+      // Force the lazy-creation path for each test.
+      (ioHost as any).activityPrinter = undefined;
+    });
+
+    test('routes a stack-activity message to the activity printer and consumes it', async () => {
+      const fakePrinter = { notify: jest.fn() };
+      const makeSpy = jest.spyOn(ioHost as any, 'makeActivityPrinter').mockReturnValue(fakePrinter);
+
+      const msg = activityMessage('CDK_TOOLKIT_I5502');
+      await ioHost.notify(msg);
+
+      // lazily created the printer and forwarded the message to it
+      expect(makeSpy).toHaveBeenCalledTimes(1);
+      expect(fakePrinter.notify).toHaveBeenCalledWith(msg);
+      // consumed: the raw message is not also written to a stream
+      expect(mockStdout).not.toHaveBeenCalled();
+      expect(mockStderr).not.toHaveBeenCalled();
+    });
+
+    test('reuses an existing activity printer for subsequent messages', async () => {
+      const fakePrinter = { notify: jest.fn() };
+      const makeSpy = jest.spyOn(ioHost as any, 'makeActivityPrinter').mockReturnValue(fakePrinter);
+
+      await ioHost.notify(activityMessage('CDK_TOOLKIT_I5501', 'start'));
+      await ioHost.notify(activityMessage('CDK_TOOLKIT_I5503', 'stop'));
+
+      // created once, then reused
+      expect(makeSpy).toHaveBeenCalledTimes(1);
+      expect(fakePrinter.notify).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/aws-cdk/test/commands/list-stacks.test.ts
+++ b/packages/aws-cdk/test/commands/list-stacks.test.ts
@@ -1,43 +1,39 @@
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
-import { Bootstrapper } from '../../lib/api/bootstrap';
+import type { StackDetails } from '@aws-cdk/toolkit-lib';
 import { Deployments } from '../../lib/api/deployments';
 import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
-import { listStacks } from '../../lib/commands/list-stacks';
+import { CliIoHost } from '../../lib/cli/io-host';
+import { formatStackList } from '../../lib/commands/list-stacks';
 import { instanceMockFrom, MockCloudExecutable } from '../_helpers';
 import type { TestStackArtifact } from '../_helpers';
 
-describe('list', () => {
+const env = {
+  account: '123456789012',
+  region: 'bermuda-triangle-1',
+  name: 'aws://123456789012/bermuda-triangle-1',
+};
+
+// The `list` command delegates stack selection and dependency ordering to the
+// toolkit-lib `list` action, which emits the selected stacks as the payload of
+// a single CDK_TOOLKIT_I2901 result message. These tests drive `CdkToolkit.list`
+// and assert on that payload to keep coverage of the selection/ordering behavior.
+describe('CdkToolkit.list', () => {
+  const ioHost = CliIoHost.instance();
   let cloudFormation: jest.Mocked<Deployments>;
-  let bootstrapper: jest.Mocked<Bootstrapper>;
+  let notifySpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetAllMocks();
-
     cloudFormation = instanceMockFrom(Deployments);
-
-    bootstrapper = instanceMockFrom(Bootstrapper);
-    bootstrapper.bootstrapEnvironment.mockResolvedValue({ noOp: false, outputs: {} } as any);
+    notifySpy = jest.spyOn(ioHost, 'notify');
   });
 
-  test('stacks with no dependencies', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
-      stacks: [
-        MockStack.MOCK_STACK_A,
-        {
-          stackName: 'Test-Stack-B',
-          template: { Resources: { TemplateName: 'Test-Stack-B' } },
-          env: 'aws://123456789012/bermuda-triangle-1',
-          metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
-          },
-        },
-      ],
-    });
-    // GIVEN
+  /**
+   * Run `cdk list` and return the selected stacks (id, name, environment and
+   * dependencies) from the emitted CDK_TOOLKIT_I2901 message. Metadata is
+   * dropped so assertions stay focused on selection and ordering.
+   */
+  async function runList(cloudExecutable: MockCloudExecutable, selectors: string[]) {
     const toolkit = new CdkToolkit({
       cloudExecutable,
       configuration: cloudExecutable.configuration,
@@ -45,34 +41,25 @@ describe('list', () => {
       deployments: cloudFormation,
     });
 
-    // WHEN
-    const workflow = await listStacks(toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-B'] });
+    notifySpy.mockClear();
+    await toolkit.list(selectors);
 
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-B',
-      name: 'Test-Stack-B',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [],
-    }]));
-  });
+    const msg = notifySpy.mock.calls
+      .map(call => call[0])
+      .find((m: any) => m.code === 'CDK_TOOLKIT_I2901');
+    if (!msg) {
+      throw new Error('expected a CDK_TOOLKIT_I2901 message to be emitted');
+    }
+    return (msg.data as { stacks: StackDetails[] }).stacks.map(stack => ({
+      id: stack.id,
+      name: stack.name,
+      environment: stack.environment,
+      dependencies: stack.dependencies,
+    }));
+  }
 
-  test('stacks with dependent stacks', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+  test('stacks with no dependencies', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         MockStack.MOCK_STACK_A,
         {
@@ -80,58 +67,53 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-B' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
+          },
+        },
+      ],
+    });
+
+    const stacks = await runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-B']);
+
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-A', name: 'Test-Stack-A', environment: env, dependencies: [] },
+      { id: 'Test-Stack-B', name: 'Test-Stack-B', environment: env, dependencies: [] },
+    ]);
+  });
+
+  test('stacks with dependent stacks', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
+      stacks: [
+        MockStack.MOCK_STACK_A,
+        {
+          stackName: 'Test-Stack-B',
+          template: { Resources: { TemplateName: 'Test-Stack-B' } },
+          env: 'aws://123456789012/bermuda-triangle-1',
+          metadata: {
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-A'],
         },
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    const stacks = await runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-B']);
 
-    // WHEN
-    const workflow = await listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-B'] });
-
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-A', name: 'Test-Stack-A', environment: env, dependencies: [] },
+      {
+        id: 'Test-Stack-B',
+        name: 'Test-Stack-B',
+        environment: env,
+        dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
       },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-B',
-      name: 'Test-Stack-B',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
-        id: 'Test-Stack-A',
-        dependencies: [],
-      }],
-    }]));
+    ]);
   });
 
-  // In the context where we have a display name set to hieraricalId/stackName
+  // In the context where we have a display name set to hierarchicalId/stackName
   // we would need to pass in the displayName to list the stacks.
-  test('stacks with dependent stacks and have display name set to hieraricalId/stackName', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+  test('stacks with dependent stacks and display name set to hierarchicalId/stackName', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         MockStack.MOCK_STACK_A,
         {
@@ -139,11 +121,7 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-B' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-A'],
           displayName: 'Test-Stack-A/Test-Stack-B',
@@ -151,45 +129,21 @@ describe('list', () => {
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    const stacks = await runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-A/Test-Stack-B']);
 
-    // WHEN
-    const workflow = await listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-A/Test-Stack-B'] });
-
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-A', name: 'Test-Stack-A', environment: env, dependencies: [] },
+      {
+        id: 'Test-Stack-A/Test-Stack-B',
+        name: 'Test-Stack-B',
+        environment: env,
+        dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
       },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-A/Test-Stack-B',
-      name: 'Test-Stack-B',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
-        id: 'Test-Stack-A',
-        dependencies: [],
-      }],
-    }]));
+    ]);
   });
 
-  test('stacks with display names and have nested dependencies', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+  test('stacks with display names and nested dependencies', async () => {
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         MockStack.MOCK_STACK_A,
         {
@@ -197,11 +151,7 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-B' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-A'],
           displayName: 'Test-Stack-A/Test-Stack-B',
@@ -211,11 +161,7 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-C' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-C': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-C': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-B'],
           displayName: 'Test-Stack-A/Test-Stack-B/Test-Stack-C',
@@ -223,61 +169,36 @@ describe('list', () => {
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    const stacks = await runList(cloudExecutable, [
+      'Test-Stack-A',
+      'Test-Stack-A/Test-Stack-B',
+      'Test-Stack-A/Test-Stack-B/Test-Stack-C',
+    ]);
 
-    // WHEN
-    const workflow = await listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-A/Test-Stack-B', 'Test-Stack-A/Test-Stack-B/Test-Stack-C'] });
-
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-A/Test-Stack-B',
-      name: 'Test-Stack-B',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
-        id: 'Test-Stack-A',
-        dependencies: [],
-      }],
-    },
-    {
-      id: 'Test-Stack-A/Test-Stack-B/Test-Stack-C',
-      name: 'Test-Stack-C',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-A', name: 'Test-Stack-A', environment: env, dependencies: [] },
+      {
         id: 'Test-Stack-A/Test-Stack-B',
-        dependencies: [{
-          id: 'Test-Stack-A',
-          dependencies: [],
-        }],
-      }],
-    }]));
+        name: 'Test-Stack-B',
+        environment: env,
+        dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
+      },
+      {
+        id: 'Test-Stack-A/Test-Stack-B/Test-Stack-C',
+        name: 'Test-Stack-C',
+        environment: env,
+        dependencies: [
+          {
+            id: 'Test-Stack-A/Test-Stack-B',
+            dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
+          },
+        ],
+      },
+    ]);
   });
 
   test('stacks with nested dependencies', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         MockStack.MOCK_STACK_A,
         {
@@ -285,11 +206,7 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-B' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-A'],
         },
@@ -298,77 +215,41 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-C' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-C': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-C': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-B'],
         },
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    const stacks = await runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-B', 'Test-Stack-C']);
 
-    // WHEN
-    const workflow = await listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-B', 'Test-Stack-C'] });
-
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-B',
-      name: 'Test-Stack-B',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
-        id: 'Test-Stack-A',
-        dependencies: [],
-      }],
-    },
-    {
-      id: 'Test-Stack-C',
-      name: 'Test-Stack-C',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-A', name: 'Test-Stack-A', environment: env, dependencies: [] },
+      {
         id: 'Test-Stack-B',
-        dependencies: [{
-          id: 'Test-Stack-A',
-          dependencies: [],
-        }],
-      }],
-    }]));
+        name: 'Test-Stack-B',
+        environment: env,
+        dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
+      },
+      {
+        id: 'Test-Stack-C',
+        name: 'Test-Stack-C',
+        environment: env,
+        dependencies: [
+          {
+            id: 'Test-Stack-B',
+            dependencies: [{ id: 'Test-Stack-A', dependencies: [] }],
+          },
+        ],
+      },
+    ]);
   });
 
-  // In the context of stacks with cross-stack or cross-region references,
-  // the dependency mechanism is responsible for appropriately applying dependencies at the correct hierarchy level,
-  // typically at the top-level stacks.
-  // This involves handling the establishment of cross-references between stacks or nested stacks
-  // and generating assets for nested stack templates as necessary.
+  // In the context of stacks with cross-stack or cross-region references, the
+  // dependency mechanism applies dependencies at the correct hierarchy level.
   test('stacks with cross stack referencing', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         {
           stackName: 'Test-Stack-A',
@@ -387,11 +268,7 @@ describe('list', () => {
           },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-A': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-A': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-C'],
         },
@@ -399,56 +276,28 @@ describe('list', () => {
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    const stacks = await runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-C']);
 
-    // WHEN
-    const workflow = await listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-C'] });
-
-    // THEN
-    expect(JSON.stringify(workflow)).toEqual(JSON.stringify([{
-      id: 'Test-Stack-C',
-      name: 'Test-Stack-C',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
+    expect(stacks).toEqual([
+      { id: 'Test-Stack-C', name: 'Test-Stack-C', environment: env, dependencies: [] },
+      {
+        id: 'Test-Stack-A',
+        name: 'Test-Stack-A',
+        environment: env,
+        dependencies: [{ id: 'Test-Stack-C', dependencies: [] }],
       },
-      dependencies: [],
-    },
-    {
-      id: 'Test-Stack-A',
-      name: 'Test-Stack-A',
-      environment: {
-        account: '123456789012',
-        region: 'bermuda-triangle-1',
-        name: 'aws://123456789012/bermuda-triangle-1',
-      },
-      dependencies: [{
-        id: 'Test-Stack-C',
-        dependencies: [],
-      }],
-    }]));
+    ]);
   });
 
   test('stacks with circular dependencies should error out', async () => {
-    let cloudExecutable = await MockCloudExecutable.create({
+    const cloudExecutable = await MockCloudExecutable.create({
       stacks: [
         {
           stackName: 'Test-Stack-A',
           template: { Resources: { TemplateName: 'Test-Stack-A' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-A': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-A': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-B'],
         },
@@ -457,29 +306,58 @@ describe('list', () => {
           template: { Resources: { TemplateName: 'Test-Stack-B' } },
           env: 'aws://123456789012/bermuda-triangle-1',
           metadata: {
-            '/Test-Stack-B': [
-              {
-                type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-              },
-            ],
+            '/Test-Stack-B': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
           },
           depends: ['Test-Stack-A'],
         },
       ],
     });
 
-    // GIVEN
-    const toolkit = new CdkToolkit({
-      cloudExecutable,
-      configuration: cloudExecutable.configuration,
-      sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
-    });
+    await expect(runList(cloudExecutable, ['Test-Stack-A', 'Test-Stack-B']))
+      .rejects.toThrow('Could not determine ordering');
+  });
+});
 
-    // WHEN
-    await expect(() =>
-      listStacks( toolkit, { selectors: ['Test-Stack-A', 'Test-Stack-B'] }),
-    ).rejects.toThrow('Could not determine ordering');
+describe('formatStackList', () => {
+  const stacks: StackDetails[] = [
+    { id: 'Stack-A', name: 'Stack-A', environment: env, dependencies: [] },
+    { id: 'Stack-B', name: 'Stack-B', environment: env, dependencies: [{ id: 'Stack-A', dependencies: [] }] },
+  ];
+
+  test('by default lists the stack ids, one per line', () => {
+    expect(formatStackList(stacks)).toEqual('Stack-A\nStack-B');
+  });
+
+  test('--json alone still only lists the stack ids', () => {
+    expect(formatStackList(stacks, { json: true })).toEqual('Stack-A\nStack-B');
+  });
+
+  test('--long --json serializes id, name and environment', () => {
+    expect(JSON.parse(formatStackList(stacks, { long: true, json: true }))).toEqual([
+      { id: 'Stack-A', name: 'Stack-A', environment: env },
+      { id: 'Stack-B', name: 'Stack-B', environment: env },
+    ]);
+  });
+
+  test('--show-dependencies --json serializes id and dependencies', () => {
+    expect(JSON.parse(formatStackList(stacks, { showDeps: true, json: true }))).toEqual([
+      { id: 'Stack-A', dependencies: [] },
+      { id: 'Stack-B', dependencies: [{ id: 'Stack-A', dependencies: [] }] },
+    ]);
+  });
+
+  test('--long --show-dependencies --json serializes the full stack details', () => {
+    expect(JSON.parse(formatStackList(stacks, { long: true, showDeps: true, json: true }))).toEqual(stacks);
+  });
+
+  test('--long --show-dependencies --json omits (potentially huge) metadata', () => {
+    const withMetadata: StackDetails[] = [
+      { id: 'Stack-A', name: 'Stack-A', environment: env, dependencies: [], metadata: { '/Stack-A': [] } },
+    ];
+
+    expect(JSON.parse(formatStackList(withMetadata, { long: true, showDeps: true, json: true }))).toEqual([
+      { id: 'Stack-A', name: 'Stack-A', environment: env, dependencies: [] },
+    ]);
   });
 });
 
@@ -489,11 +367,7 @@ class MockStack {
     template: { Resources: { TemplateName: 'Test-Stack-A' } },
     env: 'aws://123456789012/bermuda-triangle-1',
     metadata: {
-      '/Test-Stack-A': [
-        {
-          type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-        },
-      ],
+      '/Test-Stack-A': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
     },
   };
   public static readonly MOCK_STACK_C: TestStackArtifact = {
@@ -511,11 +385,7 @@ class MockStack {
     },
     env: 'aws://123456789012/bermuda-triangle-1',
     metadata: {
-      '/Test-Stack-C': [
-        {
-          type: cxschema.ArtifactMetadataEntryType.STACK_TAGS,
-        },
-      ],
+      '/Test-Stack-C': [{ type: cxschema.ArtifactMetadataEntryType.STACK_TAGS }],
     },
   };
 }


### PR DESCRIPTION
Relates to #959

The `cdk list` command kept its own stack-selection and synthesis logic (the `listStacks` helper) in parallel to the toolkit-lib `list` action. That duplicates behavior that already lives in the toolkit and means the two can drift. This routes the CLI through the toolkit-lib `list` action so there is a single source of truth for how stacks are selected and synthesized.

The wrinkle is output. The `list` action emits its result as a single `CDK_TOOLKIT_I2901` message, but the CLI needs to render that differently depending on `--long`, `--json` and `--show-dependencies`, and those flags are not something the action should know about. Rather than special-casing the message inside the io host, this introduces a small event-listener API on `CliIoHost`: `on`/`once` to observe a message by its code, and `transform`/`transformOnce` to replace a message or consume it entirely by returning `undefined`. The `list` command registers a one-shot transformer that formats the payload (extracted into a pure, unit-tested `formatStackList` helper), so the presentation logic stays with the command that owns it.

The same mechanism replaces the previously hardcoded `isStackActivity` branch in `notify`: stack-activity messages (`CDK_TOOLKIT_I5501`/`I5502`/`I5503`) are now routed to the activity printer and consumed via transformers registered at construction time, which keeps `notify` free of message-specific knowledge.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
