### PR TITLE
feat: explorer codelens nav + template resource locations

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -52,14 +52,14 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
     const sourceResolver = new SourceMapResolver();
-    const templateFiles = templateFilesByLogicalId(assembly);
+    const templateFiles = templateFilesByStack(assembly);
     const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
       ...fields,
       sourceLocation: stack
         ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
         : undefined,
-      templateFile: fields.logicalId !== undefined
-        ? templateFiles.get(fields.logicalId)
+      templateFile: fields.logicalId !== undefined && stack
+        ? templateFiles.get(stack.hierarchicalId)?.get(fields.logicalId)
         : undefined,
     }));
 
@@ -90,29 +90,42 @@ function loadViolations(assemblyDir: string): PolicyValidationReportJson | undef
   return JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as PolicyValidationReportJson;
 }
 
+/** The slice of a CloudFormation template this reader reads. */
+interface CfnTemplate {
+  readonly Resources?: Record<string, CfnResource>;
+}
+interface CfnResource {
+  readonly Type?: string;
+  readonly Metadata?: Record<string, unknown>;
+}
+
 /**
- * Maps every CFN logical ID in the assembly to the absolute path of the
- * template that declares it, descending into CDK-managed nested stacks via the
- * `aws:asset:path` resource metadata (the same link CDK's own deploy/diff uses;
- * absent when asset metadata is disabled, in which case the nested stack is not
- * resolvable and its resources are simply omitted).
+ * For each stack, maps its CFN logical IDs to the absolute path of the template
+ * that declares them, descending into CDK-managed nested stacks via the
+ * `aws:asset:path` resource metadata (the link CDK's own deploy/diff uses;
+ * absent when asset metadata is disabled, in which case the nested stack is
+ * unresolvable and its resources are omitted). Keyed by stack hierarchicalId
+ * because logical IDs are stack-relative -- two same-shape stacks reuse the
+ * same IDs in different templates, so an assembly-wide map would collide.
  */
-function templateFilesByLogicalId(assembly: CloudAssembly): Map<string, string> {
-  const byLogicalId = new Map<string, string>();
-  const walk = (templateFile: string, template: any): void => {
-    for (const [logicalId, resource] of Object.entries<any>(template?.Resources ?? {})) {
-      byLogicalId.set(logicalId, templateFile);
-      const assetPath = resource?.Type === 'AWS::CloudFormation::Stack'
-        ? resource?.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
-        : undefined;
-      if (typeof assetPath === 'string') {
-        const nestedFile = path.join(assembly.directory, assetPath);
-        walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')));
-      }
-    }
-  };
+function templateFilesByStack(assembly: CloudAssembly): Map<string, Map<string, string>> {
+  const byStack = new Map<string, Map<string, string>>();
   for (const stack of assembly.stacksRecursively) {
-    walk(stack.templateFullPath, stack.template);
+    const byLogicalId = new Map<string, string>();
+    const walk = (templateFile: string, template: CfnTemplate): void => {
+      for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
+        byLogicalId.set(logicalId, templateFile);
+        const assetPath = resource.Type === 'AWS::CloudFormation::Stack'
+          ? resource.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
+          : undefined;
+        if (typeof assetPath === 'string') {
+          const nestedFile = path.join(assembly.directory, assetPath);
+          walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')) as CfnTemplate);
+        }
+      }
+    };
+    walk(stack.templateFullPath, stack.template as CfnTemplate);
+    byStack.set(stack.hierarchicalId, byLogicalId);
   }
-  return byLogicalId;
+  return byStack;
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ASSET_RESOURCE_METADATA_PATH_KEY, buildConstructTree, CloudAssembly, PATH_METADATA_KEY, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
+import { buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
 import { SourceMapResolver, type SourceLocation } from './source-resolver';
@@ -13,12 +13,6 @@ import { SourceMapResolver, type SourceLocation } from './source-resolver';
 export interface ConstructNode extends ConstructTreeNode {
   /** User source location where the construct was created; undefined for non-TS apps. */
   readonly sourceLocation?: SourceLocation;
-  /**
-   * Absolute path to the `*.template.json` that declares this construct's CFN
-   * resource (the nested template for resources inside a NestedStack). Set only
-   * for CFN resources, and only when the template is resolvable.
-   */
-  readonly templateFile?: string;
   readonly children: readonly ConstructNode[];
 }
 
@@ -52,18 +46,10 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
     const sourceResolver = new SourceMapResolver();
-    const templateFiles = buildTemplateFileIndex(assembly);
     const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
       ...fields,
       sourceLocation: stack
         ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
-        : undefined,
-      // Construct path is globally unique, so it resolves a resource even when
-      // it shares a logical ID with a twin in a nested stack. Fall back to the
-      // per-stack logical-ID map when path metadata is off (see the index doc).
-      templateFile: fields.logicalId !== undefined && stack
-        ? templateFiles.byConstructPath.get(constructPath)
-          ?? templateFiles.byStack.get(stack.hierarchicalId)?.get(fields.logicalId)
         : undefined,
     }));
 
@@ -92,76 +78,4 @@ function loadViolations(assemblyDir: string): PolicyValidationReportJson | undef
   // check throws on older aws-cdk-lib reports that omit `version`. We only consume
   // pluginReports, which are version-independent across producer versions.
   return JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as PolicyValidationReportJson;
-}
-
-/** The slice of a CloudFormation template this reader reads. */
-interface CfnTemplate {
-  readonly Resources?: Record<string, CfnResource>;
-}
-interface CfnResource {
-  readonly Type?: string;
-  readonly Metadata?: Record<string, unknown>;
-}
-
-/**
- * Two ways to find the template that declares a resource. Both are built from
- * the same walk; the decorator tries `byConstructPath` first, then `byStack`.
- */
-interface TemplateFileIndex {
-  /**
-   * Construct path -> absolute template path. The PRIMARY key, because a
-   * construct path is globally unique across the whole assembly. Logical IDs
-   * are NOT: CDK hashes them relative to the enclosing Stack, and a NestedStack
-   * resets that scope -- so a parent resource and a resource in its own nested
-   * stack can share a logical ID while living in different templates. Keying on
-   * the construct path disambiguates those twins. Sourced from `aws:cdk:path`
-   * resource metadata, present whenever path metadata is enabled.
-   */
-  readonly byConstructPath: Map<string, string>;
-  /**
-   * Stack hierarchicalId -> (logical ID -> absolute template path). The
-   * FALLBACK, used when `aws:cdk:path` is absent (path metadata is on by
-   * default in `cdk synth` but can be disabled via `--no-path-metadata`).
-   * Keyed per stack because logical IDs are only unique within a stack.
-   */
-  readonly byStack: Map<string, Map<string, string>>;
-}
-
-/**
- * Indexes every CFN resource to the template that declares it, descending into
- * CDK-managed nested stacks via the `aws:asset:path` resource metadata (the
- * link CDK's own deploy/diff uses; absent when asset metadata is disabled, in
- * which case the nested stack is unresolvable and its resources are omitted).
- */
-function buildTemplateFileIndex(assembly: CloudAssembly): TemplateFileIndex {
-  const byConstructPath = new Map<string, string>();
-  const byStack = new Map<string, Map<string, string>>();
-  for (const stack of assembly.stacksRecursively) {
-    const byLogicalId = new Map<string, string>();
-    const walk = (templateFile: string, template: CfnTemplate): void => {
-      for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
-        byLogicalId.set(logicalId, templateFile);
-        const constructPath = resource.Metadata?.[PATH_METADATA_KEY];
-        if (typeof constructPath === 'string') {
-          byConstructPath.set(constructPath, templateFile);
-        }
-        const assetPath = resource.Type === 'AWS::CloudFormation::Stack'
-          ? resource.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
-          : undefined;
-        if (typeof assetPath === 'string') {
-          const nestedFile = path.join(assembly.directory, assetPath);
-          try {
-            walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')) as CfnTemplate);
-          } catch {
-            // Nested template missing or unparseable (e.g. its asset isn't
-            // staged yet in a mid-synth read). Skip the subtree -- those
-            // resources stay unresolved -- rather than failing the whole read.
-          }
-        }
-      }
-    };
-    walk(stack.templateFullPath, stack.template as CfnTemplate);
-    byStack.set(stack.hierarchicalId, byLogicalId);
-  }
-  return { byConstructPath, byStack };
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { ASSET_RESOURCE_METADATA_PATH_KEY, buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
+import { ASSET_RESOURCE_METADATA_PATH_KEY, buildConstructTree, CloudAssembly, PATH_METADATA_KEY, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
 import { SourceMapResolver, type SourceLocation } from './source-resolver';
@@ -52,14 +52,18 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
     const sourceResolver = new SourceMapResolver();
-    const templateFiles = templateFilesByStack(assembly);
+    const templateFiles = buildTemplateFileIndex(assembly);
     const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
       ...fields,
       sourceLocation: stack
         ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
         : undefined,
+      // Construct path is globally unique, so it resolves a resource even when
+      // it shares a logical ID with a twin in a nested stack. Fall back to the
+      // per-stack logical-ID map when path metadata is off (see the index doc).
       templateFile: fields.logicalId !== undefined && stack
-        ? templateFiles.get(stack.hierarchicalId)?.get(fields.logicalId)
+        ? templateFiles.byConstructPath.get(constructPath)
+          ?? templateFiles.byStack.get(stack.hierarchicalId)?.get(fields.logicalId)
         : undefined,
     }));
 
@@ -100,21 +104,47 @@ interface CfnResource {
 }
 
 /**
- * For each stack, maps its CFN logical IDs to the absolute path of the template
- * that declares them, descending into CDK-managed nested stacks via the
- * `aws:asset:path` resource metadata (the link CDK's own deploy/diff uses;
- * absent when asset metadata is disabled, in which case the nested stack is
- * unresolvable and its resources are omitted). Keyed by stack hierarchicalId
- * because logical IDs are stack-relative -- two same-shape stacks reuse the
- * same IDs in different templates, so an assembly-wide map would collide.
+ * Two ways to find the template that declares a resource. Both are built from
+ * the same walk; the decorator tries `byConstructPath` first, then `byStack`.
  */
