### PR TITLE
fix: bucket URL is incorrect for local S3 emulators

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -708,11 +708,11 @@ const tools = defineTools({
   ...genericCdkProps({ private: true }),
   parent: repo,
   tools: {
-    subprocess: {
+    'subprocess': {
       deps: ['cross-spawn@^7.0.6'],
       devDeps: ['@types/cross-spawn'],
     },
-    zip: {
+    'zip': {
       deps: ['yazl@^3.3.1', 'fast-glob@^3.3.3'],
       devDeps: ['@types/yazl', 'jszip', 'timezone-mock'],
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -716,6 +716,9 @@ const tools = defineTools({
       deps: ['yazl@^3.3.1', 'fast-glob@^3.3.3'],
       devDeps: ['@types/yazl', 'jszip', 'timezone-mock'],
     },
+    's3-path-style': {
+      deps: [],
+    },
   },
 });
 configureProject(tools);
@@ -773,6 +776,7 @@ const cdkAssetsLib = configureProject(
   }),
 );
 cdkAssetsLib.with(tools.zip);
+cdkAssetsLib.with(tools['s3-path-style']);
 fixupTestTask(cdkAssetsLib);
 
 // Prevent imports of private API surface
@@ -998,6 +1002,7 @@ const toolkitLib = configureProject(
 );
 fixupTestTask(toolkitLib);
 toolkitLib.with(tools.zip);
+toolkitLib.with(tools['s3-path-style']);
 toolkitLib.tasks.tryFind('test')?.updateStep(0, {
   // https://github.com/aws/aws-sdk-js-v3/issues/7420
   exec: 'NODE_OPTIONS="$NODE_OPTIONS --experimental-vm-modules" jest --passWithNoTests --updateSnapshot',

--- a/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
@@ -160,6 +160,10 @@
           {
             "name": "@aws-cdk/private-tools/lib/zip",
             "message": "Import shared tools from './private/tools' (the generated shim), not '@aws-cdk/private-tools' directly."
+          },
+          {
+            "name": "@aws-cdk/private-tools/lib/s3-path-style",
+            "message": "Import shared tools from './private/tools' (the generated shim), not '@aws-cdk/private-tools' directly."
           }
         ],
         "patterns": [

--- a/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
@@ -149,7 +149,11 @@ export class DefaultAwsClient implements IAws {
   }
 
   public async s3Client(options: ClientOptions): Promise<IS3Client> {
-    const client = new S3Client(await this.awsOptions(options));
+    const client = new S3Client({
+      ...(await this.awsOptions(options)),
+      // Allow forcing S3 path-style addressing (e.g. for custom/local endpoints).
+      forcePathStyle: process.env.CDK_S3_FORCE_PATH_STYLE ? true : undefined,
+    });
     return {
       getBucketEncryption: (
         input: GetBucketEncryptionCommandInput,

--- a/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/aws.ts
@@ -46,6 +46,7 @@ import type {
   ListObjectsV2CommandOutput,
   PutObjectCommandInput,
 } from './aws-types';
+import { forceS3PathStyle } from './private/tools';
 
 export type AssumeRoleAdditionalOptions = Partial<
   Omit<AssumeRoleCommandInput, 'ExternalId' | 'RoleArn'>
@@ -151,8 +152,8 @@ export class DefaultAwsClient implements IAws {
   public async s3Client(options: ClientOptions): Promise<IS3Client> {
     const client = new S3Client({
       ...(await this.awsOptions(options)),
-      // Allow forcing S3 path-style addressing (e.g. for custom/local endpoints).
-      forcePathStyle: process.env.CDK_S3_FORCE_PATH_STYLE ? true : undefined,
+      // Use path-style addressing for explicit opt-in or loopback endpoints.
+      forcePathStyle: forceS3PathStyle(),
     });
     return {
       getBucketEncryption: (

--- a/packages/@aws-cdk/cdk-assets-lib/lib/private/tools.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/private/tools.ts
@@ -3,3 +3,5 @@
 /* eslint-disable import/no-extraneous-dependencies -- re-exports the build-time-only @aws-cdk/private-tools package */
 /* eslint-disable no-restricted-imports -- this shim is the single sanctioned entry point to @aws-cdk/private-tools */
 export * from '@aws-cdk/private-tools/lib/zip';
+
+export * from '@aws-cdk/private-tools/lib/s3-path-style';

--- a/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
@@ -74,37 +74,48 @@ test('session tags are passed to fromTemporaryCredentials in awsOptions', async 
   });
 });
 
-describe('CDK_S3_FORCE_PATH_STYLE', () => {
+describe('S3 path-style addressing', () => {
+  const ENV_VARS = ['CDK_S3_FORCE_PATH_STYLE', 'AWS_ENDPOINT_URL_S3', 'AWS_ENDPOINT_URL'];
+  const original: Record<string, string | undefined> = {};
   let s3ClientSpy: jest.SpyInstance;
-  const originalValue = process.env.CDK_S3_FORCE_PATH_STYLE;
 
   beforeEach(() => {
+    for (const v of ENV_VARS) {
+      original[v] = process.env[v];
+      delete process.env[v];
+    }
     s3ClientSpy = jest.spyOn(s3, 'S3Client').mockImplementation(() => ({}) as any);
   });
 
   afterEach(() => {
     s3ClientSpy.mockRestore();
-    if (originalValue === undefined) {
-      delete process.env.CDK_S3_FORCE_PATH_STYLE;
-    } else {
-      process.env.CDK_S3_FORCE_PATH_STYLE = originalValue;
+    for (const v of ENV_VARS) {
+      if (original[v] === undefined) {
+        delete process.env[v];
+      } else {
+        process.env[v] = original[v];
+      }
     }
   });
 
-  test('forces path-style addressing on the S3 client when set', async () => {
+  test('forces path-style addressing on the S3 client when CDK_S3_FORCE_PATH_STYLE is set', async () => {
     process.env.CDK_S3_FORCE_PATH_STYLE = '1';
-    const aws = new DefaultAwsClient();
 
-    await aws.s3Client({ region: 'far-far-away' });
+    await new DefaultAwsClient().s3Client({ region: 'far-far-away' });
 
     expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: true }));
   });
 
-  test('leaves path-style addressing unset on the S3 client when not set', async () => {
-    delete process.env.CDK_S3_FORCE_PATH_STYLE;
-    const aws = new DefaultAwsClient();
+  test('auto-detects path-style addressing for a loopback endpoint', async () => {
+    process.env.AWS_ENDPOINT_URL_S3 = 'http://localhost:4566';
 
-    await aws.s3Client({ region: 'far-far-away' });
+    await new DefaultAwsClient().s3Client({ region: 'far-far-away' });
+
+    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: true }));
+  });
+
+  test('leaves path-style addressing unset on the S3 client by default', async () => {
+    await new DefaultAwsClient().s3Client({ region: 'far-far-away' });
 
     expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: undefined }));
   });

--- a/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
@@ -1,5 +1,6 @@
 import 'aws-sdk-client-mock-jest';
 
+import * as s3 from '@aws-sdk/client-s3';
 import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { mockSTS } from './mock-aws';
@@ -70,5 +71,41 @@ test('session tags are passed to fromTemporaryCredentials in awsOptions', async 
       ],
       TransitiveTagKeys: ['this', 'that'],
     },
+  });
+});
+
+describe('CDK_S3_FORCE_PATH_STYLE', () => {
+  let s3ClientSpy: jest.SpyInstance;
+  const originalValue = process.env.CDK_S3_FORCE_PATH_STYLE;
+
+  beforeEach(() => {
+    s3ClientSpy = jest.spyOn(s3, 'S3Client').mockImplementation(() => ({}) as any);
+  });
+
+  afterEach(() => {
+    s3ClientSpy.mockRestore();
+    if (originalValue === undefined) {
+      delete process.env.CDK_S3_FORCE_PATH_STYLE;
+    } else {
+      process.env.CDK_S3_FORCE_PATH_STYLE = originalValue;
+    }
+  });
+
+  test('forces path-style addressing on the S3 client when set', async () => {
+    process.env.CDK_S3_FORCE_PATH_STYLE = '1';
+    const aws = new DefaultAwsClient();
+
+    await aws.s3Client({ region: 'far-far-away' });
+
+    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: true }));
+  });
+
+  test('leaves path-style addressing unset on the S3 client when not set', async () => {
+    delete process.env.CDK_S3_FORCE_PATH_STYLE;
+    const aws = new DefaultAwsClient();
+
+    await aws.s3Client({ region: 'far-far-away' });
+
+    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: undefined }));
   });
 });

