### PR TITLE
feat: template ranges + two-way template/source navigation

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -580,12 +580,10 @@ const cloudAssemblyApi = configureProject(
     srcdir: 'lib',
     devDeps: [
       cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
+      '@types/json-source-map@^0.6.0',
     ],
     deps: [
-      // Position-aware JSON parser used to compute character ranges for template
-      // resource/property blocks. Maintained by the VS Code team, zero transitive
-      // deps, already resolved at 3.2.0 in the lockfile; stdlib JSON.parse discards offsets.
-      'jsonc-parser@3.2.0',
+      'json-source-map@^0.6.1',
       'jsonschema@^1.5.0',
       'semver',
     ],

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -582,6 +582,10 @@ const cloudAssemblyApi = configureProject(
       cloudAssemblySchema.customizeReference({ versionType: 'exact' }),
     ],
     deps: [
+      // Position-aware JSON parser used to compute character ranges for template
+      // resource/property blocks. Maintained by the VS Code team, zero transitive
+      // deps, already resolved at 3.2.0 in the lockfile; stdlib JSON.parse discards offsets.
+      'jsonc-parser@3.2.0',
       'jsonschema@^1.5.0',
       'semver',
     ],

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/positions.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/positions.ts
@@ -1,0 +1,18 @@
+import type { OffsetRange } from '@aws-cdk/cloud-assembly-api';
+import { type Position, type Range } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
+
+// Character offsets (from the core range resolver) and LSP positions are two
+// coordinate systems over the same text. These convert between them at the LSP
+// boundary, using TextDocument so UTF-16 column counting matches the protocol.
+
+/** Convert character offsets into an LSP range (0-based lines, UTF-16 columns). */
+export function offsetsToRange(text: string, offsets: OffsetRange): Range {
+  const doc = TextDocument.create('', 'json', 0, text);
+  return { start: doc.positionAt(offsets.start), end: doc.positionAt(offsets.end) };
+}
+
+/** Convert an LSP position into a 0-based character offset. */
+export function offsetAtPosition(text: string, position: Position): number {
+  return TextDocument.create('', 'json', 0, text).offsetAt(position);
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -1,3 +1,4 @@
+import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
@@ -11,14 +12,18 @@ import {
   TextDocumentSyncKind,
   type CodeLens,
   type CodeLensParams,
+  type DefinitionParams,
   type DidSaveTextDocumentParams,
   type Diagnostic,
   type InitializeParams,
   type InitializeResult,
+  type Location,
 } from 'vscode-languageserver/node';
 /* eslint-disable import/no-relative-packages */
 import { codeLensesForFile } from './codelens';
 import { mapViolationsToDiagnostics } from './diagnostics';
+import { offsetAtPosition } from './positions';
+import { sourceTargetAtTemplateOffset } from './template-locator';
 import { WATCH_EXCLUDE_DEFAULTS } from '../../../toolkit-lib/lib/actions/watch/private/helpers';
 import { createIgnoreMatcher } from '../../../toolkit-lib/lib/util/glob-matcher';
 import {
@@ -52,6 +57,7 @@ export interface LspHandlers {
   onInitialized(): void;
   onDidSaveTextDocument(params: DidSaveTextDocumentParams): void;
   onCodeLens(params: CodeLensParams): CodeLens[];
+  onDefinition(params: DefinitionParams): Location | undefined;
   onShutdown(): void;
 }
 
@@ -130,6 +136,8 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
           },
           // Lens title is computed up-front; no resolve round-trip needed.
           codeLensProvider: { resolveProvider: false },
+          // Go-to-definition from a synthesized template back to construct source.
+          definitionProvider: true,
         },
       };
     },
@@ -165,6 +173,27 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
     onCodeLens(params) {
       return codeLensesForFile(cachedIndex, params.textDocument.uri);
     },
+    onDefinition(params) {
+      // Only synthesized templates link back to source, and only file: URIs are
+      // readable. Check the scheme before fileURLToPath, which throws on other
+      // schemes (untitled:, git:, diff views).
+      const uri = params.textDocument.uri;
+      if (!uri.startsWith('file:') || !uri.endsWith('.template.json')) {
+        return undefined;
+      }
+      const filePath = fileURLToPath(uri);
+      let templateText: string;
+      try {
+        templateText = fs.readFileSync(filePath, 'utf-8');
+      } catch {
+        return undefined;
+      }
+      // Offsets come from current disk text; the owner is looked up in the index
+      // built at startup. If the template was re-synthesized since, a missing
+      // match degrades to undefined rather than navigating to the wrong place.
+      const offset = offsetAtPosition(templateText, params.position);
+      return sourceTargetAtTemplateOffset(cachedIndex, filePath, templateText, offset);
+    },
     onShutdown() {
       shutdownRequested = true;
     },
