### PR TITLE
fix(toolkit-lib): user-supplied glob include patterns silently ignored

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-directory-scoped-glob.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/watch/cdk-watch-detects-file-changes-with-directory-scoped-glob.integtest.ts
@@ -1,0 +1,77 @@
+import * as child_process from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { waitForOutput, waitForCondition, safeKillProcess } from './watch-helpers';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+jest.setTimeout(5 * 60 * 1000); // 5 minutes for watch tests
+
+// Regression test for https://github.com/aws/aws-cdk-cli/issues/1647:
+// a user-supplied glob scoped to a subdirectory (e.g. 'src/**/*.ts') must
+// detect changes to files nested inside that directory. The chokidar v4
+// `ignored` callback also gates directory traversal, so an earlier bug pruned
+// the 'src' directory (which does not itself match the file glob) before any
+// nested file could be discovered - watch then silently observed nothing.
+integTest(
+  'cdk watch detects file changes with a directory-scoped glob pattern',
+  withDefaultFixture(async (fixture) => {
+    // Create a watched file nested inside a subdirectory, matched by 'src/**/*.ts'.
+    const srcDir = path.join(fixture.integTestDir, 'src');
+    fs.mkdirSync(srcDir, { recursive: true });
+    const testFile = path.join(srcDir, 'watch-test-file.ts');
+    fs.writeFileSync(testFile, 'export const initial = true;');
+
+    // Update cdk.json with a watch glob scoped to the 'src' directory.
+    const cdkJsonPath = path.join(fixture.integTestDir, 'cdk.json');
+    const cdkJson = JSON.parse(fs.readFileSync(cdkJsonPath, 'utf-8'));
+    cdkJson.watch = {
+      include: ['src/**/*.ts'],
+    };
+    fs.writeFileSync(cdkJsonPath, JSON.stringify(cdkJson, null, 2));
+
+    await fixture.cli.makeCliAvailable();
+
+    let output = '';
+
+    // Start cdk watch
+    const watchProcess = child_process.spawn('cdk', [
+      'watch', '--hotswap', '-v', fixture.fullStackName('test-1'),
+    ], {
+      cwd: fixture.integTestDir,
+      stdio: 'pipe',
+      env: { ...process.env, ...fixture.cdkShellEnv() },
+    });
+
+    try {
+      watchProcess.stdout?.on('data', (data) => {
+        output += data.toString();
+        fixture.log(data.toString());
+      });
+      watchProcess.stderr?.on('data', (data) => {
+        output += data.toString();
+        fixture.log(data.toString());
+      });
+
+      await waitForOutput(() => output, "Triggering initial 'cdk deploy'");
+      fixture.log('✓ Watch start detected');
+
+      await waitForOutput(() => output, 'deployment time');
+      fixture.log('✓ Initial deployment completed');
+
+      // Modify the nested file to trigger a watch event. Before the fix the
+      // 'src' directory was pruned, so this change was never detected.
+      fs.writeFileSync(testFile, 'export const modified = true;');
+
+      await waitForOutput(() => output, 'Detected change to');
+      fixture.log('✓ Watch detected change to file nested under a directory-scoped glob');
+
+      // Wait for the second deployment to complete (2 occurrences of 'deployment time')
+      await waitForCondition(() => (output.match(/deployment time/g) || []).length >= 2);
+      fixture.log('✓ Second deployment completed');
+    } finally {
+      safeKillProcess(watchProcess);
+    }
+
+    expect.assertions(4);
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/util/glob-matcher.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/glob-matcher.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'fs';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import picomatch = require('picomatch');
 
@@ -45,17 +46,55 @@ function normalizePattern(pattern: string): string {
 }
 
 /**
- * Creates a function that returns true if a file should be ignored.
- * A file is ignored if:
- * - It matches any exclude pattern, OR
- * - It does NOT match any include pattern
+ * Builds the list of directory-prefix globs for an include pattern.
  *
- * This replicates the behavior of chokidar v3's glob pattern support.
+ * A pattern like `src/**\/*.ts` only matches files (e.g. `src/a.ts`), never the
+ * directories that contain them (`src`, `src/sub`). But chokidar v4 uses the
+ * `ignored` callback to decide whether to *descend* into a directory: if a
+ * directory is ignored, its entire subtree is pruned and no nested file is ever
+ * discovered. We must therefore allow traversal of any directory that could be
+ * an ancestor of a matching file.
+ *
+ * We derive those ancestors from the progressive `/`-delimited prefixes of the
+ * pattern: `src/**\/*.ts` yields `src`, `src/**`, `src/**\/*.ts`. Matching a
+ * directory path against this set answers "could a matching file live under
+ * here?" without touching the filesystem.
+ *
+ * @param pattern - A normalized include pattern
+ * @returns The progressive prefix globs of the pattern
+ */
+function directoryPrefixGlobs(pattern: string): string[] {
+  const segments = pattern.split('/');
+  const prefixes: string[] = [];
+  for (let i = 1; i <= segments.length; i++) {
+    prefixes.push(segments.slice(0, i).join('/'));
+  }
+  return prefixes;
+}
+
+/**
+ * Creates a function that returns true if a path should be ignored by chokidar.
+ *
+ * The function is used as chokidar v4's `ignored` callback, which is consulted
+ * both for files (to decide whether to watch them) and for directories (to
+ * decide whether to descend into them). Chokidar v4 removed native glob support,
+ * so this replicates chokidar v3's behavior using picomatch.
+ *
+ * The path is classified using the `Stats` chokidar provides (when available):
+ * - Exclude patterns always take precedence and prune both files and directories.
+ * - A **directory** is only pruned by excludes. It is never ignored merely for
+ *   failing the include filter, because nested files may still match — pruning
+ *   it would silently drop the entire subtree (the root cause of the original
+ *   bug where `include: ['src/**\/*.ts']` matched nothing).
+ * - A **file** must match an include pattern to be watched.
+ * - When `Stats` is absent (chokidar invokes the callback both with and without
+ *   stats during traversal), the path is kept if it either matches a file
+ *   include pattern or is a potential ancestor directory of one.
  *
  * @param options - The include and exclude patterns
- * @returns A function that takes a file path and returns true if it should be ignored
+ * @returns A function that takes a path (and optional stats) and returns true if it should be ignored
  */
-export function createIgnoreMatcher(options: GlobMatcherOptions): (filePath: string) => boolean {
+export function createIgnoreMatcher(options: GlobMatcherOptions): (filePath: string, stats?: Stats) => boolean {
   const includePatterns = options.include && options.include.length > 0
     ? options.include.map(normalizePattern)
     : ['**'];
@@ -68,11 +107,14 @@ export function createIgnoreMatcher(options: GlobMatcherOptions): (filePath: str
   };
 
   const includeMatcher = picomatch(includePatterns, picomatchOptions);
+  // Matches a directory that could be an ancestor of an included file, so we
+  // don't prune subtrees before discovering the files we actually want.
+  const directoryMatcher = picomatch(includePatterns.flatMap(directoryPrefixGlobs), picomatchOptions);
   const excludeMatcher = excludePatterns.length > 0
     ? picomatch(excludePatterns, picomatchOptions)
     : () => false;
 
-  return (filePath: string): boolean => {
+  return (filePath: string, stats?: Stats): boolean => {
     // Normalize path separators for cross-platform compatibility
     let normalizedPath = filePath.replace(/\\/g, '/');
 
@@ -88,17 +130,27 @@ export function createIgnoreMatcher(options: GlobMatcherOptions): (filePath: str
       }
     }
 
-    // A file is ignored if:
-    // 1. It matches any exclude pattern, OR
-    // 2. It does NOT match any include pattern
+    // Excludes always take precedence, for both files and directories.
     if (excludeMatcher(normalizedPath)) {
       return true; // Ignore: matches exclude
     }
 
-    if (!includeMatcher(normalizedPath)) {
-      return true; // Ignore: doesn't match include
+    // A directory is kept if it could be an ancestor of an included file, so we
+    // descend into it and discover the nested files we actually want. It is
+    // never pruned merely for failing the file-level include filter (it can't
+    // match a pattern like 'src/**\/*.ts'), which would drop the entire subtree.
+    if (stats?.isDirectory()) {
+      return !directoryMatcher(normalizedPath);
     }
 
-    return false; // Don't ignore: matches include and doesn't match exclude
+    // Files must match an include pattern.
+    if (stats?.isFile()) {
+      return !includeMatcher(normalizedPath);
+    }
+
+    // No stats available: chokidar consults the callback both with and without
+    // stats during traversal. Keep the path if it matches a file include
+    // pattern, or if it could be an ancestor directory of an included file.
+    return !(includeMatcher(normalizedPath) || directoryMatcher(normalizedPath));
   };
 }

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
@@ -42,10 +42,17 @@ jest.mock('chokidar', () => ({
   watch: mockChokidarWatch,
 }));
 
+import type { Stats } from 'node:fs';
 import * as path from 'node:path';
 import type { DeploymentMethod } from '../../lib/actions/deploy';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
+
+// Chokidar v4 invokes the `ignored` callback with the file system stats of the
+// entry being considered, which the matcher uses to distinguish files from
+// directories.
+const FILE = { isFile: () => true, isDirectory: () => false } as unknown as Stats;
+const DIR = { isFile: () => false, isDirectory: () => true } as unknown as Stats;
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
@@ -314,16 +321,17 @@ describe('watch chokidar configuration', () => {
       exclude: [],
     });
 
-    // Get the ignored function that was passed to chokidar
-    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string) => boolean;
+    // Get the ignored function that was passed to chokidar. Chokidar v4 invokes
+    // it with the file system stats of the entry being considered.
+    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string, stats?: Stats) => boolean;
 
     // THEN - .ts files should NOT be ignored
-    expect(ignoredFn('file.ts')).toBe(false);
-    expect(ignoredFn('src/file.ts')).toBe(false);
+    expect(ignoredFn('file.ts', FILE)).toBe(false);
+    expect(ignoredFn('src/file.ts', FILE)).toBe(false);
 
     // Non-.ts files should be ignored
-    expect(ignoredFn('file.js')).toBe(true);
-    expect(ignoredFn('file.json')).toBe(true);
+    expect(ignoredFn('file.js', FILE)).toBe(true);
+    expect(ignoredFn('file.json', FILE)).toBe(true);
   });
 
   test('ignored function filters files based on exclude patterns', async () => {
@@ -335,15 +343,15 @@ describe('watch chokidar configuration', () => {
     });
 
     // Get the ignored function that was passed to chokidar
-    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string) => boolean;
+    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string, stats?: Stats) => boolean;
 
     // THEN - excluded files should be ignored
-    expect(ignoredFn('node_modules/pkg/index.js')).toBe(true);
-    expect(ignoredFn('src/file.test.ts')).toBe(true);
+    expect(ignoredFn('node_modules/pkg/index.js', FILE)).toBe(true);
+    expect(ignoredFn('src/file.test.ts', FILE)).toBe(true);
 
     // Non-excluded files should NOT be ignored
-    expect(ignoredFn('src/file.ts')).toBe(false);
-    expect(ignoredFn('lib/index.ts')).toBe(false);
+    expect(ignoredFn('src/file.ts', FILE)).toBe(false);
+    expect(ignoredFn('lib/index.ts', FILE)).toBe(false);
   });
 
   test('ignored function applies default excludes', async () => {
@@ -355,14 +363,39 @@ describe('watch chokidar configuration', () => {
     });
 
     // Get the ignored function that was passed to chokidar
-    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string) => boolean;
+    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string, stats?: Stats) => boolean;
 
     // THEN - default excludes should be applied
