### PR TITLE
revert(deps): bump aws-cdk from 0.0.0 to 2.1125.0 in /packages/cdk

### DIFF
--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -57,7 +57,7 @@
     "typescript": "5.9"
   },
   "dependencies": {
-    "aws-cdk": "^2.1125.0"
+    "aws-cdk": "^0.0.0"
   },
   "keywords": [
     "aws",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8109,15 +8109,6 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"aws-cdk@npm:^2.1125.0":
-  version: 2.1126.0
-  resolution: "aws-cdk@npm:2.1126.0"
-  bin:
-    cdk: bin/cdk
-  checksum: 10c0/3523d17f7a102242717626152b3381617543944d50689e8c903ccd9ede2246279feb33528d429978cf5be297bcf6229c1d8c15113c6bc6b5203b52843e494d23
-  languageName: node
-  linkType: hard
-
 "aws-sdk-client-mock-jest@npm:^4.1.0":
   version: 4.1.0
   resolution: "aws-sdk-client-mock-jest@npm:4.1.0"
@@ -8771,7 +8762,7 @@ __metadata:
     "@types/node": "npm:^20"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
-    aws-cdk: "npm:^2.1125.0"
+    aws-cdk: "npm:^0.0.0"
     commit-and-tag-version: "npm:^12"
     constructs: "npm:^10.0.0"
     eslint: "npm:^9"


### PR DESCRIPTION
Reverts aws/aws-cdk-cli#1613

---

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*