### PR TITLE
feat(cli): synth prints validation report

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -347,6 +347,18 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const autoValidateStacks = options.validateStacks ? [assembly.value.selectStacksForValidation()] : [];
     await this.validateStacksMetadata(stacks.concat(...autoValidateStacks), ioHelper);
 
+    // Print the validation plugin report if present
+    const reportPath = path.join(assembly.value.directory, VALIDATION_REPORT_FILE);
+    if (await fs.pathExists(reportPath)) {
+      const report = Manifest.loadValidationReport(reportPath);
+      const selectedStackIds = new Set(stacks.hierarchicalIds);
+      const filteredReports = filterReportsByStacks(report.pluginReports, selectedStackIds);
+      const conclusion: PolicyValidationReportConclusion = filteredReports.some(
+        (pr) => pr.conclusion === 'failure',
+      ) ? 'failure' : 'success';
+      await ioHelper.notify(hostMessageFromValidation({ conclusion, title: report.title, pluginReports: filteredReports }));
+    }
+
     // if we have a single stack, print it to STDOUT
     const message = `Successfully synthesized to ${chalk.blue(path.resolve(stacks.assembly.directory))}`;
     const assemblyData: AssemblyData = {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/synth.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/synth.test.ts
@@ -3,7 +3,7 @@ import * as cdk from 'aws-cdk-lib';
 import type { AssemblyBuilder } from '../../lib/api';
 import { RWLock } from '../../lib/api';
 import { Toolkit } from '../../lib/toolkit';
-import { appFixture, autoCleanOutDir, builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
+import { appFixture, autoCleanOutDir, builderFixture, cdkOutFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
@@ -137,6 +137,30 @@ describe('synth', () => {
     const lock = new RWLock(synthDir.dir);
     expect(await lock._currentReaders()).toEqual([]);
     expect(await lock._currentWriter()).toEqual(undefined);
+  });
+
+  test('prints validation report when validation-report.json is present', async () => {
+    // WHEN
+    const cx = await cdkOutFixture(toolkit, 'stack-with-validation-report');
+    await toolkit.synth(cx);
+
+    // THEN
+    expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'synth',
+      code: 'CDK_TOOLKIT_I9600',
+      message: expect.stringContaining('Validation Report'),
+    }));
+  });
+
+  test('does not print validation report when no report file exists', async () => {
+    // WHEN
+    const cx = await cdkOutFixture(toolkit, 'stack-with-bucket');
+    await toolkit.synth(cx);
+
+    // THEN
+    expect(ioHost.notifySpy).not.toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_I9600',
+    }));
   });
 
   test('assembly is disposed when synth fails due to context lookup', async () => {


### PR DESCRIPTION
Right now, `cdk synth` relies on the legacy pretty-printed report written by the validation plugin logic in `aws/aws-cdk`. This PR aims to replace that with the modern report that `cdk validate` uses. A subsequent PR will be made to remove the legacy report stlye from `aws/aws-cdk`.

The new model is:
- The validation plugin system that runs during synthesis creates a `validation-report.json` artifact detailing all validation mechanisms in one place. It does not handle printing anymore.
- the CDK CLI handles writing to console. This means it takes the `validation-report.json` and both `cdk synth` and `cdk validate` writes the same style report to the console.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