-    expect(ignoredFn('node_modules/pkg/index.js')).toBe(true);
-    expect(ignoredFn('.gitignore')).toBe(true);
-    expect(ignoredFn('.git/config')).toBe(true);
+    expect(ignoredFn('node_modules/pkg/index.js', FILE)).toBe(true);
+    expect(ignoredFn('.gitignore', FILE)).toBe(true);
+    expect(ignoredFn('.git/config', FILE)).toBe(true);
 
     // Regular files should NOT be ignored
-    expect(ignoredFn('src/file.ts')).toBe(false);
+    expect(ignoredFn('src/file.ts', FILE)).toBe(false);
+  });
+
+  test('ignored function descends into ancestor directories of a user-supplied file glob', async () => {
+    // Regression test for https://github.com/aws/aws-cdk-cli/issues/1647:
+    // a glob like 'src/**/*.ts' must not cause chokidar to prune the 'src'
+    // directory, or the nested .ts files are never discovered.
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.watch(cx, {
+      include: ['src/**/*.ts'],
+      exclude: [],
+    });
+
+    const ignoredFn = mockChokidarWatch.mock.calls[0][1].ignored as (path: string, stats?: Stats) => boolean;
+
+    // Ancestor directories of the glob must be traversed, not pruned.
+    expect(ignoredFn('src', DIR)).toBe(false);
+    expect(ignoredFn('src/nested', DIR)).toBe(false);
+
+    // Directories that cannot contain a match are pruned.
+    expect(ignoredFn('lib', DIR)).toBe(true);
+
+    // The matching files are watched; non-matching files are ignored.
+    expect(ignoredFn('src/file.ts', FILE)).toBe(false);
+    expect(ignoredFn('src/nested/file.ts', FILE)).toBe(false);
+    expect(ignoredFn('src/file.js', FILE)).toBe(true);
   });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/util/glob-matcher.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/util/glob-matcher.test.ts