@@ -191,6 +220,7 @@ export function startServer(options: LspServerOptions): void {
   connection.onInitialized(() => handlers.onInitialized());
   connection.onDidSaveTextDocument((params) => handlers.onDidSaveTextDocument(params));
   connection.onCodeLens((params) => handlers.onCodeLens(params));
+  connection.onDefinition((params) => handlers.onDefinition(params));
   connection.onShutdown(() => handlers.onShutdown());
   connection.onExit(() => process.exit(0));
 

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -1,35 +1,27 @@
 import * as fs from 'fs';
 import { pathToFileURL } from 'url';
-import { type Position, type Range } from 'vscode-languageserver/node';
+import { resolveLogicalIdAtOffset, resolveResourceRange, type ConstructIndex } from '@aws-cdk/cloud-assembly-api';
+import { type Location, type Range } from 'vscode-languageserver/node';
+import { offsetsToRange } from './positions';
+import type { ConstructNode } from '../core/assembly-reader';
 
 /**
- * 0-based position of a resource's logical-ID key in its synthesized template.
- * A logical ID only appears as a `"<id>":` key in its own definition (every
- * Ref/GetAtt/DependsOn occurrence is a string value, never followed by `:`), so
- * anchoring on the key selects the definition without a JSON parse. Assumes
- * pretty-printed templates (one key per line). Undefined if not found.
+ * An editor navigation target: the template file and the range to reveal.
+ * Structurally an LSP `Location`, but kept as a named type because it is
+ * serialized into the `openResource` CodeLens command's QuickPick arguments
+ * (see codelens.ts), where it reads as a domain target rather than a protocol type.
  */
-function findLogicalIdPosition(templateText: string, logicalId: string): Position | undefined {
-  const key = `"${logicalId}"`;
-  const lines = templateText.split('\n');
-  for (let line = 0; line < lines.length; line++) {
-    const trimmed = lines[line].trimStart();
-    if (trimmed.startsWith(key) && trimmed.slice(key.length).trimStart().startsWith(':')) {
-      return { line, character: lines[line].length - trimmed.length };
-    }
-  }
-  return undefined;
-}
-
-/** An editor navigation target: the template file and the position to reveal. */
 export interface ResourceTarget {
   readonly uri: string;
   readonly range: Range;
 }
 
 /**
- * Resolves a construct node to its CFN resource location for an LSP "go to";
- * undefined when not navigable (no template, unreadable, or id not found).
+ * Resolves a construct node to a CFN resource location for an LSP "go to": the
+ * range of the resource's block in its synthesized template.
+ *
+ * Returns `undefined` when the node is not navigable: no resolved template, the
+ * template cannot be read, it does not parse, or the logical id is absent.
  */
 export function resourceTarget(node: { templateFile?: string; logicalId: string }): ResourceTarget | undefined {
   if (node.templateFile === undefined) {
@@ -41,12 +33,44 @@ export function resourceTarget(node: { templateFile?: string; logicalId: string 
   } catch {
     return undefined;
   }
-  const position = findLogicalIdPosition(templateText, node.logicalId);
-  if (position === undefined) {
+  const block = resolveResourceRange(templateText, node.logicalId);
+  if (block === undefined) {
     return undefined;
   }
   return {
     uri: pathToFileURL(node.templateFile).toString(),
+    range: offsetsToRange(templateText, block),
+  };
+}
+
+/**
+ * Reverse navigation: resolve a character offset inside a synthesized template to
+ * the source location of the construct that produced the enclosing resource.
+ *
+ * Finds the resource's logical id at `offset`, looks up the owning construct in
+ * `index` (matched by both `templateFile` and `logicalId`, since logical ids are
+ * only unique within a template), and returns its source location as a zero-width
+ * range. Undefined when the offset is not inside a resource, no construct owns it,
+ * or the construct has no source location (for example a non-TypeScript app).
+ */
+export function sourceTargetAtTemplateOffset(
+  index: ConstructIndex<ConstructNode>,
+  templateFile: string,
+  templateText: string,
+  offset: number,
+): Location | undefined {
+  const logicalId = resolveLogicalIdAtOffset(templateText, offset);
+  if (logicalId === undefined) {
+    return undefined;
+  }
+  const owner = [...index].find((node) => node.logicalId === logicalId && node.templateFile === templateFile);
+  if (owner?.sourceLocation === undefined) {
+    return undefined;
+  }
+  // SourceLocation is 1-based; LSP positions are 0-based.
+  const position = { line: owner.sourceLocation.line - 1, character: owner.sourceLocation.column - 1 };
+  return {
+    uri: pathToFileURL(owner.sourceLocation.file).toString(),
     range: { start: position, end: position },
   };
 }

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
@@ -16,6 +16,13 @@ const node = (overrides: Partial<ConstructNode> & { path: string }): ConstructNo
   ...overrides,
 });
 
+/** Shape of one resource choice carried in the openResource command arguments. */
+interface CommandChoice {
+  label: string;
+  description: string;
+  target: { uri: string; range: { start: unknown; end: unknown } };
+}
+
 describe('codeLensesForFile', () => {
   test('returns no lenses when tree is empty', () => {
     expect(codeLensesForFile(ConstructIndex.fromTree([]), URI)).toEqual([]);
@@ -115,8 +122,15 @@ describe('codeLensesForFile', () => {
       }),
     ];
 
-    expect(codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toHaveLength(1);
-    expect(codeLensesForFile(ConstructIndex.fromTree(tree), OTHER_URI)).toHaveLength(1);
+    const index = ConstructIndex.fromTree(tree);
+    // Each query returns only the resource defined in that file, which proves the
+    // URI filter selects by file rather than returning everything for any query.
+    const onThisFile = codeLensesForFile(index, URI);
+    expect(onThisFile).toHaveLength(1);
+    expect(onThisFile[0].command?.title).toBe('Creates AWS::S3::Bucket');
+    const onOtherFile = codeLensesForFile(index, OTHER_URI);
+    expect(onOtherFile).toHaveLength(1);
+    expect(onOtherFile[0].command?.title).toBe('Creates AWS::SQS::Queue');
   });
 
   test('walks descendants — finds resources nested under wrappers', () => {
@@ -172,14 +186,15 @@ describe('codeLensesForFile', () => {
 
       const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
-      expect(lens.command?.arguments).toEqual([[{
+      const choices = (lens.command!.arguments as CommandChoice[][])[0];
+      expect(choices).toHaveLength(1);
+      expect(choices[0]).toMatchObject({
         label: 'AWS::S3::Bucket',
         description: 'Stack1/MyBucket',
-        target: {
-          uri: pathToFileURL(templateFile).toString(),
-          range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } },
-        },
-      }]]);
+        target: { uri: pathToFileURL(templateFile).toString() },
+      });
+      // The target carries a real (non-zero-width) block range; exact offsets are covered in template-locator.test.
+      expect(choices[0].target.range.start).not.toEqual(choices[0].target.range.end);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }
@@ -200,10 +215,15 @@ describe('codeLensesForFile', () => {
       const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
       const uri = pathToFileURL(templateFile).toString();
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
-      expect(lens.command?.arguments).toEqual([[
-        { label: 'AWS::S3::Bucket', description: 'Stack1/B', target: { uri, range: { start: { line: 2, character: 4 }, end: { line: 2, character: 4 } } } },
-        { label: 'AWS::S3::BucketPolicy', description: 'Stack1/B/Policy', target: { uri, range: { start: { line: 5, character: 4 }, end: { line: 5, character: 4 } } } },
-      ]]);
+      const choices = (lens.command!.arguments as CommandChoice[][])[0];
+      expect(choices).toMatchObject([
+        { label: 'AWS::S3::Bucket', description: 'Stack1/B', target: { uri } },
+        { label: 'AWS::S3::BucketPolicy', description: 'Stack1/B/Policy', target: { uri } },
+      ]);
+      // Each carries a real span, and the two resources resolve to distinct blocks.
+      expect(choices[0].target.range.start).not.toEqual(choices[0].target.range.end);
+      expect(choices[1].target.range.start).not.toEqual(choices[1].target.range.end);
+      expect(choices[0].target.range).not.toEqual(choices[1].target.range);
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });
     }

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -1,5 +1,9 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { pathToFileURL } from 'url';
 import type { Diagnostic } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { AssemblyReadResult } from '../../lib';
 import { createLspHandlers, type LspHandlerOptions, type LspHandlers } from '../../lib/lsp/server';
 
@@ -34,7 +38,7 @@ function initializeClient(client: CapturedClient, options?: Record<string, unkno
 }
 
 describe('LSP Server', () => {
-  test('responds to initialize with capabilities', () => {
+  test('initialize advertises codeLens, definition, and save-sync capabilities', () => {
     const client = createTestClient();
 
     const result = client.handlers.onInitialize({
@@ -52,6 +56,7 @@ describe('LSP Server', () => {
           save: { includeText: false },
         },
         codeLensProvider: { resolveProvider: false },
+        definitionProvider: true,
       },
     });
   });
@@ -222,5 +227,63 @@ describe('LSP Server', () => {
     initializeClient(client, { applicationDir: '/p' });
 
     expect(client.published).toHaveLength(0);
+  });
+
+  test('onDefinition resolves a template position back to construct source', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-def-'));
+    const templateFile = path.join(dir, 'Stack1.template.json');
+    const text = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
+    fs.writeFileSync(templateFile, text);
+    try {
+      const client = createTestClient({
+        readAssembly: () => ({
+          status: 'success',
+          data: {
+            tree: [{
+              path: 'Stack1/MyBucket/Resource',
+              id: 'Resource',
+              logicalId: 'MyBucket',
+              type: 'AWS::S3::Bucket',
+              templateFile,
+              sourceLocation: { file: '/p/lib/stack.ts', line: 5, column: 3 },
+              children: [],
+            }],
+            violations: [],
+            warnings: [],
+          },
+        }),
+      });
+      initializeClient(client, { applicationDir: dir });
+
+      const uri = pathToFileURL(templateFile).toString();
+      const position = TextDocument.create(uri, 'json', 0, text).positionAt(text.indexOf('AWS::S3::Bucket'));
+      const target = client.handlers.onDefinition({ textDocument: { uri }, position });
+
+      expect(target?.uri).toBe(pathToFileURL('/p/lib/stack.ts').toString());
+      expect(target?.range.start).toEqual({ line: 4, character: 2 }); // 1-based (5,3) -> 0-based
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('onDefinition returns undefined for a non-template document', () => {
+    const client = createTestClient();
+    initializeClient(client, { applicationDir: '/p' });
+    const target = client.handlers.onDefinition({
+      textDocument: { uri: pathToFileURL('/p/lib/stack.ts').toString() },
+      position: { line: 0, character: 0 },
+    });
+    expect(target).toBeUndefined();
+  });
+
+  test('onDefinition returns undefined (does not throw) for a non-file URI', () => {
+    const client = createTestClient();
+    initializeClient(client, { applicationDir: '/p' });
+    expect(
+      client.handlers.onDefinition({
+        textDocument: { uri: 'untitled:Untitled-1' },
+        position: { line: 0, character: 0 },
+      }),
+    ).toBeUndefined();
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -2,28 +2,43 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import { pathToFileURL } from 'url';
+import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
+import { type Range } from 'vscode-languageserver/node';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 import { readAssembly, type ConstructNode } from '../../lib';
-import { resourceTarget } from '../../lib/lsp/template-locator';
+import { resourceTarget, sourceTargetAtTemplateOffset } from '../../lib/lsp/template-locator';
 import { buildFlatAssembly, cleanupFixture } from '../_fixtures/builders';
 
 // A synthesized-style template where MyBucketF68F3FF0 is defined once and also
 // referenced (Ref + DependsOn) -- the references must not be matched.
-const TEMPLATE = [
-  '{',
-  '  "Resources": {',
-  '    "MyBucketF68F3FF0": {',
-  '      "Type": "AWS::S3::Bucket"',
-  '    },',
-  '    "MyPolicy3A1B2C3D": {',
-  '      "Type": "AWS::IAM::Policy",',
-  '      "Properties": {',
-  '        "Bucket": { "Ref": "MyBucketF68F3FF0" }',
-  '      },',
-  '      "DependsOn": [ "MyBucketF68F3FF0" ]',
-  '    }',
-  '  }',
-  '}',
-].join('\n');
+const TEMPLATE = JSON.stringify(
+  {
+    Resources: {
+      MyBucketF68F3FF0: { Type: 'AWS::S3::Bucket' },
+      MyPolicy3A1B2C3D: {
+        Type: 'AWS::IAM::Policy',
+        Properties: { Bucket: { Ref: 'MyBucketF68F3FF0' } },
+        DependsOn: ['MyBucketF68F3FF0'],
+      },
+    },
+  },
+  undefined,
+  1,
+);
+
+/** Re-parse the substring that a returned range selects, so assertions need no hand-computed offsets. */
+function sliceParse(text: string, range: Range): unknown {
+  const doc = TextDocument.create('', 'json', 0, text);
+  return JSON.parse(text.slice(doc.offsetAt(range.start), doc.offsetAt(range.end)));
+}
+
+/** Write a template to a throwaway file and return its path. */
+function writeTemplate(contents: string): { dir: string; file: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locator-'));
+  const file = path.join(dir, 'T.template.json');
+  fs.writeFileSync(file, contents);
+  return { dir, file };
+}
 
 describe('resourceTarget', () => {
   let dir: string | undefined;
@@ -42,18 +57,21 @@ describe('resourceTarget', () => {
     return undefined;
   };
 
-  test('resolves a resource node to its template uri and key position', () => {
+  test('resolves a resource node to its template uri and block range', () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
     const result = readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
     const node = find(result.data.tree, 'Stack1/MyBucket/Resource')!;
+    const templateFile = path.join(dir!, 'Stack1.template.json');
 
-    const target = resourceTarget(node);
-    expect(target?.uri).toBe(pathToFileURL(path.join(dir!, 'Stack1.template.json')).toString());
-    // 2-space indented template: the key sits on line 2, opening quote at char 4.
-    expect(target?.range).toEqual({ start: { line: 2, character: 4 }, end: { line: 2, character: 4 } });
+    const target = resourceTarget(node)!;
+    expect(target.uri).toBe(pathToFileURL(templateFile).toString());
+    // The range spans the resource block (not a zero-width cursor) and re-parses to it.
+    const text = fs.readFileSync(templateFile, 'utf-8');
+    expect(target.range.start).not.toEqual(target.range.end);
+    expect(sliceParse(text, target.range)).toEqual(JSON.parse(text).Resources.MyBucketF68F3FF0);
   });
 
   test('returns undefined for a node without a resolved templateFile', () => {
@@ -71,33 +89,99 @@ describe('resourceTarget', () => {
     expect(resourceTarget({ templateFile: '/no/such/template.json', logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
   });
 
-  test('resolves to the definition key, not Ref/DependsOn occurrences of the same id', () => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locator-'));
-    const file = path.join(dir, 'T.template.json');
-    fs.writeFileSync(file, TEMPLATE);
-    // MyBucketF68F3FF0 is defined on line 2 and also referenced (Ref line 8,
-    // DependsOn line 10); only the definition is a `"<id>":` key, so line 2 wins.
-    expect(resourceTarget({ templateFile: file, logicalId: 'MyBucketF68F3FF0' })?.range.start)
-      .toEqual({ line: 2, character: 4 });
+  test('resolves the definition block, not Ref/DependsOn occurrences of the same id', () => {
+    const written = writeTemplate(TEMPLATE);
+    dir = written.dir;
+    // MyBucketF68F3FF0 is defined once and also referenced; the block must be the definition.
+    const target = resourceTarget({ templateFile: written.file, logicalId: 'MyBucketF68F3FF0' })!;
+    expect(sliceParse(TEMPLATE, target.range)).toEqual({ Type: 'AWS::S3::Bucket' });
   });
 
   test('does not match a logical id that is a prefix of a longer key', () => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'locator-'));
-    const file = path.join(dir, 'T.template.json');
-    fs.writeFileSync(file, [
-      '{',
-      '  "Resources": {',
-      '    "MyBucketF68F3FF0": {',
-      '      "Type": "AWS::S3::Bucket"',
-      '    },',
-      '    "MyBucket": {',
-      '      "Type": "AWS::S3::Bucket"',
-      '    }',
-      '  }',
-      '}',
-    ].join('\n'));
-    // The closing quote in the match key stops "MyBucket" matching "MyBucketF68F3FF0":
-    expect(resourceTarget({ templateFile: file, logicalId: 'MyBucket' })?.range.start)
-      .toEqual({ line: 5, character: 4 });
+    const contents = JSON.stringify(
+      {
+        Resources: {
+          MyBucketF68F3FF0: { Type: 'AWS::S3::Bucket' },
+          MyBucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'short' } },
+        },
+      },
+      undefined,
+      1,
+    );
+    const written = writeTemplate(contents);
+    dir = written.dir;
+    // The shorter id must resolve to its own (distinct) block, not the longer-named sibling.
+    const target = resourceTarget({ templateFile: written.file, logicalId: 'MyBucket' })!;
+    expect(sliceParse(contents, target.range)).toEqual({ Type: 'AWS::S3::Bucket', Properties: { BucketName: 'short' } });
+  });
+});
+
+describe('sourceTargetAtTemplateOffset', () => {
+  let dir: string | undefined;
+  afterEach(() => {
+    cleanupFixture(dir);
+    dir = undefined;
+  });
+
+  const indexWith = (overrides: Partial<ConstructNode> & { path: string }) =>
+    ConstructIndex.fromTree<ConstructNode>([{ id: overrides.path.split('/').pop()!, children: [], ...overrides }]);
+
+  test('resolves a template offset back to the construct source location', () => {
+    const contents = JSON.stringify(
+      { Resources: { MyBucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'b' } } } },
+      undefined,
+      1,
+    );
+    const written = writeTemplate(contents);
+    dir = written.dir;
+    const index = indexWith({
+      path: 'Stack1/MyBucket/Resource',
+      logicalId: 'MyBucket',
+      type: 'AWS::S3::Bucket',
+      templateFile: written.file,
+      sourceLocation: { file: '/p/lib/stack.ts', line: 5, column: 3 },
+    });
+
+    const offset = contents.indexOf('AWS::S3::Bucket'); // inside the MyBucket block
+    const target = sourceTargetAtTemplateOffset(index, written.file, contents, offset)!;
+    expect(target.uri).toBe(pathToFileURL('/p/lib/stack.ts').toString());
+    // 1-based source location (5, 3) maps to a 0-based LSP position (4, 2).
+    expect(target.range).toEqual({ start: { line: 4, character: 2 }, end: { line: 4, character: 2 } });
+  });
+
+  test('returns undefined for an offset outside any resource block', () => {
+    const contents = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
+    const index = indexWith({
+      path: 'Stack1/MyBucket/Resource',
+      logicalId: 'MyBucket',
+      templateFile: '/x/T.template.json',
+      sourceLocation: { file: '/p/lib/stack.ts', line: 5, column: 3 },
+    });
+    expect(sourceTargetAtTemplateOffset(index, '/x/T.template.json', contents, 0)).toBeUndefined();
+  });
+
+  test('returns undefined when the owning construct has no source location', () => {
+    const contents = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
+    const offset = contents.indexOf('AWS::S3::Bucket');
+    const index = indexWith({ path: 'Stack1/MyBucket/Resource', logicalId: 'MyBucket', templateFile: '/x/T.template.json' });
+    expect(sourceTargetAtTemplateOffset(index, '/x/T.template.json', contents, offset)).toBeUndefined();
+  });
+
+  test('matches on templateFile, not logical id alone (cross-template collision)', () => {
+    const contents = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
+    const written = writeTemplate(contents);
+    dir = written.dir;
+    // Two constructs share the logical id 'MyBucket' across different templates;
+    // logical ids are only unique within a template, so the lookup must also key
+    // on templateFile.
+    const index = ConstructIndex.fromTree<ConstructNode>([
+      { path: 'StackA/MyBucket/Resource', id: 'Resource', logicalId: 'MyBucket', templateFile: written.file, sourceLocation: { file: '/p/a.ts', line: 2, column: 1 }, children: [] },
+      { path: 'StackB/MyBucket/Resource', id: 'Resource', logicalId: 'MyBucket', templateFile: '/other/Stack2.template.json', sourceLocation: { file: '/p/b.ts', line: 9, column: 1 }, children: [] },
+    ]);
+
+    const target = sourceTargetAtTemplateOffset(index, written.file, contents, contents.indexOf('AWS::S3::Bucket'))!;
+    // Resolves to template A's construct (a.ts), not B's, despite the shared id.
+    expect(target.uri).toBe(pathToFileURL('/p/a.ts').toString());
+    expect(target.range.start).toEqual({ line: 1, character: 0 });
   });
 });

--- a/packages/@aws-cdk/cloud-assembly-api/.projen/deps.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.projen/deps.json
@@ -111,6 +111,11 @@
       "type": "peer"
     },
     {
+      "name": "jsonc-parser",
+      "version": "3.2.0",
+      "type": "runtime"
+    },
+    {
       "name": "jsonschema",
       "version": "^1.5.0",
       "type": "runtime"

--- a/packages/@aws-cdk/cloud-assembly-api/.projen/deps.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.projen/deps.json
@@ -18,6 +18,11 @@
       "type": "build"
     },
     {
+      "name": "@types/json-source-map",
+      "version": "^0.6.0",
+      "type": "build"
+    },
+    {
       "name": "@types/node",
       "version": "^20",
       "type": "build"
@@ -111,8 +116,8 @@
       "type": "peer"
     },
     {
-      "name": "jsonc-parser",
-      "version": "3.2.0",
+      "name": "json-source-map",
+      "version": "^0.6.1",
       "type": "runtime"
     },
     {

--- a/packages/@aws-cdk/cloud-assembly-api/lib/index.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/index.ts
@@ -20,3 +20,4 @@ export * from './placeholders';
 export * from './environment';
 export * from './bootstrap';
 export * from './construct-tree';
+export * from './template-ranges';

--- a/packages/@aws-cdk/cloud-assembly-api/lib/template-ranges.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/template-ranges.ts
@@ -1,4 +1,4 @@
-import { findNodeAtLocation, findNodeAtOffset, getNodePath, parseTree, type Node } from 'jsonc-parser';
+import { parse, type Pointers } from 'json-source-map';
 
 /**
  * A character-offset range into a template's text, as a half-open interval
@@ -15,23 +15,20 @@ export interface OffsetRange {
 
 /**
  * Resolves the character range of a resource's value block inside a synthesized
- * CloudFormation template. The range covers the value node `{ ... }` under
+ * CloudFormation template. The range covers the value `{ ... }` under
  * `Resources/<logicalId>`, so `JSON.parse(text.slice(start, end))` returns the
  * resource object.
  *
- * Returns `undefined` when the text cannot be parsed into a JSON tree, or when
- * `logicalId` is not a resource under `Resources`. Uses a position-aware parse
- * rather than a line scan because real templates contain literal braces and
- * escaped quotes inside string values (for example `Fn::Sub` placeholders),
- * which defeats naive brace matching.
+ * Returns `undefined` when the text is not valid JSON, or when there is no such
+ * resource.
  */
 export function resolveResourceRange(templateText: string, logicalId: string): OffsetRange | undefined {
-  const root = parseTree(templateText);
-  if (root === undefined) {
+  const pointers = parsePointers(templateText);
+  const mapping = pointers?.[`/Resources/${escapePointerSegment(logicalId)}`];
+  if (mapping === undefined) {
     return undefined;
   }
-  const blockNode = findNodeAtLocation(root, ['Resources', logicalId]);
-  return blockNode === undefined ? undefined : rangeOf(blockNode);
+  return { start: mapping.value.pos, end: mapping.valueEnd.pos };
 }
 
 /**
@@ -39,29 +36,41 @@ export function resolveResourceRange(templateText: string, logicalId: string): O
  * template's text, returns the logical id of the resource whose block contains
  * that offset, for linking a position in the template back to its construct.
  *
- * Returns `undefined` when the text cannot be parsed, or when the offset is not
+ * Returns `undefined` when the text is not valid JSON, or when the offset is not
  * inside any `Resources/<logicalId>` block (for example whitespace, the
- * top-level `Resources` key, or another top-level section).
+ * `Resources` key, or another top-level section).
  */
 export function resolveLogicalIdAtOffset(templateText: string, offset: number): string | undefined {
-  const root = parseTree(templateText);
-  if (root === undefined) {
+  const pointers = parsePointers(templateText);
+  if (pointers === undefined) {
     return undefined;
   }
-  const node = findNodeAtOffset(root, offset);
-  if (node === undefined) {
-    return undefined;
-  }
-  // The path of any node inside a resource is ['Resources', <logicalId>, ...].
-  // path[1] is always a key here; the typeof narrows getNodePath's string|number union.
-  const path = getNodePath(node);
-  if (path.length >= 2 && path[0] === 'Resources' && typeof path[1] === 'string') {
-    return path[1];
+  for (const [pointer, mapping] of Object.entries(pointers)) {
+    // Match only top-level resources (`/Resources/<id>`), not nested property
+    // pointers like `/Resources/<id>/Properties/...`.
+    const match = /^\/Resources\/([^/]+)$/.exec(pointer);
+    if (match && offset >= mapping.value.pos && offset < mapping.valueEnd.pos) {
+      return unescapePointerSegment(match[1]);
+    }
   }
   return undefined;
 }
 
-/** The character range covered by a parsed node. */
-function rangeOf(node: Node): OffsetRange {
-  return { start: node.offset, end: node.offset + node.length };
+/** Parse the template into its JSON-pointer map, or `undefined` if it is not valid JSON. */
+function parsePointers(templateText: string): Pointers | undefined {
+  try {
+    return parse(templateText).pointers;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Escape a single path segment for use in a JSON pointer. */
+function escapePointerSegment(segment: string): string {
+  return segment.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+/** Reverse of `escapePointerSegment`. */
+function unescapePointerSegment(segment: string): string {
+  return segment.replace(/~1/g, '/').replace(/~0/g, '~');
 }

--- a/packages/@aws-cdk/cloud-assembly-api/lib/template-ranges.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/template-ranges.ts
@@ -1,0 +1,67 @@
+import { findNodeAtLocation, findNodeAtOffset, getNodePath, parseTree, type Node } from 'jsonc-parser';
+
+/**
+ * A character-offset range into a template's text, as a half-open interval
+ * `[start, end)`. Framework-neutral on purpose: consumers map offsets to their
+ * own position model (for example the LSP via `TextDocument.positionAt`), which
+ * keeps this package free of editor types and of the UTF-16 column subtlety.
+ */
+export interface OffsetRange {
+  /** Start offset, a 0-based character index, inclusive. */
+  readonly start: number;
+  /** End offset, a 0-based character index, exclusive. */
+  readonly end: number;
+}
+
+/**
+ * Resolves the character range of a resource's value block inside a synthesized
+ * CloudFormation template. The range covers the value node `{ ... }` under
+ * `Resources/<logicalId>`, so `JSON.parse(text.slice(start, end))` returns the
+ * resource object.
+ *
+ * Returns `undefined` when the text cannot be parsed into a JSON tree, or when
+ * `logicalId` is not a resource under `Resources`. Uses a position-aware parse
+ * rather than a line scan because real templates contain literal braces and
+ * escaped quotes inside string values (for example `Fn::Sub` placeholders),
+ * which defeats naive brace matching.
+ */
+export function resolveResourceRange(templateText: string, logicalId: string): OffsetRange | undefined {
+  const root = parseTree(templateText);
+  if (root === undefined) {
+    return undefined;
+  }
+  const blockNode = findNodeAtLocation(root, ['Resources', logicalId]);
+  return blockNode === undefined ? undefined : rangeOf(blockNode);
+}
+
+/**
+ * The inverse of `resolveResourceRange`: given a character offset into a
+ * template's text, returns the logical id of the resource whose block contains
+ * that offset, for linking a position in the template back to its construct.
+ *
+ * Returns `undefined` when the text cannot be parsed, or when the offset is not
+ * inside any `Resources/<logicalId>` block (for example whitespace, the
+ * top-level `Resources` key, or another top-level section).
+ */
+export function resolveLogicalIdAtOffset(templateText: string, offset: number): string | undefined {
+  const root = parseTree(templateText);
+  if (root === undefined) {
+    return undefined;
+  }
+  const node = findNodeAtOffset(root, offset);
+  if (node === undefined) {
+    return undefined;
+  }
+  // The path of any node inside a resource is ['Resources', <logicalId>, ...].
+  // path[1] is always a key here; the typeof narrows getNodePath's string|number union.
+  const path = getNodePath(node);
+  if (path.length >= 2 && path[0] === 'Resources' && typeof path[1] === 'string') {
+    return path[1];
+  }
+  return undefined;
+}
+
+/** The character range covered by a parsed node. */
+function rangeOf(node: Node): OffsetRange {
+  return { start: node.offset, end: node.offset + node.length };
+}

--- a/packages/@aws-cdk/cloud-assembly-api/package.json
+++ b/packages/@aws-cdk/cloud-assembly-api/package.json
@@ -35,6 +35,7 @@
     "@cdklabs/eslint-plugin": "^2.0.8",
     "@stylistic/eslint-plugin": "^3",
     "@types/jest": "^29.5.14",
+    "@types/json-source-map": "^0.6.0",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
@@ -60,7 +61,7 @@
     "@aws-cdk/cloud-assembly-schema": "^0.0.0"
   },
   "dependencies": {
-    "jsonc-parser": "3.2.0",
+    "json-source-map": "^0.6.1",
     "jsonschema": "^1.5.0",
     "semver": "^7.8.1"
   },

--- a/packages/@aws-cdk/cloud-assembly-api/package.json
+++ b/packages/@aws-cdk/cloud-assembly-api/package.json
@@ -60,6 +60,7 @@
     "@aws-cdk/cloud-assembly-schema": "^0.0.0"
   },
   "dependencies": {
+    "jsonc-parser": "3.2.0",
     "jsonschema": "^1.5.0",
     "semver": "^7.8.1"
   },

--- a/packages/@aws-cdk/cloud-assembly-api/test/template-ranges.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/test/template-ranges.test.ts
@@ -74,15 +74,11 @@ describe('resolveResourceRange', () => {
     expect((sliceParse(block) as { Type: string }).Type).toBe('AWS::S3::Bucket');
   });
 
-  test('returns a range for lenient (trailing-comma) JSON rather than failing', () => {
-    // jsonc-parser is tolerant, so resolution does not require strict JSON; it
-    // still locates the block. (The slice is not guaranteed to be strict JSON —
-    // relevant once L3 reads half-written templates on save.)
-    const lenient = '{\n "Resources": {\n  "B": {\n   "Type": "AWS::S3::Bucket",\n  }\n }\n}';
-    const range = resolveResourceRange(lenient, 'B')!;
-    // Prove it located B specifically (not just "a range"). The lenient slice
-    // can't be strict-JSON-parsed, so match the text instead.
-    expect(lenient.slice(range.start, range.end)).toContain('AWS::S3::Bucket');
+  test('returns undefined for invalid JSON (for example a trailing comma)', () => {
+    // json-source-map is a strict parser, so a malformed template yields no
+    // range rather than a wrong one. Synthesized templates are always strict JSON.
+    const invalid = '{\n "Resources": {\n  "B": {\n   "Type": "AWS::S3::Bucket",\n  }\n }\n}';
+    expect(resolveResourceRange(invalid, 'B')).toBeUndefined();
   });
 
   test('returns undefined for an unknown logical id', () => {

--- a/packages/@aws-cdk/cloud-assembly-api/test/template-ranges.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/test/template-ranges.test.ts
@@ -1,0 +1,117 @@
+import { resolveLogicalIdAtOffset, resolveResourceRange } from '../lib';
+
+// A template object is the single source of truth: the text under test is its
+// 1-space serialization (exactly how synth writes `*.template.json`), and the
+// expected values are read straight off the object, so input and expectations
+// can never drift. The shapes pack the cases that defeat naive approaches:
+//
+// - Policy carries an `Fn::Sub` (`${...}` braces), an `InlineJson` value with
+//   escaped quotes and a `}`, and a `Description` with a lone unmatched `{` —
+//   all of which break brace-counting but not a real parse.
+// - MyBucket / MyBucketF68F3FF0 are a prefix-collision pair.
+// - MyBucket also appears as a value (Fn::Sub, DependsOn), never as another key.
+const TEMPLATE = {
+  Resources: {
+    MyBucket: {
+      Type: 'AWS::S3::Bucket',
+      Properties: { BucketName: 'plain-bucket' },
+    },
+    MyBucketF68F3FF0: {
+      Type: 'AWS::S3::Bucket',
+      Properties: { VersioningConfiguration: { Status: 'Enabled' } },
+    },
+    Policy: {
+      Type: 'AWS::IAM::Policy',
+      Properties: {
+        PolicyDocument: {
+          Statement: [{ Action: 's3:*', Resource: { 'Fn::Sub': 'arn:${AWS::Partition}:s3:::${MyBucket}/*' } }],
+        },
+        InlineJson: '{"key":"va}lue"}',
+        Description: 'trailing brace } then a lone open { inside a string',
+      },
+      DependsOn: ['MyBucket'],
+    },
+    Topic: { Type: 'AWS::SNS::Topic' },
+  },
+} as const;
+
+// 1-space indent mirrors `JSON.stringify(template, undefined, 1)` in synth.
+const TEMPLATE_TEXT = JSON.stringify(TEMPLATE, undefined, 1);
+const RESOURCES: Record<string, unknown> = TEMPLATE.Resources;
+const LOGICAL_IDS = Object.keys(RESOURCES);
+
+/** Slice the serialized text by a computed range and re-parse it. */
+const sliceParse = (range: { start: number; end: number }) =>
+  JSON.parse(TEMPLATE_TEXT.slice(range.start, range.end));
+
+describe('resolveResourceRange', () => {
+  // The authoritative check: a range is correct iff the substring it selects
+  // re-parses to the same value the template's own JSON.parse produced. No
+  // hand-computed offsets, and it runs over every resource.
+  test.each(LOGICAL_IDS)('the resolved range for %s re-parses to that exact resource', (logicalId) => {
+    const block = resolveResourceRange(TEMPLATE_TEXT, logicalId)!;
+    expect(sliceParse(block)).toEqual(RESOURCES[logicalId]);
+  });
+
+  test('resolves a block whose property values contain brace/quote hazards', () => {
+    // Policy holds an Fn::Sub (${...}), an InlineJson value with escaped quotes
+    // and a }, and a Description with a lone {, all of which defeat brace counting.
+    const block = resolveResourceRange(TEMPLATE_TEXT, 'Policy')!;
+    expect(sliceParse(block)).toEqual(RESOURCES.Policy);
+  });
+
+  test('a logical id resolves to its own block despite a prefix-named sibling', () => {
+    const short = resolveResourceRange(TEMPLATE_TEXT, 'MyBucket')!;
+    const long = resolveResourceRange(TEMPLATE_TEXT, 'MyBucketF68F3FF0')!;
+    expect(sliceParse(short)).toEqual(RESOURCES.MyBucket);
+    expect(sliceParse(long)).toEqual(RESOURCES.MyBucketF68F3FF0);
+    expect(short).not.toEqual(long);
+  });
+
+  test('resolves the definition block even when the id also appears as a value', () => {
+    // MyBucket appears under Policy's Fn::Sub and DependsOn, never as another key.
+    const block = resolveResourceRange(TEMPLATE_TEXT, 'MyBucket')!;
+    expect((sliceParse(block) as { Type: string }).Type).toBe('AWS::S3::Bucket');
+  });
+
+  test('returns a range for lenient (trailing-comma) JSON rather than failing', () => {
+    // jsonc-parser is tolerant, so resolution does not require strict JSON; it
+    // still locates the block. (The slice is not guaranteed to be strict JSON —
+    // relevant once L3 reads half-written templates on save.)
+    const lenient = '{\n "Resources": {\n  "B": {\n   "Type": "AWS::S3::Bucket",\n  }\n }\n}';
+    const range = resolveResourceRange(lenient, 'B')!;
+    // Prove it located B specifically (not just "a range"). The lenient slice
+    // can't be strict-JSON-parsed, so match the text instead.
+    expect(lenient.slice(range.start, range.end)).toContain('AWS::S3::Bucket');
+  });
+
+  test('returns undefined for an unknown logical id', () => {
+    expect(resolveResourceRange(TEMPLATE_TEXT, 'DoesNotExist')).toBeUndefined();
+  });
+
+  test('returns undefined when the text cannot be parsed into a tree', () => {
+    expect(resolveResourceRange('not json at all', 'MyBucket')).toBeUndefined();
+  });
+});
+
+describe('resolveLogicalIdAtOffset', () => {
+  // Inverse round-trip: an offset inside each resource's block resolves back to it.
+  test.each(LOGICAL_IDS)('an offset inside %s resolves to that logical id', (logicalId) => {
+    const block = resolveResourceRange(TEMPLATE_TEXT, logicalId)!;
+    const mid = Math.floor((block.start + block.end) / 2);
+    expect(resolveLogicalIdAtOffset(TEMPLATE_TEXT, mid)).toBe(logicalId);
+  });
+
+  test('an offset in a nested property value resolves to its owning resource', () => {
+    expect(resolveLogicalIdAtOffset(TEMPLATE_TEXT, TEMPLATE_TEXT.indexOf('lone open'))).toBe('Policy');
+  });
+
+  test('returns undefined for an offset outside any resource block', () => {
+    // Offset 0 is the opening brace of the whole document, before Resources.
+    expect(resolveLogicalIdAtOffset(TEMPLATE_TEXT, 0)).toBeUndefined();
+  });
+
+  test('returns undefined when the text cannot be parsed into a tree', () => {
+    expect(resolveLogicalIdAtOffset('not json at all', 3)).toBeUndefined();
+  });
+});

--- a/packages/@aws-cdk/cloud-assembly-api/tsconfig.dev.json
+++ b/packages/@aws-cdk/cloud-assembly-api/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2020",
     "types": [
       "jest",
+      "json-source-map",
       "node"
     ],
     "incremental": true,

--- a/packages/@aws-cdk/cloud-assembly-api/tsconfig.json
+++ b/packages/@aws-cdk/cloud-assembly-api/tsconfig.json
@@ -28,6 +28,7 @@
     "target": "ES2020",
     "types": [
       "jest",
+      "json-source-map",
       "node"
     ],
     "incremental": true,

--- a/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
@@ -29925,6 +29925,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+
+----------------
+
 ** jsonfile@6.2.0 - https://www.npmjs.com/package/jsonfile/v/6.2.0 | MIT
 (The MIT License)
 

--- a/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
+++ b/packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES
@@ -29925,7 +29925,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
-** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+** json-source-map@0.6.1 - https://www.npmjs.com/package/json-source-map/v/0.6.1 | MIT
+MIT License
+
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -30075,6 +30075,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+
+----------------
+
 ** jsonfile@6.2.0 - https://www.npmjs.com/package/jsonfile/v/6.2.0 | MIT
 (The MIT License)
 

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -30075,7 +30075,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
-** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+** json-source-map@0.6.1 - https://www.npmjs.com/package/json-source-map/v/0.6.1 | MIT
+MIT License
+
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 

--- a/packages/cdk-assets/THIRD_PARTY_LICENSES
+++ b/packages/cdk-assets/THIRD_PARTY_LICENSES
@@ -22176,7 +22176,29 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
-** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+** json-source-map@0.6.1 - https://www.npmjs.com/package/json-source-map/v/0.6.1 | MIT
+MIT License
+
+Copyright (c) 2017 Evgeny Poberezkin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 

--- a/packages/cdk-assets/THIRD_PARTY_LICENSES
+++ b/packages/cdk-assets/THIRD_PARTY_LICENSES
@@ -22176,6 +22176,10 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** jsonc-parser@3.2.0 - https://www.npmjs.com/package/jsonc-parser/v/3.2.0 | MIT
+
+----------------
+
 ** jsonschema@1.5.0 - https://www.npmjs.com/package/jsonschema/v/1.5.0 | MIT
 jsonschema is licensed under MIT license.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -263,6 +263,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.5"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16"
+    jsonc-parser: "npm:3.2.0"
     jsonschema: "npm:^1.5.0"
     license-checker: "npm:^25.0.1"
     nx: "npm:^22.7.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -249,6 +249,7 @@ __metadata:
     "@cdklabs/eslint-plugin": "npm:^2.0.8"
     "@stylistic/eslint-plugin": "npm:^3"
     "@types/jest": "npm:^29.5.14"
+    "@types/json-source-map": "npm:^0.6.0"
     "@types/node": "npm:^20"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
@@ -263,7 +264,7 @@ __metadata:
     eslint-plugin-prettier: "npm:^4.2.5"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16"
-    jsonc-parser: "npm:3.2.0"
+    json-source-map: "npm:^0.6.1"
     jsonschema: "npm:^1.5.0"
     license-checker: "npm:^25.0.1"
     nx: "npm:^22.7.5"
@@ -6817,6 +6818,13 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/json-source-map@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@types/json-source-map@npm:0.6.0"
+  checksum: 10c0/b7db2f52735acc70b70bf49b1e945f4749ac5c9c8429c44ad23c751193f89d030400ed966c416540647745414cd450f35795395bf0be9eae94816bbe03ad0a2f
   languageName: node
   linkType: hard
 
@@ -13655,6 +13663,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-source-map@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "json-source-map@npm:0.6.1"
+  checksum: 10c0/9fe819f7dfc1407caf8e36246f18376eb511b969954d457b251dfb506df74544cefc0c368f64474b512956eeb37807e03045332a9712ddd14b836d54debe03c3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Computes character ranges for CloudFormation resource blocks in synthesized templates and uses them for navigation in both directions:
- 
- CodeLens "go to" now selects the whole resource block (was a zero-width cursor).
- New go-to-definition from a synthesized template back to the construct's source.

A note on the JSON parser dependency Computing character ranges needs a position-aware JSON parser, since JSON.parse discards offsets. The natural choice is jsonc-parser (what the VS Code JSON language service uses). We could not use it here: its UMD entry loads internal modules through a parameter-shadowed require("./impl/...") that esbuild (used by node-backpack to bundle the CLI) cannot statically trace, so the bundled `cdk/cdk-assets` binaries fail with `Cannot find module './impl/format'`. Known, still-open: [microsoft/node-jsonc-parser#57](https://github.com/microsoft/node-jsonc-parser/issues/57), [evanw/esbuild#1619](https://github.com/evanw/esbuild/issues/1619). Its ESM build bundles fine, but the esbuild mainFields workaround isn't exposed by node-backpack, and importing the ESM build directly breaks our CommonJS tests; marking it external isn't appropriate for a self-contained CLI. So we use [json-source-map](https://www.npmjs.com/package/json-source-map), a single-file CommonJS module that bundles cleanly. 


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
