### PR TITLE
fix: not enough information to count sequential failures

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-sequential-errors.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-sequential-errors.ts
@@ -1,0 +1,49 @@
+import * as path from 'path';
+import * as fs from 'fs-extra';
+import { integTest, withSpecificFixture } from '../../lib';
+
+integTest(
+  'multiple deploys track their failures',
+  withSpecificFixture('diagnose-app', async (fixture) => {
+    const telemetryFile = path.join(fixture.integTestDir, 'telemetry.json');
+
+    // Deploy a stack that will fail (IAM Policy without PolicyDocument)
+    await fixture.cdkDeploy('diagnose-deploy-fail', {
+      allowErrExit: true,
+      telemetryFile,
+    });
+
+    await fixture.cdkDeploy('diagnose-deploy-fail', {
+      allowErrExit: true,
+      telemetryFile,
+    });
+
+    // Should see a DEPLOY event with sequentialDeploymentFailures: 2
+    const json = fs.readJSONSync(telemetryFile);
+    expect(json).toEqual([
+      expect.objectContaining({
+        event: expect.objectContaining({
+          eventType: 'SYNTH',
+        }),
+      }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          eventType: 'ASSET',
+        }),
+      }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          eventType: 'DEPLOY',
+        }),
+        counters: expect.objectContaining({
+          sequentialDeploymentFailures: 2,
+        }),
+      }),
+      expect.objectContaining({
+        event: expect.objectContaining({
+          eventType: 'INVOKE',
+        }),
+      }),
+    ]);
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-telemetry.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/telemetry-integ-tests/cdk-deploy-telemetry.integtest.ts
@@ -56,6 +56,9 @@ integTest(
         identifiers: expect.objectContaining({
           eventId: expect.stringContaining(':3'),
         }),
+        counters: expect.objectContaining({
+          sequentialDeploymentFailures: 0,
+        }),
       }),
       expect.objectContaining({
         event: expect.objectContaining({

--- a/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
@@ -35,9 +35,7 @@ export function cdkHomeDir() {
 }
 
 export async function ensureCacheDir() {
-  if (!fs.existsSync(cdkCacheDir())) {
-    fs.mkdirSync(cdkCacheDir(), { recursive: true });
-  }
+  fs.mkdirSync(cdkCacheDir(), { recursive: true });
 }
 
 export function cdkCacheDir() {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
@@ -34,10 +34,6 @@ export function cdkHomeDir() {
     : home || fs.mkdtempSync(path.join(tmpDir, '.cdk')).trim();
 }
 
-export async function ensureCacheDir() {
-  await fs.promises.mkdir(cdkCacheDir(), { recursive: true });
-}
-
 export function cdkCacheDir() {
   return path.join(cdkHomeDir(), 'cache');
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
@@ -35,7 +35,7 @@ export function cdkHomeDir() {
 }
 
 export async function ensureCacheDir() {
-  fs.mkdirSync(cdkCacheDir(), { recursive: true });
+  await fs.promises.mkdir(cdkCacheDir(), { recursive: true });
 }
 
 export function cdkCacheDir() {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/directories.ts
@@ -34,6 +34,12 @@ export function cdkHomeDir() {
     : home || fs.mkdtempSync(path.join(tmpDir, '.cdk')).trim();
 }
 
+export async function ensureCacheDir() {
+  if (!fs.existsSync(cdkCacheDir())) {
+    fs.mkdirSync(cdkCacheDir(), { recursive: true });
+  }
+}
+
 export function cdkCacheDir() {
   return path.join(cdkHomeDir(), 'cache');
 }

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -2,8 +2,7 @@ import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { IoHelper } from '../../api-private';
-import { cdkCacheDir, ensureCacheDir } from '../../util';
-
+import { cdkCacheDir } from '../../util';
 
 /**
  * Get or create installation id
@@ -11,7 +10,6 @@ import { cdkCacheDir, ensureCacheDir } from '../../util';
 export async function getOrCreateInstallationId(ioHelper: IoHelper) {
   // Do this quite lazily, so we can mock `cdkCacheDir` during tests
   const installationIdPath = path.join(cdkCacheDir(), 'installation-id.json');
-  console.log('path', installationIdPath);
 
   try {
     // Check if the installation ID file exists
@@ -32,16 +30,28 @@ export async function getOrCreateInstallationId(ioHelper: IoHelper) {
       await ensureCacheDir();
       fs.writeFileSync(installationIdPath, newId);
     } catch (e: any) {
-      console.error(e);
       // If we can't write the file, still return the generated ID
       // but log a trace message about the failure
       await ioHelper.defaults.trace(`Failed to write installation ID to ${installationIdPath}: ${e}`);
     }
     return newId;
   } catch (e: any) {
+    // eslint-disable-next-line no-console
+    console.log(e);
     // If anything goes wrong, generate a temporary ID for this session
     // and log a trace message about the failure
     await ioHelper.defaults.trace(`Error getting installation ID: ${e}`);
     return randomUUID();
   }
 }
+
+/**
+ * Make sure the cache dir exists
+ *
+ * Not part of `directories.ts` because that module is mocked in tests in order to mock the temporary directory
+ * to write to, and then I need to mock this function as well.
+ */
+export async function ensureCacheDir() {
+  await fs.promises.mkdir(cdkCacheDir(), { recursive: true });
+}
+

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { IoHelper } from '../../api-private';
-import { cdkCacheDir } from '../../util';
+import { cdkCacheDir, ensureCacheDir } from '../../util';
 
 const INSTALLATION_ID_PATH = path.join(cdkCacheDir(), 'installation-id.json');
 
@@ -11,10 +11,7 @@ const INSTALLATION_ID_PATH = path.join(cdkCacheDir(), 'installation-id.json');
  */
 export async function getOrCreateInstallationId(ioHelper: IoHelper) {
   try {
-    // Create the cache directory if it doesn't exist
-    if (!fs.existsSync(path.dirname(INSTALLATION_ID_PATH))) {
-      fs.mkdirSync(path.dirname(INSTALLATION_ID_PATH), { recursive: true });
-    }
+    await ensureCacheDir();
 
     // Check if the installation ID file exists
     if (fs.existsSync(INSTALLATION_ID_PATH)) {

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -4,16 +4,19 @@ import * as path from 'node:path';
 import type { IoHelper } from '../../api-private';
 import { cdkCacheDir, ensureCacheDir } from '../../util';
 
-const INSTALLATION_ID_PATH = path.join(cdkCacheDir(), 'installation-id.json');
 
 /**
  * Get or create installation id
  */
 export async function getOrCreateInstallationId(ioHelper: IoHelper) {
+  // Do this quite lazily, so we can mock `cdkCacheDir` during tests
+  const installationIdPath = path.join(cdkCacheDir(), 'installation-id.json');
+  console.log('path', installationIdPath);
+
   try {
     // Check if the installation ID file exists
-    if (fs.existsSync(INSTALLATION_ID_PATH)) {
-      const cachedId = fs.readFileSync(INSTALLATION_ID_PATH, 'utf-8').trim();
+    if (fs.existsSync(installationIdPath)) {
+      const cachedId = fs.readFileSync(installationIdPath, 'utf-8').trim();
 
       // Validate that the cached ID is a valid UUID
       const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -27,11 +30,12 @@ export async function getOrCreateInstallationId(ioHelper: IoHelper) {
     const newId = randomUUID();
     try {
       await ensureCacheDir();
-      fs.writeFileSync(INSTALLATION_ID_PATH, newId);
+      fs.writeFileSync(installationIdPath, newId);
     } catch (e: any) {
+      console.error(e);
       // If we can't write the file, still return the generated ID
       // but log a trace message about the failure
-      await ioHelper.defaults.trace(`Failed to write installation ID to ${INSTALLATION_ID_PATH}: ${e}`);
+      await ioHelper.defaults.trace(`Failed to write installation ID to ${installationIdPath}: ${e}`);
     }
     return newId;
   } catch (e: any) {

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -11,8 +11,6 @@ const INSTALLATION_ID_PATH = path.join(cdkCacheDir(), 'installation-id.json');
  */
 export async function getOrCreateInstallationId(ioHelper: IoHelper) {
   try {
-    await ensureCacheDir();
-
     // Check if the installation ID file exists
     if (fs.existsSync(INSTALLATION_ID_PATH)) {
       const cachedId = fs.readFileSync(INSTALLATION_ID_PATH, 'utf-8').trim();
@@ -28,6 +26,7 @@ export async function getOrCreateInstallationId(ioHelper: IoHelper) {
     // Create a new installation ID
     const newId = randomUUID();
     try {
+      await ensureCacheDir();
       fs.writeFileSync(INSTALLATION_ID_PATH, newId);
     } catch (e: any) {
       // If we can't write the file, still return the generated ID

--- a/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/installation-id.ts
@@ -36,8 +36,6 @@ export async function getOrCreateInstallationId(ioHelper: IoHelper) {
     }
     return newId;
   } catch (e: any) {
-    // eslint-disable-next-line no-console
-    console.log(e);
     // If anything goes wrong, generate a temporary ID for this session
     // and log a trace message about the failure
     await ioHelper.defaults.trace(`Error getting installation ID: ${e}`);

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -14,6 +14,7 @@ import { CLI_PRIVATE_SPAN } from '../telemetry/messages';
 import { isCI } from '../util/ci';
 import { versionNumber } from '../version';
 import { USER_INTERRUPTED_CODE } from './error';
+import { withTelemetryState } from './telemetry-state';
 
 const ABORTED_ERROR_MESSAGE = '__CDK-Toolkit__Aborted';
 
@@ -231,6 +232,10 @@ export class TelemetrySession {
     };
     this._nextEventCounters = undefined;
 
+    if (event.eventType == 'DEPLOY') {
+      await this.trackDeployStatistics(event.error === undefined, counters);
+    }
+
     return this.client.emit({
       event: {
         command: this.sessionInfo.event.command,
@@ -253,6 +258,26 @@ export class TelemetrySession {
         },
       } : {}),
       ...(Object.keys(counters).length > 0 ? { counters } : {}),
+    });
+  }
+
+  /**
+   * This is a DEPLOY event, track some additional statistics about it
+   *
+   * We use this to measure things about deployment failures, such as the number of
+   * failed DEPLOY events in a sequence.
+   */
+  private async trackDeployStatistics(isSuccessful: boolean, counters: Record<string, number>) {
+    await withTelemetryState((state) => {
+      const recentFailures = state.sequentialDeploymentFailures ?? 0;
+
+      if (isSuccessful) {
+        state.sequentialDeploymentFailures = 0;
+      } else {
+        state.sequentialDeploymentFailures = recentFailures + 1;
+      }
+
+      counters['sequentialDeploymentFailures'] = state.sequentialDeploymentFailures;
     });
   }
 

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -277,7 +277,7 @@ export class TelemetrySession {
         state.sequentialDeploymentFailures = recentFailures + 1;
       }
 
-      counters['sequentialDeploymentFailures'] = state.sequentialDeploymentFailures;
+      counters.sequentialDeploymentFailures = state.sequentialDeploymentFailures;
     });
   }
 

--- a/packages/aws-cdk/lib/cli/telemetry/telemetry-state.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/telemetry-state.ts
@@ -1,0 +1,52 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { cdkCacheDir, ensureCacheDir } from '../../util';
+
+/**
+ * Telemetry state across CLI invocations
+ */
+export interface TelemetryState {
+  /**
+   * How many deployment failures we've seen since the last success.
+   */
+  sequentialDeploymentFailures?: number;
+}
+
+/**
+ * Run a function that can modify the given telemetry state.
+ */
+export async function withTelemetryState<A>(block: (x: TelemetryState) => A): Promise<A> {
+  const state = await loadTelemetryState();
+  const oldState = JSON.stringify(state);
+
+  const ret = block(state);
+
+  // Only write a file if the contents changed.
+  if (JSON.stringify(ret) !== oldState) {
+    await writeTelemetryState(state);
+  }
+
+  return ret;
+}
+
+/**
+ * Load telemetry state
+ */
+export async function loadTelemetryState(): Promise<TelemetryState> {
+  try {
+    return JSON.parse(await fs.readFile(TELEMETRY_STATE_PATH, 'utf-8'));
+  } catch (e: any) {
+    if (e.code === 'ENOENT') {
+      return {};
+    }
+    throw e;
+  }
+}
+
+export async function writeTelemetryState(state: TelemetryState) {
+  await ensureCacheDir();
+
+  await fs.writeFile(TELEMETRY_STATE_PATH, JSON.stringify(state, undefined, 2), 'utf-8');
+}
+
+const TELEMETRY_STATE_PATH = path.join(cdkCacheDir(), 'telemetry-state.json');

--- a/packages/aws-cdk/lib/cli/telemetry/telemetry-state.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/telemetry-state.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { cdkCacheDir, ensureCacheDir } from '../../util';
+import { ensureCacheDir } from './installation-id';
+import { cdkCacheDir } from '../../util';
 
 /**
  * Telemetry state across CLI invocations

--- a/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
+++ b/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
@@ -25,24 +25,9 @@ describe(getOrCreateInstallationId, () => {
   let mockIoHelper: IoHelper;
   let traceSpy: jest.Mock;
 
-  beforeAll(() => {
-    // Create the temp directory before any tests run
-    fs.mkdirSync(tempDir, { recursive: true });
-  });
-
   beforeEach(() => {
-    // Clean the temp directory for each test
-    if (fs.existsSync(tempDir)) {
-      const files = fs.readdirSync(tempDir);
-      for (const file of files) {
-        const filePath = path.join(tempDir, file);
-        if (fs.statSync(filePath).isDirectory()) {
-          fs.rmSync(filePath, { recursive: true, force: true });
-        } else {
-          fs.unlinkSync(filePath);
-        }
-      }
-    }
+    fs.rmSync(tempDir, { force: true, recursive: true });
+    fs.mkdirSync(tempDir, { recursive: true });
 
     // Mock randomUUID to return predictable values
     mockRandomUUID.mockReturnValue('12345678-1234-1234-1234-123456789abc');
@@ -77,6 +62,7 @@ describe(getOrCreateInstallationId, () => {
 
     // Verify the file was created
     const installationIdPath = path.join(tempDir, 'installation-id.json');
+    console.log({ installationIdPath });
     expect(fs.existsSync(installationIdPath)).toBe(true);
     expect(fs.readFileSync(installationIdPath, 'utf-8')).toBe('12345678-1234-1234-1234-123456789abc');
 
@@ -130,7 +116,7 @@ describe(getOrCreateInstallationId, () => {
     expect(traceSpy).not.toHaveBeenCalled();
   });
 
-  test('creates cache directory if it does not exist', async() => {
+  test('creates cache directory if it does not exist', async () => {
     // GIVEN
     // Remove the temp directory to test directory creation
     fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
+++ b/packages/aws-cdk/test/cli/telemetry/installation-id.test.ts
@@ -62,7 +62,6 @@ describe(getOrCreateInstallationId, () => {
 
     // Verify the file was created
     const installationIdPath = path.join(tempDir, 'installation-id.json');
-    console.log({ installationIdPath });
     expect(fs.existsSync(installationIdPath)).toBe(true);
     expect(fs.readFileSync(installationIdPath, 'utf-8')).toBe('12345678-1234-1234-1234-123456789abc');
 
@@ -157,24 +156,24 @@ describe(getOrCreateInstallationId, () => {
   test('handles general error gracefully and returns temporary ID', async () => {
     // GIVEN
     // Mock fs.existsSync to throw an error
-    const originalExistsSync = fs.existsSync;
-    jest.spyOn(fs, 'existsSync').mockImplementation(() => {
+    const mockExistsSync = jest.spyOn(fs, 'existsSync').mockImplementation(() => {
       throw new Error('Filesystem error');
     });
+    try {
+      // WHEN
+      const result = await getOrCreateInstallationId(mockIoHelper);
 
-    // WHEN
-    const result = await getOrCreateInstallationId(mockIoHelper);
+      // THEN
+      expect(result).toBe('12345678-1234-1234-1234-123456789abc');
+      expect(mockRandomUUID).toHaveBeenCalledTimes(1);
 
-    // THEN
-    expect(result).toBe('12345678-1234-1234-1234-123456789abc');
-    expect(mockRandomUUID).toHaveBeenCalledTimes(1);
-
-    // Should have logged a trace message about the general error
-    expect(traceSpy).toHaveBeenCalledWith(
-      expect.stringContaining('Error getting installation ID:'),
-    );
-
-    // Restore original function
-    (fs.existsSync as jest.Mock).mockImplementation(originalExistsSync);
+      // Should have logged a trace message about the general error
+      expect(traceSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error getting installation ID:'),
+      );
+    } finally {
+      // Restore original function
+      mockExistsSync.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
We would like to know how many sequential failures a user encounters. Count them up in a state file and send that information along when we send deployment statistics.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
