### PR TITLE
fix: constrain assembly-derived file reads to the project dir

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
+import { buildConstructTreeAsync, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
 import { SourceMapResolver, isWithinRoot, type SourceLocation } from './source-resolver';
@@ -33,9 +33,9 @@ export type AssemblyReadResult =
 /**
  * Decorates the cloud assembly's construct tree with the source location of
  * each node and attaches any policy-validation violations. Tree construction
- * (tree.json + stack-metadata join) is delegated to buildConstructTree.
+ * (tree.json + stack-metadata join) is delegated to buildConstructTreeAsync.
  */
-export function readAssembly(assemblyDir: string): AssemblyReadResult {
+export async function readAssembly(assemblyDir: string): Promise<AssemblyReadResult> {
   const manifestPath = path.join(assemblyDir, 'manifest.json');
   if (!fs.existsSync(manifestPath)) {
     return { status: 'not-found' };
@@ -52,17 +52,17 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
     const sourceResolver = new SourceMapResolver(projectRoot);
-    const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
+    const tree = await buildConstructTreeAsync<ConstructNode>(assembly, async (fields, stack, constructPath) => ({
       ...fields,
       // templateFile comes from the manifest / a nested stack's aws:asset:path,
       // both attacker-influenceable if cdk.out is tampered with. Drop any that
       // escape the assembly dir so the template read in resourceTarget stays
       // contained
-      templateFile: fields.templateFile && isWithinRoot(assemblyDir, fields.templateFile)
+      templateFile: fields.templateFile && (await isWithinRoot(assemblyDir, fields.templateFile))
         ? fields.templateFile
         : undefined,
       sourceLocation: stack
-        ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
+        ? await sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
         : undefined,
     }));
 

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import { buildConstructTree, CloudAssembly, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
-import { SourceMapResolver, type SourceLocation } from './source-resolver';
+import { SourceMapResolver, isWithinRoot, type SourceLocation } from './source-resolver';
 
 /**
  * A construct from the cloud assembly, decorated with the user source location
@@ -43,11 +43,24 @@ export function readAssembly(assemblyDir: string): AssemblyReadResult {
 
   try {
     const assembly = new CloudAssembly(assemblyDir);
+    // The project root is the parent of the assembly dir: server.ts always
+    // builds it as <projectDir>/cdk.out, so dirname() recovers the project dir.
+    // (If --output support is added to relocate cdk.out, thread the IDE-provided
+    // application dir here instead.) Used to keep every file the resolver reads
+    // within the project
+    const projectRoot = path.dirname(assemblyDir);
     // One resolver per readAssembly call: caches parsed source maps across
     // constructs, scoped so a fresh synth observes any moved/edited maps.
-    const sourceResolver = new SourceMapResolver();
+    const sourceResolver = new SourceMapResolver(projectRoot);
     const tree = buildConstructTree<ConstructNode>(assembly, (fields, stack, constructPath) => ({
       ...fields,
+      // templateFile comes from the manifest / a nested stack's aws:asset:path,
+      // both attacker-influenceable if cdk.out is tampered with. Drop any that
+      // escape the assembly dir so the template read in resourceTarget stays
+      // contained
+      templateFile: fields.templateFile && isWithinRoot(assemblyDir, fields.templateFile)
+        ? fields.templateFile
+        : undefined,
       sourceLocation: stack
         ? sourceResolver.resolveFrames(findCreationStackTrace(stack, constructPath))
         : undefined,

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -26,6 +26,16 @@ export class SourceMapResolver {
   private readonly cache = new Map<string, TraceMap | null>();
   private readonly collectedWarnings: string[] = [];
 
+  /**
+   * @param projectRoot - Absolute path to the project the assembly belongs to.
+   *   Every file this resolver reads or returns must stay within it. The paths
+   *   driving those reads come from the cloud assembly (stack-trace frames and
+   *   the source maps they point at), which are attacker-influenceable if
+   *   cdk.out is tampered with, so anything escaping the root is dropped
+   */
+  constructor(private readonly projectRoot: string) {
+  }
+
   /** Non-fatal warnings collected during resolution (e.g. an unparseable .js.map). */
   public get warnings(): readonly string[] {
     return this.collectedWarnings;
@@ -48,6 +58,9 @@ export class SourceMapResolver {
       const parsed = parseFrame(frame);
       if (!parsed) continue;
       if (!isSupportedSourceFile(parsed.file)) return undefined;
+      // The frame's file path is assembly-derived and attacker-influenceable.
+      // Never read or surface a location outside the project.
+      if (!isWithinRoot(this.projectRoot, parsed.file)) return undefined;
       return this.mapJsToOriginalSource(parsed);
     }
     return undefined;
@@ -73,6 +86,9 @@ export class SourceMapResolver {
     // map URL when building the TraceMap), with any sourceRoot applied — so it's
     // a file:// URL for local maps. Convert it back to a path.
     const file = orig.source.startsWith('file://') ? fileURLToPath(orig.source) : orig.source;
+    // `sources` comes from the .js.map, which is also assembly-derived. Keep the
+    // mapped original within the project, else fall back to the (in-root) .js.
+    if (!isWithinRoot(this.projectRoot, file)) return loc;
     return { file, line: orig.line, column: orig.column + 1 };
   }
 
@@ -107,6 +123,11 @@ export class SourceMapResolver {
         convertSourceMap.fromSource(code)
         ?? convertSourceMap.fromMapFileSource(code, (mapFile) => {
           const mapPath = path.resolve(path.dirname(jsFile), mapFile);
+          // sourceMappingURL is assembly-derived; don't read a map outside the
+          // project. The throw is caught below and surfaced as a load warning.
+          if (!isWithinRoot(this.projectRoot, mapPath)) {
+            throw new Error(`source map path escapes the project root: ${mapPath}`);
+          }
           mapUrl = pathToFileURL(mapPath).href;
           return fs.readFileSync(mapPath, 'utf-8');
         });
@@ -136,4 +157,26 @@ function parseFrame(frame: string): SourceLocation | undefined {
   const column = Number(m[3]);
   if (!Number.isFinite(line) || !Number.isFinite(column)) return undefined;
   return { file: m[1], line, column };
+}
+
+/**
+ * True when `candidate` resolves to a path inside `root` (or is `root` itself).
+ * Both are resolved to absolute, symlink-real paths first, so a file reached
+ * through a symlinked directory pointing outside `root` is rejected too. Used
+ * to keep file reads driven by (attacker-influenceable) cloud-assembly paths
+ * within the project before any read happens.
+ */
+export function isWithinRoot(root: string, candidate: string): boolean {
+  const realRoot = realOrSelf(path.resolve(root));
+  const realCandidate = realOrSelf(path.resolve(candidate));
+  return realCandidate === realRoot || realCandidate.startsWith(realRoot + path.sep);
+}
+
+/** Real path with symlinks resolved, or the resolved input if it does not exist. */
+function realOrSelf(p: string): string {
+  try {
+    return fs.realpathSync(p);
+  } catch {
+    return p;
+  }
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -47,7 +47,7 @@ export class SourceMapResolver {
    * there's no trace (non-TS apps) or every frame is a skip-placeholder
    * (framework-only call sites).
    */
-  public resolveFrames(frames: readonly string[] | undefined): SourceLocation | undefined {
+  public async resolveFrames(frames: readonly string[] | undefined): Promise<SourceLocation | undefined> {
     if (!frames) return undefined;
 
     // aws-cdk-lib's renderCallStackJustMyCode (in node_modules/aws-cdk-lib/core/
@@ -60,7 +60,7 @@ export class SourceMapResolver {
       if (!isSupportedSourceFile(parsed.file)) return undefined;
       // The frame's file path is assembly-derived and attacker-influenceable.
       // Never read or surface a location outside the project.
-      if (!isWithinRoot(this.projectRoot, parsed.file)) return undefined;
+      if (!(await isWithinRoot(this.projectRoot, parsed.file))) return undefined;
       return this.mapJsToOriginalSource(parsed);
     }
     return undefined;
@@ -70,12 +70,12 @@ export class SourceMapResolver {
    * Map a .js location to its original .ts via a sibling .js.map. Returns the
    * input location unchanged when it isn't a .js file or has no usable map.
    */
-  private mapJsToOriginalSource(loc: SourceLocation): SourceLocation {
+  private async mapJsToOriginalSource(loc: SourceLocation): Promise<SourceLocation> {
     // Input is allow-listed to .ts/.tsx/.js by resolveFrames; .ts/.tsx are
     // already source-space, only .js needs mapping back to its original.
     if (!loc.file.endsWith('.js')) return loc;
 
-    const tracer = this.loadTraceMap(loc.file);
+    const tracer = await this.loadTraceMap(loc.file);
     if (!tracer) return loc;
 
     // trace-mapping uses 0-based columns, stack frames are 1-based.
@@ -88,15 +88,15 @@ export class SourceMapResolver {
     const file = orig.source.startsWith('file://') ? fileURLToPath(orig.source) : orig.source;
     // `sources` comes from the .js.map, which is also assembly-derived. Keep the
     // mapped original within the project, else fall back to the (in-root) .js.
-    if (!isWithinRoot(this.projectRoot, file)) return loc;
+    if (!(await isWithinRoot(this.projectRoot, file))) return loc;
     return { file, line: orig.line, column: orig.column + 1 };
   }
 
-  private loadTraceMap(jsFile: string): TraceMap | null {
+  private async loadTraceMap(jsFile: string): Promise<TraceMap | null> {
     const cached = this.cache.get(jsFile);
     if (cached !== undefined) return cached;
 
-    const tracer = this.readSourceMap(jsFile);
+    const tracer = await this.readSourceMap(jsFile);
     this.cache.set(jsFile, tracer);
     return tracer;
   }
@@ -107,10 +107,10 @@ export class SourceMapResolver {
    * any filename (resolved relative to the .js). Returns null when the file has
    * no map; warns when a referenced map exists but can't be read or parsed.
    */
-  private readSourceMap(jsFile: string): TraceMap | null {
+  private async readSourceMap(jsFile: string): Promise<TraceMap | null> {
     let code: string;
     try {
-      code = fs.readFileSync(jsFile, 'utf-8');
+      code = await fs.promises.readFile(jsFile, 'utf-8');
     } catch {
       return null; // .js not present/readable -> treat as "no map"
     }
@@ -121,16 +121,16 @@ export class SourceMapResolver {
       let mapUrl = pathToFileURL(jsFile).href;
       const converter =
         convertSourceMap.fromSource(code)
-        ?? convertSourceMap.fromMapFileSource(code, (mapFile) => {
+        ?? (await convertSourceMap.fromMapFileSource(code, async (mapFile) => {
           const mapPath = path.resolve(path.dirname(jsFile), mapFile);
           // sourceMappingURL is assembly-derived; don't read a map outside the
           // project. The throw is caught below and surfaced as a load warning.
-          if (!isWithinRoot(this.projectRoot, mapPath)) {
+          if (!(await isWithinRoot(this.projectRoot, mapPath))) {
             throw new Error(`source map path escapes the project root: ${mapPath}`);
           }
           mapUrl = pathToFileURL(mapPath).href;
-          return fs.readFileSync(mapPath, 'utf-8');
-        });
+          return fs.promises.readFile(mapPath, 'utf-8');
+        }));
       return converter ? new TraceMap(converter.toObject(), mapUrl) : null;
     } catch (err) {
       // A map was referenced but couldn't be read/parsed. Surface it once
@@ -166,16 +166,16 @@ function parseFrame(frame: string): SourceLocation | undefined {
  * to keep file reads driven by (attacker-influenceable) cloud-assembly paths
  * within the project before any read happens.
  */
-export function isWithinRoot(root: string, candidate: string): boolean {
-  const realRoot = realOrSelf(path.resolve(root));
-  const realCandidate = realOrSelf(path.resolve(candidate));
+export async function isWithinRoot(root: string, candidate: string): Promise<boolean> {
+  const realRoot = await realOrSelf(path.resolve(root));
+  const realCandidate = await realOrSelf(path.resolve(candidate));
   return realCandidate === realRoot || realCandidate.startsWith(realRoot + path.sep);
 }
 
 /** Real path with symlinks resolved, or the resolved input if it does not exist. */
-function realOrSelf(p: string): string {
+async function realOrSelf(p: string): Promise<string> {
   try {
-    return fs.realpathSync(p);
+    return await fs.promises.realpath(p);
   } catch {
     return p;
   }

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -36,7 +36,7 @@ export interface LspHandlerOptions {
   /** Callback invoked on `didSave` for tracked source files. */
   readonly onSynthRequest?: (projectDir: string) => void;
   /** Override readAssembly for tests. Defaults to reading <applicationDir>/cdk.out. */
-  readonly readAssembly?: (assemblyDir: string) => AssemblyReadResult;
+  readonly readAssembly?: (assemblyDir: string) => Promise<AssemblyReadResult>;
   /**
    * Sink for non-fatal messages. In production, the connection's console writes
    * to the editor's Output panel; in tests, capture into an array.
@@ -54,7 +54,7 @@ export interface LspServerOptions extends LspHandlerOptions {
 /** Pure handler functions for LSP messages, extracted for direct unit testing. */
 export interface LspHandlers {
   onInitialize(params: InitializeParams): InitializeResult;
-  onInitialized(): void;
+  onInitialized(): Promise<void>;
   onDidSaveTextDocument(params: DidSaveTextDocumentParams): void;
   onCodeLens(params: CodeLensParams): CodeLens[];
   onDefinition(params: DefinitionParams): Location | undefined;
@@ -92,9 +92,9 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
   // cdk.out. Refreshed on every onInitialized; cdk.out watcher is a future feature.
   let cachedIndex: ConstructIndex<ConstructNode> = ConstructIndex.fromTree<ConstructNode>([]);
 
-  function refreshFromAssembly(projectDir: string): void {
+  async function refreshFromAssembly(projectDir: string): Promise<void> {
     const assemblyDir = path.join(projectDir, 'cdk.out');
-    const result = readAssembly(assemblyDir);
+    const result = await readAssembly(assemblyDir);
 
     if (result.status === 'error') {
       log.error(`Failed to read cloud assembly: ${result.message}`);
@@ -141,7 +141,7 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
         },
       };
     },
-    onInitialized() {
+    async onInitialized() {
       const projectDir = applicationDir ?? process.cwd();
       // Same exclusion logic as toolkit-lib's watch():
       // WATCH_EXCLUDE_DEFAULTS covers common non-source dirs, then we add cdk.out
@@ -157,7 +157,7 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
         ],
         rootDir: projectDir,
       });
-      refreshFromAssembly(projectDir);
+      await refreshFromAssembly(projectDir);
     },
     onDidSaveTextDocument(params) {
       if (shutdownRequested) return;
@@ -217,7 +217,14 @@ export function startServer(options: LspServerOptions): void {
   });
 
   connection.onInitialize((params) => handlers.onInitialize(params));
-  connection.onInitialized(() => handlers.onInitialized());
+  connection.onInitialized(() => {
+    // `initialized` is a notification, so nothing awaits us, but onInitialized's
+    // async work can still reject. Surface it to the editor Output panel rather
+    // than leaving an unhandled rejection.
+    handlers.onInitialized().catch((err) => {
+      connection.console.error(`onInitialized failed: ${(err as Error).message}`);
+    });
+  });
   connection.onDidSaveTextDocument((params) => handlers.onDidSaveTextDocument(params));
   connection.onCodeLens((params) => handlers.onCodeLens(params));
   connection.onDefinition((params) => handlers.onDefinition(params));

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
@@ -20,7 +20,7 @@ describe('fixture builders', () => {
     dir = undefined;
   });
 
-  test('buildFlatAssembly produces a readAssembly-compatible directory', () => {
+  test('buildFlatAssembly produces a readAssembly-compatible directory', async () => {
     dir = buildFlatAssembly({
       stacks: [{
         id: 'Stack1',
@@ -32,14 +32,14 @@ describe('fixture builders', () => {
       }],
     });
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error(`expected success, got ${result.status}: ${(result as any).message ?? ''}`);
 
     expect(result.data.tree).toHaveLength(1);
     expect(result.data.tree[0].id).toBe('Stack1');
   });
 
-  test('buildFlatAssembly attaches logicalId and cfnType correctly', () => {
+  test('buildFlatAssembly attaches logicalId and cfnType correctly', async () => {
     dir = buildFlatAssembly({
       stacks: [{
         id: 'Stack1',
@@ -51,7 +51,7 @@ describe('fixture builders', () => {
       }],
     });
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     const resource = result.data.tree[0].children[0].children[0];
@@ -62,7 +62,7 @@ describe('fixture builders', () => {
     expect(resource.sourceLocation).toBeUndefined();
   });
 
-  test('buildFlatAssembly with creationTrace exposes sourceLocation', () => {
+  test('buildFlatAssembly with creationTrace exposes sourceLocation', async () => {
     dir = buildFlatAssembly({
       stacks: [{
         id: 'Stack1',
@@ -82,7 +82,7 @@ describe('fixture builders', () => {
     });
     const projectRoot = path.dirname(dir);
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     const resource = result.data.tree[0].children[0].children[0];
@@ -93,7 +93,7 @@ describe('fixture builders', () => {
     });
   });
 
-  test('buildNestedAssembly produces a Stage-based assembly with correct tree', () => {
+  test('buildNestedAssembly produces a Stage-based assembly with correct tree', async () => {
     dir = buildNestedAssembly({
       stages: [{
         id: 'Prod',
@@ -108,7 +108,7 @@ describe('fixture builders', () => {
       }],
     });
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     expect(result.data.tree).toHaveLength(1);
@@ -125,7 +125,7 @@ describe('fixture builders', () => {
     expect(resource.type).toBe('AWS::S3::Bucket');
   });
 
-  test('buildNestedStackAssembly enriches resources INSIDE a NestedStack via parent metadata', () => {
+  test('buildNestedStackAssembly enriches resources INSIDE a NestedStack via parent metadata', async () => {
     // aws-cdk-lib emits nested-stack-internal metadata into the parent's
     // artifact metadata. Verifies buildNode's metadata inheritance handles
     // this with no separate walker.
@@ -153,7 +153,7 @@ describe('fixture builders', () => {
     });
     const projectRoot = path.dirname(dir);
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     const parent = result.data.tree[0];
@@ -177,10 +177,10 @@ describe('fixture builders', () => {
     });
   });
 
-  test('buildNonTypeScriptAssembly returns success without crashing', () => {
+  test('buildNonTypeScriptAssembly returns success without crashing', async () => {
     dir = buildNonTypeScriptAssembly();
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     expect(result.data.tree).toHaveLength(1);
@@ -190,13 +190,13 @@ describe('fixture builders', () => {
     expect(stack.sourceLocation).toBeUndefined();
   });
 
-  test('withMalformedValidationReport surfaces the error without breaking the tree', () => {
+  test('withMalformedValidationReport surfaces the error without breaking the tree', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [] }],
     });
     withMalformedValidationReport(dir);
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     expect(result.data.tree).toHaveLength(1);
@@ -204,7 +204,7 @@ describe('fixture builders', () => {
     expect(result.data.violationsError).toBeTruthy();
   });
 
-  test('withValidationReport produces a parseable report', () => {
+  test('withValidationReport produces a parseable report', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [] }],
     });
@@ -221,7 +221,7 @@ describe('fixture builders', () => {
       }],
     });
 
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     expect(result.data.violationsError).toBeUndefined();

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.test.ts
@@ -1,5 +1,6 @@
 // Sanity tests for the fixture builders. If these pass, every other test
 // that uses the builders inherits a known-good baseline.
+import * as path from 'path';
 import {
   buildFlatAssembly,
   buildNestedAssembly,
@@ -74,18 +75,19 @@ describe('fixture builders', () => {
           // so the first frame that parses is the user's call site.
           creationTrace: [
             '    ...node_modules-aws-cdk-lib...',
-            '    at new MyStack (/project/lib/my-stack.ts:12:5)',
+            '    at new MyStack (<PROJECT>/lib/my-stack.ts:12:5)',
           ],
         }],
       }],
     });
+    const projectRoot = path.dirname(dir);
 
     const result = readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
 
     const resource = result.data.tree[0].children[0].children[0];
     expect(resource.sourceLocation).toEqual({
-      file: '/project/lib/my-stack.ts',
+      file: path.join(projectRoot, 'lib/my-stack.ts'),
       line: 12,
       column: 5,
     });
@@ -143,12 +145,13 @@ describe('fixture builders', () => {
             cfnType: 'AWS::S3::Bucket',
             creationTrace: [
               '    ...node_modules-aws-cdk-lib...',
-              '    at new MyNestedStack (/project/lib/nested.ts:7:5)',
+              '    at new MyNestedStack (<PROJECT>/lib/nested.ts:7:5)',
             ],
           }],
         }],
       },
     });
+    const projectRoot = path.dirname(dir);
 
     const result = readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
@@ -168,7 +171,7 @@ describe('fixture builders', () => {
     expect(nestedBucket.logicalId).toBe('NestedBucketBBB');
     expect(nestedBucket.type).toBe('AWS::S3::Bucket');
     expect(nestedBucket.sourceLocation).toEqual({
-      file: '/project/lib/nested.ts',
+      file: path.join(projectRoot, 'lib/nested.ts'),
       line: 7,
       column: 5,
     });

--- a/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/_fixtures/builders.ts
@@ -86,12 +86,13 @@ export interface NestedStackParentSpec {
 /** Build a flat assembly (stacks directly under App, no Stages). */
 export function buildFlatAssembly(spec: FlatAssemblySpec): string {
   const dir = mkAssemblyDir('flat');
+  const projectRoot = path.dirname(dir);
   const artifacts: Record<string, unknown> = {
     Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
   };
 
   for (const stack of spec.stacks) {
-    artifacts[stack.id] = stackArtifact(stack);
+    artifacts[stack.id] = stackArtifact(stack, projectRoot);
     writeTemplate(dir, stack.id, stack.resources, stack.id, spec.pathMetadata ?? true);
   }
 
@@ -110,6 +111,7 @@ export function buildFlatAssembly(spec: FlatAssemblySpec): string {
 /** Build a Stage-based assembly (each stage produces a nested cloud-assembly). */
 export function buildNestedAssembly(spec: NestedAssemblySpec): string {
   const rootDir = mkAssemblyDir('nested');
+  const projectRoot = path.dirname(rootDir);
   const rootArtifacts: Record<string, unknown> = {
     Tree: { type: 'cdk:tree', properties: { file: 'tree.json' } },
   };
@@ -137,7 +139,7 @@ export function buildNestedAssembly(spec: NestedAssemblySpec): string {
         // displayName is the construct path; the reader keys metadata by
         // hierarchicalId, which falls back to displayName.
         displayName: constructPath,
-        metadata: stackMetadata(stack.resources, `/${constructPath}`),
+        metadata: stackMetadata(stack.resources, `/${constructPath}`, projectRoot),
       };
       writeTemplate(stageDir, artifactId, stack.resources, constructPath);
     }
@@ -181,6 +183,7 @@ export function buildNestedAssembly(spec: NestedAssemblySpec): string {
  */
 export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }): string {
   const dir = mkAssemblyDir('nestedstack');
+  const projectRoot = path.dirname(dir);
   const { parent } = spec;
 
   // All nested resources' metadata lives under the PARENT artifact, keyed by
@@ -190,7 +193,7 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
   const parentResources: Record<string, unknown> = {};
 
   for (const r of parent.resources) {
-    metadata[`/${parent.id}/${r.id}/Resource`] = [logicalIdEntry(r)];
+    metadata[`/${parent.id}/${r.id}/Resource`] = [logicalIdEntry(r, projectRoot)];
     parentChildren[r.id] = resourceTreeNode(parent.id, r);
     parentResources[r.logicalId] = {
       Type: r.cfnType,
@@ -199,7 +202,7 @@ export function buildNestedStackAssembly(spec: { parent: NestedStackParentSpec }
     };
   }
   for (const ns of parent.nestedStacks) {
-    emitNestedStack(dir, metadata, parentChildren, parentResources, parent.id, ns);
+    emitNestedStack(dir, metadata, parentChildren, parentResources, parent.id, ns, projectRoot);
   }
 
   writeJson(path.join(dir, 'manifest.json'), {
@@ -243,6 +246,7 @@ function emitNestedStack(
   parentResources: Record<string, unknown>,
   parentPath: string,
   ns: NestedStackSpec,
+  projectRoot: string,
 ): void {
   const nsPath = `${parentPath}/${ns.id}`;
   const templateFile = `${nsPath.replace(/\//g, '')}.nested.template.json`;
@@ -277,7 +281,7 @@ function emitNestedStack(
   const nsChildren: Record<string, unknown> = {};
   const nsResources: Record<string, unknown> = {};
   for (const r of ns.resources) {
-    metadata[`/${nsPath}/${r.id}/Resource`] = [logicalIdEntry(r)];
+    metadata[`/${nsPath}/${r.id}/Resource`] = [logicalIdEntry(r, projectRoot)];
     nsChildren[r.id] = resourceTreeNode(nsPath, r);
     nsResources[r.logicalId] = {
       Type: r.cfnType,
@@ -286,7 +290,7 @@ function emitNestedStack(
     };
   }
   for (const child of ns.nestedStacks ?? []) {
-    emitNestedStack(dir, metadata, nsChildren, nsResources, nsPath, child);
+    emitNestedStack(dir, metadata, nsChildren, nsResources, nsPath, child, projectRoot);
   }
   writeJson(path.join(dir, templateFile), { Resources: nsResources });
 
@@ -382,7 +386,10 @@ export function cleanupFixture(dir: string | undefined): void {
 // ---------- internals ----------
 
 function mkAssemblyDir(prefix: string): string {
-  const base = fs.mkdtempSync(path.join(os.tmpdir(), `cdk-explorer-${prefix}-`));
+  // realpath the temp dir so the project root (its parent) is canonical and
+  // matches source paths resolved from traces under the reader's containment
+  // check (e.g. macOS /var -> /private/var).
+  const base = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), `cdk-explorer-${prefix}-`)));
   return path.join(base, 'cdk.out');
 }
 
@@ -435,30 +442,45 @@ function resourceTreeNode(parentPath: string, r: ResourceSpec): unknown {
   };
 }
 
-function stackArtifact(stack: StackSpec): unknown {
+function stackArtifact(stack: StackSpec, projectRoot: string): unknown {
   return {
     type: 'aws:cloudformation:stack',
     environment: 'aws://unknown-account/unknown-region',
     properties: { templateFile: `${stack.id}.template.json` },
     displayName: stack.id,
-    metadata: stackMetadata(stack.resources, `/${stack.id}`),
+    metadata: stackMetadata(stack.resources, `/${stack.id}`, projectRoot),
   };
 }
 
-function stackMetadata(resources: readonly ResourceSpec[], pathPrefix: string): Record<string, unknown[]> {
+function stackMetadata(
+  resources: readonly ResourceSpec[],
+  pathPrefix: string,
+  projectRoot: string,
+): Record<string, unknown[]> {
   const metadata: Record<string, unknown[]> = {};
   for (const r of resources) {
-    metadata[`${pathPrefix}/${r.id}/Resource`] = [logicalIdEntry(r)];
+    metadata[`${pathPrefix}/${r.id}/Resource`] = [logicalIdEntry(r, projectRoot)];
   }
   return metadata;
 }
 
-function logicalIdEntry(r: ResourceSpec): Record<string, unknown> {
+function logicalIdEntry(r: ResourceSpec, projectRoot: string): Record<string, unknown> {
   const entry: Record<string, unknown> = { type: ArtifactMetadataEntryType.LOGICAL_ID, data: r.logicalId };
-  if (r.creationTrace && r.creationTrace.length > 0) {
-    entry.trace = [...r.creationTrace];
+  const trace = rebaseTrace(r.creationTrace, projectRoot);
+  if (trace && trace.length > 0) {
+    entry.trace = trace;
   }
   return entry;
+}
+
+/**
+ * Anchor a creation trace's source paths to the fixture's project root (the
+ * parent of cdk.out), mirroring real apps whose sources live beside cdk.out.
+ * Tests write `<PROJECT>` in a frame; the reader's containment check then
+ * accepts the resolved path instead of dropping it as out-of-project.
+ */
+function rebaseTrace(trace: readonly string[] | undefined, projectRoot: string): string[] | undefined {
+  return trace?.map((frame) => frame.replace(/<PROJECT>/g, projectRoot));
 }
 
 function writeTemplate(

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-reader.test.ts
@@ -28,20 +28,20 @@ describe('readAssembly', () => {
     dir = undefined;
   });
 
-  test('returns not-found for nonexistent directory', () => {
-    expect(readAssembly('/nonexistent/path').status).toBe('not-found');
+  test('returns not-found for nonexistent directory', async () => {
+    expect((await readAssembly('/nonexistent/path')).status).toBe('not-found');
   });
 
-  test('returns not-found for directory without manifest.json', () => {
+  test('returns not-found for directory without manifest.json', async () => {
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-explorer-empty-'));
     try {
-      expect(readAssembly(empty).status).toBe('not-found');
+      expect((await readAssembly(empty)).status).toBe('not-found');
     } finally {
       fs.rmSync(empty, { recursive: true, force: true });
     }
   });
 
-  test('parses tree from a flat assembly', () => {
+  test('parses tree from a flat assembly', async () => {
     dir = buildFlatAssembly({
       stacks: [
         { id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] },
@@ -49,13 +49,13 @@ describe('readAssembly', () => {
       ],
     });
 
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.tree).toHaveLength(2);
     expect(data.tree.map((n) => n.id).sort()).toEqual(['Stack1', 'Stack2']);
   });
 
-  test('enriches resource nodes with logicalId and cfnType', () => {
+  test('enriches resource nodes with logicalId and cfnType', async () => {
     dir = buildFlatAssembly({
       stacks: [{
         id: 'Stack1',
@@ -64,14 +64,14 @@ describe('readAssembly', () => {
         }],
       }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     const resource = findNode(data.tree, 'Stack1/MyBucket/Resource')!;
     expect(resource.logicalId).toBe('MyBucketF68F3FF0');
     expect(resource.type).toBe('AWS::S3::Bucket');
   });
 
-  test('non-resource constructs (L2 wrappers) have no logicalId or type', () => {
+  test('non-resource constructs (L2 wrappers) have no logicalId or type', async () => {
     dir = buildFlatAssembly({
       stacks: [{
         id: 'Stack1',
@@ -82,28 +82,28 @@ describe('readAssembly', () => {
         }],
       }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     const wrapper = findNode(data.tree, 'Stack1/MyBucket')!;
     expect(wrapper.logicalId).toBeUndefined();
     expect(wrapper.type).toBeUndefined();
   });
 
-  test('children are arrays', () => {
+  test('children are arrays', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'X', logicalId: 'X', cfnType: 'AWS::S3::Bucket' }] }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(Array.isArray(data.tree)).toBe(true);
     expect(Array.isArray(data.tree[0].children)).toBe(true);
   });
 
-  test('returns error for malformed manifest', () => {
+  test('returns error for malformed manifest', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-explorer-malformed-'));
     fs.writeFileSync(path.join(tmpDir, 'manifest.json'), 'not json{{{');
     try {
-      const result = readAssembly(tmpDir);
+      const result = await readAssembly(tmpDir);
       expect(result.status).toBe('error');
       if (result.status === 'error') expect(result.message).toBeTruthy();
     } finally {
@@ -120,7 +120,7 @@ describe('readAssembly with violations', () => {
     dir = undefined;
   });
 
-  test('parses validation report when present', () => {
+  test('parses validation report when present', async () => {
     dir = buildFlatAssembly({ stacks: [{ id: 'Stack1', resources: [] }] });
     withValidationReport(dir, {
       pluginReports: [{
@@ -138,7 +138,7 @@ describe('readAssembly with violations', () => {
       }],
     });
 
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.violations).toBeDefined();
     expect(data.violations!.pluginReports[0].conclusion).toBe('failure');
@@ -146,30 +146,30 @@ describe('readAssembly with violations', () => {
     expect(data.violationsError).toBeUndefined();
   });
 
-  test('returns undefined violations when report file is absent', () => {
+  test('returns undefined violations when report file is absent', async () => {
     dir = buildFlatAssembly({ stacks: [{ id: 'Stack1', resources: [] }] });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.violations).toBeUndefined();
     expect(data.violationsError).toBeUndefined();
   });
 
-  test('malformed validation report does not crash the tree read', () => {
+  test('malformed validation report does not crash the tree read', async () => {
     dir = buildFlatAssembly({ stacks: [{ id: 'Stack1', resources: [] }] });
     withMalformedValidationReport(dir);
 
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.tree).toHaveLength(1);
     expect(data.violations).toBeUndefined();
     expect(data.violationsError).toBeTruthy();
   });
 
-  test('loads a version-less validation report (legacy aws-cdk-lib shape)', () => {
+  test('loads a version-less validation report (legacy aws-cdk-lib shape)', async () => {
     dir = buildFlatAssembly({ stacks: [{ id: 'Stack1', resources: [] }] });
     withVersionlessValidationReport(dir);
 
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.tree).toHaveLength(1);
     expect(data.violations).toBeDefined();
@@ -185,17 +185,17 @@ describe('readAssembly with Stage-based (nested-assembly) apps', () => {
     dir = undefined;
   });
 
-  test('preserves Stage grouping node in the tree', () => {
+  test('preserves Stage grouping node in the tree', async () => {
     dir = buildNestedAssembly({
       stages: [{ id: 'Prod', stacks: [{ id: 'Service', resources: [] }] }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     const stage = data.tree.find((n) => n.id === 'Prod')!;
     expect(stage.path).toBe('Prod');
   });
 
-  test('resources inside a Stage stack get logicalId and cfnType', () => {
+  test('resources inside a Stage stack get logicalId and cfnType', async () => {
     dir = buildNestedAssembly({
       stages: [{
         id: 'Prod',
@@ -205,14 +205,14 @@ describe('readAssembly with Stage-based (nested-assembly) apps', () => {
         }],
       }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     const resource = findNode(data.tree, 'Prod/Service/MyBucket/Resource')!;
     expect(resource.logicalId).toBe('MyBucketABC');
     expect(resource.type).toBe('AWS::S3::Bucket');
   });
 
-  test('multi-stage apps route metadata to the correct nested assembly', () => {
+  test('multi-stage apps route metadata to the correct nested assembly', async () => {
     // Two stages, same construct ids — proves we don't cross-contaminate
     // metadata from one stage's nested-assembly manifest to another's.
     dir = buildNestedAssembly({
@@ -221,7 +221,7 @@ describe('readAssembly with Stage-based (nested-assembly) apps', () => {
         { id: 'Staging', stacks: [{ id: 'Service', resources: [{ id: 'X', logicalId: 'StagingX', cfnType: 'AWS::S3::Bucket' }] }] },
       ],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Prod/Service/X/Resource')!.logicalId).toBe('ProdX');
     expect(findNode(data.tree, 'Staging/Service/X/Resource')!.logicalId).toBe('StagingX');
@@ -236,10 +236,10 @@ describe('readAssembly graceful degradation', () => {
     dir = undefined;
   });
 
-  test('non-TypeScript app returns success with no source enrichment, no crash', () => {
+  test('non-TypeScript app returns success with no source enrichment, no crash', async () => {
     dir = buildNonTypeScriptAssembly();
 
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(data.tree).toHaveLength(1);
     const stack = data.tree[0];
@@ -256,11 +256,11 @@ describe('readAssembly resource templateFile', () => {
     dir = undefined;
   });
 
-  test('sets templateFile to the resource\'s own stack template, none on wrappers', () => {
+  test('sets templateFile to the resource\'s own stack template, none on wrappers', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Stack1/MyBucket/Resource')!.templateFile)
       .toBe(path.join(dir!, 'Stack1.template.json'));
@@ -268,7 +268,7 @@ describe('readAssembly resource templateFile', () => {
     expect(findNode(data.tree, 'Stack1/MyBucket')!.templateFile).toBeUndefined();
   });
 
-  test('resolves nested-stack resources to the nested template, not the parent', () => {
+  test('resolves nested-stack resources to the nested template, not the parent', async () => {
     dir = buildNestedStackAssembly({
       parent: {
         id: 'Parent',
@@ -279,7 +279,7 @@ describe('readAssembly resource templateFile', () => {
         }],
       },
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     // Top-level resource lives in the parent template.
     expect(findNode(data.tree, 'Parent/TopBucket/Resource')!.templateFile)
@@ -289,7 +289,7 @@ describe('readAssembly resource templateFile', () => {
       .toBe(path.join(dir!, 'ParentMyNested.nested.template.json'));
   });
 
-  test('keeps templates distinct when two stacks share a logical id (stack-relative ids)', () => {
+  test('keeps templates distinct when two stacks share a logical id (stack-relative ids)', async () => {
     // Same-shape stacks produce the SAME stack-relative logicalId in different
     // templates; each resource must resolve to its OWN stack's template.
     dir = buildFlatAssembly({
@@ -298,13 +298,13 @@ describe('readAssembly resource templateFile', () => {
         { id: 'Dev', resources: [{ id: 'Data', logicalId: 'DataX', cfnType: 'AWS::S3::Bucket' }] },
       ],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Prod/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Prod.template.json'));
     expect(findNode(data.tree, 'Dev/Data/Resource')!.templateFile).toBe(path.join(dir!, 'Dev.template.json'));
   });
 
-  test('resolves a parent resource and its nested-stack twin that share a logical id', () => {
+  test('resolves a parent resource and its nested-stack twin that share a logical id', async () => {
     // A NestedStack resets the logical-ID namespace, so a parent resource and a
     // resource in its own nested stack can share an id. The globally-unique
     // construct path (aws:cdk:path) disambiguates them.
@@ -318,7 +318,7 @@ describe('readAssembly resource templateFile', () => {
         }],
       },
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Parent/Data/Resource')!.templateFile)
       .toBe(path.join(dir!, 'Parent.template.json'));
@@ -326,7 +326,7 @@ describe('readAssembly resource templateFile', () => {
       .toBe(path.join(dir!, 'ParentNested.nested.template.json'));
   });
 
-  test('resolves a resource in a doubly-nested stack to the innermost template', () => {
+  test('resolves a resource in a doubly-nested stack to the innermost template', async () => {
     dir = buildNestedStackAssembly({
       parent: {
         id: 'Parent',
@@ -341,7 +341,7 @@ describe('readAssembly resource templateFile', () => {
         }],
       },
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Parent/Outer/OuterFn/Resource')!.templateFile)
       .toBe(path.join(dir!, 'ParentOuter.nested.template.json'));
@@ -349,7 +349,7 @@ describe('readAssembly resource templateFile', () => {
       .toBe(path.join(dir!, 'ParentOuterInner.nested.template.json'));
   });
 
-  test('skips an unreadable nested template instead of failing the whole read', () => {
+  test('skips an unreadable nested template instead of failing the whole read', async () => {
     dir = buildNestedStackAssembly({
       parent: {
         id: 'Parent',
@@ -362,20 +362,20 @@ describe('readAssembly resource templateFile', () => {
     });
     fs.rmSync(path.join(dir, 'ParentNested.nested.template.json'));
     // Still a success: the missing nested template degrades only its subtree.
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
     expect(findNode(data.tree, 'Parent/TopBucket/Resource')!.templateFile)
       .toBe(path.join(dir!, 'Parent.template.json'));
     expect(findNode(data.tree, 'Parent/Nested/NestedQueue/Resource')!.templateFile).toBeUndefined();
   });
 
-  test('resolves templateFile without path metadata (positional, not id-based)', () => {
+  test('resolves templateFile without path metadata (positional, not id-based)', async () => {
     // Resolution threads the template down the construct tree, so it works
     // regardless of --no-path-metadata (no reliance on aws:cdk:path).
     dir = buildFlatAssembly({
       pathMetadata: false,
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
-    const data = expectSuccess(readAssembly(dir));
+    const data = expectSuccess(await readAssembly(dir));
 
     expect(findNode(data.tree, 'Stack1/MyBucket/Resource')!.templateFile)
       .toBe(path.join(dir!, 'Stack1.template.json'));

--- a/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
@@ -1,21 +1,42 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { SourceMapResolver } from '../../lib/core/source-resolver';
+import { SourceMapResolver, isWithinRoot } from '../../lib/core/source-resolver';
 
 const SOURCE_MAPS_DIR = path.join(__dirname, '..', '_fixtures', 'source-maps');
+const SAMPLE_JS = path.join(SOURCE_MAPS_DIR, 'sample.js');
+const SAMPLE_MAP = path.join(SOURCE_MAPS_DIR, 'sample.js.map');
 
-let resolver: SourceMapResolver;
-
-beforeEach(() => {
-  // Fresh resolver (and cache) per test so source-map parses don't bleed between cases.
-  resolver = new SourceMapResolver();
+const tmpDirs: string[] = [];
+afterEach(() => {
+  tmpDirs.forEach((d) => fs.rmSync(d, { recursive: true, force: true }));
+  tmpDirs.length = 0;
+  jest.restoreAllMocks();
 });
+
+const tmpDir = (): string => {
+  // realpath so the macOS /var -> /private/var symlink doesn't make an existing
+  // root and a not-yet-created child disagree under isWithinRoot.
+  const dir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'srcmap-')));
+  tmpDirs.push(dir);
+  return dir;
+};
+
+// sample.js body without its trailing sourceMappingURL comment, so each test
+// can attach its own (inline or external) form. greet() stays on line 5.
+const sampleBody = (): string =>
+  fs.readFileSync(SAMPLE_JS, 'utf-8').replace(/\/\/# sourceMappingURL=.*$/m, '').trimEnd();
 
 // NOTE: choosing WHICH metadata entry's frames to use (LOGICAL_ID.trace vs
 // aws:cdk:creationStack) is toolkit-lib's findCreationStackTrace; this resolver
 // only turns the chosen frames into a user source location.
 describe('SourceMapResolver.resolveFrames', () => {
+  // All frames in this block live under /project; the resolver is rooted there.
+  let resolver: SourceMapResolver;
+  beforeEach(() => {
+    resolver = new SourceMapResolver('/project');
+  });
+
   test('returns undefined for no frames', () => {
     expect(resolver.resolveFrames(undefined)).toBeUndefined();
   });
@@ -51,24 +72,9 @@ describe('SourceMapResolver.resolveFrames', () => {
 });
 
 describe('source-map resolution', () => {
-  const SAMPLE_JS = path.join(SOURCE_MAPS_DIR, 'sample.js');
-  const SAMPLE_MAP = path.join(SOURCE_MAPS_DIR, 'sample.js.map');
-
-  const tmpDirs: string[] = [];
-  afterEach(() => tmpDirs.forEach((d) => fs.rmSync(d, { recursive: true, force: true })));
-
-  // sample.js body without its trailing sourceMappingURL comment, so each test
-  // can attach its own (inline or external) form. greet() stays on line 5.
-  const sampleBody = (): string =>
-    fs.readFileSync(SAMPLE_JS, 'utf-8').replace(/\/\/# sourceMappingURL=.*$/m, '').trimEnd();
-  const tmpDir = (): string => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'srcmap-'));
-    tmpDirs.push(dir);
-    return dir;
-  };
-
   test('resolves .js to .ts using sibling .js.map', () => {
     // sample.js line 5: `function greet(name) {`
+    const resolver = new SourceMapResolver(SOURCE_MAPS_DIR);
     const result = resolver.resolveFrames([`    at greet (${SAMPLE_JS}:5:10)`]);
     expect(result).toBeDefined();
     expect(result!.file).toContain('sample.ts');
@@ -76,12 +82,16 @@ describe('source-map resolution', () => {
   });
 
   test('falls back to .js location when no .js.map exists', () => {
-    expect(resolver.resolveFrames(['    at someFn (/tmp/no-map-here.js:1:1)'])).toEqual({
-      file: '/tmp/no-map-here.js', line: 1, column: 1,
+    const dir = tmpDir();
+    const jsPath = path.join(dir, 'no-map-here.js');
+    const resolver = new SourceMapResolver(dir);
+    expect(resolver.resolveFrames([`    at someFn (${jsPath}:1:1)`])).toEqual({
+      file: jsPath, line: 1, column: 1,
     });
   });
 
   test('returns .ts location unchanged (no source-map needed)', () => {
+    const resolver = new SourceMapResolver('/project');
     expect(resolver.resolveFrames(['    at someFn (/project/lib/foo.ts:3:2)'])).toEqual({
       file: '/project/lib/foo.ts', line: 3, column: 2,
     });
@@ -93,6 +103,7 @@ describe('source-map resolution', () => {
     const jsPath = path.join(dir, 'sample.js');
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=data:application/json;base64,${b64}\n`);
 
+    const resolver = new SourceMapResolver(dir);
     const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toContain('sample.ts');
     expect(result!.line).toBe(2);
@@ -104,6 +115,7 @@ describe('source-map resolution', () => {
     const jsPath = path.join(dir, 'sample.js');
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
 
+    const resolver = new SourceMapResolver(dir);
     const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toContain('sample.ts');
     expect(result!.line).toBe(2);
@@ -117,8 +129,91 @@ describe('source-map resolution', () => {
     const jsPath = path.join(dir, 'sample.js');
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
 
+    const resolver = new SourceMapResolver(dir);
     const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toBe(path.join(dir, 'nested', 'sample.ts'));
     expect(result!.line).toBe(2);
+  });
+});
+
+// Paths from the (attacker-influenceable) cloud assembly must never drive a
+// read or a navigation target outside the project.
+describe('path containment', () => {
+  test('drops a frame whose file escapes the project root, without reading it', () => {
+    const root = tmpDir();
+    const readSpy = jest.spyOn(fs, 'readFileSync');
+    const resolver = new SourceMapResolver(root);
+
+    expect(resolver.resolveFrames(['    at evil (/etc/passwd.js:1:1)'])).toBeUndefined();
+    // The escaping path must be rejected before any read of it.
+    expect(readSpy.mock.calls.some(([p]) => String(p).includes('/etc/passwd'))).toBe(false);
+  });
+
+  test('drops a .ts frame that escapes the project root', () => {
+    const root = tmpDir();
+    const resolver = new SourceMapResolver(root);
+    expect(resolver.resolveFrames([`    at f (${path.join(root, '..', 'outside.ts')}:1:1)`])).toBeUndefined();
+  });
+
+  test('ignores an external source map that escapes the root, falling back to the .js', () => {
+    const dir = tmpDir();
+    const jsPath = path.join(dir, 'sample.js');
+    // In-root .js, but its sourceMappingURL points outside the project.
+    fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=../../../../etc/evil.map\n`);
+    const readSpy = jest.spyOn(fs, 'readFileSync');
+
+    const resolver = new SourceMapResolver(dir);
+    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+
+    // Falls back to the (in-root) .js location; the escaping map is never read.
+    expect(result).toEqual({ file: jsPath, line: 5, column: 10 });
+    expect(readSpy.mock.calls.some(([p]) => String(p).includes('etc/evil.map'))).toBe(false);
+    expect(resolver.warnings.join('\n')).toMatch(/escapes the project root/);
+  });
+
+  test('falls back to the .js when the mapped original resolves outside the root', () => {
+    const dir = tmpDir();
+    const map = JSON.parse(fs.readFileSync(SAMPLE_MAP, 'utf-8'));
+    map.sourceRoot = '../../../../../../etc/'; // pushes sample.ts outside the root
+    fs.writeFileSync(path.join(dir, 'renamed.map'), JSON.stringify(map));
+    const jsPath = path.join(dir, 'sample.js');
+    fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
+
+    const resolver = new SourceMapResolver(dir);
+    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    expect(result).toEqual({ file: jsPath, line: 5, column: 10 });
+  });
+});
+
+describe('isWithinRoot', () => {
+  const root = path.resolve('/srv/app');
+
+  test('accepts a path inside the root', () => {
+    expect(isWithinRoot(root, path.join(root, 'lib/stack.ts'))).toBe(true);
+  });
+
+  test('accepts the root itself', () => {
+    expect(isWithinRoot(root, root)).toBe(true);
+  });
+
+  test('rejects traversal above the root', () => {
+    expect(isWithinRoot(root, path.join(root, '../../etc/passwd'))).toBe(false);
+  });
+
+  test('accepts traversal that stays within the root', () => {
+    expect(isWithinRoot(root, path.join(root, 'lib/../bin/cdk.ts'))).toBe(true);
+  });
+
+  test('does not treat a sibling dir with a shared prefix as inside', () => {
+    expect(isWithinRoot(root, path.resolve('/srv/app-secrets/file'))).toBe(false);
+  });
+
+  test('rejects a target reached through a symlink that points outside the root', () => {
+    const root2 = tmpDir();
+    const outside = tmpDir();
+    fs.writeFileSync(path.join(outside, 'secret.ts'), 'secret');
+    fs.symlinkSync(outside, path.join(root2, 'link'));
+    // Lexically inside root2, but realpath lands in `outside`.
+    expect(isWithinRoot(root2, path.join(root2, 'link', 'secret.ts'))).toBe(false);
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
@@ -37,11 +37,11 @@ describe('SourceMapResolver.resolveFrames', () => {
     resolver = new SourceMapResolver('/project');
   });
 
-  test('returns undefined for no frames', () => {
-    expect(resolver.resolveFrames(undefined)).toBeUndefined();
+  test('returns undefined for no frames', async () => {
+    expect(await resolver.resolveFrames(undefined)).toBeUndefined();
   });
 
-  test('returns undefined when all frames are skip-placeholders', () => {
+  test('returns undefined when all frames are skip-placeholders', async () => {
     // aws-cdk-lib's renderCallStackJustMyCode emits these for filtered frames
     // (e.g. node_modules and node: internals). They have no parens and no
     // :line:col, so they don't match FRAME_RE.
@@ -50,78 +50,78 @@ describe('SourceMapResolver.resolveFrames', () => {
       '    ...node internals...',
       '    (no user code in 10 frames, use --stack-trace-limit to capture more)',
     ];
-    expect(resolver.resolveFrames(frames)).toBeUndefined();
+    expect(await resolver.resolveFrames(frames)).toBeUndefined();
   });
 
-  test('skips skip-placeholder frames and picks the first parseable user frame', () => {
+  test('skips skip-placeholder frames and picks the first parseable user frame', async () => {
     const frames = [
       '    ...node_modules-aws-cdk-lib...',
       '    at new MyStack (/project/lib/my-stack.ts:42:7)',
       '    at Object.<anonymous> (/project/bin/app.ts:8:1)',
     ];
-    expect(resolver.resolveFrames(frames)).toEqual({
+    expect(await resolver.resolveFrames(frames)).toEqual({
       file: '/project/lib/my-stack.ts',
       line: 42,
       column: 7,
     });
   });
 
-  test('returns undefined for a non-TypeScript (host-language) frame', () => {
-    expect(resolver.resolveFrames(['    at <module> (/project/app/my_stack.py:42:5)'])).toBeUndefined();
+  test('returns undefined for a non-TypeScript (host-language) frame', async () => {
+    expect(await resolver.resolveFrames(['    at <module> (/project/app/my_stack.py:42:5)'])).toBeUndefined();
   });
 });
 
 describe('source-map resolution', () => {
-  test('resolves .js to .ts using sibling .js.map', () => {
+  test('resolves .js to .ts using sibling .js.map', async () => {
     // sample.js line 5: `function greet(name) {`
     const resolver = new SourceMapResolver(SOURCE_MAPS_DIR);
-    const result = resolver.resolveFrames([`    at greet (${SAMPLE_JS}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${SAMPLE_JS}:5:10)`]);
     expect(result).toBeDefined();
     expect(result!.file).toContain('sample.ts');
     expect(result!.line).toBe(2); // ts line 2 = `export function greet`
   });
 
-  test('falls back to .js location when no .js.map exists', () => {
+  test('falls back to .js location when no .js.map exists', async () => {
     const dir = tmpDir();
     const jsPath = path.join(dir, 'no-map-here.js');
     const resolver = new SourceMapResolver(dir);
-    expect(resolver.resolveFrames([`    at someFn (${jsPath}:1:1)`])).toEqual({
+    expect(await resolver.resolveFrames([`    at someFn (${jsPath}:1:1)`])).toEqual({
       file: jsPath, line: 1, column: 1,
     });
   });
 
-  test('returns .ts location unchanged (no source-map needed)', () => {
+  test('returns .ts location unchanged (no source-map needed)', async () => {
     const resolver = new SourceMapResolver('/project');
-    expect(resolver.resolveFrames(['    at someFn (/project/lib/foo.ts:3:2)'])).toEqual({
+    expect(await resolver.resolveFrames(['    at someFn (/project/lib/foo.ts:3:2)'])).toEqual({
       file: '/project/lib/foo.ts', line: 3, column: 2,
     });
   });
 
-  test('resolves an inline (data: URI) source map', () => {
+  test('resolves an inline (data: URI) source map', async () => {
     const b64 = Buffer.from(fs.readFileSync(SAMPLE_MAP, 'utf-8'), 'utf-8').toString('base64');
     const dir = tmpDir();
     const jsPath = path.join(dir, 'sample.js');
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=data:application/json;base64,${b64}\n`);
 
     const resolver = new SourceMapResolver(dir);
-    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toContain('sample.ts');
     expect(result!.line).toBe(2);
   });
 
-  test('resolves an external map referenced under a non-default filename', () => {
+  test('resolves an external map referenced under a non-default filename', async () => {
     const dir = tmpDir();
     fs.copyFileSync(SAMPLE_MAP, path.join(dir, 'renamed.map'));
     const jsPath = path.join(dir, 'sample.js');
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
 
     const resolver = new SourceMapResolver(dir);
-    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toContain('sample.ts');
     expect(result!.line).toBe(2);
   });
 
-  test('applies sourceRoot, resolving sources relative to the map', () => {
+  test('applies sourceRoot, resolving sources relative to the map', async () => {
     const dir = tmpDir();
     const map = JSON.parse(fs.readFileSync(SAMPLE_MAP, 'utf-8'));
     map.sourceRoot = 'nested/';
@@ -130,7 +130,7 @@ describe('source-map resolution', () => {
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
 
     const resolver = new SourceMapResolver(dir);
-    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result!.file).toBe(path.join(dir, 'nested', 'sample.ts'));
     expect(result!.line).toBe(2);
   });
@@ -139,23 +139,23 @@ describe('source-map resolution', () => {
 // Paths from the (attacker-influenceable) cloud assembly must never drive a
 // read or a navigation target outside the project.
 describe('path containment', () => {
-  test('drops a frame whose file escapes the project root, without reading it', () => {
+  test('drops a frame whose file escapes the project root, without reading it', async () => {
     const root = tmpDir();
     const readSpy = jest.spyOn(fs, 'readFileSync');
     const resolver = new SourceMapResolver(root);
 
-    expect(resolver.resolveFrames(['    at evil (/etc/passwd.js:1:1)'])).toBeUndefined();
+    expect(await resolver.resolveFrames(['    at evil (/etc/passwd.js:1:1)'])).toBeUndefined();
     // The escaping path must be rejected before any read of it.
     expect(readSpy.mock.calls.some(([p]) => String(p).includes('/etc/passwd'))).toBe(false);
   });
 
-  test('drops a .ts frame that escapes the project root', () => {
+  test('drops a .ts frame that escapes the project root', async () => {
     const root = tmpDir();
     const resolver = new SourceMapResolver(root);
-    expect(resolver.resolveFrames([`    at f (${path.join(root, '..', 'outside.ts')}:1:1)`])).toBeUndefined();
+    expect(await resolver.resolveFrames([`    at f (${path.join(root, '..', 'outside.ts')}:1:1)`])).toBeUndefined();
   });
 
-  test('ignores an external source map that escapes the root, falling back to the .js', () => {
+  test('ignores an external source map that escapes the root, falling back to the .js', async () => {
     const dir = tmpDir();
     const jsPath = path.join(dir, 'sample.js');
     // In-root .js, but its sourceMappingURL points outside the project.
@@ -163,7 +163,7 @@ describe('path containment', () => {
     const readSpy = jest.spyOn(fs, 'readFileSync');
 
     const resolver = new SourceMapResolver(dir);
-    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
 
     // Falls back to the (in-root) .js location; the escaping map is never read.
     expect(result).toEqual({ file: jsPath, line: 5, column: 10 });
@@ -171,7 +171,7 @@ describe('path containment', () => {
     expect(resolver.warnings.join('\n')).toMatch(/escapes the project root/);
   });
 
-  test('falls back to the .js when the mapped original resolves outside the root', () => {
+  test('falls back to the .js when the mapped original resolves outside the root', async () => {
     const dir = tmpDir();
     const map = JSON.parse(fs.readFileSync(SAMPLE_MAP, 'utf-8'));
     map.sourceRoot = '../../../../../../etc/'; // pushes sample.ts outside the root
@@ -180,7 +180,7 @@ describe('path containment', () => {
     fs.writeFileSync(jsPath, `${sampleBody()}\n//# sourceMappingURL=renamed.map\n`);
 
     const resolver = new SourceMapResolver(dir);
-    const result = resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
+    const result = await resolver.resolveFrames([`    at greet (${jsPath}:5:10)`]);
     expect(result).toEqual({ file: jsPath, line: 5, column: 10 });
   });
 });
@@ -188,32 +188,32 @@ describe('path containment', () => {
 describe('isWithinRoot', () => {
   const root = path.resolve('/srv/app');
 
-  test('accepts a path inside the root', () => {
-    expect(isWithinRoot(root, path.join(root, 'lib/stack.ts'))).toBe(true);
+  test('accepts a path inside the root', async () => {
+    expect(await isWithinRoot(root, path.join(root, 'lib/stack.ts'))).toBe(true);
   });
 
-  test('accepts the root itself', () => {
-    expect(isWithinRoot(root, root)).toBe(true);
+  test('accepts the root itself', async () => {
+    expect(await isWithinRoot(root, root)).toBe(true);
   });
 
-  test('rejects traversal above the root', () => {
-    expect(isWithinRoot(root, path.join(root, '../../etc/passwd'))).toBe(false);
+  test('rejects traversal above the root', async () => {
+    expect(await isWithinRoot(root, path.join(root, '../../etc/passwd'))).toBe(false);
   });
 
-  test('accepts traversal that stays within the root', () => {
-    expect(isWithinRoot(root, path.join(root, 'lib/../bin/cdk.ts'))).toBe(true);
+  test('accepts traversal that stays within the root', async () => {
+    expect(await isWithinRoot(root, path.join(root, 'lib/../bin/cdk.ts'))).toBe(true);
   });
 
-  test('does not treat a sibling dir with a shared prefix as inside', () => {
-    expect(isWithinRoot(root, path.resolve('/srv/app-secrets/file'))).toBe(false);
+  test('does not treat a sibling dir with a shared prefix as inside', async () => {
+    expect(await isWithinRoot(root, path.resolve('/srv/app-secrets/file'))).toBe(false);
   });
 
-  test('rejects a target reached through a symlink that points outside the root', () => {
+  test('rejects a target reached through a symlink that points outside the root', async () => {
     const root2 = tmpDir();
     const outside = tmpDir();
     fs.writeFileSync(path.join(outside, 'secret.ts'), 'secret');
     fs.symlinkSync(outside, path.join(root2, 'link'));
     // Lexically inside root2, but realpath lands in `outside`.
-    expect(isWithinRoot(root2, path.join(root2, 'link', 'secret.ts'))).toBe(false);
+    expect(await isWithinRoot(root2, path.join(root2, 'link', 'secret.ts'))).toBe(false);
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -20,21 +20,21 @@ function createTestClient(opts?: Partial<Pick<LspHandlerOptions, 'onSynthRequest
     onSynthRequest: opts?.onSynthRequest,
     // Default to "no assembly" so tests that don't care about diagnostics
     // don't need a fake fixture. Tests that do care override this.
-    readAssembly: opts?.readAssembly ?? (() => ({ status: 'not-found' })),
+    readAssembly: opts?.readAssembly ?? (async () => ({ status: 'not-found' })),
     logger: log,
     onPublishDiagnostics: (uri, diagnostics) => published.push({ uri, diagnostics }),
   });
   return { handlers, published, log };
 }
 
-function initializeClient(client: CapturedClient, options?: Record<string, unknown>): void {
+async function initializeClient(client: CapturedClient, options?: Record<string, unknown>): Promise<void> {
   client.handlers.onInitialize({
     processId: null,
     capabilities: {},
     rootUri: null,
     initializationOptions: options ?? {},
   });
-  client.handlers.onInitialized();
+  await client.handlers.onInitialized();
 }
 
 describe('LSP Server', () => {
@@ -61,12 +61,12 @@ describe('LSP Server', () => {
     });
   });
 
-  test('didSave triggers onSynthRequest for source files', () => {
+  test('didSave triggers onSynthRequest for source files', async () => {
     const synthRequests: string[] = [];
     const client = createTestClient({
       onSynthRequest: (dir) => synthRequests.push(dir),
     });
-    initializeClient(client, { applicationDir: '/tmp/test-project' });
+    await initializeClient(client, { applicationDir: '/tmp/test-project' });
 
     client.handlers.onDidSaveTextDocument({
       textDocument: { uri: 'file:///tmp/test-project/lib/my-stack.ts' },
@@ -75,12 +75,12 @@ describe('LSP Server', () => {
     expect(synthRequests).toEqual(['/tmp/test-project']);
   });
 
-  test('didSave does not trigger for ignored files', () => {
+  test('didSave does not trigger for ignored files', async () => {
     const synthRequests: string[] = [];
     const client = createTestClient({
       onSynthRequest: (dir) => synthRequests.push(dir),
     });
-    initializeClient(client, { applicationDir: '/tmp/test-project' });
+    await initializeClient(client, { applicationDir: '/tmp/test-project' });
 
     client.handlers.onDidSaveTextDocument({
       textDocument: { uri: 'file:///tmp/test-project/node_modules/foo/index.ts' },
@@ -92,9 +92,9 @@ describe('LSP Server', () => {
     expect(synthRequests).toEqual([]);
   });
 
-  test('didSave does not throw without onSynthRequest configured', () => {
+  test('didSave does not throw without onSynthRequest configured', async () => {
     const client = createTestClient();
-    initializeClient(client, { applicationDir: '/tmp/test-project' });
+    await initializeClient(client, { applicationDir: '/tmp/test-project' });
 
     expect(() => client.handlers.onDidSaveTextDocument({
       textDocument: { uri: 'file:///tmp/test-project/lib/my-stack.ts' },
@@ -104,19 +104,19 @@ describe('LSP Server', () => {
     expect(() => client.handlers.onShutdown()).not.toThrow();
   });
 
-  test('shutdown completes without error', () => {
+  test('shutdown completes without error', async () => {
     const client = createTestClient();
-    initializeClient(client);
+    await initializeClient(client);
 
     expect(() => client.handlers.onShutdown()).not.toThrow();
   });
 
-  test('didSave is ignored after shutdown', () => {
+  test('didSave is ignored after shutdown', async () => {
     const synthRequests: string[] = [];
     const client = createTestClient({
       onSynthRequest: (dir) => synthRequests.push(dir),
     });
-    initializeClient(client, { applicationDir: '/tmp/test-project' });
+    await initializeClient(client, { applicationDir: '/tmp/test-project' });
 
     client.handlers.onShutdown();
 
@@ -127,13 +127,13 @@ describe('LSP Server', () => {
     expect(synthRequests).toEqual([]);
   });
 
-  test('onSynthRequest errors are caught gracefully', () => {
+  test('onSynthRequest errors are caught gracefully', async () => {
     const client = createTestClient({
       onSynthRequest: () => {
         throw new Error('synth failed');
       },
     });
-    initializeClient(client, { applicationDir: '/tmp/test-project' });
+    await initializeClient(client, { applicationDir: '/tmp/test-project' });
 
     expect(() => client.handlers.onDidSaveTextDocument({
       textDocument: { uri: 'file:///tmp/test-project/lib/my-stack.ts' },
@@ -143,9 +143,9 @@ describe('LSP Server', () => {
     expect(() => client.handlers.onShutdown()).not.toThrow();
   });
 
-  test('publishes diagnostics on initialized when assembly has violations', () => {
+  test('publishes diagnostics on initialized when assembly has violations', async () => {
     const client = createTestClient({
-      readAssembly: () => ({
+      readAssembly: async () => ({
         status: 'success',
         data: {
           warnings: [],
@@ -176,19 +176,19 @@ describe('LSP Server', () => {
       }),
     });
 
-    initializeClient(client, { applicationDir: '/p' });
+    await initializeClient(client, { applicationDir: '/p' });
 
     expect(client.published).toHaveLength(1);
     expect(client.published[0].uri).toContain('stack.ts');
     expect(client.published[0].diagnostics).toHaveLength(1);
   });
 
-  test('responds to codeLens with resources for the requested file', () => {
+  test('responds to codeLens with resources for the requested file', async () => {
     const stackTs = '/p/lib/stack.ts';
     const stackUri = pathToFileURL(stackTs).toString();
 
     const client = createTestClient({
-      readAssembly: (): AssemblyReadResult => ({
+      readAssembly: async (): Promise<AssemblyReadResult> => ({
         status: 'success',
         data: {
           warnings: [],
@@ -208,7 +208,7 @@ describe('LSP Server', () => {
       }),
     });
 
-    initializeClient(client, { applicationDir: '/p' });
+    await initializeClient(client, { applicationDir: '/p' });
 
     const lenses = client.handlers.onCodeLens({
       textDocument: { uri: stackUri },
@@ -219,24 +219,24 @@ describe('LSP Server', () => {
     expect(lenses[0].command?.title).toBe('Creates AWS::S3::Bucket');
   });
 
-  test('publishes nothing when assembly is not-found (pre-synth)', () => {
+  test('publishes nothing when assembly is not-found (pre-synth)', async () => {
     const client = createTestClient({
-      readAssembly: () => ({ status: 'not-found' }),
+      readAssembly: async () => ({ status: 'not-found' }),
     });
 
-    initializeClient(client, { applicationDir: '/p' });
+    await initializeClient(client, { applicationDir: '/p' });
 
     expect(client.published).toHaveLength(0);
   });
 
-  test('onDefinition resolves a template position back to construct source', () => {
+  test('onDefinition resolves a template position back to construct source', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-def-'));
     const templateFile = path.join(dir, 'Stack1.template.json');
     const text = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
     fs.writeFileSync(templateFile, text);
     try {
       const client = createTestClient({
-        readAssembly: () => ({
+        readAssembly: async () => ({
           status: 'success',
           data: {
             tree: [{
@@ -253,7 +253,7 @@ describe('LSP Server', () => {
           },
         }),
       });
-      initializeClient(client, { applicationDir: dir });
+      await initializeClient(client, { applicationDir: dir });
 
       const uri = pathToFileURL(templateFile).toString();
       const position = TextDocument.create(uri, 'json', 0, text).positionAt(text.indexOf('AWS::S3::Bucket'));
@@ -266,9 +266,9 @@ describe('LSP Server', () => {
     }
   });
 
-  test('onDefinition returns undefined for a non-template document', () => {
+  test('onDefinition returns undefined for a non-template document', async () => {
     const client = createTestClient();
-    initializeClient(client, { applicationDir: '/p' });
+    await initializeClient(client, { applicationDir: '/p' });
     const target = client.handlers.onDefinition({
       textDocument: { uri: pathToFileURL('/p/lib/stack.ts').toString() },
       position: { line: 0, character: 0 },
@@ -276,9 +276,9 @@ describe('LSP Server', () => {
     expect(target).toBeUndefined();
   });
 
-  test('onDefinition returns undefined (does not throw) for a non-file URI', () => {
+  test('onDefinition returns undefined (does not throw) for a non-file URI', async () => {
     const client = createTestClient();
-    initializeClient(client, { applicationDir: '/p' });
+    await initializeClient(client, { applicationDir: '/p' });
     expect(
       client.handlers.onDefinition({
         textDocument: { uri: 'untitled:Untitled-1' },

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -57,11 +57,11 @@ describe('resourceTarget', () => {
     return undefined;
   };
 
-  test('resolves a resource node to its template uri and block range', () => {
+  test('resolves a resource node to its template uri and block range', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
-    const result = readAssembly(dir);
+    const result = await readAssembly(dir);
     if (result.status !== 'success') throw new Error('expected success');
     const node = find(result.data.tree, 'Stack1/MyBucket/Resource')!;
     const templateFile = path.join(dir!, 'Stack1.template.json');

--- a/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/lib/construct-tree.ts
@@ -55,6 +55,18 @@ export type ConstructNodeDecorator<T extends ConstructTreeNode> = (
 ) => T;
 
 /**
+ * Async variant of {@link ConstructNodeDecorator}: the decorator may return a
+ * `Promise<T>`, so it can do non-blocking I/O (for example reading source maps
+ * off disk with `fs.promises`) while building each node. Used by
+ * {@link buildConstructTreeAsync}.
+ */
+export type AsyncConstructNodeDecorator<T extends ConstructTreeNode> = (
+  fields: ConstructTreeNodeFields<T>,
+  stack: CloudFormationStackArtifact | undefined,
+  constructPath: string,
+) => T | Promise<T>;
+
+/**
  * A pre-built index over a construct tree. Walks the tree once and exposes
  * O(1) path lookup plus pre-order iteration over every node, so callers never
  * re-implement the recursive descent over `children`.
@@ -114,28 +126,70 @@ function visit<T extends ConstructTreeNode>(nodes: readonly T[], fn: (node: T) =
  *
  * The `decorate` callback turns each node's generic fields and its metadata
  * entries into the concrete node type (e.g. attaching a resolved source location).
+ *
+ * This is the synchronous variant: `decorate` must return `T`. Callers whose
+ * decoration needs non-blocking I/O should use {@link buildConstructTreeAsync}.
  */
 export function buildConstructTree<T extends ConstructTreeNode>(
   assembly: CloudAssembly,
   decorate: ConstructNodeDecorator<T>,
 ): T[] {
-  const treeArtifact = assembly.tree();
-  if (!treeArtifact) return [];
-
-  const rawTree = loadTree(path.join(assembly.directory, treeArtifact.file));
-  if (!rawTree) return [];
-
-  const stackIndex = buildStackIndex(assembly.stacksRecursively);
-  const ctx: WalkContext<T> = { stackIndex, decorate, templateCache: new Map() };
-  return Object.values(rawTree.children ?? {})
-    .filter((child) => !isCdkInternal(child.id))
-    .map((child) => buildNode(child, ctx, undefined, NO_TEMPLATE));
+  const roots = readRoots(assembly);
+  if (!roots) return [];
+  const { rawRoots, ctx } = roots;
+  return rawRoots.map((child) => buildNodeSync(child, ctx, undefined, NO_TEMPLATE, decorate));
 }
 
-/** Shared state for a single {@link buildConstructTree} walk. */
-interface WalkContext<T extends ConstructTreeNode> {
+/**
+ * Async counterpart of {@link buildConstructTree}: the `decorate` callback may
+ * return a `Promise<T>`, letting it do non-blocking I/O per node (for example
+ * tracing source locations with `fs.promises`) without blocking the calling
+ * thread. Behaves identically otherwise; the tree is walked in pre-order and
+ * each node's children are resolved before the node is decorated.
+ */
+export async function buildConstructTreeAsync<T extends ConstructTreeNode>(
+  assembly: CloudAssembly,
+  decorate: AsyncConstructNodeDecorator<T>,
+): Promise<T[]> {
+  const roots = readRoots(assembly);
+  if (!roots) return [];
+  const { rawRoots, ctx } = roots;
+  const out: T[] = [];
+  for (const child of rawRoots) {
+    out.push(await buildNodeAsync(child, ctx, undefined, NO_TEMPLATE, decorate));
+  }
+  return out;
+}
+
+/**
+ * Load tree.json and build the walk context shared by both tree builders.
+ * Returns the user-facing root raw nodes (cdk-internal ids filtered out) plus
+ * the context, or undefined when there's no tree to walk.
+ */
+function readRoots(assembly: CloudAssembly): WalkRoots | undefined {
+  const treeArtifact = assembly.tree();
+  if (!treeArtifact) return undefined;
+
+  const rawTree = loadTree(path.join(assembly.directory, treeArtifact.file));
+  if (!rawTree) return undefined;
+
+  const ctx: WalkContext = {
+    stackIndex: buildStackIndex(assembly.stacksRecursively),
+    templateCache: new Map(),
+  };
+  const rawRoots = Object.values(rawTree.children ?? {}).filter((child) => !isCdkInternal(child.id));
+  return { rawRoots, ctx };
+}
+
+/** The user-facing root raw nodes plus the shared walk context. */
+interface WalkRoots {
+  readonly rawRoots: RawTreeNode[];
+  readonly ctx: WalkContext;
+}
+
+/** Shared state for a single tree walk (decorator-independent). */
+interface WalkContext {
   readonly stackIndex: StackMetadataIndex;
-  readonly decorate: ConstructNodeDecorator<T>;
   /** Parsed nested templates, cached by absolute path. */
   readonly templateCache: Map<string, CfnTemplate | undefined>;
 }
@@ -180,6 +234,29 @@ interface StackMetadata {
 }
 type StackMetadataIndex = Map<string, StackMetadata>;
 
+/** The generic fields for one node, minus its (decorated) children. */
+type NodeFieldsBase = Omit<ConstructTreeNodeFields<ConstructTreeNode>, 'children'>;
+
+/** A child to recurse into, paired with the template scope it inherits. */
+interface ChildInput {
+  readonly raw: RawTreeNode;
+  readonly scope: TemplateScope;
+}
+
+/**
+ * Everything {@link buildNodeSync}/{@link buildNodeAsync} need for one node,
+ * computed once (no I/O beyond the cached template reads), so the two builders
+ * differ only in how they recurse and invoke `decorate`.
+ */
+interface PreparedNode {
+  readonly base: NodeFieldsBase;
+  /** Owning stack metadata: its `stack` is the decorate arg and the children's inheritedStack. */
+  readonly owner: StackMetadata | undefined;
+  readonly constructPath: string;
+  readonly childInputs: readonly ChildInput[];
+}
+
+/** Reads and parses tree.json. Kept synchronous on purpose; see {@link loadTemplate}. */
 function loadTree(treePath: string): RawTreeNode | undefined {
   if (!fs.existsSync(treePath)) return undefined;
   const content = JSON.parse(fs.readFileSync(treePath, 'utf-8'));
@@ -199,12 +276,17 @@ function buildStackIndex(stacks: CloudFormationStackArtifact[]): StackMetadataIn
   return index;
 }
 
-function buildNode<T extends ConstructTreeNode>(
+/**
+ * Compute the generic fields, owning stack, and per-child template scopes for a
+ * single node. Owns all of the tree/metadata/template join logic; the sync and
+ * async builders share it so the substantive walk lives in exactly one place.
+ */
+function prepareNode(
   raw: RawTreeNode,
-  ctx: WalkContext<T>,
+  ctx: WalkContext,
   inheritedStack: StackMetadata | undefined,
   inherited: TemplateScope,
-): T {
+): PreparedNode {
   const stackHere = ctx.stackIndex.get(raw.path);
   const owner = stackHere ?? inheritedStack;
   // A stack node switches to its own template via the artifact's cached getter,
@@ -222,17 +304,47 @@ function buildNode<T extends ConstructTreeNode>(
   const cfnType = typeof cfnTypeRaw === 'string' ? cfnTypeRaw : undefined;
 
   // A NestedStack switches its subtree to the nested scope; other nodes inherit.
-  const children = Object.values(raw.children ?? {})
+  const childInputs: ChildInput[] = Object.values(raw.children ?? {})
     .filter((child) => !isCdkInternal(child.id))
-    .map((child) => buildNode(child, ctx, owner, nestedBoundary(child, raw, owner, scope.template, ctx) ?? scope));
+    .map((child) => ({ raw: child, scope: nestedBoundary(child, raw, owner, scope.template, ctx) ?? scope }));
 
   // Only CFN resources (those with a logical ID) carry a templateFile.
   const nodeTemplateFile = logicalId !== undefined ? scope.file : undefined;
-  return ctx.decorate(
-    { path: raw.path, id: raw.id, type: cfnType, logicalId, templateFile: nodeTemplateFile, children },
-    owner?.stack,
-    raw.path,
+  return {
+    base: { path: raw.path, id: raw.id, type: cfnType, logicalId, templateFile: nodeTemplateFile },
+    owner,
+    constructPath: raw.path,
+    childInputs,
+  };
+}
+
+function buildNodeSync<T extends ConstructTreeNode>(
+  raw: RawTreeNode,
+  ctx: WalkContext,
+  inheritedStack: StackMetadata | undefined,
+  inherited: TemplateScope,
+  decorate: ConstructNodeDecorator<T>,
+): T {
+  const prepared = prepareNode(raw, ctx, inheritedStack, inherited);
+  const children = prepared.childInputs.map(
+    (ci) => buildNodeSync(ci.raw, ctx, prepared.owner, ci.scope, decorate),
   );
+  return decorate({ ...prepared.base, children }, prepared.owner?.stack, prepared.constructPath);
+}
+
+async function buildNodeAsync<T extends ConstructTreeNode>(
+  raw: RawTreeNode,
+  ctx: WalkContext,
+  inheritedStack: StackMetadata | undefined,
+  inherited: TemplateScope,
+  decorate: AsyncConstructNodeDecorator<T>,
+): Promise<T> {
+  const prepared = prepareNode(raw, ctx, inheritedStack, inherited);
+  const children: T[] = [];
+  for (const ci of prepared.childInputs) {
+    children.push(await buildNodeAsync(ci.raw, ctx, prepared.owner, ci.scope, decorate));
+  }
+  return decorate({ ...prepared.base, children }, prepared.owner?.stack, prepared.constructPath);
 }
 
 function logicalIdFromEntries(entries: MetadataEntry[]): string | undefined {
@@ -240,7 +352,14 @@ function logicalIdFromEntries(entries: MetadataEntry[]): string | undefined {
   return typeof entry?.data === 'string' ? entry.data : undefined;
 }
 
-/** Parses a template file (cached by absolute path); undefined when missing/unparseable. */
+/**
+ * Parses a template file (cached by absolute path); undefined when missing/unparseable.
+ *
+ * Synchronous by design: {@link prepareNode} is shared by the sync `buildConstructTree`
+ * and the async `buildConstructTreeAsync`, so it cannot await. These reads are O(stacks)
+ * (one tree.json plus a handful of nested templates), not the per-construct hot path, so
+ * blocking here is acceptable. Do not switch to `fs.promises` without splitting the shared walk.
+ */
 function loadTemplate(absPath: string, cache: Map<string, CfnTemplate | undefined>): CfnTemplate | undefined {
   if (cache.has(absPath)) return cache.get(absPath);
   let template: CfnTemplate | undefined;
@@ -265,12 +384,12 @@ function loadTemplate(absPath: string, cache: Map<string, CfnTemplate | undefine
  * NO_TEMPLATE (not the parent's) when unresolvable, since the nested stack's
  * resources don't live in the parent template.
  */
-function nestedBoundary<T extends ConstructTreeNode>(
+function nestedBoundary(
   child: RawTreeNode,
   parent: RawTreeNode,
   owner: StackMetadata | undefined,
   currentTemplate: CfnTemplate | undefined,
-  ctx: WalkContext<T>,
+  ctx: WalkContext,
 ): TemplateScope | undefined {
   const resourceNode = parent.children?.[`${child.id}.NestedStack`]?.children?.[`${child.id}.NestedStackResource`];
   // No sibling -> not a nested stack. A real nested stack always lives under a

--- a/packages/@aws-cdk/cloud-assembly-api/test/construct-tree.test.ts
+++ b/packages/@aws-cdk/cloud-assembly-api/test/construct-tree.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import { buildConstructTree, CloudAssembly, ConstructIndex, type ConstructTreeNode } from '../lib';
+import { buildConstructTree, buildConstructTreeAsync, CloudAssembly, ConstructIndex, type ConstructTreeNode } from '../lib';
 import { rimraf } from './util';
 
 const node = (nodePath: string, children: ConstructTreeNode[] = []): ConstructTreeNode => ({
@@ -151,6 +151,22 @@ describe('buildConstructTree', () => {
     const assembly = new CloudAssembly(writeAssembly({ withTree: false }));
     expect(buildConstructTree(assembly, (f) => f)).toEqual([]);
   });
+
+  test('buildConstructTreeAsync awaits the decorator and produces the same joined tree', async () => {
+    const assembly = new CloudAssembly(writeAssembly({ withTree: true }));
+    const tree = await buildConstructTreeAsync(assembly, async (fields, stack, constructPath) => ({
+      ...fields,
+      stackId: stack?.id,
+      // Resolve through a real Promise to prove the async decorator is awaited,
+      // not merely returned synchronously.
+      decoratedPath: await Promise.resolve(constructPath),
+    }));
+    const resource = ConstructIndex.fromTree(tree).byPath('MyStack/Bucket/Resource');
+    expect(resource?.type).toBe('AWS::S3::Bucket');
+    expect(resource?.logicalId).toBe('BucketABC');
+    expect((resource as any)?.decoratedPath).toBe('MyStack/Bucket/Resource');
+    expect((resource as any)?.stackId).toBe('MyStack');
+  });
 });
 
 describe('buildConstructTree -- nested stacks', () => {
@@ -287,5 +303,14 @@ describe('buildConstructTree -- nested stacks', () => {
   test('yields no templateFile when asset metadata is absent (--no-asset-metadata)', () => {
     const d = writeNestedAssembly({ withAssetMetadata: false });
     expect(templateFileOf(d, 'MyStack/Nested/Bucket/Resource')).toBeUndefined();
+  });
+
+  test('buildConstructTreeAsync threads nested-stack scope positionally via for...await (twin logical IDs)', async () => {
+    // Twin logical IDs (NestedStack resets the namespace): the async for...await
+    // recursion must still route each bucket to its own template, like the sync walk.
+    const d = writeNestedAssembly({ nestedBucketLogicalId: 'ParentBucket' });
+    const index = ConstructIndex.fromTree(await buildConstructTreeAsync(new CloudAssembly(d), async (f) => f));
+    expect(index.byPath('MyStack/Bucket/Resource')?.templateFile).toBe(path.join(d, 'template.json'));
+    expect(index.byPath('MyStack/Nested/Bucket/Resource')?.templateFile).toBe(path.join(d, 'nested.template.json'));
   });
 });


### PR DESCRIPTION
The LSP followed source/template paths from the cloud assembly (stack-trace
frames, source maps, template paths) with only an extension allow-list. If
cdk.out is tampered with, a crafted path like `../../../etc/passwd.js` could be
read or surfaced as a nav target.

Adds a symlink-aware `isWithinRoot` and gates every read: source paths against
the project dir, `templateFile` against the assembly dir. Out-of-root paths are
dropped as not-navigable (same as non-TS apps). No change for valid assemblies.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