@@ -1,4 +1,12 @@
+import type { Stats } from 'fs';
 import { createIgnoreMatcher } from '../../lib/util/glob-matcher';
+
+// Chokidar v4 invokes the `ignored` callback with the file system `Stats` of
+// the entry being considered. These helpers let tests state, explicitly, that a
+// given path is a file or a directory - which is what drives the matcher's
+// file-vs-directory branching.
+const FILE = { isFile: () => true, isDirectory: () => false } as unknown as Stats;
+const DIR = { isFile: () => false, isDirectory: () => true } as unknown as Stats;
 
 describe('glob-matcher', () => {
   describe('createIgnoreMatcher', () => {
@@ -7,16 +15,16 @@ describe('glob-matcher', () => {
         const shouldIgnore = createIgnoreMatcher({});
 
         // Should NOT ignore any files (default include is **)
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('deep/nested/path/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('deep/nested/path/file.ts', FILE)).toBe(false);
       });
 
       test('matches all files when include is empty array', () => {
         const shouldIgnore = createIgnoreMatcher({ include: [] });
 
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
       });
     });
 
@@ -24,36 +32,36 @@ describe('glob-matcher', () => {
       test('matches files with ** pattern', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['**'] });
 
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('a/b/c/d/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('a/b/c/d/file.ts', FILE)).toBe(false);
       });
 
       test('matches TypeScript files with **/*.ts pattern', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['**/*.ts'] });
 
         // Should NOT ignore .ts files
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('deep/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('deep/nested/file.ts', FILE)).toBe(false);
 
         // Should ignore non-.ts files
-        expect(shouldIgnore('file.js')).toBe(true);
-        expect(shouldIgnore('file.json')).toBe(true);
-        expect(shouldIgnore('README.md')).toBe(true);
+        expect(shouldIgnore('file.js', FILE)).toBe(true);
+        expect(shouldIgnore('file.json', FILE)).toBe(true);
+        expect(shouldIgnore('README.md', FILE)).toBe(true);
       });
 
       test('matches files in specific directory with src/** pattern', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['src/**'] });
 
         // Should NOT ignore files in src/
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('src/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/nested/file.ts', FILE)).toBe(false);
 
         // Should ignore files outside src/
-        expect(shouldIgnore('file.ts')).toBe(true);
-        expect(shouldIgnore('test/file.ts')).toBe(true);
-        expect(shouldIgnore('lib/file.ts')).toBe(true);
+        expect(shouldIgnore('file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('test/file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('lib/file.ts', FILE)).toBe(true);
       });
 
       test('supports multiple include patterns', () => {
@@ -62,14 +70,130 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore .ts and .js files
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('file.js')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.js')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('file.js', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.js', FILE)).toBe(false);
 
         // Should ignore other files
