### PR TITLE
chore: upgrade CodeQL Action from v3 to v4

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -95,6 +95,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4
       with:
         category: "/language:${{matrix.language}}"


### PR DESCRIPTION
CodeQL Action v3 is being deprecated in December 2026 ([announcement](https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/)). v4 was released on October 7, 2025 and runs on the Node.js 24 runtime. It's a drop-in replacement with no configuration changes required.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version: https://github.blog/changelog/2025-10-28-upcoming-deprecation-of-codeql-action-v3/

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
