### PR TITLE
feat: refresh diagnostics and CodeLens when cdk.out changes

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1686,6 +1686,7 @@ const cdkExplorer = configureProject(
       'vscode-languageserver-textdocument@^1',
       'vscode-jsonrpc@^8',
       'express@^4',
+      'chokidar@^4',
       '@jridgewell/trace-mapping@^0.3',
       'convert-source-map@^2',
     ],

--- a/packages/@aws-cdk/cdk-explorer/.projen/deps.json
+++ b/packages/@aws-cdk/cdk-explorer/.projen/deps.json
@@ -126,6 +126,11 @@
       "type": "runtime"
     },
     {
+      "name": "chokidar",
+      "version": "^4",
+      "type": "runtime"
+    },
+    {
       "name": "convert-source-map",
       "version": "^2",
       "type": "runtime"

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
+import { buildConstructTree, CloudAssembly, MANIFEST_FILE, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
 import { SourceMapResolver, type SourceLocation } from './source-resolver';
@@ -19,8 +19,6 @@ export interface ConstructNode extends ConstructTreeNode {
 export interface AssemblyData {
   readonly tree: readonly ConstructNode[];
   readonly violations?: PolicyValidationReportJson;
-  /** Set when validation-report.json fails to load. The tree still loads. */
-  readonly violationsError?: string;
   /** Non-fatal warnings collected while reading the assembly (e.g. unparseable source maps). */
   readonly warnings: readonly string[];
 }
@@ -36,7 +34,7 @@ export type AssemblyReadResult =
  * (tree.json + stack-metadata join) is delegated to buildConstructTree.
  */
 export function readAssembly(assemblyDir: string): AssemblyReadResult {
-  const manifestPath = path.join(assemblyDir, 'manifest.json');
+  const manifestPath = path.join(assemblyDir, MANIFEST_FILE);
   if (!fs.existsSync(manifestPath)) {
     return { status: 'not-found' };
   }
@@ -54,16 +52,19 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     }));
 
     let violations: PolicyValidationReportJson | undefined;
-    let violationsError: string | undefined;
+    const warnings = [...sourceResolver.warnings];
     try {
       violations = loadViolations(assemblyDir);
     } catch (err) {
-      violationsError = (err as Error).message;
+      // The producer writes the validation report synchronously, so a corrupt
+      // file is not reachable through normal synth flow. We treat it the same
+      // as "no report present" and surface a warning for the rare case.
+      warnings.push(`Failed to load ${VALIDATION_REPORT_FILE}: ${(err as Error).message}`);
     }
 
     return {
       status: 'success',
-      data: { tree, violations, violationsError, warnings: sourceResolver.warnings },
+      data: { tree, violations, warnings },
     };
   } catch (err) {
     return { status: 'error', message: (err as Error).message };

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
@@ -1,0 +1,109 @@
+import * as path from 'path';
+import * as chokidar from 'chokidar';
+
+/**
+ * Basenames whose change signals that the cloud assembly was (re)written.
+ * The construct tree, manifest, and policy validation report cover everything
+ * the explorer reads; other files in cdk.out (templates, asset files, RWLock
+ * markers) are intentionally ignored to avoid spurious refreshes.
+ */
+const ASSEMBLY_SIGNAL_FILES = new Set([
+  'manifest.json',
+  'tree.json',
+  'validation-report.json',
+]);
+
+const DEBOUNCE_MS = 200;
+
+/** A running assembly watcher. */
+export interface AssemblyWatcher {
+  /** Stop watching and release the underlying file handles. */
+  close(): Promise<void>;
+}
+
+/**
+ * Minimal file-watcher surface this module depends on, satisfied by chokidar's
+ * `FSWatcher`. Declared explicitly so tests can inject a fake emitter and verify
+ * debouncing/filtering without real filesystem events.
+ */
+export interface FileWatcher {
+  on(event: 'all', listener: (eventName: string, filePath: string) => void): FileWatcher;
+  on(event: 'error', listener: (error: unknown) => void): FileWatcher;
+  close(): Promise<void>;
+}
+
+export interface AssemblyWatcherOptions {
+  /** The cloud assembly directory to watch (e.g. `<project>/cdk.out`). */
+  readonly assemblyDir: string;
+  /** Invoked (debounced) when the assembly's signal files change. */
+  readonly onChange: () => void;
+  /** Receives non-fatal watcher errors. */
+  readonly onError?: (error: unknown) => void;
+  /**
+   * Factory for the underlying file watcher. Defaults to chokidar; overridden
+   * in tests with a fake so behavior is verified without real file IO.
+   */
+  readonly createWatcher?: (assemblyDir: string) => FileWatcher;
+}
+
+// Thin wrapper over real chokidar; exercised via integration, not unit tests.
+/* c8 ignore start */
+function defaultCreateWatcher(assemblyDir: string): FileWatcher {
+  // Watch the assembly directory itself. chokidar tolerates the directory not
+  // existing yet and emits events once synth creates it. `ignoreInitial` skips
+  // the synthetic 'add' events for already-present files, because the caller
+  // performs its own initial read separately.
+  return chokidar.watch(assemblyDir, {
+    ignoreInitial: true,
+  }) as unknown as FileWatcher;
+}
+/* c8 ignore stop */
+
+/**
+ * Watch a cloud assembly directory and fire `onChange` (debounced) whenever the
+ * assembly is rewritten, regardless of which process produced it (an external
+ * `cdk synth`/`cdk watch`, or a future in-process synth).
+ *
+ * Only the assembly signal files trigger a refresh. Template files and, crucially,
+ * the RWLock marker files (`synth.lock` / `read.<pid>.lock`) are ignored: their
+ * rapid create/delete during a synth would otherwise cause spurious refreshes.
+ */
+export function startAssemblyWatcher(options: AssemblyWatcherOptions): AssemblyWatcher {
+  const createWatcher = options.createWatcher ?? defaultCreateWatcher;
+
+  let timer: NodeJS.Timeout | undefined;
+  let closed = false;
+
+  const watcher = createWatcher(options.assemblyDir);
+
+  watcher.on('all', (_eventName, filePath) => {
+    if (closed) return;
+    if (!ASSEMBLY_SIGNAL_FILES.has(path.basename(filePath))) return;
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      try {
+        options.onChange();
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }, DEBOUNCE_MS);
+  });
+
+  watcher.on('error', (error) => {
+    options.onError?.(error);
+  });
+
+  return {
+    async close() {
+      closed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      await watcher.close();
+    },
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
@@ -1,5 +1,15 @@
 import * as path from 'path';
+import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
+import { VALIDATION_REPORT_FILE } from '@aws-cdk/cloud-assembly-schema';
 import * as chokidar from 'chokidar';
+
+/**
+ * The name of the construct tree metadata file emitted alongside the manifest.
+ * Producer (`aws-cdk-lib`) hard-codes this filename in its `TreeMetadata`
+ * synthesizer rather than importing a shared constant, so this is a
+ * consumer-side label only.
+ */
+export const TREE_FILE = 'tree.json';
 
 /**
  * Basenames whose change signals that the cloud assembly was (re)written.
@@ -8,9 +18,9 @@ import * as chokidar from 'chokidar';
  * markers) are intentionally ignored to avoid spurious refreshes.
  */
 const ASSEMBLY_SIGNAL_FILES = new Set([
-  'manifest.json',
-  'tree.json',
-  'validation-report.json',
+  MANIFEST_FILE,
+  TREE_FILE,
+  VALIDATION_REPORT_FILE,
 ]);
 
 const DEBOUNCE_MS = 200;

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -7,6 +7,7 @@ import {
 } from 'vscode-jsonrpc/node';
 import {
   createConnection,
+  CodeLensRefreshRequest,
   ProposedFeatures,
   TextDocumentSyncKind,
   type CodeLens,
@@ -26,6 +27,11 @@ import {
   type AssemblyReadResult,
   type ConstructNode,
 } from '../core/assembly-reader';
+import {
+  startAssemblyWatcher as defaultStartAssemblyWatcher,
+  type AssemblyWatcher,
+  type AssemblyWatcherOptions,
+} from '../core/assembly-watcher';
 
 export interface LspHandlerOptions {
   /** Callback invoked on `didSave` for tracked source files. */
@@ -39,6 +45,17 @@ export interface LspHandlerOptions {
   readonly logger?: LogSink;
   /** Receives diagnostics ready to be published to the editor. */
   readonly onPublishDiagnostics?: (uri: string, diagnostics: Diagnostic[]) => void;
+  /**
+   * Invoked after a refresh when new assembly data may have changed CodeLenses,
+   * to ask the editor to re-query them. Only called when the client advertised
+   * `workspace.codeLens.refreshSupport`.
+   */
+  readonly onRefreshCodeLenses?: () => void;
+  /**
+   * Starts the cdk.out watcher. Defaults to the real chokidar-backed watcher;
+   * overridden in tests to drive refreshes deterministically.
+   */
+  readonly startAssemblyWatcher?: (options: AssemblyWatcherOptions) => AssemblyWatcher;
 }
 
 export interface LspServerOptions extends LspHandlerOptions {
@@ -78,13 +95,25 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
   const log = options.logger ?? NOOP_LOGGER;
   const onPublishDiagnostics = options.onPublishDiagnostics ?? (() => {
   });
+  const onRefreshCodeLenses = options.onRefreshCodeLenses ?? (() => {
+  });
+  const startWatcher = options.startAssemblyWatcher ?? defaultStartAssemblyWatcher;
 
   let applicationDir: string | undefined;
   let shutdownRequested = false;
   let shouldIgnore: (filePath: string) => boolean = () => false;
-  // Latest index from readAssembly, served to CodeLens without re-reading
-  // cdk.out. Refreshed on every onInitialized; cdk.out watcher is a future feature.
+  let assemblyWatcher: AssemblyWatcher | undefined;
+  // Latest index from readAssembly, served to CodeLens. Refreshed at startup
+  // and whenever the cdk.out watcher detects a re-synth.
   let cachedIndex: ConstructIndex<ConstructNode> = ConstructIndex.fromTree<ConstructNode>([]);
+  // URIs that currently have published diagnostics. On each refresh we publish
+  // an empty array for any URI that no longer has diagnostics, otherwise a
+  // resolved violation would leave a stale squiggle behind.
+  let publishedUris = new Set<string>();
+  // Whether the client supports a server-initiated CodeLens refresh. Captured
+  // at initialize; if false we skip the refresh request and lenses update on
+  // the editor's next natural re-query.
+  let codeLensRefreshSupported = false;
 
   function refreshFromAssembly(projectDir: string): void {
     const assemblyDir = path.join(projectDir, 'cdk.out');
@@ -106,19 +135,40 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
 
     cachedIndex = ConstructIndex.fromTree(tree);
 
-    const { byUri, dropped } = mapViolationsToDiagnostics(violations, cachedIndex);
+    // When violations fail to load we cannot distinguish resolved violations
+    // from missing data, so preserve last-good diagnostics. The tree itself
+    // is still valid, so cachedIndex/CodeLenses do refresh below.
+    if (!violationsError) {
+      const { byUri, dropped } = mapViolationsToDiagnostics(violations, cachedIndex);
 
-    for (const drop of dropped) {
-      log.warn(`Dropped diagnostic for '${drop.ruleName}' at '${drop.constructPath}': ${drop.reason}`);
+      for (const drop of dropped) {
+        log.warn(`Dropped diagnostic for '${drop.ruleName}' at '${drop.constructPath}': ${drop.reason}`);
+      }
+      const nextUris = new Set(byUri.keys());
+      // Clear diagnostics for files that had violations on the previous refresh
+      // but no longer do, so resolved violations disappear from the editor.
+      for (const uri of publishedUris) {
+        if (!nextUris.has(uri)) {
+          onPublishDiagnostics(uri, []);
+        }
+      }
+      for (const [uri, diagnostics] of byUri) {
+        onPublishDiagnostics(uri, diagnostics);
+      }
+      publishedUris = nextUris;
     }
-    for (const [uri, diagnostics] of byUri) {
-      onPublishDiagnostics(uri, diagnostics);
+
+    // New assembly data may change lens titles or positions; ask the editor to
+    // re-query CodeLenses (it serves them from the now-updated cachedIndex).
+    if (codeLensRefreshSupported) {
+      onRefreshCodeLenses();
     }
   }
 
   return {
     onInitialize(params) {
       applicationDir = params.initializationOptions?.applicationDir;
+      codeLensRefreshSupported = params.capabilities.workspace?.codeLens?.refreshSupport ?? false;
       return {
         capabilities: {
           textDocumentSync: {
@@ -150,6 +200,14 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
         rootDir: projectDir,
       });
       refreshFromAssembly(projectDir);
+
+      // Watch cdk.out so any synth (an external `cdk synth`/`cdk watch`, or a
+      // future in-process synth) refreshes the editor's diagnostics and lenses.
+      assemblyWatcher = startWatcher({
+        assemblyDir: path.join(projectDir, 'cdk.out'),
+        onChange: () => refreshFromAssembly(projectDir),
+        onError: (err) => log.error(`Assembly watcher error: ${(err as Error).message}`),
+      });
     },
     onDidSaveTextDocument(params) {
       if (shutdownRequested) return;
@@ -167,6 +225,8 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
     },
     onShutdown() {
       shutdownRequested = true;
+      void assemblyWatcher?.close();
+      assemblyWatcher = undefined;
     },
   };
 }
@@ -184,6 +244,9 @@ export function startServer(options: LspServerOptions): void {
     logger: connection.console,
     onPublishDiagnostics: (uri, diagnostics) => {
       void connection.sendDiagnostics({ uri, diagnostics });
+    },
+    onRefreshCodeLenses: () => {
+      void connection.sendRequest(CodeLensRefreshRequest.type);
     },
   });
 

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -125,38 +125,30 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
     }
     if (result.status === 'not-found') return;
 
-    const { tree, violations, violationsError, warnings } = result.data;
+    const { tree, violations, warnings } = result.data;
     for (const warning of warnings) {
       log.warn(warning);
-    }
-    if (violationsError) {
-      log.warn(`validation-report.json failed to load: ${violationsError}`);
     }
 
     cachedIndex = ConstructIndex.fromTree(tree);
 
-    // When violations fail to load we cannot distinguish resolved violations
-    // from missing data, so preserve last-good diagnostics. The tree itself
-    // is still valid, so cachedIndex/CodeLenses do refresh below.
-    if (!violationsError) {
-      const { byUri, dropped } = mapViolationsToDiagnostics(violations, cachedIndex);
+    const { byUri, dropped } = mapViolationsToDiagnostics(violations, cachedIndex);
 
-      for (const drop of dropped) {
-        log.warn(`Dropped diagnostic for '${drop.ruleName}' at '${drop.constructPath}': ${drop.reason}`);
-      }
-      const nextUris = new Set(byUri.keys());
-      // Clear diagnostics for files that had violations on the previous refresh
-      // but no longer do, so resolved violations disappear from the editor.
-      for (const uri of publishedUris) {
-        if (!nextUris.has(uri)) {
-          onPublishDiagnostics(uri, []);
-        }
-      }
-      for (const [uri, diagnostics] of byUri) {
-        onPublishDiagnostics(uri, diagnostics);
-      }
-      publishedUris = nextUris;
+    for (const drop of dropped) {
+      log.warn(`Dropped diagnostic for '${drop.ruleName}' at '${drop.constructPath}': ${drop.reason}`);
     }
+    const nextUris = new Set(byUri.keys());
+    // Clear diagnostics for files that had violations on the previous refresh
+    // but no longer do, so resolved violations disappear from the editor.
+    for (const uri of publishedUris) {
+      if (!nextUris.has(uri)) {
+        onPublishDiagnostics(uri, []);
+      }
+    }
+    for (const [uri, diagnostics] of byUri) {
+      onPublishDiagnostics(uri, diagnostics);
+    }
+    publishedUris = nextUris;
 
     // New assembly data may change lens titles or positions; ask the editor to
     // re-query CodeLenses (it serves them from the now-updated cachedIndex).

--- a/packages/@aws-cdk/cdk-explorer/package.json
+++ b/packages/@aws-cdk/cdk-explorer/package.json
@@ -60,6 +60,7 @@
     "@aws-cdk/cloud-assembly-schema": "^0.0.0",
     "@aws-cdk/toolkit-lib": "^0.0.0",
     "@jridgewell/trace-mapping": "^0.3",
+    "chokidar": "^4",
     "convert-source-map": "^2",
     "express": "^4",
     "vscode-jsonrpc": "^8",

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
@@ -198,7 +198,7 @@ describe('fixture builders', () => {
 
     expect(result.data.tree).toHaveLength(1);
     expect(result.data.violations).toBeUndefined();
-    expect(result.data.violationsError).toBeTruthy();
+    expect(result.data.warnings.some((w) => w.includes('validation-report.json'))).toBe(true);
   });
 
   test('withValidationReport produces a parseable report', () => {
@@ -221,7 +221,6 @@ describe('fixture builders', () => {
     const result = readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
-    expect(result.data.violationsError).toBeUndefined();
     expect(result.data.violations?.pluginReports[0].pluginName).toBe('test');
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -1,7 +1,9 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
 import { ArtifactMetadataEntryType, VALIDATION_REPORT_FILE } from '@aws-cdk/cloud-assembly-schema';
+import { TREE_FILE } from '../../lib/core/assembly-watcher';
 
 /**
  * Programmatic fixture builders. Each builder writes a minimal cdk.out/ to a
@@ -87,7 +89,7 @@ export interface NestedStackParentSpec {
 export function buildFlatAssembly(spec: FlatAssemblySpec): string {
   const dir = mkAssemblyDir('flat');
   const artifacts: Record<string, unknown> = {
-    Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
+    Tree: { type: 'cdk:tree', properties: { file: TREE_FILE } },
   };
 
   for (const stack of spec.stacks) {
@@ -95,11 +97,11 @@ export function buildFlatAssembly(spec: FlatAssemblySpec): string {
     writeTemplate(dir, stack.id, stack.resources, stack.id, spec.pathMetadata ?? true);
   }
 
-  writeJson(path.join(dir, 'manifest.json'), {
+  writeJson(path.join(dir, MANIFEST_FILE), {
     version: ASSEMBLY_SCHEMA_VERSION,
     artifacts,
   });
-  writeJson(path.join(dir, 'tree.json'), {
+  writeJson(path.join(dir, TREE_FILE), {
     version: TREE_SCHEMA_VERSION,
     tree: appNode(spec.stacks.map(stackTreeNode)),
   });
@@ -111,7 +113,7 @@ export function buildFlatAssembly(spec: FlatAssemblySpec): string {
 export function buildNestedAssembly(spec: NestedAssemblySpec): string {
   const rootDir = mkAssemblyDir('nested');
   const rootArtifacts: Record<string, unknown> = {
-    Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
+    Tree: { type: 'cdk:tree', properties: { file: TREE_FILE } },
   };
 
   const treeChildren: Record<string, unknown> = {};
@@ -142,7 +144,7 @@ export function buildNestedAssembly(spec: NestedAssemblySpec): string {
       writeTemplate(stageDir, artifactId, stack.resources, constructPath);
     }
 
-    writeJson(path.join(stageDir, 'manifest.json'), {
+    writeJson(path.join(stageDir, MANIFEST_FILE), {
       version: ASSEMBLY_SCHEMA_VERSION,
       artifacts: stageArtifacts,
     });
@@ -161,11 +163,11 @@ export function buildNestedAssembly(spec: NestedAssemblySpec): string {
     };
   }
 
-  writeJson(path.join(rootDir, 'manifest.json'), {
+  writeJson(path.join(rootDir, MANIFEST_FILE), {
     version: ASSEMBLY_SCHEMA_VERSION,
     artifacts: rootArtifacts,
   });
-  writeJson(path.join(rootDir, 'tree.json'), {
+  writeJson(path.join(rootDir, TREE_FILE), {
     version: TREE_SCHEMA_VERSION,
     tree: appNode(Object.values(treeChildren)),
   });
@@ -202,10 +204,10 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
     emitNestedStack(dir, metadata, parentChildren, parentResources, parent.id, ns);
   }
 
-  writeJson(path.join(dir, 'manifest.json'), {
+  writeJson(path.join(dir, MANIFEST_FILE), {
     version: ASSEMBLY_SCHEMA_VERSION,
     artifacts: {
-      Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
+      Tree: { type: 'cdk:tree', properties: { file: TREE_FILE } },
       [parent.id]: {
         type: 'aws:cloudformation:stack',
         environment: 'aws://unknown-account/unknown-region',
@@ -215,7 +217,7 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
       },
     },
   });
-  writeJson(path.join(dir, 'tree.json'), {
+  writeJson(path.join(dir, TREE_FILE), {
     version: TREE_SCHEMA_VERSION,
     tree: appNode([{
       id: parent.id,
@@ -301,7 +303,7 @@ function emitNestedStack(
 /** Manifest + tree with no metadata, no traces — for non-TS app graceful-degradation tests. */
 export function buildNonTypeScriptAssembly(): string {
   const dir = mkAssemblyDir('nonts');
-  writeJson(path.join(dir, 'manifest.json'), {
+  writeJson(path.join(dir, MANIFEST_FILE), {
     version: ASSEMBLY_SCHEMA_VERSION,
     artifacts: {
       Stack1: {
@@ -311,10 +313,10 @@ export function buildNonTypeScriptAssembly(): string {
         displayName: 'Stack1',
         // No metadata: non-TS apps emit no aws:cdk:logicalId entries.
       },
-      Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
+      Tree: { type: 'cdk:tree', properties: { file: TREE_FILE } },
     },
   });
-  writeJson(path.join(dir, 'tree.json'), {
+  writeJson(path.join(dir, TREE_FILE), {
     version: TREE_SCHEMA_VERSION,
     tree: {
       id: 'App',

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
 import { readAssembly, type AssemblyData, type AssemblyReadResult, type ConstructNode } from '../../lib';
 import {
   buildFlatAssembly,
@@ -101,7 +102,7 @@ describe('readAssembly', () => {
 
   test('returns error for malformed manifest', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-explorer-malformed-'));
-    fs.writeFileSync(path.join(tmpDir, 'manifest.json'), 'not json{{{');
+    fs.writeFileSync(path.join(tmpDir, MANIFEST_FILE), 'not json{{{');
     try {
       const result = readAssembly(tmpDir);
       expect(result.status).toBe('error');
@@ -143,7 +144,6 @@ describe('readAssembly with violations', () => {
     expect(data.violations).toBeDefined();
     expect(data.violations!.pluginReports[0].conclusion).toBe('failure');
     expect(data.violations!.pluginReports[0].violations[0].ruleName).toBe('no-public-buckets');
-    expect(data.violationsError).toBeUndefined();
   });
 
   test('returns undefined violations when report file is absent', () => {
@@ -151,7 +151,6 @@ describe('readAssembly with violations', () => {
     const data = expectSuccess(readAssembly(dir));
 
     expect(data.violations).toBeUndefined();
-    expect(data.violationsError).toBeUndefined();
   });
 
   test('malformed validation report does not crash the tree read', () => {
@@ -162,7 +161,7 @@ describe('readAssembly with violations', () => {
 
     expect(data.tree).toHaveLength(1);
     expect(data.violations).toBeUndefined();
-    expect(data.violationsError).toBeTruthy();
+    expect(data.warnings.some((w) => w.includes('validation-report.json'))).toBe(true);
   });
 
   test('loads a version-less validation report (legacy aws-cdk-lib shape)', () => {
@@ -173,7 +172,6 @@ describe('readAssembly with violations', () => {
 
     expect(data.tree).toHaveLength(1);
     expect(data.violations).toBeDefined();
-    expect(data.violationsError).toBeUndefined();
   });
 });
 

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
@@ -1,0 +1,135 @@
+import { startAssemblyWatcher, type FileWatcher } from '../../lib/core/assembly-watcher';
+
+type AnyListener = (...args: unknown[]) => void;
+
+/** A controllable in-memory stand-in for chokidar's FSWatcher. */
+class FakeWatcher implements FileWatcher {
+  public closed = false;
+  private readonly listeners: Record<string, AnyListener[]> = {};
+
+  public on(event: string, listener: AnyListener): FileWatcher {
+    (this.listeners[event] ??= []).push(listener);
+    return this;
+  }
+
+  /** Simulate a chokidar 'all' event for the given file. */
+  public emitFile(eventName: string, filePath: string): void {
+    for (const listener of this.listeners.all ?? []) {
+      listener(eventName, filePath);
+    }
+  }
+
+  /** Simulate any emitted event (e.g. 'error'). */
+  public emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners[event] ?? []) {
+      listener(...args);
+    }
+  }
+
+  public async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function setup() {
+  const fake = new FakeWatcher();
+  const onChange = jest.fn();
+  const watcher = startAssemblyWatcher({
+    assemblyDir: '/p/cdk.out',
+    onChange,
+    createWatcher: () => fake,
+  });
+  return { fake, onChange, watcher };
+}
+
+describe('Assembly Watcher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('coalesces a burst of assembly file changes into a single onChange', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/p/cdk.out/manifest.json');
+    fake.emitFile('change', '/p/cdk.out/tree.json');
+    fake.emitFile('change', '/p/cdk.out/validation-report.json');
+    expect(onChange).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores RWLock marker files', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('add', '/p/cdk.out/synth.lock');
+    fake.emitFile('add', '/p/cdk.out/read.12345.1.lock');
+    fake.emitFile('unlink', '/p/cdk.out/synth.lock');
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('ignores non-signal files such as templates', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/p/cdk.out/MyStack.template.json');
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('reacts to nested stage assembly manifests', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('add', '/p/cdk.out/assembly-Prod/manifest.json');
+
+    jest.advanceTimersByTime(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('close stops a pending onChange and closes the underlying watcher', async () => {
+    const { fake, onChange, watcher } = setup();
+
+    fake.emitFile('change', '/p/cdk.out/manifest.json');
+    await watcher.close();
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(fake.closed).toBe(true);
+  });
+
+  test('forwards watcher errors to onError', () => {
+    const fake = new FakeWatcher();
+    const onError = jest.fn();
+    startAssemblyWatcher({
+      assemblyDir: '/p/cdk.out',
+      onChange: jest.fn(),
+      createWatcher: () => fake,
+      onError,
+    });
+
+    fake.emit('error', new Error('boom'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('forwards an onChange throw to onError instead of leaking from the timer', () => {
+    const fake = new FakeWatcher();
+    const onError = jest.fn();
+    const failure = new Error('refresh blew up');
+    startAssemblyWatcher({
+      assemblyDir: '/p/cdk.out',
+      onChange: () => {
+        throw failure;
+      },
+      createWatcher: () => fake,
+      onError,
+    });
+
+    fake.emitFile('change', '/p/cdk.out/manifest.json');
+    expect(() => jest.advanceTimersByTime(200)).not.toThrow();
+
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
@@ -1,4 +1,6 @@
-import { startAssemblyWatcher, type FileWatcher } from '../../lib/core/assembly-watcher';
+import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
+import { VALIDATION_REPORT_FILE } from '@aws-cdk/cloud-assembly-schema';
+import { startAssemblyWatcher, TREE_FILE, type FileWatcher } from '../../lib/core/assembly-watcher';
 
 type AnyListener = (...args: unknown[]) => void;
 
@@ -49,9 +51,9 @@ describe('Assembly Watcher', () => {
   test('coalesces a burst of assembly file changes into a single onChange', () => {
     const { fake, onChange } = setup();
 
-    fake.emitFile('change', '/p/cdk.out/manifest.json');
-    fake.emitFile('change', '/p/cdk.out/tree.json');
-    fake.emitFile('change', '/p/cdk.out/validation-report.json');
+    fake.emitFile('change', `/p/cdk.out/${MANIFEST_FILE}`);
+    fake.emitFile('change', `/p/cdk.out/${TREE_FILE}`);
+    fake.emitFile('change', `/p/cdk.out/${VALIDATION_REPORT_FILE}`);
     expect(onChange).not.toHaveBeenCalled();
 
     jest.advanceTimersByTime(200);
@@ -81,7 +83,7 @@ describe('Assembly Watcher', () => {
   test('reacts to nested stage assembly manifests', () => {
     const { fake, onChange } = setup();
 
-    fake.emitFile('add', '/p/cdk.out/assembly-Prod/manifest.json');
+    fake.emitFile('add', `/p/cdk.out/assembly-Prod/${MANIFEST_FILE}`);
 
     jest.advanceTimersByTime(200);
     expect(onChange).toHaveBeenCalledTimes(1);
@@ -90,7 +92,7 @@ describe('Assembly Watcher', () => {
   test('close stops a pending onChange and closes the underlying watcher', async () => {
     const { fake, onChange, watcher } = setup();
 
-    fake.emitFile('change', '/p/cdk.out/manifest.json');
+    fake.emitFile('change', `/p/cdk.out/${MANIFEST_FILE}`);
     await watcher.close();
 
     jest.advanceTimersByTime(500);
@@ -127,7 +129,7 @@ describe('Assembly Watcher', () => {
       onError,
     });
 
-    fake.emitFile('change', '/p/cdk.out/manifest.json');
+    fake.emitFile('change', `/p/cdk.out/${MANIFEST_FILE}`);
     expect(() => jest.advanceTimersByTime(200)).not.toThrow();
 
     expect(onError).toHaveBeenCalledWith(failure);

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -288,36 +288,6 @@ describe('LSP Server', () => {
     expect(client.published[1]).toEqual({ uri: violationUri, diagnostics: [] });
   });
 
-  test('preserves last-good diagnostics when a later refresh fails to load the validation report', () => {
-    const { tree, violations } = bucketViolationFixtures();
-    let call = 0;
-    const client = createTestClient({
-      readAssembly: (): AssemblyReadResult => {
-        call += 1;
-        // Second read mimics a corrupt validation-report.json: the tree still
-        // loads, but violations come back undefined with a violationsError.
-        return {
-          status: 'success',
-          data: call === 1
-            ? { warnings: [], tree, violations }
-            : { warnings: [], tree, violationsError: 'unexpected token' },
-        };
-      },
-    });
-
-    initializeClient(client, { applicationDir: '/p' });
-    expect(client.published).toHaveLength(1);
-
-    client.triggerWatcher();
-
-    // No additional diagnostics published: last-good is preserved, and the
-    // load failure is logged rather than silently wiping squiggles.
-    expect(client.published).toHaveLength(1);
-    expect(client.log.warn).toHaveBeenCalledWith(
-      expect.stringContaining('validation-report.json failed to load'),
-    );
-  });
-
   test('requests a CodeLens refresh after a refresh when the client supports it', () => {
     const client = createTestClient({
       readAssembly: (): AssemblyReadResult => ({

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -1,5 +1,5 @@
 import { pathToFileURL } from 'url';
-import type { Diagnostic } from 'vscode-languageserver/node';
+import type { Diagnostic, InitializeParams } from 'vscode-languageserver/node';
 import type { AssemblyReadResult } from '../../lib';
 import { createLspHandlers, type LspHandlerOptions, type LspHandlers } from '../../lib/lsp/server';
 
@@ -7,11 +7,18 @@ interface CapturedClient {
   handlers: LspHandlers;
   published: Array<{ uri: string; diagnostics: Diagnostic[] }>;
   log: { warn: jest.Mock; error: jest.Mock };
+  refreshCodeLens: jest.Mock;
+  watcherClosed: jest.Mock;
+  /** Fire the cdk.out watcher's onChange, as a real re-synth would. */
+  triggerWatcher: () => void;
 }
 
 function createTestClient(opts?: Partial<Pick<LspHandlerOptions, 'onSynthRequest' | 'readAssembly'>>): CapturedClient {
   const published: Array<{ uri: string; diagnostics: Diagnostic[] }> = [];
   const log = { warn: jest.fn(), error: jest.fn() };
+  const refreshCodeLens = jest.fn();
+  const watcherClosed = jest.fn();
+  let watcherOnChange: (() => void) | undefined;
   const handlers = createLspHandlers({
     onSynthRequest: opts?.onSynthRequest,
     // Default to "no assembly" so tests that don't care about diagnostics
@@ -19,18 +26,84 @@ function createTestClient(opts?: Partial<Pick<LspHandlerOptions, 'onSynthRequest
     readAssembly: opts?.readAssembly ?? (() => ({ status: 'not-found' })),
     logger: log,
     onPublishDiagnostics: (uri, diagnostics) => published.push({ uri, diagnostics }),
+    onRefreshCodeLenses: refreshCodeLens,
+    // Inject a fake watcher so unit tests never start a real chokidar instance;
+    // capture its onChange so tests can simulate a re-synth deterministically.
+    startAssemblyWatcher: (watchOpts) => {
+      watcherOnChange = watchOpts.onChange;
+      return {
+        close: async () => {
+          watcherClosed();
+        },
+      };
+    },
   });
-  return { handlers, published, log };
+  return {
+    handlers,
+    published,
+    log,
+    refreshCodeLens,
+    watcherClosed,
+    triggerWatcher: () => watcherOnChange?.(),
+  };
 }
 
-function initializeClient(client: CapturedClient, options?: Record<string, unknown>): void {
+function initializeClient(
+  client: CapturedClient,
+  options?: Record<string, unknown>,
+  capabilities?: InitializeParams['capabilities'],
+): void {
   client.handlers.onInitialize({
     processId: null,
-    capabilities: {},
+    capabilities: capabilities ?? {},
     rootUri: null,
     initializationOptions: options ?? {},
   });
   client.handlers.onInitialized();
+}
+
+function bucketViolationFixtures() {
+  const tree = [{
+    path: 'Stack1',
+    id: 'Stack1',
+    children: [{
+      path: 'Stack1/MyBucket',
+      id: 'MyBucket',
+      children: [],
+      sourceLocation: { file: '/p/lib/stack.ts', line: 12, column: 5 },
+    }],
+  }];
+  const violations = {
+    version: '1.0.0',
+    pluginReports: [{
+      pluginName: 'test-plugin',
+      conclusion: 'failure',
+      violations: [{
+        ruleName: 'no-public-buckets',
+        description: 'no public buckets',
+        severity: 'error',
+        violatingConstructs: [{ constructPath: 'Stack1/MyBucket' }],
+      }],
+    }],
+  };
+  return { tree, violations };
+}
+
+/**
+ * A readAssembly that reports a violation on the first read and the same tree
+ * with the violation resolved on every read after, simulating a user fixing it
+ * and re-synthing.
+ */
+function readAssemblyResolvingAfterFirst(): () => AssemblyReadResult {
+  const { tree, violations } = bucketViolationFixtures();
+  let call = 0;
+  return (): AssemblyReadResult => {
+    call += 1;
+    return {
+      status: 'success',
+      data: call === 1 ? { warnings: [], tree, violations } : { warnings: [], tree },
+    };
+  };
 }
 
 describe('LSP Server', () => {
@@ -139,35 +212,11 @@ describe('LSP Server', () => {
   });
 
   test('publishes diagnostics on initialized when assembly has violations', () => {
+    const { tree, violations } = bucketViolationFixtures();
     const client = createTestClient({
       readAssembly: () => ({
         status: 'success',
-        data: {
-          warnings: [],
-          tree: [{
-            path: 'Stack1',
-            id: 'Stack1',
-            children: [{
-              path: 'Stack1/MyBucket',
-              id: 'MyBucket',
-              children: [],
-              sourceLocation: { file: '/p/lib/stack.ts', line: 12, column: 5 },
-            }],
-          }],
-          violations: {
-            version: '1.0.0',
-            pluginReports: [{
-              pluginName: 'test-plugin',
-              conclusion: 'failure',
-              violations: [{
-                ruleName: 'no-public-buckets',
-                description: 'no public buckets',
-                severity: 'error',
-                violatingConstructs: [{ constructPath: 'Stack1/MyBucket' }],
-              }],
-            }],
-          },
-        },
+        data: { warnings: [], tree, violations },
       }),
     });
 
@@ -222,5 +271,105 @@ describe('LSP Server', () => {
     initializeClient(client, { applicationDir: '/p' });
 
     expect(client.published).toHaveLength(0);
+  });
+
+  test('clears diagnostics for a violation resolved on a later refresh', () => {
+    const client = createTestClient({ readAssembly: readAssemblyResolvingAfterFirst() });
+
+    initializeClient(client, { applicationDir: '/p' });
+    expect(client.published).toHaveLength(1);
+    const violationUri = client.published[0].uri;
+    expect(client.published[0].diagnostics).toHaveLength(1);
+
+    // Simulate a re-synth picked up by the cdk.out watcher.
+    client.triggerWatcher();
+
+    expect(client.published).toHaveLength(2);
+    expect(client.published[1]).toEqual({ uri: violationUri, diagnostics: [] });
+  });
+
+  test('preserves last-good diagnostics when a later refresh fails to load the validation report', () => {
+    const { tree, violations } = bucketViolationFixtures();
+    let call = 0;
+    const client = createTestClient({
+      readAssembly: (): AssemblyReadResult => {
+        call += 1;
+        // Second read mimics a corrupt validation-report.json: the tree still
+        // loads, but violations come back undefined with a violationsError.
+        return {
+          status: 'success',
+          data: call === 1
+            ? { warnings: [], tree, violations }
+            : { warnings: [], tree, violationsError: 'unexpected token' },
+        };
+      },
+    });
+
+    initializeClient(client, { applicationDir: '/p' });
+    expect(client.published).toHaveLength(1);
+
+    client.triggerWatcher();
+
+    // No additional diagnostics published: last-good is preserved, and the
+    // load failure is logged rather than silently wiping squiggles.
+    expect(client.published).toHaveLength(1);
+    expect(client.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('validation-report.json failed to load'),
+    );
+  });
+
+  test('requests a CodeLens refresh after a refresh when the client supports it', () => {
+    const client = createTestClient({
+      readAssembly: (): AssemblyReadResult => ({
+        status: 'success',
+        data: { warnings: [], tree: [{ path: 'Stack1', id: 'Stack1', children: [] }] },
+      }),
+    });
+
+    initializeClient(client, { applicationDir: '/p' }, {
+      workspace: { codeLens: { refreshSupport: true } },
+    });
+
+    expect(client.refreshCodeLens).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not request a CodeLens refresh when the client lacks refreshSupport', () => {
+    const client = createTestClient({
+      readAssembly: (): AssemblyReadResult => ({
+        status: 'success',
+        data: { warnings: [], tree: [{ path: 'Stack1', id: 'Stack1', children: [] }] },
+      }),
+    });
+
+    initializeClient(client, { applicationDir: '/p' });
+
+    expect(client.refreshCodeLens).not.toHaveBeenCalled();
+  });
+
+  test('a watcher-detected re-synth refreshes diagnostics and lenses', () => {
+    const client = createTestClient({ readAssembly: readAssemblyResolvingAfterFirst() });
+
+    initializeClient(client, { applicationDir: '/p' }, {
+      workspace: { codeLens: { refreshSupport: true } },
+    });
+    expect(client.published).toHaveLength(1);
+    const violationUri = client.published[0].uri;
+    expect(client.refreshCodeLens).toHaveBeenCalledTimes(1);
+
+    // Simulate a re-synth picked up by the cdk.out watcher.
+    client.triggerWatcher();
+
+    expect(client.published).toHaveLength(2);
+    expect(client.published[1]).toEqual({ uri: violationUri, diagnostics: [] });
+    expect(client.refreshCodeLens).toHaveBeenCalledTimes(2);
+  });
+
+  test('closes the cdk.out watcher on shutdown', () => {
+    const client = createTestClient();
+    initializeClient(client, { applicationDir: '/p' });
+
+    client.handlers.onShutdown();
+
+    expect(client.watcherClosed).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/@aws-cdk/cloud-assembly-api/lib/cloud-assembly.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/cloud-assembly.ts
@@ -15,7 +15,7 @@ const CLOUD_ASSEMBLY_SYMBOL = Symbol.for('@aws-cdk/cx-api.CloudAssembly');
 /**
  * The name of the root manifest file of the assembly.
  */
-const MANIFEST_FILE = 'manifest.json';
+export const MANIFEST_FILE = 'manifest.json';
 
 /**
  * Represents a deployable cloud application.

--- a/yarn.lock
+++ b/yarn.lock
@@ -187,6 +187,7 @@ __metadata:
     "@types/node": "npm:^20"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
+    chokidar: "npm:^4"
     constructs: "npm:^10.0.0"
     convert-source-map: "npm:^2"
     eslint: "npm:^9"


### PR DESCRIPTION
The LSP currently reads `cdk.out` once at startup and never refreshes. After this PR, any
rewrite of `cdk.out` refreshes the editor's diagnostics and CodeLenses
automatically. 

* New `lib/core/assembly-watcher.ts`: a chokidar-backed watcher with a debounced
  200ms `onChange`, filtered to `manifest.json`, `tree.json`,
  `validation-report.json`. RWLock marker files (`synth.lock`,
  `read.<pid>.<n>.lock`) are excluded. Throws from `onChange` route through
  `onError` rather than leaking from the timer. Lives in `lib/core/` so the web
  explorer can reuse it.
* `refreshFromAssembly` is now the single fan-out for new assembly data:
  rebuild `cachedIndex`, publish empty diagnostics for URIs that no longer have
  violations (clearing resolved squiggles), republish current diagnostics, and
  send `workspace/codeLens/refresh` (gated on `workspace.codeLens.refreshSupport`).
* When the validation report fails to load, last-good diagnostics are preserved,
  matching the existing contract for `'error'` and `'not-found'` reads.
* Watcher started in `onInitialized` after the initial refresh, closed in
  `onShutdown`.
Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