-        expect(shouldIgnore('file.json')).toBe(true);
-        expect(shouldIgnore('file.md')).toBe(true);
+        expect(shouldIgnore('file.json', FILE)).toBe(true);
+        expect(shouldIgnore('file.md', FILE)).toBe(true);
+      });
+    });
+
+    describe('directory traversal', () => {
+      // Regression test for https://github.com/aws/aws-cdk-cli/issues/1647:
+      // a user-supplied file glob like 'src/**/*.ts' must not cause chokidar to
+      // prune the 'src' directory (which doesn't itself match the glob), or the
+      // nested .ts files are never discovered and watch silently does nothing.
+      test('does not prune ancestor directories of a file glob', () => {
+        const shouldIgnore = createIgnoreMatcher({ include: ['src/**/*.ts'] });
+
+        // Directories that could contain matching files must be traversed.
+        expect(shouldIgnore('src', DIR)).toBe(false);
+        expect(shouldIgnore('src/sub', DIR)).toBe(false);
+        expect(shouldIgnore('src/sub/deep', DIR)).toBe(false);
+
+        // The matching files themselves are watched.
+        expect(shouldIgnore('src/a.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/sub/b.ts', FILE)).toBe(false);
+
+        // Non-matching files under those directories are still ignored.
+        expect(shouldIgnore('src/a.js', FILE)).toBe(true);
+        expect(shouldIgnore('src/sub/b.css', FILE)).toBe(true);
+      });
+
+      test('prunes directories that cannot contain matching files', () => {
+        const shouldIgnore = createIgnoreMatcher({ include: ['src/**/*.ts'] });
+
+        // 'lib' can never hold a file matching 'src/**/*.ts', so it is pruned.
+        expect(shouldIgnore('lib', DIR)).toBe(true);
+        expect(shouldIgnore('test', DIR)).toBe(true);
+      });
+
+      test('directories are only pruned by excludes, never by the include filter', () => {
+        const shouldIgnore = createIgnoreMatcher({
+          include: ['**/*.ts'],
+          exclude: ['**/node_modules/**'],
+        });
+
+        // A directory never matches a file glob like '**/*.ts', but it must
+        // still be traversed - only excludes prune directories.
+        expect(shouldIgnore('src', DIR)).toBe(false);
+        expect(shouldIgnore('any/deep/dir', DIR)).toBe(false);
+
+        // Excluded directories are pruned.
+        expect(shouldIgnore('node_modules', DIR)).toBe(true);
+        expect(shouldIgnore('src/node_modules', DIR)).toBe(true);
+      });
+
+      test('handles multiple file globs across separate directory trees', () => {
+        const shouldIgnore = createIgnoreMatcher({
+          include: ['src/**/*.ts', 'cdk/**/*.ts'],
+        });
+
+        // Both roots and their subtrees are traversed.
+        expect(shouldIgnore('src', DIR)).toBe(false);
+        expect(shouldIgnore('cdk', DIR)).toBe(false);
+        expect(shouldIgnore('src/sub', DIR)).toBe(false);
+
+        // A directory matched by neither glob is pruned.
+        expect(shouldIgnore('lib', DIR)).toBe(true);
+
+        // Files match according to their tree.
+        expect(shouldIgnore('src/a.ts', FILE)).toBe(false);
+        expect(shouldIgnore('cdk/b.ts', FILE)).toBe(false);
+        expect(shouldIgnore('lib/c.ts', FILE)).toBe(true);
+      });
+
+      test('no-stats invocations keep potential ancestors and matching files', () => {
+        // Chokidar consults the callback both with and without stats during
+        // traversal (e.g. the cheap pre-check in `_addToNodeFs` before it stats
+        // a path, and again with the real stats afterwards). Without stats we
+        // cannot prune a path that might be a directory ancestor of a match, so
+        // it must be kept.
+        const shouldIgnore = createIgnoreMatcher({ include: ['src/**/*.ts'] });
+
+        expect(shouldIgnore('src')).toBe(false);
+        expect(shouldIgnore('src/sub')).toBe(false);
+        expect(shouldIgnore('src/a.ts')).toBe(false);
+
+        // A path that can be neither an ancestor nor a matching file is ignored.
+        expect(shouldIgnore('lib')).toBe(true);
+        expect(shouldIgnore('lib/a.ts')).toBe(true);
+      });
+
+      test('no-stats invocations are permissive for **-leading globs, deferring to the stats call', () => {
+        // A '**'-leading include (e.g. '**/my-dir/*') could match a file in any
+        // directory, so every directory is a potential ancestor. The no-stats
+        // pre-check therefore cannot prune anything - the real filtering happens
+        // on the subsequent invocation that carries stats. This is the exact
+        // shape that surfaced as test churn: the no-stats call keeps a path the
+        // with-stats FILE call then rejects.
+        const shouldIgnore = createIgnoreMatcher({ include: ['**/my-dir/*'] });
+
+        // No-stats: nothing can be pruned, because any directory might lead to
+        // a 'my-dir' somewhere below it.
+        expect(shouldIgnore('other-dir/file.ts')).toBe(false);
+        expect(shouldIgnore('other-dir')).toBe(false);
+
+        // With stats: the file is correctly rejected (it isn't under a my-dir),
+        // while the matching file is kept and its ancestor directory traversed.
+        expect(shouldIgnore('other-dir/file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('nested/my-dir/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('nested', DIR)).toBe(false);
+      });
+
+      test('an excluded path is ignored even without stats', () => {
+        // Excludes apply uniformly regardless of whether stats are present, so
+        // the no-stats pre-check still prunes excluded subtrees up front.
+        const shouldIgnore = createIgnoreMatcher({
+          include: ['**/*.ts'],
+          exclude: ['**/node_modules/**'],
+        });
+
+        expect(shouldIgnore('node_modules/pkg/index.ts')).toBe(true);
+        expect(shouldIgnore('src/node_modules')).toBe(true);
       });
     });
 
@@ -80,12 +204,12 @@ describe('glob-matcher', () => {
         });
 
         // Should ignore node_modules
-        expect(shouldIgnore('node_modules/package/index.js')).toBe(true);
-        expect(shouldIgnore('src/node_modules/package/index.js')).toBe(true);
+        expect(shouldIgnore('node_modules/package/index.js', FILE)).toBe(true);
+        expect(shouldIgnore('src/node_modules/package/index.js', FILE)).toBe(true);
 
         // Should NOT ignore other files
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('file.ts')).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
       });
 
       test('excludes dotfiles with .* pattern', () => {
@@ -94,12 +218,12 @@ describe('glob-matcher', () => {
         });
 
         // Should ignore dotfiles at root
-        expect(shouldIgnore('.gitignore')).toBe(true);
-        expect(shouldIgnore('.eslintrc')).toBe(true);
+        expect(shouldIgnore('.gitignore', FILE)).toBe(true);
+        expect(shouldIgnore('.eslintrc', FILE)).toBe(true);
 
         // Should NOT ignore regular files
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
       });
 
       test('excludes nested dotfiles with **/.*/** pattern', () => {
@@ -108,12 +232,12 @@ describe('glob-matcher', () => {
         });
 
         // Should ignore files inside dot directories
-        expect(shouldIgnore('.git/config')).toBe(true);
-        expect(shouldIgnore('src/.hidden/file.ts')).toBe(true);
+        expect(shouldIgnore('.git/config', FILE)).toBe(true);
+        expect(shouldIgnore('src/.hidden/file.ts', FILE)).toBe(true);
 
         // Should NOT ignore regular files
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
       });
 
       test('supports multiple exclude patterns', () => {
@@ -122,13 +246,13 @@ describe('glob-matcher', () => {
         });
 
         // Should ignore all excluded patterns
-        expect(shouldIgnore('node_modules/pkg/index.js')).toBe(true);
-        expect(shouldIgnore('dist/bundle.js')).toBe(true);
-        expect(shouldIgnore('src/file.test.ts')).toBe(true);
+        expect(shouldIgnore('node_modules/pkg/index.js', FILE)).toBe(true);
+        expect(shouldIgnore('dist/bundle.js', FILE)).toBe(true);
+        expect(shouldIgnore('src/file.test.ts', FILE)).toBe(true);
 
         // Should NOT ignore other files
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('lib/index.ts')).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('lib/index.ts', FILE)).toBe(false);
       });
     });
 