--- a/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/aws.test.ts
@@ -1,6 +1,6 @@
 import 'aws-sdk-client-mock-jest';
 
-import * as s3 from '@aws-sdk/client-s3';
+import s3 from '@aws-sdk/client-s3';
 import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { fromTemporaryCredentials } from '@aws-sdk/credential-providers';
 import { mockSTS } from './mock-aws';

--- a/packages/@aws-cdk/private-tools/lib/s3-path-style/index.ts
+++ b/packages/@aws-cdk/private-tools/lib/s3-path-style/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Determine whether the S3 client should use path-style addressing.
+ *
+ * The AWS SDK defaults to virtual-hosted-style addressing
+ * (`https://<bucket>.s3.amazonaws.com`). That doesn't work for S3-compatible
+ * emulators reached over loopback (e.g. LocalStack or MinIO on `localhost`),
+ * which only serve path-style URLs (`https://<endpoint>/<bucket>`).
+ *
+ * Returns `true` when path-style should be forced, or `undefined` to leave the
+ * SDK default in place.
+ *
+ * - The `CDK_S3_FORCE_PATH_STYLE` environment variable forces it explicitly.
+ * - Otherwise it is auto-detected when the configured S3 endpoint
+ *   (`AWS_ENDPOINT_URL_S3`, falling back to `AWS_ENDPOINT_URL`) points at a
+ *   loopback host.
+ */
+export function forceS3PathStyle(): boolean | undefined {
+  if (process.env.CDK_S3_FORCE_PATH_STYLE) {
+    return true;
+  }
+
+  const endpoint = process.env.AWS_ENDPOINT_URL_S3 ?? process.env.AWS_ENDPOINT_URL;
+  if (endpoint && isLoopbackEndpoint(endpoint)) {
+    return true;
+  }
+
+  return undefined;
+}
+
+function isLoopbackEndpoint(endpoint: string): boolean {
+  let host: string;
+  try {
+    host = new URL(endpoint).hostname;
+  } catch {
+    return false;
+  }
+
+  // The URL parser wraps IPv6 addresses in brackets to make use of colons unambiguous, e.g. "http://[::1]:4566"
+  // Strip them for easier comparison.
+  const normalized = host.replace(/^\[|\]$/g, '').toLowerCase();
+  return normalized === 'localhost'
+    || normalized.startsWith('127.')
+    || normalized === '::1';
+}