-function templateFilesByStack(assembly: CloudAssembly): Map<string, Map<string, string>> {
+interface TemplateFileIndex {
+  /**
+   * Construct path -> absolute template path. The PRIMARY key, because a
+   * construct path is globally unique across the whole assembly. Logical IDs
+   * are NOT: CDK hashes them relative to the enclosing Stack, and a NestedStack
+   * resets that scope -- so a parent resource and a resource in its own nested
+   * stack can share a logical ID while living in different templates. Keying on
+   * the construct path disambiguates those twins. Sourced from `aws:cdk:path`
+   * resource metadata, present whenever path metadata is enabled.
+   */
+  readonly byConstructPath: Map<string, string>;
+  /**
+   * Stack hierarchicalId -> (logical ID -> absolute template path). The
+   * FALLBACK, used when `aws:cdk:path` is absent (path metadata is on by
+   * default in `cdk synth` but can be disabled via `--no-path-metadata`).
+   * Keyed per stack because logical IDs are only unique within a stack.
+   */
+  readonly byStack: Map<string, Map<string, string>>;
+}
+
+/**
+ * Indexes every CFN resource to the template that declares it, descending into
+ * CDK-managed nested stacks via the `aws:asset:path` resource metadata (the
+ * link CDK's own deploy/diff uses; absent when asset metadata is disabled, in
+ * which case the nested stack is unresolvable and its resources are omitted).
+ */
+function buildTemplateFileIndex(assembly: CloudAssembly): TemplateFileIndex {
+  const byConstructPath = new Map<string, string>();
   const byStack = new Map<string, Map<string, string>>();
   for (const stack of assembly.stacksRecursively) {
     const byLogicalId = new Map<string, string>();
     const walk = (templateFile: string, template: CfnTemplate): void => {
       for (const [logicalId, resource] of Object.entries(template.Resources ?? {})) {
         byLogicalId.set(logicalId, templateFile);
+        const constructPath = resource.Metadata?.[PATH_METADATA_KEY];
+        if (typeof constructPath === 'string') {
+          byConstructPath.set(constructPath, templateFile);
+        }
         const assetPath = resource.Type === 'AWS::CloudFormation::Stack'
           ? resource.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
           : undefined;
@@ -127,5 +157,5 @@ function templateFilesByStack(assembly: CloudAssembly): Map<string, Map<string, 
     walk(stack.templateFullPath, stack.template as CfnTemplate);
     byStack.set(stack.hierarchicalId, byLogicalId);
   }
-  return byStack;
+  return { byConstructPath, byStack };
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
+import { ASSET_RESOURCE_METADATA_PATH_KEY, buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
 import { SourceMapResolver, type SourceLocation } from './source-resolver';
@@ -13,6 +13,12 @@ import { SourceMapResolver, type SourceLocation } from './source-resolver';
 export interface ConstructNode extends ConstructTreeNode {
   /** User source location where the construct was created; undefined for non-TS apps. */
   readonly sourceLocation?: SourceLocation;
+  /**
+   * Absolute path to the `*.template.json` that declares this construct's CFN
+   * resource (the nested template for resources inside a NestedStack). Set only
+   * for CFN resources, and only when the template is resolvable.
+   */
+  readonly templateFile?: string;
   readonly children: readonly ConstructNode[];
 }
 
@@ -46,10 +52,14 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
     const sourceResolver = new SourceMapResolver();
+    const templateFiles = templateFilesByLogicalId(assembly);
     const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
       ...fields,
       sourceLocation: stack
         ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
+        : undefined,
+      templateFile: fields.logicalId !== undefined
+        ? templateFiles.get(fields.logicalId)
         : undefined,
     }));
 
@@ -78,4 +88,31 @@ function loadViolations(assemblyDir: string): PolicyValidationReportJson | undef
   // check throws on older aws-cdk-lib reports that omit `version`. We only consume
   // pluginReports, which are version-independent across producer versions.
   return JSON.parse(fs.readFileSync(reportPath, 'utf-8')) as PolicyValidationReportJson;
+}
+
+/**
+ * Maps every CFN logical ID in the assembly to the absolute path of the
+ * template that declares it, descending into CDK-managed nested stacks via the
+ * `aws:asset:path` resource metadata (the same link CDK's own deploy/diff uses;
+ * absent when asset metadata is disabled, in which case the nested stack is not
+ * resolvable and its resources are simply omitted).
+ */
+function templateFilesByLogicalId(assembly: CloudAssembly): Map<string, string> {
+  const byLogicalId = new Map<string, string>();
+  const walk = (templateFile: string, template: any): void => {
+    for (const [logicalId, resource] of Object.entries<any>(template?.Resources ?? {})) {
+      byLogicalId.set(logicalId, templateFile);
+      const assetPath = resource?.Type === 'AWS::CloudFormation::Stack'
+        ? resource?.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
+        : undefined;
+      if (typeof assetPath === 'string') {
+        const nestedFile = path.join(assembly.directory, assetPath);
+        walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')));
+      }
+    }
+  };
+  for (const stack of assembly.stacksRecursively) {
+    walk(stack.templateFullPath, stack.template);
+  }
+  return byLogicalId;
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -150,7 +150,13 @@ function buildTemplateFileIndex(assembly: CloudAssembly): TemplateFileIndex {
           : undefined;
         if (typeof assetPath === 'string') {
           const nestedFile = path.join(assembly.directory, assetPath);
-          walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')) as CfnTemplate);
+          try {
+            walk(nestedFile, JSON.parse(fs.readFileSync(nestedFile, 'utf-8')) as CfnTemplate);
+          } catch {
+            // Nested template missing or unparseable (e.g. its asset isn't
+            // staged yet in a mid-synth read). Skip the subtree -- those
+            // resources stay unresolved -- rather than failing the whole read.
+          }
         }
       }
     };

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
@@ -1,7 +1,7 @@
 import { pathToFileURL } from 'url';
 import type { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
 import { type CodeLens, type Command, type Range } from 'vscode-languageserver/node';
-import { resourceTarget } from './template-locator';
+import { resourceTarget, type ResourceTarget } from './template-locator';
 import type { ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
 
@@ -31,22 +31,28 @@ interface ResourceLensInfo {
   readonly cfnType: string;
 }
 
+/** One selectable resource in a lens: a display label and where to open it. */
+export interface ResourceChoice {
+  readonly label: string;
+  readonly target: ResourceTarget;
+}
+
 /**
- * Builds the lens command for the resources on one line. A single resource gets
- * a clickable command carrying its navigation target, so the client can open
- * the template at the resource. Multiple resources (an L2 fanning out)
- * stay title-only until the picker is added; a single resource whose target
- * cannot be resolved also degrades to title-only (empty command = no-op click).
+ * Builds the lens command for the resources on one line. The command carries an
+ * array of resolvable resource choices; the client opens the only one directly
+ * or shows a picker when several share a line (an L2 fanning out). Resources
+ * whose target cannot be resolved are dropped, and a line where none resolve
+ * stays title-only (empty command = no-op click).
  */
 function commandFor(nodes: readonly ResourceConstruct[]): Command {
   const title = titleFor(nodes.map((n) => ({ logicalId: n.logicalId, cfnType: n.type })));
-  if (nodes.length === 1) {
-    const target = resourceTarget(nodes[0]);
-    if (target !== undefined) {
-      return { title, command: OPEN_RESOURCE_COMMAND, arguments: [target] };
-    }
+  const choices = nodes
+    .map((node) => ({ label: `${node.type}  ${node.logicalId}`, target: resourceTarget(node) }))
+    .filter((choice): choice is ResourceChoice => choice.target !== undefined);
+  if (choices.length === 0) {
+    return { title, command: '' };
   }
-  return { title, command: '' };
+  return { title, command: OPEN_RESOURCE_COMMAND, arguments: [choices] };
 }
 
 /** A construct that produces a CFN resource and carries a source location. */

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
@@ -26,14 +26,14 @@ export function codeLensesForFile(index: ConstructIndex<ConstructNode>, fileUri:
   }));
 }
 
-interface ResourceLensInfo {
-  readonly logicalId: string;
-  readonly cfnType: string;
-}
-
-/** One selectable resource in a lens: a display label and where to open it. */
-export interface ResourceChoice {
+/**
+ * One selectable resource on a lens, shaped as a VS Code QuickPick item so the
+ * client renders it directly: `label` is the CFN type, `description` the
+ * developer-facing construct name.
+ */
+interface ResourceChoice {
   readonly label: string;
+  readonly description: string;
   readonly target: ResourceTarget;
 }
 
@@ -41,13 +41,13 @@ export interface ResourceChoice {
  * Builds the lens command for the resources on one line. The command carries an
  * array of resolvable resource choices; the client opens the only one directly
  * or shows a picker when several share a line (an L2 fanning out). Resources
- * whose target cannot be resolved are dropped, and a line where none resolve
- * stays title-only (empty command = no-op click).
+ * whose target cannot be resolved are dropped; a line where none resolve stays
+ * title-only.
  */
 function commandFor(nodes: readonly ResourceConstruct[]): Command {
-  const title = titleFor(nodes.map((n) => ({ logicalId: n.logicalId, cfnType: n.type })));
+  const title = titleFor(nodes);
   const choices = nodes
-    .map((node) => ({ label: `${node.type}  ${node.logicalId}`, target: resourceTarget(node) }))
+    .map((node) => ({ label: node.type, description: friendlyName(node.path), target: resourceTarget(node) }))
     .filter((choice): choice is ResourceChoice => choice.target !== undefined);
   if (choices.length === 0) {
     return { title, command: '' };
@@ -94,11 +94,20 @@ function lineRange(line1Based: number): Range {
   return { start: { line, character: 0 }, end: { line, character: 0 } };
 }
 
-function titleFor(resources: readonly ResourceLensInfo[]): string {
+function titleFor(resources: readonly ResourceConstruct[]): string {
   if (resources.length === 1) {
-    const r = resources[0];
-    return `Creates: ${r.cfnType} [logical: ${r.logicalId}]`;
+    return `Creates ${resources[0].type}`;
   }
-  const ids = resources.map((r) => r.logicalId).join(', ');
-  return `${resources.length} resources: ${ids}`;
+  const types = resources.map((r) => r.type).join(', ');
+  return `Creates ${resources.length} resources: ${types}`;
+}
+
+/** Developer-facing construct name: the construct path without the synthetic CfnResource leaf. */
+function friendlyName(constructPath: string): string {
+  const segments = constructPath.split('/');
+  const leaf = segments[segments.length - 1];
+  if (segments.length > 1 && (leaf === 'Resource' || leaf === 'Default')) {
+    segments.pop();
+  }
+  return segments.join('/');
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
@@ -38,11 +38,9 @@ interface ResourceChoice {
 }
 
 /**
- * Builds the lens command for the resources on one line. The command carries an
- * array of resolvable resource choices; the client opens the only one directly
- * or shows a picker when several share a line (an L2 fanning out). Resources
- * whose target cannot be resolved are dropped; a line where none resolve stays
- * title-only.
+ * Builds the lens command for one line's resources: resolvable choices the
+ * client opens directly (one) or via a picker (several). Unresolvable resources
+ * are dropped; a line where none resolve stays title-only.
  */
 function commandFor(nodes: readonly ResourceConstruct[]): Command {
   const title = titleFor(nodes);

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
@@ -1,8 +1,12 @@
 import { pathToFileURL } from 'url';
 import type { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
-import { type CodeLens, type Range } from 'vscode-languageserver/node';
+import { type CodeLens, type Command, type Range } from 'vscode-languageserver/node';
+import { resourceTarget } from './template-locator';
 import type { ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
+
+/** Command the client registers to open a resource in its template. */
+export const OPEN_RESOURCE_COMMAND = 'cdkExplorer.openResource';
 
 /**
  * Build CodeLens entries for a single source file. For every construct whose
@@ -12,23 +16,37 @@ import type { SourceLocation } from '../core/source-resolver';
 export function codeLensesForFile(index: ConstructIndex<ConstructNode>, fileUri: string): CodeLens[] {
   const matches = [...index]
     .filter((node) => isResourceOnFile(node, fileUri))
-    .map((node) => ({
-      line: node.sourceLocation.line,
-      resource: { logicalId: node.logicalId, cfnType: node.type },
-    }));
+    .map((node) => ({ line: node.sourceLocation.line, node }));
 
   // Multiple resources can map to one line when an L2 construct fans out
   // (e.g. an L2 producing a primary resource + auxiliary resources).
-  // Empty command name = title-only lens; click does nothing for now.
   return [...groupBy(matches, (m) => m.line)].map(([line, group]) => ({
     range: lineRange(line),
-    command: { title: titleFor(group.map((m) => m.resource)), command: '' },
+    command: commandFor(group.map((m) => m.node)),
   }));
 }
 
 interface ResourceLensInfo {
   readonly logicalId: string;
   readonly cfnType: string;
+}
+
+/**
+ * Builds the lens command for the resources on one line. A single resource gets
+ * a clickable command carrying its navigation target, so the client can open
+ * the template at the resource. Multiple resources (an L2 fanning out)
+ * stay title-only until the picker is added; a single resource whose target
+ * cannot be resolved also degrades to title-only (empty command = no-op click).
+ */
+function commandFor(nodes: readonly ResourceConstruct[]): Command {
+  const title = titleFor(nodes.map((n) => ({ logicalId: n.logicalId, cfnType: n.type })));
+  if (nodes.length === 1) {
+    const target = resourceTarget(nodes[0]);
+    if (target !== undefined) {
+      return { title, command: OPEN_RESOURCE_COMMAND, arguments: [target] };
+    }
+  }
+  return { title, command: '' };
 }
 
 /** A construct that produces a CFN resource and carries a source location. */

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -3,32 +3,22 @@ import { pathToFileURL } from 'url';
 import { type Position, type Range } from 'vscode-languageserver/node';
 
 /**
- * Locates a resource definition within a synthesized CloudFormation template
- * and returns the 0-based position of its logical-ID key.
- *
- * A logical ID is unique within its template and appears as a JSON *key*
- * (`"<id>":`) only in its own resource definition. Every other occurrence
- * (Ref / Fn::GetAtt / DependsOn / Fn::Sub) is a string *value*, never followed
- * by a colon, so anchoring on `"<id>":` selects the definition without matching
- * references -- no JSON parse needed. Operates on synthesized (pretty-printed)
- * templates, where each key sits on its own line.
- *
- * @returns the position of the key's opening quote, or undefined if absent.
+ * 0-based position of a resource's logical-ID key in its synthesized template.
+ * A logical ID only appears as a `"<id>":` key in its own definition (every
+ * Ref/GetAtt/DependsOn occurrence is a string value, never followed by `:`), so
+ * anchoring on the key selects the definition without a JSON parse. Assumes
+ * pretty-printed templates (one key per line). Undefined if not found.
  */
 export function findLogicalIdPosition(templateText: string, logicalId: string): Position | undefined {
-  const keyPattern = new RegExp(`^\\s*"${escapeRegExp(logicalId)}"\\s*:`);
+  const key = `"${logicalId}"`;
   const lines = templateText.split('\n');
   for (let line = 0; line < lines.length; line++) {
-    if (keyPattern.test(lines[line])) {
-      return { line, character: lines[line].indexOf('"') };
+    const trimmed = lines[line].trimStart();
+    if (trimmed.startsWith(key) && trimmed.slice(key.length).trimStart().startsWith(':')) {
+      return { line, character: lines[line].length - trimmed.length };
     }
   }
   return undefined;
-}
-
-/** Escapes regex metacharacters so a literal string matches itself. */
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /** An editor navigation target: the template file and the position to reveal. */
@@ -38,11 +28,8 @@ export interface ResourceTarget {
 }
 
 /**
- * Resolves a construct node to the location of its CFN resource in the
- * synthesized template, suitable for an LSP "go to" navigation. Returns
- * undefined when the node has no resolved template, when the template can no
- * longer be read, or when the logical ID cannot be located in the template
- * text.
+ * Resolves a construct node to its CFN resource location for an LSP "go to";
+ * undefined when not navigable (no template, unreadable, or id not found).
  */
 export function resourceTarget(node: { templateFile?: string; logicalId: string }): ResourceTarget | undefined {
   if (node.templateFile === undefined) {

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -9,7 +9,7 @@ import { type Position, type Range } from 'vscode-languageserver/node';
  * anchoring on the key selects the definition without a JSON parse. Assumes
  * pretty-printed templates (one key per line). Undefined if not found.
  */
-export function findLogicalIdPosition(templateText: string, logicalId: string): Position | undefined {
+function findLogicalIdPosition(templateText: string, logicalId: string): Position | undefined {
   const key = `"${logicalId}"`;
   const lines = templateText.split('\n');
   for (let line = 0; line < lines.length; line++) {

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -1,14 +1,13 @@
 import * as fs from 'fs';
 import { pathToFileURL } from 'url';
 import { type Position, type Range } from 'vscode-languageserver/node';
-import type { ConstructNode } from '../core/assembly-reader';
 
 /**
  * Locates a resource definition within a synthesized CloudFormation template
  * and returns the 0-based position of its logical-ID key.
  *
- * A logical ID is globally unique and appears as a JSON *key* (`"<id>":`) only
- * in its own resource definition under `Resources`. Every other occurrence
+ * A logical ID is unique within its template and appears as a JSON *key*
+ * (`"<id>":`) only in its own resource definition. Every other occurrence
  * (Ref / Fn::GetAtt / DependsOn / Fn::Sub) is a string *value*, never followed
  * by a colon, so anchoring on `"<id>":` selects the definition without matching
  * references -- no JSON parse needed. Operates on synthesized (pretty-printed)
@@ -41,12 +40,12 @@ export interface ResourceTarget {
 /**
  * Resolves a construct node to the location of its CFN resource in the
  * synthesized template, suitable for an LSP "go to" navigation. Returns
- * undefined when the node has no resolved template or logical ID, when the
- * template can no longer be read , or when the logical ID cannot be located
- * in the template text.
+ * undefined when the node has no resolved template, when the template can no
+ * longer be read, or when the logical ID cannot be located in the template
+ * text.
  */
-export function resourceTarget(node: Pick<ConstructNode, 'templateFile' | 'logicalId'>): ResourceTarget | undefined {
-  if (node.templateFile === undefined || node.logicalId === undefined) {
+export function resourceTarget(node: { templateFile?: string; logicalId: string }): ResourceTarget | undefined {
+  if (node.templateFile === undefined) {
     return undefined;
   }
   let templateText: string;

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -1,0 +1,30 @@
+import { type Position } from 'vscode-languageserver/node';
+
+/**
+ * Locates a resource definition within a synthesized CloudFormation template
+ * and returns the 0-based position of its logical-ID key.
+ *
+ * A logical ID is globally unique and appears as a JSON *key* (`"<id>":`) only
+ * in its own resource definition under `Resources`. Every other occurrence
+ * (Ref / Fn::GetAtt / DependsOn / Fn::Sub) is a string *value*, never followed
+ * by a colon, so anchoring on `"<id>":` selects the definition without matching
+ * references -- no JSON parse needed. Operates on synthesized (pretty-printed)
+ * templates, where each key sits on its own line.
+ *
+ * @returns the position of the key's opening quote, or undefined if absent.
+ */
+export function findLogicalIdPosition(templateText: string, logicalId: string): Position | undefined {
+  const keyPattern = new RegExp(`^\\s*"${escapeRegExp(logicalId)}"\\s*:`);
+  const lines = templateText.split('\n');
+  for (let line = 0; line < lines.length; line++) {
+    if (keyPattern.test(lines[line])) {
+      return { line, character: lines[line].indexOf('"') };
+    }
+  }
+  return undefined;
+}
+
+/** Escapes regex metacharacters so a literal string matches itself. */
+function escapeRegExp(literal: string): string {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -1,4 +1,7 @@
-import { type Position } from 'vscode-languageserver/node';
+import * as fs from 'fs';
+import { pathToFileURL } from 'url';
+import { type Position, type Range } from 'vscode-languageserver/node';
+import type { ConstructNode } from '../core/assembly-reader';
 
 /**
  * Locates a resource definition within a synthesized CloudFormation template
@@ -27,4 +30,37 @@ export function findLogicalIdPosition(templateText: string, logicalId: string): 
 /** Escapes regex metacharacters so a literal string matches itself. */
 function escapeRegExp(literal: string): string {
   return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** An editor navigation target: the template file and the position to reveal. */
+export interface ResourceTarget {
+  readonly uri: string;
+  readonly range: Range;
+}
+
+/**
+ * Resolves a construct node to the location of its CFN resource in the
+ * synthesized template, suitable for an LSP "go to" navigation. Returns
+ * undefined when the node has no resolved template or logical ID, when the
+ * template can no longer be read , or when the logical ID cannot be located
+ * in the template text.
+ */
+export function resourceTarget(node: Pick<ConstructNode, 'templateFile' | 'logicalId'>): ResourceTarget | undefined {
+  if (node.templateFile === undefined || node.logicalId === undefined) {
+    return undefined;
+  }
+  let templateText: string;
+  try {
+    templateText = fs.readFileSync(node.templateFile, 'utf-8');
+  } catch {
+    return undefined;
+  }
+  const position = findLogicalIdPosition(templateText, node.logicalId);
+  if (position === undefined) {
+    return undefined;
+  }
+  return {
+    uri: pathToFileURL(node.templateFile).toString(),
+    range: { start: position, end: position },
+  };
 }

--- a/packages/@aws-cdk/cdk-explorer/package.json
+++ b/packages/@aws-cdk/cdk-explorer/package.json
@@ -30,7 +30,7 @@
     "organization": true
   },
   "devDependencies": {
-    "@cdklabs/eslint-plugin": "^2.0.6",
+    "@cdklabs/eslint-plugin": "^2.0.8",
     "@stylistic/eslint-plugin": "^3",
     "@types/convert-source-map": "^2",
     "@types/express": "^4",
@@ -41,16 +41,16 @@
     "constructs": "^10.0.0",
     "eslint": "^9",
     "eslint-config-prettier": "^10.1.8",
-    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-import-resolver-typescript": "^4.4.5",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jest": "^29.15.2",
     "eslint-plugin-jsdoc": "^62.9.0",
     "eslint-plugin-prettier": "^4.2.5",
     "jest": "^29.7.0",
     "jest-junit": "^16",
-    "nx": "^22.7.2",
+    "nx": "^22.7.5",
     "prettier": "^2.8",
-    "projen": "^0.99.63",
+    "projen": "^0.99.70",
     "ts-jest": "^29.4.11",
     "typescript": "5.9",
     "vscode-languageserver-protocol": "^3"

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -199,13 +199,7 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
     };
   }
   for (const ns of parent.nestedStacks) {
-    const nested = emitNestedStack(dir, metadata, parent.id, ns);
-    parentChildren[ns.id] = nested.treeNode;
-    parentResources[`${ns.id}NestedStackResource`] = {
-      Type: 'AWS::CloudFormation::Stack',
-      Metadata: { 'aws:asset:path': nested.templateFile },
-      Properties: {},
-    };
+    emitNestedStack(dir, metadata, parentChildren, parentResources, parent.id, ns);
   }
 
   writeJson(path.join(dir, 'manifest.json'), {
@@ -245,42 +239,62 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
 function emitNestedStack(
   dir: string,
   metadata: Record<string, unknown[]>,
+  parentChildren: Record<string, unknown>,
+  parentResources: Record<string, unknown>,
   parentPath: string,
   ns: NestedStackSpec,
-): { treeNode: unknown; templateFile: string } {
+): void {
   const nsPath = `${parentPath}/${ns.id}`;
   const templateFile = `${nsPath.replace(/\//g, '')}.nested.template.json`;
-  const resources: Record<string, unknown> = {};
-  const children: Record<string, unknown> = {};
+  const cfnStackLogicalId = `${ns.id}NestedStackResource`;
 
+  // Parent template: the AWS::CloudFormation::Stack resource pointing at the
+  // nested template via aws:asset:path.
+  parentResources[cfnStackLogicalId] = {
+    Type: 'AWS::CloudFormation::Stack',
+    Metadata: { 'aws:asset:path': templateFile },
+    Properties: {},
+  };
+  // Tree: mirror aws-cdk-lib -- the CfnStack resource lives in a SIBLING
+  // `<id>.NestedStack` wrapper (not under the NestedStack construct), and its
+  // logical ID is emitted into the owning stack's metadata.
+  const resourcePath = `${nsPath}.NestedStack/${ns.id}.NestedStackResource`;
+  parentChildren[`${ns.id}.NestedStack`] = {
+    id: `${ns.id}.NestedStack`,
+    path: `${nsPath}.NestedStack`,
+    constructInfo: { fqn: 'constructs.Construct', version: CONSTRUCT_INFO_VERSION },
+    children: {
+      [`${ns.id}.NestedStackResource`]: {
+        id: `${ns.id}.NestedStackResource`,
+        path: resourcePath,
+        attributes: { 'aws:cdk:cloudformation:type': 'AWS::CloudFormation::Stack' },
+      },
+    },
+  };
+  metadata[`/${resourcePath}`] = [{ type: ArtifactMetadataEntryType.LOGICAL_ID, data: cfnStackLogicalId }];
+
+  // The nested stack's own construct subtree + template.
+  const nsChildren: Record<string, unknown> = {};
+  const nsResources: Record<string, unknown> = {};
   for (const r of ns.resources) {
     metadata[`/${nsPath}/${r.id}/Resource`] = [logicalIdEntry(r)];
-    children[r.id] = resourceTreeNode(nsPath, r);
-    resources[r.logicalId] = {
+    nsChildren[r.id] = resourceTreeNode(nsPath, r);
+    nsResources[r.logicalId] = {
       Type: r.cfnType,
       Metadata: { 'aws:cdk:path': `${nsPath}/${r.id}/Resource` },
       Properties: {},
     };
   }
   for (const child of ns.nestedStacks ?? []) {
-    const nested = emitNestedStack(dir, metadata, nsPath, child);
-    children[child.id] = nested.treeNode;
-    resources[`${child.id}NestedStackResource`] = {
-      Type: 'AWS::CloudFormation::Stack',
-      Metadata: { 'aws:asset:path': nested.templateFile },
-      Properties: {},
-    };
+    emitNestedStack(dir, metadata, nsChildren, nsResources, nsPath, child);
   }
+  writeJson(path.join(dir, templateFile), { Resources: nsResources });
 
-  writeJson(path.join(dir, templateFile), { Resources: resources });
-  return {
-    treeNode: {
-      id: ns.id,
-      path: nsPath,
-      constructInfo: { fqn: 'aws-cdk-lib.NestedStack', version: CONSTRUCT_INFO_VERSION },
-      children,
-    },
-    templateFile,
+  parentChildren[ns.id] = {
+    id: ns.id,
+    path: nsPath,
+    constructInfo: { fqn: 'aws-cdk-lib.NestedStack', version: CONSTRUCT_INFO_VERSION },
+    children: nsChildren,
   };
 }
 

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -70,6 +70,8 @@ export interface NestedStackSpec {
   readonly id: string;
   /** Resources inside the nested stack. */
   readonly resources: readonly ResourceSpec[];
+  /** Nested stacks inside this nested stack (for nested-in-nested fixtures). */
+  readonly nestedStacks?: readonly NestedStackSpec[];
 }
 
 export interface NestedStackParentSpec {
@@ -181,14 +183,29 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
   const dir = mkAssemblyDir('nestedstack');
   const { parent } = spec;
 
+  // All nested resources' metadata lives under the PARENT artifact, keyed by
+  // full construct path (any depth), mirroring aws-cdk-lib.
   const metadata: Record<string, unknown[]> = {};
+  const parentChildren: Record<string, unknown> = {};
+  const parentResources: Record<string, unknown> = {};
+
   for (const r of parent.resources) {
     metadata[`/${parent.id}/${r.id}/Resource`] = [logicalIdEntry(r)];
+    parentChildren[r.id] = resourceTreeNode(parent.id, r);
+    parentResources[r.logicalId] = {
+      Type: r.cfnType,
+      Metadata: { 'aws:cdk:path': `${parent.id}/${r.id}/Resource` },
+      Properties: {},
+    };
   }
   for (const ns of parent.nestedStacks) {
-    for (const r of ns.resources) {
-      metadata[`/${parent.id}/${ns.id}/${r.id}/Resource`] = [logicalIdEntry(r)];
-    }
+    const nested = emitNestedStack(dir, metadata, parent.id, ns);
+    parentChildren[ns.id] = nested.treeNode;
+    parentResources[`${ns.id}NestedStackResource`] = {
+      Type: 'AWS::CloudFormation::Stack',
+      Metadata: { 'aws:asset:path': nested.templateFile },
+      Properties: {},
+    };
   }
 
   writeJson(path.join(dir, 'manifest.json'), {
@@ -204,22 +221,6 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
       },
     },
   });
-
-  const parentChildren: Record<string, unknown> = {};
-  for (const r of parent.resources) {
-    parentChildren[r.id] = resourceTreeNode(parent.id, r);
-  }
-  for (const ns of parent.nestedStacks) {
-    parentChildren[ns.id] = {
-      id: ns.id,
-      path: `${parent.id}/${ns.id}`,
-      constructInfo: { fqn: 'aws-cdk-lib.NestedStack', version: CONSTRUCT_INFO_VERSION },
-      children: Object.fromEntries(
-        ns.resources.map((r) => [r.id, resourceTreeNode(`${parent.id}/${ns.id}`, r)]),
-      ),
-    };
-  }
-
   writeJson(path.join(dir, 'tree.json'), {
     version: TREE_SCHEMA_VERSION,
     tree: appNode([{
@@ -229,39 +230,58 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
       children: parentChildren,
     }]),
   });
-  // Parent template: the parent's own resources, plus one
-  // AWS::CloudFormation::Stack per nested stack carrying the `aws:asset:path`
-  // metadata that points at the nested template (the contract toolkit-lib's
-  // nested-stack resolver follows). Each nested template is written flat in the
-  // assembly root, holding that nested stack's resources.
-  const parentResources: Record<string, unknown> = {};
-  for (const r of parent.resources) {
-    parentResources[r.logicalId] = {
-      Type: r.cfnType,
-      Metadata: { 'aws:cdk:path': `${parent.id}/${r.id}/Resource` },
-      Properties: {},
-    };
-  }
-  for (const ns of parent.nestedStacks) {
-    const nestedTemplateFile = `${parent.id}${ns.id}.nested.template.json`;
-    parentResources[`${ns.id}NestedStackResource`] = {
-      Type: 'AWS::CloudFormation::Stack',
-      Metadata: { 'aws:asset:path': nestedTemplateFile },
-      Properties: {},
-    };
-    const nestedResources: Record<string, unknown> = {};
-    for (const r of ns.resources) {
-      nestedResources[r.logicalId] = {
-        Type: r.cfnType,
-        Metadata: { 'aws:cdk:path': `${parent.id}/${ns.id}/${r.id}/Resource` },
-        Properties: {},
-      };
-    }
-    writeJson(path.join(dir, nestedTemplateFile), { Resources: nestedResources });
-  }
   writeJson(path.join(dir, `${parent.id}.template.json`), { Resources: parentResources });
   fs.writeFileSync(path.join(dir, 'cdk.out'), JSON.stringify({ version: ASSEMBLY_SCHEMA_VERSION }));
   return dir;
+}
+
+/**
+ * Writes one nested stack's template (its resources plus an
+ * AWS::CloudFormation::Stack + aws:asset:path per child nested stack) and
+ * recurses for those children. Accumulates every resource's logical-ID
+ * metadata into the parent artifact's metadata map, keyed by full construct
+ * path. Returns the tree node and the nested template filename.
+ */
+function emitNestedStack(
+  dir: string,
+  metadata: Record<string, unknown[]>,
+  parentPath: string,
+  ns: NestedStackSpec,
+): { treeNode: unknown; templateFile: string } {
+  const nsPath = `${parentPath}/${ns.id}`;
+  const templateFile = `${nsPath.replace(/\//g, '')}.nested.template.json`;
+  const resources: Record<string, unknown> = {};
+  const children: Record<string, unknown> = {};
+
+  for (const r of ns.resources) {
+    metadata[`/${nsPath}/${r.id}/Resource`] = [logicalIdEntry(r)];
+    children[r.id] = resourceTreeNode(nsPath, r);
+    resources[r.logicalId] = {
+      Type: r.cfnType,
+      Metadata: { 'aws:cdk:path': `${nsPath}/${r.id}/Resource` },
+      Properties: {},
+    };
+  }
+  for (const child of ns.nestedStacks ?? []) {
+    const nested = emitNestedStack(dir, metadata, nsPath, child);
+    children[child.id] = nested.treeNode;
+    resources[`${child.id}NestedStackResource`] = {
+      Type: 'AWS::CloudFormation::Stack',
+      Metadata: { 'aws:asset:path': nested.templateFile },
+      Properties: {},
+    };
+  }
+
+  writeJson(path.join(dir, templateFile), { Resources: resources });
+  return {
+    treeNode: {
+      id: ns.id,
+      path: nsPath,
+      constructInfo: { fqn: 'aws-cdk-lib.NestedStack', version: CONSTRUCT_INFO_VERSION },
+      children,
+    },
+    templateFile,
+  };
 }
 
 /** Manifest + tree with no metadata, no traces — for non-TS app graceful-degradation tests. */

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -227,7 +227,29 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
       children: parentChildren,
     }]),
   });
-  writeJson(path.join(dir, `${parent.id}.template.json`), { Resources: {} });
+  // Parent template: the parent's own resources, plus one
+  // AWS::CloudFormation::Stack per nested stack carrying the `aws:asset:path`
+  // metadata that points at the nested template (the contract toolkit-lib's
+  // nested-stack resolver follows). Each nested template is written flat in the
+  // assembly root, holding that nested stack's resources.
+  const parentResources: Record<string, unknown> = {};
+  for (const r of parent.resources) {
+    parentResources[r.logicalId] = { Type: r.cfnType, Properties: {} };
+  }
+  for (const ns of parent.nestedStacks) {
+    const nestedTemplateFile = `${parent.id}${ns.id}.nested.template.json`;
+    parentResources[`${ns.id}NestedStackResource`] = {
+      Type: 'AWS::CloudFormation::Stack',
+      Metadata: { 'aws:asset:path': nestedTemplateFile },
+      Properties: {},
+    };
+    const nestedResources: Record<string, unknown> = {};
+    for (const r of ns.resources) {
+      nestedResources[r.logicalId] = { Type: r.cfnType, Properties: {} };
+    }
+    writeJson(path.join(dir, nestedTemplateFile), { Resources: nestedResources });
+  }
+  writeJson(path.join(dir, `${parent.id}.template.json`), { Resources: parentResources });
   fs.writeFileSync(path.join(dir, 'cdk.out'), JSON.stringify({ version: ASSEMBLY_SCHEMA_VERSION }));
   return dir;
 }

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -46,6 +46,8 @@ export interface StackSpec {
 
 export interface FlatAssemblySpec {
   readonly stacks: readonly StackSpec[];
+  /** Emit `aws:cdk:path` on template resources (default true); false simulates `--no-path-metadata`. */
+  readonly pathMetadata?: boolean;
 }
 
 export interface StageStackSpec {
@@ -88,7 +90,7 @@ export function buildFlatAssembly(spec: FlatAssemblySpec): string {
 
   for (const stack of spec.stacks) {
     artifacts[stack.id] = stackArtifact(stack);
-    writeTemplate(dir, stack);
+    writeTemplate(dir, stack.id, stack.resources, stack.id, spec.pathMetadata ?? true);
   }
 
   writeJson(path.join(dir, 'manifest.json'), {
@@ -135,7 +137,7 @@ export function buildNestedAssembly(spec: NestedAssemblySpec): string {
         displayName: constructPath,
         metadata: stackMetadata(stack.resources, `/${constructPath}`),
       };
-      writeTemplate(stageDir, { id: artifactId, resources: stack.resources });
+      writeTemplate(stageDir, artifactId, stack.resources, constructPath);
     }
 
     writeJson(path.join(stageDir, 'manifest.json'), {
@@ -234,7 +236,11 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
   // assembly root, holding that nested stack's resources.
   const parentResources: Record<string, unknown> = {};
   for (const r of parent.resources) {
-    parentResources[r.logicalId] = { Type: r.cfnType, Properties: {} };
+    parentResources[r.logicalId] = {
+      Type: r.cfnType,
+      Metadata: { 'aws:cdk:path': `${parent.id}/${r.id}/Resource` },
+      Properties: {},
+    };
   }
   for (const ns of parent.nestedStacks) {
     const nestedTemplateFile = `${parent.id}${ns.id}.nested.template.json`;
@@ -245,7 +251,11 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
     };
     const nestedResources: Record<string, unknown> = {};
     for (const r of ns.resources) {
-      nestedResources[r.logicalId] = { Type: r.cfnType, Properties: {} };
+      nestedResources[r.logicalId] = {
+        Type: r.cfnType,
+        Metadata: { 'aws:cdk:path': `${parent.id}/${ns.id}/${r.id}/Resource` },
+        Properties: {},
+      };
     }
     writeJson(path.join(dir, nestedTemplateFile), { Resources: nestedResources });
   }
@@ -417,10 +427,22 @@ function logicalIdEntry(r: ResourceSpec): Record<string, unknown> {
   return entry;
 }
 
-function writeTemplate(dir: string, stack: { id: string; resources: readonly ResourceSpec[] }): void {
-  const resources: Record<string, unknown> = {};
-  for (const r of stack.resources) {
-    resources[r.logicalId] = { Type: r.cfnType, Properties: {} };
+function writeTemplate(
+  dir: string,
+  fileBaseId: string,
+  resources: readonly ResourceSpec[],
+  constructPathPrefix: string,
+  pathMetadata = true,
+): void {
+  const out: Record<string, unknown> = {};
+  for (const r of resources) {
+    out[r.logicalId] = {
+      Type: r.cfnType,
+      // aws:cdk:path mirrors real synth output (on by default), giving each
+      // resource its globally-unique construct path for collision-free lookup.
+      ...(pathMetadata ? { Metadata: { 'aws:cdk:path': `${constructPathPrefix}/${r.id}/Resource` } } : {}),
+      Properties: {},
+    };
   }
-  writeJson(path.join(dir, `${stack.id}.template.json`), { Resources: resources });
+  writeJson(path.join(dir, `${fileBaseId}.template.json`), { Resources: out });
 }

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -288,6 +288,21 @@ describe('readAssembly resource templateFile', () => {
     expect(findNode(data.tree, 'Parent/MyNested/NestedQueue/Resource')!.templateFile)
       .toBe(path.join(dir!, 'ParentMyNested.nested.template.json'));
   });
+
+  test('keeps templates distinct when two stacks share a logical id (stack-relative ids)', () => {
+    // Same-shape stacks produce the SAME stack-relative logicalId in different
+    // templates; each resource must resolve to its OWN stack's template.
+    dir = buildFlatAssembly({
+      stacks: [
+        { id: 'Prod', resources: [{ id: 'Data', logicalId: 'DataX', cfnType: 'AWS::S3::Bucket' }] },
+        { id: 'Dev', resources: [{ id: 'Data', logicalId: 'DataX', cfnType: 'AWS::S3::Bucket' }] },
+      ],
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    expect(findNode(data.tree, 'Prod/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Prod.template.json'));
+    expect(findNode(data.tree, 'Dev/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Dev.template.json'));
+  });
 });
 
 function findNode(nodes: readonly ConstructNode[], targetPath: string): ConstructNode | undefined {

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -368,9 +368,9 @@ describe('readAssembly resource templateFile', () => {
     expect(findNode(data.tree, 'Parent/Nested/NestedQueue/Resource')!.templateFile).toBeUndefined();
   });
 
-  test('falls back to the per-stack logical-id map when path metadata is off', () => {
-    // --no-path-metadata strips aws:cdk:path; resolution still works via the
-    // per-stack logical-ID fallback (only the rare parent/nested collision is lost).
+  test('resolves templateFile without path metadata (positional, not id-based)', () => {
+    // Resolution threads the template down the construct tree, so it works
+    // regardless of --no-path-metadata (no reliance on aws:cdk:path).
     dir = buildFlatAssembly({
       pathMetadata: false,
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -5,6 +5,7 @@ import { readAssembly, type AssemblyData, type AssemblyReadResult, type Construc
 import {
   buildFlatAssembly,
   buildNestedAssembly,
+  buildNestedStackAssembly,
   buildNonTypeScriptAssembly,
   cleanupFixture,
   withMalformedValidationReport,
@@ -244,6 +245,48 @@ describe('readAssembly graceful degradation', () => {
     const stack = data.tree[0];
     expect(stack.id).toBe('Stack1');
     expect(stack.sourceLocation).toBeUndefined();
+  });
+});
+
+describe('readAssembly resource templateFile', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    cleanupFixture(dir);
+    dir = undefined;
+  });
+
+  test('sets templateFile to the resource\'s own stack template, none on wrappers', () => {
+    dir = buildFlatAssembly({
+      stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    expect(findNode(data.tree, 'Stack1/MyBucket/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'Stack1.template.json'));
+    // L2 wrapper is not a CFN resource -> no template.
+    expect(findNode(data.tree, 'Stack1/MyBucket')!.templateFile).toBeUndefined();
+  });
+
+  test('resolves nested-stack resources to the nested template, not the parent', () => {
+    dir = buildNestedStackAssembly({
+      parent: {
+        id: 'Parent',
+        resources: [{ id: 'TopBucket', logicalId: 'TopBucketABC', cfnType: 'AWS::S3::Bucket' }],
+        nestedStacks: [{
+          id: 'MyNested',
+          resources: [{ id: 'NestedQueue', logicalId: 'NestedQueueXYZ', cfnType: 'AWS::SQS::Queue' }],
+        }],
+      },
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    // Top-level resource lives in the parent template.
+    expect(findNode(data.tree, 'Parent/TopBucket/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'Parent.template.json'));
+    // The resource inside the NestedStack lives in the nested template.
+    expect(findNode(data.tree, 'Parent/MyNested/NestedQueue/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'ParentMyNested.nested.template.json'));
   });
 });
 

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -303,6 +303,41 @@ describe('readAssembly resource templateFile', () => {
     expect(findNode(data.tree, 'Prod/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Prod.template.json'));
     expect(findNode(data.tree, 'Dev/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Dev.template.json'));
   });
+
+  test('resolves a parent resource and its nested-stack twin that share a logical id', () => {
+    // A NestedStack resets the logical-ID namespace, so a parent resource and a
+    // resource in its own nested stack can share an id. The globally-unique
+    // construct path (aws:cdk:path) disambiguates them.
+    dir = buildNestedStackAssembly({
+      parent: {
+        id: 'Parent',
+        resources: [{ id: 'Data', logicalId: 'DataX', cfnType: 'AWS::S3::Bucket' }],
+        nestedStacks: [{
+          id: 'Nested',
+          resources: [{ id: 'Data', logicalId: 'DataX', cfnType: 'AWS::S3::Bucket' }],
+        }],
+      },
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    expect(findNode(data.tree, 'Parent/Data/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'Parent.template.json'));
+    expect(findNode(data.tree, 'Parent/Nested/Data/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'ParentNested.nested.template.json'));
+  });
+
+  test('falls back to the per-stack logical-id map when path metadata is off', () => {
+    // --no-path-metadata strips aws:cdk:path; resolution still works via the
+    // per-stack logical-ID fallback (only the rare parent/nested collision is lost).
+    dir = buildFlatAssembly({
+      pathMetadata: false,
+      stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    expect(findNode(data.tree, 'Stack1/MyBucket/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'Stack1.template.json'));
+  });
 });
 
 function findNode(nodes: readonly ConstructNode[], targetPath: string): ConstructNode | undefined {

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -326,6 +326,48 @@ describe('readAssembly resource templateFile', () => {
       .toBe(path.join(dir!, 'ParentNested.nested.template.json'));
   });
 
+  test('resolves a resource in a doubly-nested stack to the innermost template', () => {
+    dir = buildNestedStackAssembly({
+      parent: {
+        id: 'Parent',
+        resources: [],
+        nestedStacks: [{
+          id: 'Outer',
+          resources: [{ id: 'OuterFn', logicalId: 'OuterFnABC', cfnType: 'AWS::Lambda::Function' }],
+          nestedStacks: [{
+            id: 'Inner',
+            resources: [{ id: 'InnerQueue', logicalId: 'InnerQueueXYZ', cfnType: 'AWS::SQS::Queue' }],
+          }],
+        }],
+      },
+    });
+    const data = expectSuccess(readAssembly(dir));
+
+    expect(findNode(data.tree, 'Parent/Outer/OuterFn/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'ParentOuter.nested.template.json'));
+    expect(findNode(data.tree, 'Parent/Outer/Inner/InnerQueue/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'ParentOuterInner.nested.template.json'));
+  });
+
+  test('skips an unreadable nested template instead of failing the whole read', () => {
+    dir = buildNestedStackAssembly({
+      parent: {
+        id: 'Parent',
+        resources: [{ id: 'TopBucket', logicalId: 'TopBucketABC', cfnType: 'AWS::S3::Bucket' }],
+        nestedStacks: [{
+          id: 'Nested',
+          resources: [{ id: 'NestedQueue', logicalId: 'NestedQueueXYZ', cfnType: 'AWS::SQS::Queue' }],
+        }],
+      },
+    });
+    fs.rmSync(path.join(dir, 'ParentNested.nested.template.json'));
+    // Still a success: the missing nested template degrades only its subtree.
+    const data = expectSuccess(readAssembly(dir));
+    expect(findNode(data.tree, 'Parent/TopBucket/Resource')!.templateFile)
+      .toBe(path.join(dir!, 'Parent.template.json'));
+    expect(findNode(data.tree, 'Parent/Nested/NestedQueue/Resource')!.templateFile).toBeUndefined();
+  });
+
   test('falls back to the per-stack logical-id map when path metadata is off', () => {
     // --no-path-metadata strips aws:cdk:path; resolution still works via the
     // per-stack logical-ID fallback (only the rare parent/nested collision is lost).

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
@@ -172,20 +172,46 @@ describe('codeLensesForFile', () => {
 
       const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
-      expect(lens.command?.arguments).toEqual([{
-        uri: pathToFileURL(templateFile).toString(),
-        range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } },
-      }]);
+      expect(lens.command?.arguments).toEqual([[{
+        label: 'AWS::S3::Bucket  MyBucketF68F3FF0',
+        target: {
+          uri: pathToFileURL(templateFile).toString(),
+          range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } },
+        },
+      }]]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
   });
 
-  test('a multi-resource lens stays title-only (picker not wired yet)', () => {
-    // Two resources on one line: even with a templateFile, no clickable command.
+  test('a multi-resource line carries all resolvable resources as choices', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
+    const templateFile = path.join(dir, 'Stack1.template.json');
+    fs.writeFileSync(templateFile, JSON.stringify({
+      Resources: { B1: { Type: 'AWS::S3::Bucket' }, B2: { Type: 'AWS::S3::BucketPolicy' } },
+    }, null, 2));
+    try {
+      const tree = [
+        node({ path: 'Stack1/B/Resource', logicalId: 'B1', type: 'AWS::S3::Bucket', templateFile, sourceLocation: { file: FILE, line: 12, column: 5 } }),
+        node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile, sourceLocation: { file: FILE, line: 12, column: 5 } }),
+      ];
+
+      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      const uri = pathToFileURL(templateFile).toString();
+      expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
+      expect(lens.command?.arguments).toEqual([[
+        { label: 'AWS::S3::Bucket  B1', target: { uri, range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } } } },
+        { label: 'AWS::S3::BucketPolicy  B2', target: { uri, range: { start: { line: 5, character: 4 }, end: { line: 5, character: 4 } } } },
+      ]]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a multi-resource line with no resolvable templates stays title-only', () => {
     const tree = [
-      node({ path: 'Stack1/B/Resource', logicalId: 'B1', type: 'AWS::S3::Bucket', templateFile: '/unused.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
-      node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile: '/unused.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
+      node({ path: 'Stack1/B/Resource', logicalId: 'B1', type: 'AWS::S3::Bucket', templateFile: '/no/such.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
+      node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile: '/no/such.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
     ];
 
     const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
@@ -1,7 +1,10 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
 import type { ConstructNode } from '../../lib';
-import { codeLensesForFile } from '../../lib/lsp/codelens';
+import { codeLensesForFile, OPEN_RESOURCE_COMMAND } from '../../lib/lsp/codelens';
 
 const FILE = '/p/lib/stack.ts';
 const URI = pathToFileURL(FILE).toString();
@@ -152,5 +155,61 @@ describe('codeLensesForFile', () => {
     })];
 
     expect(codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toEqual([]);
+  });
+
+  test('a single resource with a resolvable template gets a clickable openResource command', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
+    const templateFile = path.join(dir, 'Stack1.template.json');
+    fs.writeFileSync(templateFile, JSON.stringify({ Resources: { MyBucketF68F3FF0: { Type: 'AWS::S3::Bucket' } } }, null, 2));
+    try {
+      const tree = [node({
+        path: 'Stack1/MyBucket/Resource',
+        logicalId: 'MyBucketF68F3FF0',
+        type: 'AWS::S3::Bucket',
+        templateFile,
+        sourceLocation: { file: FILE, line: 12, column: 5 },
+      })];
+
+      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
+      expect(lens.command?.arguments).toEqual([{
+        uri: pathToFileURL(templateFile).toString(),
+        range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } },
+      }]);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('a multi-resource lens stays title-only (picker not wired yet)', () => {
+    // Two resources on one line: even with a templateFile, no clickable command.
+    const tree = [
+      node({ path: 'Stack1/B/Resource', logicalId: 'B1', type: 'AWS::S3::Bucket', templateFile: '/unused.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
+      node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile: '/unused.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
+    ];
+
+    const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+    expect(lens.command?.command).toBe('');
+    expect(lens.command?.arguments).toBeUndefined();
+  });
+
+  test('a single resource whose id is missing from the template degrades to title-only', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
+    const templateFile = path.join(dir, 'Stack1.template.json');
+    fs.writeFileSync(templateFile, JSON.stringify({ Resources: { SomethingElse: { Type: 'AWS::S3::Bucket' } } }, null, 2));
+    try {
+      const tree = [node({
+        path: 'Stack1/MyBucket/Resource',
+        logicalId: 'MyBucketF68F3FF0',
+        type: 'AWS::S3::Bucket',
+        templateFile,
+        sourceLocation: { file: FILE, line: 12, column: 5 },
+      })];
+
+      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      expect(lens.command?.command).toBe('');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
@@ -46,7 +46,7 @@ describe('codeLensesForFile', () => {
       start: { line: 11, character: 0 },
       end: { line: 11, character: 0 },
     });
-    expect(lenses[0].command?.title).toBe('Creates: AWS::S3::Bucket [logical: MyBucketF68F3FF0]');
+    expect(lenses[0].command?.title).toBe('Creates AWS::S3::Bucket');
   });
 
   test('groups multiple resources on the same source line into one lens', () => {
@@ -75,7 +75,7 @@ describe('codeLensesForFile', () => {
 
     const lenses = codeLensesForFile(ConstructIndex.fromTree(tree), URI);
     expect(lenses).toHaveLength(1);
-    expect(lenses[0].command?.title).toBe('3 resources: BucketABC, BucketPolicyDEF, KeyGHI');
+    expect(lenses[0].command?.title).toBe('Creates 3 resources: AWS::S3::Bucket, AWS::S3::BucketPolicy, AWS::KMS::Key');
   });
 
   test('emits separate lenses for resources on different lines', () => {
@@ -173,7 +173,8 @@ describe('codeLensesForFile', () => {
       const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
       expect(lens.command?.arguments).toEqual([[{
-        label: 'AWS::S3::Bucket  MyBucketF68F3FF0',
+        label: 'AWS::S3::Bucket',
+        description: 'Stack1/MyBucket',
         target: {
           uri: pathToFileURL(templateFile).toString(),
           range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } },
@@ -200,8 +201,8 @@ describe('codeLensesForFile', () => {
       const uri = pathToFileURL(templateFile).toString();
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
       expect(lens.command?.arguments).toEqual([[
-        { label: 'AWS::S3::Bucket  B1', target: { uri, range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } } } },
-        { label: 'AWS::S3::BucketPolicy  B2', target: { uri, range: { start: { line: 5, character: 4 }, end: { line: 5, character: 4 } } } },
+        { label: 'AWS::S3::Bucket', description: 'Stack1/B', target: { uri, range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } } } },
+        { label: 'AWS::S3::BucketPolicy', description: 'Stack1/B/Policy', target: { uri, range: { start: { line: 5, character: 4 }, end: { line: 5, character: 4 } } } },
       ]]);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -211,8 +211,7 @@ describe('LSP Server', () => {
 
     expect(lenses).toHaveLength(1);
     expect(lenses[0].range.start.line).toBe(11); // 1-based 12 -> 0-based 11
-    expect(lenses[0].command?.title).toContain('AWS::S3::Bucket');
-    expect(lenses[0].command?.title).toContain('MyBucketABC');
+    expect(lenses[0].command?.title).toBe('Creates AWS::S3::Bucket');
   });
 
   test('publishes nothing when assembly is not-found (pre-synth)', () => {

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -1,7 +1,9 @@
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
 import { readAssembly, type ConstructNode } from '../../lib';
-import { findLogicalIdPosition, resourceTarget } from '../../lib/lsp/template-locator';
+import { resourceTarget } from '../../lib/lsp/template-locator';
 import { buildFlatAssembly, cleanupFixture } from '../_fixtures/builders';
 
 // A synthesized-style template where MyBucketF68F3FF0 is defined once and also
@@ -22,23 +24,6 @@ const TEMPLATE = [
   '  }',
   '}',
 ].join('\n');
-
-describe('findLogicalIdPosition', () => {
-  test('returns the 0-based position of the resource key', () => {
-    // Key sits on line index 5, opening quote at character 4 (4-space indent).
-    expect(findLogicalIdPosition(TEMPLATE, 'MyPolicy3A1B2C3D')).toEqual({ line: 5, character: 4 });
-  });
-
-  test('matches the definition key, not Ref/DependsOn occurrences of the same id', () => {
-    // MyBucketF68F3FF0 appears on lines 2 (definition), 8 (Ref) and 10 (DependsOn);
-    // only the definition is a `"<id>":` key, so line 2 must win.
-    expect(findLogicalIdPosition(TEMPLATE, 'MyBucketF68F3FF0')).toEqual({ line: 2, character: 4 });
-  });
-
-  test('returns undefined when the logical id is absent', () => {
-    expect(findLogicalIdPosition(TEMPLATE, 'NotARealId')).toBeUndefined();
-  });
-});
 
 describe('resourceTarget', () => {
   let dir: string | undefined;
@@ -84,5 +69,35 @@ describe('resourceTarget', () => {
 
   test('returns undefined (does not throw) when the template can no longer be read', () => {
     expect(resourceTarget({ templateFile: '/no/such/template.json', logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
+  });
+
+  test('resolves to the definition key, not Ref/DependsOn occurrences of the same id', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locator-'));
+    const file = path.join(dir, 'T.template.json');
+    fs.writeFileSync(file, TEMPLATE);
+    // MyBucketF68F3FF0 is defined on line 2 and also referenced (Ref line 8,
+    // DependsOn line 10); only the definition is a `"<id>":` key, so line 2 wins.
+    expect(resourceTarget({ templateFile: file, logicalId: 'MyBucketF68F3FF0' })?.range.start)
+      .toEqual({ line: 2, character: 4 });
+  });
+
+  test('does not match a logical id that is a prefix of a longer key', () => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locator-'));
+    const file = path.join(dir, 'T.template.json');
+    fs.writeFileSync(file, [
+      '{',
+      '  "Resources": {',
+      '    "MyBucketF68F3FF0": {',
+      '      "Type": "AWS::S3::Bucket"',
+      '    },',
+      '    "MyBucket": {',
+      '      "Type": "AWS::S3::Bucket"',
+      '    }',
+      '  }',
+      '}',
+    ].join('\n'));
+    // The closing quote in the match key stops "MyBucket" matching "MyBucketF68F3FF0":
+    expect(resourceTarget({ templateFile: file, logicalId: 'MyBucket' })?.range.start)
+      .toEqual({ line: 5, character: 4 });
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -1,4 +1,8 @@
-import { findLogicalIdPosition } from '../../lib/lsp/template-locator';
+import * as path from 'path';
+import { pathToFileURL } from 'url';
+import { readAssembly, type ConstructNode } from '../../lib';
+import { findLogicalIdPosition, resourceTarget } from '../../lib/lsp/template-locator';
+import { buildFlatAssembly, cleanupFixture } from '../_fixtures/builders';
 
 // A synthesized-style template where MyBucketF68F3FF0 is defined once and also
 // referenced (Ref + DependsOn) -- the references must not be matched.
@@ -33,5 +37,56 @@ describe('findLogicalIdPosition', () => {
 
   test('returns undefined when the logical id is absent', () => {
     expect(findLogicalIdPosition(TEMPLATE, 'NotARealId')).toBeUndefined();
+  });
+});
+
+describe('resourceTarget', () => {
+  let dir: string | undefined;
+
+  afterEach(() => {
+    cleanupFixture(dir);
+    dir = undefined;
+  });
+
+  const find = (nodes: readonly ConstructNode[], targetPath: string): ConstructNode | undefined => {
+    for (const node of nodes) {
+      if (node.path === targetPath) return node;
+      const hit = find(node.children, targetPath);
+      if (hit) return hit;
+    }
+    return undefined;
+  };
+
+  test('resolves a resource node to its template uri and key position', () => {
+    dir = buildFlatAssembly({
+      stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
+    });
+    const result = readAssembly(dir);
+    if (result.status !== 'success') throw new Error('expected success');
+    const node = find(result.data.tree, 'Stack1/MyBucket/Resource')!;
+
+    const target = resourceTarget(node);
+    expect(target?.uri).toBe(pathToFileURL(path.join(dir!, 'Stack1.template.json')).toString());
+    // 2-space indented template: the key sits on line 2, opening quote at char 4.
+    expect(target?.range).toEqual({ start: { line: 2, character: 4 }, end: { line: 2, character: 4 } });
+  });
+
+  test('returns undefined for a node without a logical id (wrapper) -- no file read', () => {
+    expect(resourceTarget({ templateFile: '/does/not/matter.json', logicalId: undefined })).toBeUndefined();
+  });
+
+  test('returns undefined for a node without a resolved templateFile', () => {
+    expect(resourceTarget({ templateFile: undefined, logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
+  });
+
+  test('returns undefined when the logical id is not in the resolved template', () => {
+    dir = buildFlatAssembly({
+      stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
+    });
+    expect(resourceTarget({ templateFile: path.join(dir, 'Stack1.template.json'), logicalId: 'GhostId' })).toBeUndefined();
+  });
+
+  test('returns undefined (does not throw) when the template can no longer be read', () => {
+    expect(resourceTarget({ templateFile: '/no/such/template.json', logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -1,0 +1,37 @@
+import { findLogicalIdPosition } from '../../lib/lsp/template-locator';
+
+// A synthesized-style template where MyBucketF68F3FF0 is defined once and also
+// referenced (Ref + DependsOn) -- the references must not be matched.
+const TEMPLATE = [
+  '{',
+  '  "Resources": {',
+  '    "MyBucketF68F3FF0": {',
+  '      "Type": "AWS::S3::Bucket"',
+  '    },',
+  '    "MyPolicy3A1B2C3D": {',
+  '      "Type": "AWS::IAM::Policy",',
+  '      "Properties": {',
+  '        "Bucket": { "Ref": "MyBucketF68F3FF0" }',
+  '      },',
+  '      "DependsOn": [ "MyBucketF68F3FF0" ]',
+  '    }',
+  '  }',
+  '}',
+].join('\n');
+
+describe('findLogicalIdPosition', () => {
+  test('returns the 0-based position of the resource key', () => {
+    // Key sits on line index 5, opening quote at character 4 (4-space indent).
+    expect(findLogicalIdPosition(TEMPLATE, 'MyPolicy3A1B2C3D')).toEqual({ line: 5, character: 4 });
+  });
+
+  test('matches the definition key, not Ref/DependsOn occurrences of the same id', () => {
+    // MyBucketF68F3FF0 appears on lines 2 (definition), 8 (Ref) and 10 (DependsOn);
+    // only the definition is a `"<id>":` key, so line 2 must win.
+    expect(findLogicalIdPosition(TEMPLATE, 'MyBucketF68F3FF0')).toEqual({ line: 2, character: 4 });
+  });
+
+  test('returns undefined when the logical id is absent', () => {
+    expect(findLogicalIdPosition(TEMPLATE, 'NotARealId')).toBeUndefined();
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -71,10 +71,6 @@ describe('resourceTarget', () => {
     expect(target?.range).toEqual({ start: { line: 2, character: 4 }, end: { line: 2, character: 4 } });
   });
 
-  test('returns undefined for a node without a logical id (wrapper) -- no file read', () => {
-    expect(resourceTarget({ templateFile: '/does/not/matter.json', logicalId: undefined })).toBeUndefined();
-  });
-
   test('returns undefined for a node without a resolved templateFile', () => {
     expect(resourceTarget({ templateFile: undefined, logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
   });

--- a/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ArtifactMetadataEntryType, CFN_RESOURCE_TYPE_ATTRIBUTE, type MetadataEntry } from '@aws-cdk/cloud-assembly-schema';
 import type { CloudFormationStackArtifact } from './artifacts/cloudformation-artifact';
+import { ASSET_RESOURCE_METADATA_PATH_KEY } from './assets';
 import type { CloudAssembly } from './cloud-assembly';
 
 /** Construct ids that aws-cdk-lib injects into the tree but aren't user constructs. */
@@ -20,6 +21,12 @@ export interface ConstructTreeNode {
   readonly type?: string;
   /** CFN logical ID, if this construct maps to a CFN resource. */
   readonly logicalId?: string;
+  /**
+   * Absolute path to the `*.template.json` that declares this construct's CFN
+   * resource -- the nested template for resources inside a NestedStack. Set
+   * only for CFN resources whose template is resolvable.
+   */
+  readonly templateFile?: string;
   readonly children: readonly ConstructTreeNode[];
 }
 
@@ -32,6 +39,7 @@ export interface ConstructTreeNodeFields<T extends ConstructTreeNode> {
   readonly id: string;
   readonly type?: string;
   readonly logicalId?: string;
+  readonly templateFile?: string;
   readonly children: readonly T[];
 }
 
@@ -118,9 +126,24 @@ export function buildConstructTree<T extends ConstructTreeNode>(
   if (!rawTree) return [];
 
   const stackIndex = buildStackIndex(assembly.stacksRecursively);
+  const ctx: WalkContext<T> = { assembly, stackIndex, decorate, templateCache: new Map() };
   return Object.values(rawTree.children ?? {})
     .filter((child) => !isCdkInternal(child.id))
-    .map((child) => buildNode(child, stackIndex, undefined, decorate));
+    .map((child) => buildNode(child, ctx, undefined, undefined, undefined));
+}
+
+/** Shared state for a single {@link buildConstructTree} walk. */
+interface WalkContext<T extends ConstructTreeNode> {
+  readonly assembly: CloudAssembly;
+  readonly stackIndex: StackMetadataIndex;
+  readonly decorate: ConstructNodeDecorator<T>;
+  /** Parsed nested templates, cached by absolute path. */
+  readonly templateCache: Map<string, CfnTemplate | undefined>;
+}
+
+/** The slice of a CloudFormation template the tree walk reads. */
+interface CfnTemplate {
+  readonly Resources?: Record<string, { readonly Type?: string; readonly Metadata?: Record<string, unknown> }>;
 }
 
 /**
@@ -163,29 +186,97 @@ function buildStackIndex(stacks: CloudFormationStackArtifact[]): StackMetadataIn
 
 function buildNode<T extends ConstructTreeNode>(
   raw: RawTreeNode,
-  stackIndex: StackMetadataIndex,
+  ctx: WalkContext<T>,
   inheritedStack: StackMetadata | undefined,
-  decorate: ConstructNodeDecorator<T>,
+  inheritedTemplateFile: string | undefined,
+  inheritedTemplate: CfnTemplate | undefined,
 ): T {
-  // When a node IS a stack, switch to that stack. Otherwise inherit the
-  // parent's: this routes NestedStack children to the parent's metadata,
-  // since aws-cdk-lib emits their entries there.
-  const owner = stackIndex.get(raw.path) ?? inheritedStack;
+  // A top-level/Stage stack node switches the active template to its own; a
+  // NestedStack subtree is switched by its parent (see nestedTemplateOf).
+  // Everything else inherits the active template.
+  const stackHere = ctx.stackIndex.get(raw.path);
+  const owner = stackHere ?? inheritedStack;
+  const templateFile = stackHere ? stackHere.stack.templateFullPath : inheritedTemplateFile;
+  const template = stackHere ? loadTemplate(stackHere.stack.templateFullPath, ctx.templateCache) : inheritedTemplate;
 
   // Metadata keys carry a leading "/", construct paths in tree.json don't.
   const entries = owner?.metadata.get('/' + raw.path) ?? [];
-
-  const logicalIdEntry = entries.find((e) => e.type === ArtifactMetadataEntryType.LOGICAL_ID);
-  const logicalId = typeof logicalIdEntry?.data === 'string' ? logicalIdEntry.data : undefined;
+  const logicalId = logicalIdFromEntries(entries);
 
   const cfnTypeRaw = raw.attributes?.[CFN_RESOURCE_TYPE_ATTRIBUTE];
   const cfnType = typeof cfnTypeRaw === 'string' ? cfnTypeRaw : undefined;
 
   const children = Object.values(raw.children ?? {})
     .filter((child) => !isCdkInternal(child.id))
-    .map((child) => buildNode(child, stackIndex, owner, decorate));
+    .map((child) => {
+      // A NestedStack switches its subtree to the nested template (or to "no
+      // template" when it isn't CDK-resolvable, since its resources don't live
+      // in the parent template); every other node inherits the active template.
+      const boundary = nestedBoundary(child, raw, owner, template, ctx);
+      return boundary
+        ? buildNode(child, ctx, owner, boundary.file, boundary.template)
+        : buildNode(child, ctx, owner, templateFile, template);
+    });
 
-  return decorate({ path: raw.path, id: raw.id, type: cfnType, logicalId, children }, owner?.stack, raw.path);
+  // Only CFN resources (those with a logical ID) carry a templateFile.
+  const nodeTemplateFile = logicalId !== undefined ? templateFile : undefined;
+  return ctx.decorate(
+    { path: raw.path, id: raw.id, type: cfnType, logicalId, templateFile: nodeTemplateFile, children },
+    owner?.stack,
+    raw.path,
+  );
+}
+
+function logicalIdFromEntries(entries: MetadataEntry[]): string | undefined {
+  const entry = entries.find((e) => e.type === ArtifactMetadataEntryType.LOGICAL_ID);
+  return typeof entry?.data === 'string' ? entry.data : undefined;
+}
+
+/** Parses a template file (cached by absolute path); undefined when missing/unparseable. */
+function loadTemplate(absPath: string, cache: Map<string, CfnTemplate | undefined>): CfnTemplate | undefined {
+  if (cache.has(absPath)) return cache.get(absPath);
+  let template: CfnTemplate | undefined;
+  try {
+    template = JSON.parse(fs.readFileSync(absPath, 'utf-8')) as CfnTemplate;
+  } catch {
+    template = undefined; // missing/unparseable: that subtree just won't resolve a templateFile
+  }
+  cache.set(absPath, template);
+  return template;
+}
+
+/**
+ * Classifies `child` as a NestedStack boundary and resolves the nested template
+ * for its subtree. aws-cdk-lib models a NestedStack `<id>` as the construct at
+ * `<parent>/<id>` (fqn `*.NestedStack`) plus a sibling
+ * `AWS::CloudFormation::Stack` at `<parent>/<id>.NestedStack/<id>.NestedStackResource`
+ * whose `aws:asset:path` metadata points at the nested template.
+ *
+ * Returns `undefined` when `child` is not a nested stack (caller inherits the
+ * active template). For a nested stack it returns a boundary `{ file, template }`
+ * -- both populated when resolvable, or both undefined when asset metadata is
+ * off or the template can't be read, so the subtree gets NO template rather than
+ * the parent's (its resources don't live there).
+ */
+function nestedBoundary<T extends ConstructTreeNode>(
+  child: RawTreeNode,
+  parent: RawTreeNode,
+  owner: StackMetadata | undefined,
+  currentTemplate: CfnTemplate | undefined,
+  ctx: WalkContext<T>,
+): { file?: string; template?: CfnTemplate } | undefined {
+  if (!child.constructInfo?.fqn.endsWith('.NestedStack')) return undefined;
+  const resourceNode = parent.children?.[`${child.id}.NestedStack`]?.children?.[`${child.id}.NestedStackResource`];
+  const logicalId = resourceNode && owner
+    ? logicalIdFromEntries(owner.metadata.get('/' + resourceNode.path) ?? [])
+    : undefined;
+  const assetPath = logicalId !== undefined
+    ? currentTemplate?.Resources?.[logicalId]?.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
+    : undefined;
+  if (typeof assetPath !== 'string') return {};
+  const file = path.join(ctx.assembly.directory, assetPath);
+  const template = loadTemplate(file, ctx.templateCache);
+  return template ? { file, template } : {};
 }
 
 function isCdkInternal(id: string): boolean {

--- a/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
@@ -126,15 +126,14 @@ export function buildConstructTree<T extends ConstructTreeNode>(
   if (!rawTree) return [];
 
   const stackIndex = buildStackIndex(assembly.stacksRecursively);
-  const ctx: WalkContext<T> = { assembly, stackIndex, decorate, templateCache: new Map() };
+  const ctx: WalkContext<T> = { stackIndex, decorate, templateCache: new Map() };
   return Object.values(rawTree.children ?? {})
     .filter((child) => !isCdkInternal(child.id))
-    .map((child) => buildNode(child, ctx, undefined, undefined, undefined));
+    .map((child) => buildNode(child, ctx, undefined, NO_TEMPLATE));
 }
 
 /** Shared state for a single {@link buildConstructTree} walk. */
 interface WalkContext<T extends ConstructTreeNode> {
-  readonly assembly: CloudAssembly;
   readonly stackIndex: StackMetadataIndex;
   readonly decorate: ConstructNodeDecorator<T>;
   /** Parsed nested templates, cached by absolute path. */
@@ -143,8 +142,25 @@ interface WalkContext<T extends ConstructTreeNode> {
 
 /** The slice of a CloudFormation template the tree walk reads. */
 interface CfnTemplate {
-  readonly Resources?: Record<string, { readonly Type?: string; readonly Metadata?: Record<string, unknown> }>;
+  readonly Resources?: Record<string, CfnResource>;
 }
+interface CfnResource {
+  readonly Type?: string;
+  readonly Metadata?: Record<string, unknown>;
+}
+
+/**
+ * The active CloudFormation template threaded down the tree walk: a resolved
+ * `{ file, template }` pair, or both `undefined` when there's no resolvable
+ * template (the root, or a nested stack that isn't CDK-resolvable). Never a
+ * partial mix.
+ */
+type TemplateScope =
+  | { readonly file: string; readonly template: CfnTemplate }
+  | { readonly file: undefined; readonly template: undefined };
+
+/** Scope for nodes with no resolvable template: the root seed and unresolvable nested stacks. */
+const NO_TEMPLATE: TemplateScope = { file: undefined, template: undefined };
 
 /**
  * Raw tree.json node. The root tree.json holds the FULL hierarchy including
@@ -155,7 +171,6 @@ interface RawTreeNode {
   readonly path: string;
   readonly children?: { [key: string]: RawTreeNode };
   readonly attributes?: { [key: string]: unknown };
-  readonly constructInfo?: { readonly fqn: string; readonly version: string };
 }
 
 /** A stack artifact plus its metadata Map, keyed (in the index) by construct path. */
@@ -188,16 +203,16 @@ function buildNode<T extends ConstructTreeNode>(
   raw: RawTreeNode,
   ctx: WalkContext<T>,
   inheritedStack: StackMetadata | undefined,
-  inheritedTemplateFile: string | undefined,
-  inheritedTemplate: CfnTemplate | undefined,
+  inherited: TemplateScope,
 ): T {
-  // A top-level/Stage stack node switches the active template to its own; a
-  // NestedStack subtree is switched by its parent (see nestedTemplateOf).
-  // Everything else inherits the active template.
   const stackHere = ctx.stackIndex.get(raw.path);
   const owner = stackHere ?? inheritedStack;
-  const templateFile = stackHere ? stackHere.stack.templateFullPath : inheritedTemplateFile;
-  const template = stackHere ? loadTemplate(stackHere.stack.templateFullPath, ctx.templateCache) : inheritedTemplate;
+  // A stack node switches to its own template via the artifact's cached getter,
+  // which throws on a missing/corrupt top-level template -- a real assembly error
+  // we surface rather than swallow. Other nodes inherit the active scope.
+  const scope: TemplateScope = stackHere
+    ? { file: stackHere.stack.templateFullPath, template: stackHere.stack.template as CfnTemplate }
+    : inherited;
 
   // Metadata keys carry a leading "/", construct paths in tree.json don't.
   const entries = owner?.metadata.get('/' + raw.path) ?? [];
@@ -206,20 +221,13 @@ function buildNode<T extends ConstructTreeNode>(
   const cfnTypeRaw = raw.attributes?.[CFN_RESOURCE_TYPE_ATTRIBUTE];
   const cfnType = typeof cfnTypeRaw === 'string' ? cfnTypeRaw : undefined;
 
+  // A NestedStack switches its subtree to the nested scope; other nodes inherit.
   const children = Object.values(raw.children ?? {})
     .filter((child) => !isCdkInternal(child.id))
-    .map((child) => {
-      // A NestedStack switches its subtree to the nested template (or to "no
-      // template" when it isn't CDK-resolvable, since its resources don't live
-      // in the parent template); every other node inherits the active template.
-      const boundary = nestedBoundary(child, raw, owner, template, ctx);
-      return boundary
-        ? buildNode(child, ctx, owner, boundary.file, boundary.template)
-        : buildNode(child, ctx, owner, templateFile, template);
-    });
+    .map((child) => buildNode(child, ctx, owner, nestedBoundary(child, raw, owner, scope.template, ctx) ?? scope));
 
   // Only CFN resources (those with a logical ID) carry a templateFile.
-  const nodeTemplateFile = logicalId !== undefined ? templateFile : undefined;
+  const nodeTemplateFile = logicalId !== undefined ? scope.file : undefined;
   return ctx.decorate(
     { path: raw.path, id: raw.id, type: cfnType, logicalId, templateFile: nodeTemplateFile, children },
     owner?.stack,
@@ -246,17 +254,16 @@ function loadTemplate(absPath: string, cache: Map<string, CfnTemplate | undefine
 }
 
 /**
- * Classifies `child` as a NestedStack boundary and resolves the nested template
- * for its subtree. aws-cdk-lib models a NestedStack `<id>` as the construct at
- * `<parent>/<id>` (fqn `*.NestedStack`) plus a sibling
- * `AWS::CloudFormation::Stack` at `<parent>/<id>.NestedStack/<id>.NestedStackResource`
- * whose `aws:asset:path` metadata points at the nested template.
+ * If `child` is a NestedStack, resolves the template scope for its subtree;
+ * otherwise returns `undefined` (caller keeps the active scope).
  *
- * Returns `undefined` when `child` is not a nested stack (caller inherits the
- * active template). For a nested stack it returns a boundary `{ file, template }`
- * -- both populated when resolvable, or both undefined when asset metadata is
- * off or the template can't be read, so the subtree gets NO template rather than
- * the parent's (its resources don't live there).
+ * Detection keys off the sibling `AWS::CloudFormation::Stack` that aws-cdk-lib
+ * emits at `<parent>/<id>.NestedStack/<id>.NestedStackResource` (whose
+ * `aws:asset:path` points at the nested template), NOT the construct's fqn -- a
+ * jsii-published NestedStack subclass has an fqn that doesn't end in
+ * ".NestedStack", but the sibling is named the same regardless. Returns
+ * NO_TEMPLATE (not the parent's) when unresolvable, since the nested stack's
+ * resources don't live in the parent template.
  */
 function nestedBoundary<T extends ConstructTreeNode>(
   child: RawTreeNode,
@@ -264,19 +271,22 @@ function nestedBoundary<T extends ConstructTreeNode>(
   owner: StackMetadata | undefined,
   currentTemplate: CfnTemplate | undefined,
   ctx: WalkContext<T>,
-): { file?: string; template?: CfnTemplate } | undefined {
-  if (!child.constructInfo?.fqn.endsWith('.NestedStack')) return undefined;
+): TemplateScope | undefined {
   const resourceNode = parent.children?.[`${child.id}.NestedStack`]?.children?.[`${child.id}.NestedStackResource`];
-  const logicalId = resourceNode && owner
-    ? logicalIdFromEntries(owner.metadata.get('/' + resourceNode.path) ?? [])
-    : undefined;
+  // No sibling -> not a nested stack. A real nested stack always lives under a
+  // stack, so `owner` is defined here; the check also narrows it.
+  if (!resourceNode || !owner) return undefined;
+
+  const logicalId = logicalIdFromEntries(owner.metadata.get('/' + resourceNode.path) ?? []);
   const assetPath = logicalId !== undefined
     ? currentTemplate?.Resources?.[logicalId]?.Metadata?.[ASSET_RESOURCE_METADATA_PATH_KEY]
     : undefined;
-  if (typeof assetPath !== 'string') return {};
-  const file = path.join(ctx.assembly.directory, assetPath);
+  if (typeof assetPath !== 'string') return NO_TEMPLATE;
+  // Asset path is relative to the OWNER stack's assembly dir (the Stage
+  // sub-assembly for staged stacks), not necessarily the root assembly.
+  const file = path.join(path.dirname(owner.stack.templateFullPath), assetPath);
   const template = loadTemplate(file, ctx.templateCache);
-  return template ? { file, template } : {};
+  return template ? { file, template } : NO_TEMPLATE;
 }
 
 function isCdkInternal(id: string): boolean {

--- a/packages/@aws-cdk/cloud-assembly-api/test/construct-tree.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/test/construct-tree.test.ts
@@ -152,3 +152,140 @@ describe('buildConstructTree', () => {
     expect(buildConstructTree(assembly, (f) => f)).toEqual([]);
   });
 });
+
+describe('buildConstructTree -- nested stacks', () => {
+  let dir: string;
+  afterEach(() => dir && rimraf(dir));
+
+  const TREE_FILE = 'tree.json';
+
+  interface NestedOpts {
+    /** Logical ID of the bucket inside the nested stack (parent bucket is always 'ParentBucket'). */
+    readonly nestedBucketLogicalId?: string;
+    /** false simulates --no-asset-metadata: the CfnStack carries no aws:asset:path. */
+    readonly withAssetMetadata?: boolean;
+    /** false simulates a missing/unstaged asset: the nested template file isn't written. */
+    readonly writeNestedTemplate?: boolean;
+  }
+
+  /**
+   * Emits the real aws-cdk-lib NestedStack topology: a `Nested` construct, its
+   * sibling `Nested.NestedStack/Nested.NestedStackResource` AWS::CloudFormation::Stack
+   * (carrying aws:asset:path), and a bucket in both the parent and nested stacks.
+   * The `Nested` node deliberately carries a jsii fqn that does NOT end in
+   * ".NestedStack" -- so every test here also proves detection is by the sibling,
+   * not the fqn (P2b).
+   */
+  function writeNestedAssembly(opts: NestedOpts = {}): string {
+    const withAsset = opts.withAssetMetadata ?? true;
+    const writeNested = opts.writeNestedTemplate ?? true;
+    const nestedBucketLid = opts.nestedBucketLogicalId ?? 'NestedBucket';
+
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'caa-nested-'));
+
+    const nestedStackResource: Record<string, unknown> = { Type: 'AWS::CloudFormation::Stack' };
+    if (withAsset) nestedStackResource.Metadata = { 'aws:asset:path': 'nested.template.json' };
+    const parentTemplate = { Resources: { ParentBucket: { Type: 'AWS::S3::Bucket' }, NestedStackRes: nestedStackResource } };
+    const nestedTemplate = { Resources: { [nestedBucketLid]: { Type: 'AWS::S3::Bucket' } } };
+
+    const artifacts = {
+      MyStack: {
+        type: 'aws:cloudformation:stack',
+        environment: 'aws://111/us-east-1',
+        properties: { templateFile: 'template.json' },
+        metadata: {
+          '/MyStack/Bucket/Resource': [{ type: 'aws:cdk:logicalId', data: 'ParentBucket' }],
+          '/MyStack/Nested/Bucket/Resource': [{ type: 'aws:cdk:logicalId', data: nestedBucketLid }],
+          '/MyStack/Nested.NestedStack/Nested.NestedStackResource': [{ type: 'aws:cdk:logicalId', data: 'NestedStackRes' }],
+        },
+      },
+      Tree: { type: 'cdk:tree', properties: { file: TREE_FILE } },
+    };
+
+    const tree = {
+      version: 'tree-0.1',
+      tree: {
+        id: 'App',
+        path: '',
+        children: {
+          MyStack: {
+            id: 'MyStack',
+            path: 'MyStack',
+            children: {
+              'Bucket': {
+                id: 'Bucket',
+                path: 'MyStack/Bucket',
+                children: { Resource: { id: 'Resource', path: 'MyStack/Bucket/Resource', attributes: { 'aws:cdk:cloudformation:type': 'AWS::S3::Bucket' } } },
+              },
+              'Nested': {
+                id: 'Nested',
+                path: 'MyStack/Nested',
+                // jsii fqn intentionally NOT ending in ".NestedStack" (P2b regression).
+                constructInfo: { fqn: 'my-lib.DatabaseNestedStack', version: '1.0.0' },
+                children: {
+                  Bucket: {
+                    id: 'Bucket',
+                    path: 'MyStack/Nested/Bucket',
+                    children: { Resource: { id: 'Resource', path: 'MyStack/Nested/Bucket/Resource', attributes: { 'aws:cdk:cloudformation:type': 'AWS::S3::Bucket' } } },
+                  },
+                },
+              },
+              'Nested.NestedStack': {
+                id: 'Nested.NestedStack',
+                path: 'MyStack/Nested.NestedStack',
+                children: {
+                  'Nested.NestedStackResource': {
+                    id: 'Nested.NestedStackResource',
+                    path: 'MyStack/Nested.NestedStack/Nested.NestedStackResource',
+                    attributes: { 'aws:cdk:cloudformation:type': 'AWS::CloudFormation::Stack' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    fs.writeFileSync(path.join(dir, 'manifest.json'), JSON.stringify({ version: '0.0.0', artifacts }));
+    fs.writeFileSync(path.join(dir, 'template.json'), JSON.stringify(parentTemplate));
+    if (writeNested) fs.writeFileSync(path.join(dir, 'nested.template.json'), JSON.stringify(nestedTemplate));
+    fs.writeFileSync(path.join(dir, TREE_FILE), JSON.stringify(tree));
+    return dir;
+  }
+
+  const templateFileOf = (assemblyDir: string, nodePath: string): string | undefined =>
+    ConstructIndex.fromTree(buildConstructTree(new CloudAssembly(assemblyDir), (f) => f)).byPath(nodePath)?.templateFile;
+
+  test('resolves nested resources to the nested template and parent resources to the parent template', () => {
+    const d = writeNestedAssembly();
+    expect(templateFileOf(d, 'MyStack/Bucket/Resource')).toBe(path.join(d, 'template.json'));
+    expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBe(path.join(d, 'nested.template.json'));
+  });
+
+  test('resolves parent and nested twins (same logical ID) to their own templates', () => {
+    // NestedStack resets the logical-ID namespace, so both buckets are "ParentBucket".
+    // Positional threading must still send each to its own template.
+    const d = writeNestedAssembly({ nestedBucketLogicalId: 'ParentBucket' });
+    expect(templateFileOf(d, 'MyStack/Bucket/Resource')).toBe(path.join(d, 'template.json'));
+    expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBe(path.join(d, 'nested.template.json'));
+  });
+
+  test('detects the NestedStack by its sibling resource, not the construct fqn (jsii subclass)', () => {
+    // The fixture's Nested node fqn is "my-lib.DatabaseNestedStack" (does not end in
+    // ".NestedStack"); a suffix gate would miss it and mis-inherit the parent template.
+    const d = writeNestedAssembly();
+    expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBe(path.join(d, 'nested.template.json'));
+  });
+
+  test('yields no templateFile when the nested template is missing/unreadable', () => {
+    const d = writeNestedAssembly({ writeNestedTemplate: false });
+    expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBeUndefined();
+    expect(templateFileOf(d, 'MyStack/Bucket/Resource')).toBe(path.join(d, 'template.json'));
+  });
+
+  test('yields no templateFile when asset metadata is absent (--no-asset-metadata)', () => {
+    const d = writeNestedAssembly({ withAssetMetadata: false });
+    expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBeUndefined();
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,6 +3895,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cdklabs/eslint-plugin@npm:^2.0.6":
+  version: 2.0.9
+  resolution: "@cdklabs/eslint-plugin@npm:2.0.9"
+  dependencies:
+    "@typescript-eslint/utils": "npm:^8.60.1"
+    fs-extra: "npm:^11.3.5"
+    typescript: "npm:^5.9.3"
+  peerDependencies:
+    eslint: ">=9 <11"
+  checksum: 10c0/33cdb7f1e59da98f1b447276b9a3f2f1e75c0c5174e9f28953f479dcaf6d8d0edb860aa18c4bf48af73585391701b1629a3c9e5b2135d2d755464e70d470fe38
+  languageName: node
+  linkType: hard
+
 "@cdklabs/eslint-plugin@npm:^2.0.8":
   version: 2.0.8
   resolution: "@cdklabs/eslint-plugin@npm:2.0.8"
@@ -7158,6 +7171,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/project-service@npm:8.61.0"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": "npm:^8.61.0"
+    "@typescript-eslint/types": "npm:^8.61.0"
+    debug: "npm:^4.4.3"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/8ff86b93bfcf103a42e8e996e11c46ded83da07d3a0bc8bd9ec4d536116d7f6253a404786510ab13847e69d6e185b17d15d7140075c26966e9b4f85c03296f21
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/scope-manager@npm:8.58.1"
@@ -7178,6 +7204,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/scope-manager@npm:8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/scope-manager@npm:8.61.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.61.0"
+    "@typescript-eslint/visitor-keys": "npm:8.61.0"
+  checksum: 10c0/76cdf1c181ebbc706ddc8b2366e8ebfda529c13d82ff10c0797c96c0b38dd82f6471b24995f58ac267194a753b23d77452d925dd615b1e651922ddbe6e451c6b
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/tsconfig-utils@npm:8.58.1, @typescript-eslint/tsconfig-utils@npm:^8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.1"
@@ -7193,6 +7229,15 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/231d6c6ef0b305d5b007ce89af11c5871c14a5e3be43d1c131100f60053783169c1ce3133af767b8874bce6cc20ece1d2501c2ef315f467ecdc04e8acdd0dc9c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/tsconfig-utils@npm:8.61.0, @typescript-eslint/tsconfig-utils@npm:^8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.61.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/b498675f14ef90a5730de7c58388eb2522085a56c3fcad42ad9f89320b96221eafb5b4f9650375f29092025153d03533e3f23ea8f45ce3bc95a57593059edef3
   languageName: node
   linkType: hard
 
@@ -7233,6 +7278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/types@npm:8.61.0, @typescript-eslint/types@npm:^8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/types@npm:8.61.0"
+  checksum: 10c0/c19407d66fb5ad26e2670cd272bee91d150087d917752422257759e17920220af27cd54593205e9726367a440a237bf8d27ed805cae0b282a79172161f007207
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/typescript-estree@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.58.1"
@@ -7268,6 +7320,25 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/76274d3974fd56675df71b010a2b6799a886537625228f89150fcb4563597eb619be4a22937cacacb0bb20b66c11b03e04f913fb6b44790ce63a7d070f27d3aa
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/typescript-estree@npm:8.61.0"
+  dependencies:
+    "@typescript-eslint/project-service": "npm:8.61.0"
+    "@typescript-eslint/tsconfig-utils": "npm:8.61.0"
+    "@typescript-eslint/types": "npm:8.61.0"
+    "@typescript-eslint/visitor-keys": "npm:8.61.0"
+    debug: "npm:^4.4.3"
+    minimatch: "npm:^10.2.2"
+    semver: "npm:^7.7.3"
+    tinyglobby: "npm:^0.2.15"
+    ts-api-utils: "npm:^2.5.0"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/460819feeca826bfd895f821a5008c3eaa79b9495259641976fdc6ec319a7e9587bc28603437ea3d9a10c3b28037f1dea883cbe8d2858616dd33847e8db2179e
   languageName: node
   linkType: hard
 
@@ -7319,6 +7390,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^8.60.1":
+  version: 8.61.0
+  resolution: "@typescript-eslint/utils@npm:8.61.0"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.9.1"
+    "@typescript-eslint/scope-manager": "npm:8.61.0"
+    "@typescript-eslint/types": "npm:8.61.0"
+    "@typescript-eslint/typescript-estree": "npm:8.61.0"
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+    typescript: ">=4.8.4 <6.1.0"
+  checksum: 10c0/f7b2241fc4defd40107243642e26697193707be12af1552c60bc414e71df1285c9cdff429f913b30ed08ae87a7e6e13388eaf05c1be5fb8310f6a63a6c4f7f73
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:4.33.0":
   version: 4.33.0
   resolution: "@typescript-eslint/visitor-keys@npm:4.33.0"
@@ -7346,6 +7432,16 @@ __metadata:
     "@typescript-eslint/types": "npm:8.60.1"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/d9831624c0dde1655a83f3e10b85fe3655ec015fd57cac9295bf3ad302ef30736eb58417b1d9a5c8639a8b05b665f9acc6bcc34f9def386846ae8d6833a5e3ce
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.61.0":
+  version: 8.61.0
+  resolution: "@typescript-eslint/visitor-keys@npm:8.61.0"
+  dependencies:
+    "@typescript-eslint/types": "npm:8.61.0"
+    eslint-visitor-keys: "npm:^5.0.0"
+  checksum: 10c0/5b656aed426a92dfc9a481f0bf535ceb47321303f476f32ba979f73423c739b51d7a5ad76c81d7be9df0a9beb361f4a11ff530dd86d59f41b89bb5f09af7be9f
   languageName: node
   linkType: hard
 
@@ -10674,7 +10770,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^4.4.5":
+"eslint-import-resolver-typescript@npm:^4.4.4, eslint-import-resolver-typescript@npm:^4.4.5":
   version: 4.4.5
   resolution: "eslint-import-resolver-typescript@npm:4.4.5"
   dependencies:
@@ -15153,7 +15249,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nx@npm:^22.7.5":
+"nx@npm:^22.7.2, nx@npm:^22.7.5":
   version: 22.7.5
   resolution: "nx@npm:22.7.5"
   dependencies:
@@ -16196,6 +16292,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"projen@npm:^0.99.63":
+  version: 0.99.72
+  resolution: "projen@npm:0.99.72"
+  dependencies:
+    "@iarna/toml": "npm:^2.2.5"
+    case: "npm:^1.6.3"
+    chalk: "npm:^4.1.2"
+    comment-json: "npm:4.2.2"
+    constructs: "npm:^10.5.0"
+    conventional-changelog-config-spec: "npm:^2.1.0"
+    fast-glob: "npm:^3.3.3"
+    fast-json-patch: "npm:^3.1.1"
+    ini: "npm:^2.0.0"
+    parse-conflict-json: "npm:^4.0.0"
+    semver: "npm:^7.8.3"
+    shx: "npm:^0.4.0"
+    xmlbuilder2: "npm:^4.0.3"
+    yaml: "npm:^2.2.2"
+    yargs: "npm:^17.7.2"
+  peerDependencies:
+    constructs: ^10.5.0
+  bin:
+    projen: bin/projen
+  checksum: 10c0/b9e2d099cf2c5e5c8a664556f6c5450529cc3fcde6934b1d355aa2a580f967a55f536022aec9f5302de91f05f67952c4a823a4bc8a8bf8419621190d9e6f41ed
+  languageName: node
+  linkType: hard
+
 "projen@npm:^0.99.70":
   version: 0.99.70
   resolution: "projen@npm:0.99.70"
@@ -17006,6 +17129,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.8.3":
+  version: 7.8.4
+  resolution: "semver@npm:7.8.4"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,7 +178,7 @@ __metadata:
     "@aws-cdk/cloud-assembly-api": "npm:^0.0.0"
     "@aws-cdk/cloud-assembly-schema": "npm:^0.0.0"
     "@aws-cdk/toolkit-lib": "npm:^0.0.0"
-    "@cdklabs/eslint-plugin": "npm:^2.0.6"
+    "@cdklabs/eslint-plugin": "npm:^2.0.8"
     "@jridgewell/trace-mapping": "npm:^0.3"
     "@stylistic/eslint-plugin": "npm:^3"
     "@types/convert-source-map": "npm:^2"
@@ -191,7 +191,7 @@ __metadata:
     convert-source-map: "npm:^2"
     eslint: "npm:^9"
     eslint-config-prettier: "npm:^10.1.8"
-    eslint-import-resolver-typescript: "npm:^4.4.4"
+    eslint-import-resolver-typescript: "npm:^4.4.5"
     eslint-plugin-import: "npm:^2.32.0"
     eslint-plugin-jest: "npm:^29.15.2"
     eslint-plugin-jsdoc: "npm:^62.9.0"
@@ -199,9 +199,9 @@ __metadata:
     express: "npm:^4"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16"
-    nx: "npm:^22.7.2"
+    nx: "npm:^22.7.5"
     prettier: "npm:^2.8"
-    projen: "npm:^0.99.63"
+    projen: "npm:^0.99.70"
     ts-jest: "npm:^29.4.11"
     typescript: "npm:5.9"
     vscode-jsonrpc: "npm:^8"
@@ -3895,19 +3895,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@cdklabs/eslint-plugin@npm:^2.0.6":
-  version: 2.0.9
-  resolution: "@cdklabs/eslint-plugin@npm:2.0.9"
-  dependencies:
-    "@typescript-eslint/utils": "npm:^8.60.1"
-    fs-extra: "npm:^11.3.5"
-    typescript: "npm:^5.9.3"
-  peerDependencies:
-    eslint: ">=9 <11"
-  checksum: 10c0/33cdb7f1e59da98f1b447276b9a3f2f1e75c0c5174e9f28953f479dcaf6d8d0edb860aa18c4bf48af73585391701b1629a3c9e5b2135d2d755464e70d470fe38
-  languageName: node
-  linkType: hard
-
 "@cdklabs/eslint-plugin@npm:^2.0.8":
   version: 2.0.8
   resolution: "@cdklabs/eslint-plugin@npm:2.0.8"
@@ -7171,19 +7158,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/project-service@npm:8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/project-service@npm:8.61.0"
-  dependencies:
-    "@typescript-eslint/tsconfig-utils": "npm:^8.61.0"
-    "@typescript-eslint/types": "npm:^8.61.0"
-    debug: "npm:^4.4.3"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/8ff86b93bfcf103a42e8e996e11c46ded83da07d3a0bc8bd9ec4d536116d7f6253a404786510ab13847e69d6e185b17d15d7140075c26966e9b4f85c03296f21
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/scope-manager@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/scope-manager@npm:8.58.1"
@@ -7204,16 +7178,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/scope-manager@npm:8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/scope-manager@npm:8.61.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.61.0"
-    "@typescript-eslint/visitor-keys": "npm:8.61.0"
-  checksum: 10c0/76cdf1c181ebbc706ddc8b2366e8ebfda529c13d82ff10c0797c96c0b38dd82f6471b24995f58ac267194a753b23d77452d925dd615b1e651922ddbe6e451c6b
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/tsconfig-utils@npm:8.58.1, @typescript-eslint/tsconfig-utils@npm:^8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/tsconfig-utils@npm:8.58.1"
@@ -7229,15 +7193,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/231d6c6ef0b305d5b007ce89af11c5871c14a5e3be43d1c131100f60053783169c1ce3133af767b8874bce6cc20ece1d2501c2ef315f467ecdc04e8acdd0dc9c
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/tsconfig-utils@npm:8.61.0, @typescript-eslint/tsconfig-utils@npm:^8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/tsconfig-utils@npm:8.61.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/b498675f14ef90a5730de7c58388eb2522085a56c3fcad42ad9f89320b96221eafb5b4f9650375f29092025153d03533e3f23ea8f45ce3bc95a57593059edef3
   languageName: node
   linkType: hard
 
@@ -7278,13 +7233,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/types@npm:8.61.0, @typescript-eslint/types@npm:^8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/types@npm:8.61.0"
-  checksum: 10c0/c19407d66fb5ad26e2670cd272bee91d150087d917752422257759e17920220af27cd54593205e9726367a440a237bf8d27ed805cae0b282a79172161f007207
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/typescript-estree@npm:8.58.1":
   version: 8.58.1
   resolution: "@typescript-eslint/typescript-estree@npm:8.58.1"
@@ -7320,25 +7268,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4 <6.1.0"
   checksum: 10c0/76274d3974fd56675df71b010a2b6799a886537625228f89150fcb4563597eb619be4a22937cacacb0bb20b66c11b03e04f913fb6b44790ce63a7d070f27d3aa
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/typescript-estree@npm:8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/typescript-estree@npm:8.61.0"
-  dependencies:
-    "@typescript-eslint/project-service": "npm:8.61.0"
-    "@typescript-eslint/tsconfig-utils": "npm:8.61.0"
-    "@typescript-eslint/types": "npm:8.61.0"
-    "@typescript-eslint/visitor-keys": "npm:8.61.0"
-    debug: "npm:^4.4.3"
-    minimatch: "npm:^10.2.2"
-    semver: "npm:^7.7.3"
-    tinyglobby: "npm:^0.2.15"
-    ts-api-utils: "npm:^2.5.0"
-  peerDependencies:
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/460819feeca826bfd895f821a5008c3eaa79b9495259641976fdc6ec319a7e9587bc28603437ea3d9a10c3b28037f1dea883cbe8d2858616dd33847e8db2179e
   languageName: node
   linkType: hard
 
@@ -7390,21 +7319,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:^8.60.1":
-  version: 8.61.0
-  resolution: "@typescript-eslint/utils@npm:8.61.0"
-  dependencies:
-    "@eslint-community/eslint-utils": "npm:^4.9.1"
-    "@typescript-eslint/scope-manager": "npm:8.61.0"
-    "@typescript-eslint/types": "npm:8.61.0"
-    "@typescript-eslint/typescript-estree": "npm:8.61.0"
-  peerDependencies:
-    eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-    typescript: ">=4.8.4 <6.1.0"
-  checksum: 10c0/f7b2241fc4defd40107243642e26697193707be12af1552c60bc414e71df1285c9cdff429f913b30ed08ae87a7e6e13388eaf05c1be5fb8310f6a63a6c4f7f73
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/visitor-keys@npm:4.33.0":
   version: 4.33.0
   resolution: "@typescript-eslint/visitor-keys@npm:4.33.0"
@@ -7432,16 +7346,6 @@ __metadata:
     "@typescript-eslint/types": "npm:8.60.1"
     eslint-visitor-keys: "npm:^5.0.0"
   checksum: 10c0/d9831624c0dde1655a83f3e10b85fe3655ec015fd57cac9295bf3ad302ef30736eb58417b1d9a5c8639a8b05b665f9acc6bcc34f9def386846ae8d6833a5e3ce
-  languageName: node
-  linkType: hard
-
-"@typescript-eslint/visitor-keys@npm:8.61.0":
-  version: 8.61.0
-  resolution: "@typescript-eslint/visitor-keys@npm:8.61.0"
-  dependencies:
-    "@typescript-eslint/types": "npm:8.61.0"
-    eslint-visitor-keys: "npm:^5.0.0"
-  checksum: 10c0/5b656aed426a92dfc9a481f0bf535ceb47321303f476f32ba979f73423c739b51d7a5ad76c81d7be9df0a9beb361f4a11ff530dd86d59f41b89bb5f09af7be9f
   languageName: node
   linkType: hard
 
@@ -10770,7 +10674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-import-resolver-typescript@npm:^4.4.4, eslint-import-resolver-typescript@npm:^4.4.5":
+"eslint-import-resolver-typescript@npm:^4.4.5":
   version: 4.4.5
   resolution: "eslint-import-resolver-typescript@npm:4.4.5"
   dependencies:
@@ -15249,7 +15153,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nx@npm:^22.7.2, nx@npm:^22.7.5":
+"nx@npm:^22.7.5":
   version: 22.7.5
   resolution: "nx@npm:22.7.5"
   dependencies:
@@ -16292,33 +16196,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"projen@npm:^0.99.63":
-  version: 0.99.72
-  resolution: "projen@npm:0.99.72"
-  dependencies:
-    "@iarna/toml": "npm:^2.2.5"
-    case: "npm:^1.6.3"
-    chalk: "npm:^4.1.2"
-    comment-json: "npm:4.2.2"
-    constructs: "npm:^10.5.0"
-    conventional-changelog-config-spec: "npm:^2.1.0"
-    fast-glob: "npm:^3.3.3"
-    fast-json-patch: "npm:^3.1.1"
-    ini: "npm:^2.0.0"
-    parse-conflict-json: "npm:^4.0.0"
-    semver: "npm:^7.8.3"
-    shx: "npm:^0.4.0"
-    xmlbuilder2: "npm:^4.0.3"
-    yaml: "npm:^2.2.2"
-    yargs: "npm:^17.7.2"
-  peerDependencies:
-    constructs: ^10.5.0
-  bin:
-    projen: bin/projen
-  checksum: 10c0/b9e2d099cf2c5e5c8a664556f6c5450529cc3fcde6934b1d355aa2a580f967a55f536022aec9f5302de91f05f67952c4a823a4bc8a8bf8419621190d9e6f41ed
-  languageName: node
-  linkType: hard
-
 "projen@npm:^0.99.70":
   version: 0.99.70
   resolution: "projen@npm:0.99.70"
@@ -17129,15 +17006,6 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.8.3":
-  version: 7.8.4
-  resolution: "semver@npm:7.8.4"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Builds on #1592, which surfaced display-only CodeLens entries for the CFN
resources each construct produces. This PR makes them **clickable**. Selecting a
lens jumps to the resource's definition in the synthesized CloudFormation template.

Features:
- **Clickable navigation** — each lens carries an `openResource` command that opens
  the resource's template file at its logical-ID line.
- **Multi-resource picker** — constructs producing several resources show a QuickPick;
  single-resource constructs open directly.
- **Positional `templateFile` resolution (cloud-assembly-api)** — `buildConstructTree`
  threads the owning template through the tree, switching at NestedStack boundaries.
- **Clearer titles** — `Creates AWS::S3::Bucket`, or
  `Creates 3 resources: AWS::S3::Bucket, AWS::S3::BucketPolicy, AWS::KMS::Key`.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