@@ -140,15 +264,15 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore regular .ts files
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
 
         // Should ignore .test.ts files (exclude wins)
-        expect(shouldIgnore('file.test.ts')).toBe(true);
-        expect(shouldIgnore('src/file.test.ts')).toBe(true);
+        expect(shouldIgnore('file.test.ts', FILE)).toBe(true);
+        expect(shouldIgnore('src/file.test.ts', FILE)).toBe(true);
 
         // Should ignore non-.ts files (not in include)
-        expect(shouldIgnore('file.js')).toBe(true);
+        expect(shouldIgnore('file.js', FILE)).toBe(true);
       });
 
       test('realistic watch configuration', () => {
@@ -164,19 +288,19 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore source files
-        expect(shouldIgnore('src/index.ts')).toBe(false);
-        expect(shouldIgnore('lib/stack.ts')).toBe(false);
-        expect(shouldIgnore('bin/app.ts')).toBe(false);
+        expect(shouldIgnore('src/index.ts', FILE)).toBe(false);
+        expect(shouldIgnore('lib/stack.ts', FILE)).toBe(false);
+        expect(shouldIgnore('bin/app.ts', FILE)).toBe(false);
 
         // Should ignore node_modules
-        expect(shouldIgnore('node_modules/aws-cdk/index.js')).toBe(true);
+        expect(shouldIgnore('node_modules/aws-cdk/index.js', FILE)).toBe(true);
 
         // Should ignore cdk.out
-        expect(shouldIgnore('cdk.out/manifest.json')).toBe(true);
+        expect(shouldIgnore('cdk.out/manifest.json', FILE)).toBe(true);
 
         // Should ignore dotfiles
-        expect(shouldIgnore('.gitignore')).toBe(true);
-        expect(shouldIgnore('.git/config')).toBe(true);
+        expect(shouldIgnore('.gitignore', FILE)).toBe(true);
+        expect(shouldIgnore('.git/config', FILE)).toBe(true);
       });
     });
 
@@ -187,8 +311,8 @@ describe('glob-matcher', () => {
         });
 
         // Should handle backslashes (Windows paths)
-        expect(shouldIgnore('src\\file.ts')).toBe(false);
-        expect(shouldIgnore('src\\nested\\file.ts')).toBe(false);
+        expect(shouldIgnore('src\\file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src\\nested\\file.ts', FILE)).toBe(false);
       });
     });
 
@@ -196,22 +320,22 @@ describe('glob-matcher', () => {
       test('handles empty string path', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['**'] });
         // Empty path doesn't match ** pattern
-        expect(shouldIgnore('')).toBe(true);
+        expect(shouldIgnore('', FILE)).toBe(true);
       });
 
       test('handles paths with special characters', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['**'] });
 
-        expect(shouldIgnore('file with spaces.ts')).toBe(false);
-        expect(shouldIgnore('file-with-dashes.ts')).toBe(false);
-        expect(shouldIgnore('file_with_underscores.ts')).toBe(false);
+        expect(shouldIgnore('file with spaces.ts', FILE)).toBe(false);
+        expect(shouldIgnore('file-with-dashes.ts', FILE)).toBe(false);
+        expect(shouldIgnore('file_with_underscores.ts', FILE)).toBe(false);
       });
 
       test('handles deeply nested paths', () => {
         const shouldIgnore = createIgnoreMatcher({ include: ['**/*.ts'] });
 
-        expect(shouldIgnore('a/b/c/d/e/f/g/h/i/j/file.ts')).toBe(false);
-        expect(shouldIgnore('a/b/c/d/e/f/g/h/i/j/file.js')).toBe(true);
+        expect(shouldIgnore('a/b/c/d/e/f/g/h/i/j/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('a/b/c/d/e/f/g/h/i/j/file.js', FILE)).toBe(true);
       });
 
       test('handles root-level files', () => {
@@ -220,8 +344,8 @@ describe('glob-matcher', () => {
           exclude: ['**/test/**'],
         });
 
-        expect(shouldIgnore('index.ts')).toBe(false);
-        expect(shouldIgnore('app.ts')).toBe(false);
+        expect(shouldIgnore('index.ts', FILE)).toBe(false);
+        expect(shouldIgnore('app.ts', FILE)).toBe(false);
       });
     });
 