--- a/packages/@aws-cdk/private-tools/test/s3-path-style/s3-path-style.test.ts
+++ b/packages/@aws-cdk/private-tools/test/s3-path-style/s3-path-style.test.ts
@@ -1,0 +1,70 @@
+import { forceS3PathStyle } from '../../lib/s3-path-style';
+
+const ENV_VARS = ['CDK_S3_FORCE_PATH_STYLE', 'AWS_ENDPOINT_URL_S3', 'AWS_ENDPOINT_URL'];
+
+describe('forceS3PathStyle', () => {
+  const original: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const v of ENV_VARS) {
+      original[v] = process.env[v];
+      delete process.env[v];
+    }
+  });
+
+  afterEach(() => {
+    for (const v of ENV_VARS) {
+      if (original[v] === undefined) {
+        delete process.env[v];
+      } else {
+        process.env[v] = original[v];
+      }
+    }
+  });
+
+  test('returns undefined when nothing is configured', () => {
+    expect(forceS3PathStyle()).toBeUndefined();
+  });
+
+  test('CDK_S3_FORCE_PATH_STYLE forces path-style explicitly', () => {
+    process.env.CDK_S3_FORCE_PATH_STYLE = '1';
+    expect(forceS3PathStyle()).toBe(true);
+  });
+
+  test.each([
+    'http://localhost:4566',
+    'https://localhost',
+    'http://127.0.0.1:9000',
+    'http://127.1.2.3:9000',
+    'http://[::1]:4566',
+    'http://LOCALHOST:4566',
+  ])('auto-detects loopback endpoint %s from AWS_ENDPOINT_URL_S3', (endpoint) => {
+    process.env.AWS_ENDPOINT_URL_S3 = endpoint;
+    expect(forceS3PathStyle()).toBe(true);
+  });
+
+  test('falls back to AWS_ENDPOINT_URL when AWS_ENDPOINT_URL_S3 is unset', () => {
+    process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+    expect(forceS3PathStyle()).toBe(true);
+  });
+
+  test('AWS_ENDPOINT_URL_S3 takes precedence over AWS_ENDPOINT_URL', () => {
+    process.env.AWS_ENDPOINT_URL_S3 = 'https://s3.amazonaws.com';
+    process.env.AWS_ENDPOINT_URL = 'http://localhost:4566';
+    expect(forceS3PathStyle()).toBeUndefined();
+  });
+
+  test.each([
+    'https://s3.amazonaws.com',
+    'https://s3.us-east-1.amazonaws.com',
+    'https://my-custom-endpoint.example.com',
+  ])('leaves non-loopback endpoint %s on the SDK default', (endpoint) => {
+    process.env.AWS_ENDPOINT_URL_S3 = endpoint;
+    expect(forceS3PathStyle()).toBeUndefined();
+  });
+
+  test('ignores an unparseable endpoint', () => {
+    process.env.AWS_ENDPOINT_URL_S3 = 'not a url';
+    expect(forceS3PathStyle()).toBeUndefined();
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -157,6 +157,10 @@
           {
             "name": "@aws-cdk/private-tools/lib/zip",
             "message": "Import shared tools from './private/tools' (the generated shim), not '@aws-cdk/private-tools' directly."
+          },
+          {
+            "name": "@aws-cdk/private-tools/lib/s3-path-style",
+            "message": "Import shared tools from './private/tools' (the generated shim), not '@aws-cdk/private-tools' directly."
           }
         ],
         "patterns": [

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -1123,7 +1123,11 @@ export class SDK {
   }
 
   public s3(): IS3Client {
-    const client = new S3Client(this.config);
+    const client = new S3Client({
+      ...this.config,
+      // Allow forcing S3 path-style addressing (e.g. for custom/local endpoints).
+      forcePathStyle: process.env.CDK_S3_FORCE_PATH_STYLE ? true : undefined,
+    });
     return {
       deleteObjects: (input: DeleteObjectsCommandInput): Promise<DeleteObjectsCommandOutput> =>
         client.send(new DeleteObjectsCommand({

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -425,6 +425,7 @@ import type { ISdkLogger } from './sdk-logger';
 import type { Account } from './sdk-provider';
 import { traceMemberMethods } from './tracing';
 import { defaultCliUserAgent } from './user-agent';
+import { forceS3PathStyle } from '../../private/tools';
 import { AuthenticationError } from '../../toolkit/toolkit-error';
 import { formatErrorMessage } from '../../util';
 import type { IoHelper } from '../io/private';
@@ -1125,8 +1126,8 @@ export class SDK {
   public s3(): IS3Client {
     const client = new S3Client({
       ...this.config,
-      // Allow forcing S3 path-style addressing (e.g. for custom/local endpoints).
-      forcePathStyle: process.env.CDK_S3_FORCE_PATH_STYLE ? true : undefined,
+      // Use path-style addressing for explicit opt-in or loopback endpoints.
+      forcePathStyle: forceS3PathStyle(),
     });
     return {
       deleteObjects: (input: DeleteObjectsCommandInput): Promise<DeleteObjectsCommandOutput> =>

--- a/packages/@aws-cdk/toolkit-lib/lib/private/tools.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/private/tools.ts
@@ -3,3 +3,5 @@
 /* eslint-disable import/no-extraneous-dependencies -- re-exports the build-time-only @aws-cdk/private-tools package */
 /* eslint-disable no-restricted-imports -- this shim is the single sanctioned entry point to @aws-cdk/private-tools */
 export * from '@aws-cdk/private-tools/lib/zip';
+
+export * from '@aws-cdk/private-tools/lib/s3-path-style';

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
@@ -1,36 +1,51 @@
 import * as s3 from '@aws-sdk/client-s3';
 import { MockSdk } from '../../_helpers/mock-sdk';
 
-describe('CDK_S3_FORCE_PATH_STYLE', () => {
+describe('S3 path-style addressing', () => {
+  const ENV_VARS = ['CDK_S3_FORCE_PATH_STYLE', 'AWS_ENDPOINT_URL_S3', 'AWS_ENDPOINT_URL'];
+  const original: Record<string, string | undefined> = {};
   let s3ClientSpy: jest.SpyInstance;
-  const originalValue = process.env.CDK_S3_FORCE_PATH_STYLE;
 
   beforeEach(() => {
+    for (const v of ENV_VARS) {
+      original[v] = process.env[v];
+      delete process.env[v];
+    }
     s3ClientSpy = jest.spyOn(s3, 'S3Client').mockImplementation(() => ({}) as any);
   });
 
   afterEach(() => {
     s3ClientSpy.mockRestore();
-    if (originalValue === undefined) {
-      delete process.env.CDK_S3_FORCE_PATH_STYLE;
-    } else {
-      process.env.CDK_S3_FORCE_PATH_STYLE = originalValue;
+    for (const v of ENV_VARS) {
+      if (original[v] === undefined) {
+        delete process.env[v];
+      } else {
+        process.env[v] = original[v];
+      }
     }
   });
 
-  test('forces path-style addressing on the S3 client when set', () => {
+  // MockSdk only supplies fake credentials and region; `.s3()` is the real SDK
+  // method under test. Returns the `forcePathStyle` value it passes when
+  // constructing the underlying S3 client.
+  function forcePathStylePassedToS3Client(): boolean | undefined {
+    new MockSdk().s3();
+    return s3ClientSpy.mock.calls[0][0].forcePathStyle;
+  }
+
+  test('is forced when CDK_S3_FORCE_PATH_STYLE is set', () => {
     process.env.CDK_S3_FORCE_PATH_STYLE = '1';
 
-    new MockSdk().s3();
-
-    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: true }));
+    expect(forcePathStylePassedToS3Client()).toBe(true);
   });
 
-  test('leaves path-style addressing unset on the S3 client when not set', () => {
-    delete process.env.CDK_S3_FORCE_PATH_STYLE;
+  test('is auto-detected for a loopback endpoint', () => {
+    process.env.AWS_ENDPOINT_URL_S3 = 'http://localhost:4566';
 
-    new MockSdk().s3();
+    expect(forcePathStylePassedToS3Client()).toBe(true);
+  });
 
-    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: undefined }));
+  test('is left unset by default', () => {
+    expect(forcePathStylePassedToS3Client()).toBeUndefined();
   });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
@@ -1,0 +1,36 @@
+import * as s3 from '@aws-sdk/client-s3';
+import { MockSdk } from '../../_helpers/mock-sdk';
+
+describe('CDK_S3_FORCE_PATH_STYLE', () => {
+  let s3ClientSpy: jest.SpyInstance;
+  const originalValue = process.env.CDK_S3_FORCE_PATH_STYLE;
+
+  beforeEach(() => {
+    s3ClientSpy = jest.spyOn(s3, 'S3Client').mockImplementation(() => ({}) as any);
+  });
+
+  afterEach(() => {
+    s3ClientSpy.mockRestore();
+    if (originalValue === undefined) {
+      delete process.env.CDK_S3_FORCE_PATH_STYLE;
+    } else {
+      process.env.CDK_S3_FORCE_PATH_STYLE = originalValue;
+    }
+  });
+
+  test('forces path-style addressing on the S3 client when set', () => {
+    process.env.CDK_S3_FORCE_PATH_STYLE = '1';
+
+    new MockSdk().s3();
+
+    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: true }));
+  });
+
+  test('leaves path-style addressing unset on the S3 client when not set', () => {
+    delete process.env.CDK_S3_FORCE_PATH_STYLE;
+
+    new MockSdk().s3();
+
+    expect(s3ClientSpy).toHaveBeenCalledWith(expect.objectContaining({ forcePathStyle: undefined }));
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/aws-auth/sdk.test.ts
@@ -1,4 +1,4 @@
-import * as s3 from '@aws-sdk/client-s3';
+import s3 from '@aws-sdk/client-s3';
 import { MockSdk } from '../../_helpers/mock-sdk';
 
 describe('S3 path-style addressing', () => {


### PR DESCRIPTION
The AWS SDK addresses S3 buckets using virtual-hosted-style URLs by default (`https://<bucket>.s3.amazonaws.com`). When targeting custom or local S3-compatible endpoints (for example LocalStack or MinIO), path-style addressing (`https://<endpoint>/<bucket>`) is often required instead.

There are two ways to enable path-style addressing on the S3 clients, used for asset publishing (`cdk-assets-lib`) and by the toolkit (`toolkit-lib`).

1. Setting `AWS_ENDPOINT_URL` (or `AWS_ENDPOINT_URL_S3`) to use a local loopback host, such as `localhost`, `127.0.0.1` or `::1`. 
2. Setting the `CDK_S3_FORCE_PATH_STYLE` environment variable to explicitly enable the feature. This name follows the existing convention of CDK-specific environment variables such as `CDK_DOCKER` and `CDK_HOME`.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if deploying new resource types or cross-service interactions)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license