@@ -234,12 +358,12 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore files inside my-dir
-        expect(shouldIgnore('my-dir/file.ts')).toBe(false);
-        expect(shouldIgnore('my-dir/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('my-dir/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('my-dir/nested/file.ts', FILE)).toBe(false);
 
         // Should ignore files outside my-dir
-        expect(shouldIgnore('other-dir/file.ts')).toBe(true);
-        expect(shouldIgnore('file.ts')).toBe(true);
+        expect(shouldIgnore('other-dir/file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('file.ts', FILE)).toBe(true);
       });
 
       test('directory name without glob is treated as directory/** for exclude', () => {
@@ -248,12 +372,12 @@ describe('glob-matcher', () => {
         });
 
         // Should ignore files inside my-dir
-        expect(shouldIgnore('my-dir/file.ts')).toBe(true);
-        expect(shouldIgnore('my-dir/nested/file.ts')).toBe(true);
+        expect(shouldIgnore('my-dir/file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('my-dir/nested/file.ts', FILE)).toBe(true);
 
         // Should NOT ignore files outside my-dir
-        expect(shouldIgnore('other-dir/file.ts')).toBe(false);
-        expect(shouldIgnore('file.ts')).toBe(false);
+        expect(shouldIgnore('other-dir/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
       });
 
       test('directory with trailing slash is normalized', () => {
@@ -262,11 +386,11 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore files inside my-dir
-        expect(shouldIgnore('my-dir/file.ts')).toBe(false);
-        expect(shouldIgnore('my-dir/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('my-dir/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('my-dir/nested/file.ts', FILE)).toBe(false);
 
         // Should ignore files outside my-dir
-        expect(shouldIgnore('other-dir/file.ts')).toBe(true);
+        expect(shouldIgnore('other-dir/file.ts', FILE)).toBe(true);
       });
 
       test('patterns with glob characters are not normalized', () => {
@@ -276,13 +400,13 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore .ts files directly in src/
-        expect(shouldIgnore('src/file.ts')).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
 
         // Should ignore nested .ts files (pattern doesn't have **)
-        expect(shouldIgnore('src/nested/file.ts')).toBe(true);
+        expect(shouldIgnore('src/nested/file.ts', FILE)).toBe(true);
 
         // Should ignore non-.ts files
-        expect(shouldIgnore('src/file.js')).toBe(true);
+        expect(shouldIgnore('src/file.js', FILE)).toBe(true);
       });
 
       test('dot pattern is treated as directory', () => {
@@ -291,9 +415,9 @@ describe('glob-matcher', () => {
           include: ['.'],
         });
 
-        expect(shouldIgnore('file.ts')).toBe(false);
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('deep/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('deep/nested/file.ts', FILE)).toBe(false);
       });
 
       test('multiple directory patterns work together', () => {
@@ -302,13 +426,13 @@ describe('glob-matcher', () => {
         });
 
         // Should NOT ignore files in src/ or lib/
-        expect(shouldIgnore('src/file.ts')).toBe(false);
-        expect(shouldIgnore('lib/file.ts')).toBe(false);
-        expect(shouldIgnore('src/nested/file.ts')).toBe(false);
+        expect(shouldIgnore('src/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('lib/file.ts', FILE)).toBe(false);
+        expect(shouldIgnore('src/nested/file.ts', FILE)).toBe(false);
 
         // Should ignore files outside src/ and lib/
-        expect(shouldIgnore('test/file.ts')).toBe(true);
-        expect(shouldIgnore('file.ts')).toBe(true);
+        expect(shouldIgnore('test/file.ts', FILE)).toBe(true);
+        expect(shouldIgnore('file.ts', FILE)).toBe(true);
       });
     });
   });
@@ -325,13 +449,13 @@ describe('rootDir option (absolute path handling)', () => {
     });
 
     // Absolute paths should be converted to relative and matched
-    expect(shouldIgnore(`${rootDir}/README.md`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/cdk.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/cdk.context.json`)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/README.md`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/cdk.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/cdk.context.json`, FILE)).toBe(true);
 
     // Non-excluded files should NOT be ignored
-    expect(shouldIgnore(`${rootDir}/src/index.ts`)).toBe(false);
-    expect(shouldIgnore(`${rootDir}/lib/stack.ts`)).toBe(false);
+    expect(shouldIgnore(`${rootDir}/src/index.ts`, FILE)).toBe(false);
+    expect(shouldIgnore(`${rootDir}/lib/stack.ts`, FILE)).toBe(false);
   });
 
   test('handles the root directory itself', () => {
@@ -342,7 +466,7 @@ describe('rootDir option (absolute path handling)', () => {
     });
 
     // The root directory itself should NOT be ignored
-    expect(shouldIgnore(rootDir)).toBe(false);
+    expect(shouldIgnore(rootDir, DIR)).toBe(false);
   });
 
   test('still works with relative paths when rootDir is provided', () => {
@@ -353,9 +477,9 @@ describe('rootDir option (absolute path handling)', () => {
     });
 
     // Relative paths should still work
-    expect(shouldIgnore('README.md')).toBe(true);
-    expect(shouldIgnore('cdk.json')).toBe(true);
-    expect(shouldIgnore('src/index.ts')).toBe(false);
+    expect(shouldIgnore('README.md', FILE)).toBe(true);
+    expect(shouldIgnore('cdk.json', FILE)).toBe(true);
+    expect(shouldIgnore('src/index.ts', FILE)).toBe(false);
   });
 
   test('handles paths outside rootDir', () => {
@@ -369,8 +493,8 @@ describe('rootDir option (absolute path handling)', () => {
     // They remain as absolute paths. The ** pattern still matches them,
     // but the exclude pattern 'README.md' won't match '/other/path/README.md'
     // because it's not relative
-    expect(shouldIgnore('/other/path/README.md')).toBe(false); // Matches ** but not excluded
-    expect(shouldIgnore('/other/path/file.ts')).toBe(false); // Matches **
+    expect(shouldIgnore('/other/path/README.md', FILE)).toBe(false); // Matches ** but not excluded
+    expect(shouldIgnore('/other/path/file.ts', FILE)).toBe(false); // Matches **
   });
 
   test('handles Windows-style rootDir', () => {
@@ -382,8 +506,8 @@ describe('rootDir option (absolute path handling)', () => {
     });
 
     // Windows paths should be normalized and converted to relative
-    expect(shouldIgnore('C:/Users/test/my-project/README.md')).toBe(true);
-    expect(shouldIgnore('C:/Users/test/my-project/src/index.ts')).toBe(false);
+    expect(shouldIgnore('C:/Users/test/my-project/README.md', FILE)).toBe(true);
+    expect(shouldIgnore('C:/Users/test/my-project/src/index.ts', FILE)).toBe(false);
   });
 
   test('handles rootDir with trailing slash', () => {
@@ -393,8 +517,8 @@ describe('rootDir option (absolute path handling)', () => {
       rootDir: '/Users/test/my-project/',
     });
 
-    expect(shouldIgnore('/Users/test/my-project/README.md')).toBe(true);
-    expect(shouldIgnore('/Users/test/my-project/src/index.ts')).toBe(false);
+    expect(shouldIgnore('/Users/test/my-project/README.md', FILE)).toBe(true);
+    expect(shouldIgnore('/Users/test/my-project/src/index.ts', FILE)).toBe(false);
   });
 
   test('realistic chokidar v4 scenario', () => {
@@ -421,23 +545,23 @@ describe('rootDir option (absolute path handling)', () => {
     });
 
     // Files that should be ignored (absolute paths as chokidar passes them)
-    expect(shouldIgnore(`${rootDir}/README.md`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/cdk.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/cdk.context.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/package.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/yarn.lock`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/tsconfig.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/node_modules/pkg/index.js`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/.gitignore`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/.git/config`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/cdk.out/manifest.json`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/src/index.js`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/lib/stack.d.ts`)).toBe(true);
-    expect(shouldIgnore(`${rootDir}/test/stack.test.ts`)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/README.md`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/cdk.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/cdk.context.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/package.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/yarn.lock`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/tsconfig.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/node_modules/pkg/index.js`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/.gitignore`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/.git/config`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/cdk.out/manifest.json`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/src/index.js`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/lib/stack.d.ts`, FILE)).toBe(true);
+    expect(shouldIgnore(`${rootDir}/test/stack.test.ts`, FILE)).toBe(true);
 
     // Files that should NOT be ignored
-    expect(shouldIgnore(`${rootDir}/src/index.ts`)).toBe(false);
-    expect(shouldIgnore(`${rootDir}/lib/stack.ts`)).toBe(false);
-    expect(shouldIgnore(`${rootDir}/bin/app.ts`)).toBe(false);
+    expect(shouldIgnore(`${rootDir}/src/index.ts`, FILE)).toBe(false);
+    expect(shouldIgnore(`${rootDir}/lib/stack.ts`, FILE)).toBe(false);
+    expect(shouldIgnore(`${rootDir}/bin/app.ts`, FILE)).toBe(false);
   });
 });

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -42,7 +42,7 @@ const fakeChokidarWatch = {
     return mockChokidarWatch.mock.calls[0][0];
   },
 
-  get ignoredFn(): (path: string) => boolean {
+  get ignoredFn(): (path: string, stats?: Stats) => boolean {
     expect(mockChokidarWatch.mock.calls.length).toBe(1);
     // the ignored function is a property of the second parameter to the 'watch()' call
     const chokidarWatchOpts = mockChokidarWatch.mock.calls[0][1];
@@ -50,8 +50,16 @@ const fakeChokidarWatch = {
   },
 };
 
+// Chokidar v4 invokes the `ignored` callback with the file system stats of the
+// entry being considered, which the matcher uses to distinguish files from
+// directories (a directory is traversed even when it doesn't itself match a
+// file glob, so nested matching files can be discovered).
+const FILE = { isFile: () => true, isDirectory: () => false } as unknown as Stats;
+const DIR = { isFile: () => false, isDirectory: () => true } as unknown as Stats;
+
 jest.setTimeout(30_000);
 
+import type { Stats } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import * as cdkAssets from '@aws-cdk/cdk-assets-lib';
@@ -1843,9 +1851,9 @@ describe('watch', () => {
     // Verify we watch root directory and filter via ignored function
     expect(fakeChokidarWatch.watchPath).toBe('.');
     const ignoredFn = fakeChokidarWatch.ignoredFn;
-    expect(ignoredFn('my-dir')).toBe(false); // included - not ignored
-    expect(ignoredFn('my-dir/file.ts')).toBe(false); // included - not ignored
-    expect(ignoredFn('other-dir/file.ts')).toBe(true); // not included - ignored
+    expect(ignoredFn('my-dir', DIR)).toBe(false); // included - not ignored
+    expect(ignoredFn('my-dir/file.ts', FILE)).toBe(false); // included - not ignored
+    expect(ignoredFn('other-dir/file.ts', FILE)).toBe(true); // not included - ignored
   });
 
   test("allows providing an array of strings in 'watch.include'", async () => {
@@ -1862,9 +1870,9 @@ describe('watch', () => {
     // Verify we watch root directory and filter via ignored function
     expect(fakeChokidarWatch.watchPath).toBe('.');
     const ignoredFn = fakeChokidarWatch.ignoredFn;
-    expect(ignoredFn('my-dir1')).toBe(false); // matches first pattern - not ignored
-    expect(ignoredFn('nested/my-dir2/file.ts')).toBe(false); // matches second pattern - not ignored
-    expect(ignoredFn('other-dir/file.ts')).toBe(true); // matches neither - ignored
+    expect(ignoredFn('my-dir1', DIR)).toBe(false); // matches first pattern - not ignored
+    expect(ignoredFn('nested/my-dir2/file.ts', FILE)).toBe(false); // matches second pattern - not ignored
+    expect(ignoredFn('other-dir/file.ts', FILE)).toBe(true); // matches neither - ignored
   });
 
   test('ignores the output dir, dot files, dot directories, and node_modules by default', async () => {
@@ -1880,11 +1888,11 @@ describe('watch', () => {
     // Verify we watch root directory and filter via ignored function
     expect(fakeChokidarWatch.watchPath).toBe('.');
     const ignoredFn = fakeChokidarWatch.ignoredFn;
-    expect(ignoredFn('cdk.out/stack.template.json')).toBe(true); // output dir - ignored
-    expect(ignoredFn('.hidden')).toBe(true); // dot file - ignored
-    expect(ignoredFn('.git/config')).toBe(true); // dot directory - ignored
-    expect(ignoredFn('node_modules/package/index.js')).toBe(true); // node_modules - ignored
-    expect(ignoredFn('src/app.ts')).toBe(false); // regular file - not ignored
+    expect(ignoredFn('cdk.out/stack.template.json', FILE)).toBe(true); // output dir - ignored
+    expect(ignoredFn('.hidden', FILE)).toBe(true); // dot file - ignored
+    expect(ignoredFn('.git/config', FILE)).toBe(true); // dot directory - ignored
+    expect(ignoredFn('node_modules/package/index.js', FILE)).toBe(true); // node_modules - ignored
+    expect(ignoredFn('src/app.ts', FILE)).toBe(false); // regular file - not ignored
   });
 
   test("allows providing a single string in 'watch.exclude'", async () => {
@@ -1901,9 +1909,9 @@ describe('watch', () => {
     // Verify we watch root directory and filter via ignored function
     expect(fakeChokidarWatch.watchPath).toBe('.');
     const ignoredFn = fakeChokidarWatch.ignoredFn;
-    expect(ignoredFn('my-dir')).toBe(true); // excluded - ignored
-    expect(ignoredFn('my-dir/file.ts')).toBe(true); // excluded - ignored
-    expect(ignoredFn('other-dir/file.ts')).toBe(false); // not excluded - not ignored
+    expect(ignoredFn('my-dir', DIR)).toBe(true); // excluded - ignored
+    expect(ignoredFn('my-dir/file.ts', FILE)).toBe(true); // excluded - ignored
+    expect(ignoredFn('other-dir/file.ts', FILE)).toBe(false); // not excluded - not ignored
   });
 
   test("allows providing an array of strings in 'watch.exclude'", async () => {
@@ -1920,10 +1928,10 @@ describe('watch', () => {
     // Verify we watch root directory and filter via ignored function
     expect(fakeChokidarWatch.watchPath).toBe('.');
     const ignoredFn = fakeChokidarWatch.ignoredFn;
-    expect(ignoredFn('my-dir1')).toBe(true); // matches first exclude - ignored
-    expect(ignoredFn('my-dir1/file.ts')).toBe(true); // matches first exclude - ignored
-    expect(ignoredFn('nested/my-dir2')).toBe(true); // matches second exclude - ignored
-    expect(ignoredFn('other-dir/file.ts')).toBe(false); // matches neither exclude - not ignored
+    expect(ignoredFn('my-dir1', DIR)).toBe(true); // matches first exclude - ignored
+    expect(ignoredFn('my-dir1/file.ts', FILE)).toBe(true); // matches first exclude - ignored
+    expect(ignoredFn('nested/my-dir2', DIR)).toBe(true); // matches second exclude - ignored
+    expect(ignoredFn('other-dir/file.ts', FILE)).toBe(false); // matches neither exclude - not ignored
   });
 
   test('allows watching with deploy concurrency', async () => {


### PR DESCRIPTION
Fixes #1647

### Summary

User-specified glob patterns in `cdk.json`'s `watch.include` (e.g. `src/**/*.ts`) were silently ignored: `cdk watch` started, observed nothing, and never triggered on file changes. Only literal directory paths worked, and no error was shown — so watch appeared to be running but was effectively dead.

### Root cause

This is remaining fallout from the chokidar v3→v4 migration (#1146 fixed only the default `include: ['**']` case). In chokidar v4 the `ignored` callback also controls **directory traversal**: if a directory is ignored, its entire subtree is pruned and no nested file is ever discovered.

The matcher ignored any path that didn't match an include pattern. But a directory like `src` never matches a file glob like `src/**/*.ts`, so `src` was pruned before any `.ts` file inside it could be found — leaving watch observing nothing.

### Fix

The matcher now uses the `Stats` chokidar provides to distinguish files from directories:

- Excludes always take precedence and prune both files and directories.
- A **directory** is kept if it could be an ancestor of an included file (derived from the progressive `/`-delimited prefixes of each include pattern, e.g. `src/**/*.ts` → `src`, `src/**`, `src/**/*.ts`), so we descend and discover the nested files we actually want. It is never pruned merely for failing the file-level include filter.
- A **file** must match an include pattern to be watched.
- When stats are absent (chokidar invokes the callback both with and without stats during traversal), the path is kept if it matches a file include pattern or is a potential ancestor directory of one.

This restores chokidar v3 glob semantics: globs like `src/**/*.ts` watch exactly the matching files, while excludes still prune entire subtrees (e.g. `node_modules/**`) efficiently. Literal directory paths and the default `['**']` config continue to work unchanged.

### Testing

- New unit tests in `glob-matcher.test.ts` covering directory traversal: ancestor directories of a file glob are descended into, directories that cannot contain a match are pruned, directories are only pruned by excludes, multiple globs across separate trees, and the no-stats traversal path.
- New regression test in `watch.test.ts` asserting the `ignored` callback descends into ancestor directories of a user-supplied file glob (`src/**/*.ts`).
- Existing tests updated to invoke the `ignored` callback the way chokidar v4 actually does — with file system `Stats`.
- New integ test

#### Q. Why did every test need to be updated to pass a stats argument?

The fix changes the matcher's contract. It used to be a pure path filter — one string in, ignore/keep out — so tests called shouldIgnore('some/path') and asserted the result directly. Now the correct answer depends on whether the path is a file or a directory: src must be kept (so chokidar descends and finds src/a.ts) even though it doesn't match a file glob like src/**/*.ts, while src/a.js under that same glob must be ignored. Since 'src' looks just like a file path, the only way to tell them apart is the Stats argument chokidar v4 actually passes. The old single-argument calls now hit the stats-absent fallback — which is intentionally permissive and defers real filtering to the later with-stats call — so they no longer reflect how chokidar invokes the callback. Passing FILE/DIR stats updates the tests to exercise it the way production does.

### Checklist
- [x] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
