### PR TITLE
feat: construct tree and violations

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -81,7 +81,7 @@ function ViolationsContent({ violations }: { readonly violations?: ViolationsRes
   if (violations.status === 'not-synthesized') {
     return <Box color="text-status-inactive">No cloud assembly found.</Box>;
   }
-  return <ViolationsPanel violations={violations.violations} reportError={violations.reportError} />;
+  return <ViolationsPanel violations={violations.violations} />;
 }
 
 interface SplitOptions {

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -14,12 +14,14 @@ export function App(): JSX.Element {
   const [tree, setTree] = React.useState<TreeResponse | undefined>();
   const [violations, setViolations] = React.useState<ViolationsResponse | undefined>();
   const [error, setError] = React.useState<string | undefined>();
+  const [appDir, setAppDir] = React.useState<string | undefined>();
 
   React.useEffect(() => {
-    Promise.all([api.getTree(), api.getViolations()])
-      .then(([t, v]) => {
+    Promise.all([api.getTree(), api.getViolations(), api.getAppInfo()])
+      .then(([t, v, info]) => {
         setTree(t);
         setViolations(v);
+        setAppDir(info.appDir);
         setError(undefined);
       })
       .catch((err) => setError(err instanceof Error ? err.message : String(err)));
@@ -33,7 +35,7 @@ export function App(): JSX.Element {
   return (
     <div style={PAGE_STYLE} ref={vSplit.containerRef}>
       <header style={TITLE_BLOCK_STYLE}>
-        <Header variant="h1" description="last updated: —">CDK Web Explorer</Header>
+        <Header variant="h1" description={appDir ?? '—'}>CDK Web Explorer</Header>
       </header>
       {error && <Box color="text-status-error">{error}</Box>}
       <div style={topRowStyle(vSplit)} ref={hSplit.containerRef}>

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -1,9 +1,7 @@
 import Box from '@cloudscape-design/components/box';
 import Container from '@cloudscape-design/components/container';
-import ContentLayout from '@cloudscape-design/components/content-layout';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
-import SpaceBetween from '@cloudscape-design/components/space-between';
 import Spinner from '@cloudscape-design/components/spinner';
 import * as React from 'react';
 import { api, type TreeResponse, type ViolationsResponse } from './api';
@@ -11,80 +9,66 @@ import { ConstructTree } from './components/ConstructTree';
 import { FilePane } from './components/FilePane';
 import { ViolationsPanel } from './components/ViolationsPanel';
 
-/** Web explorer shell: Resource Tree (left), two file panes, Violations (bottom). */
+/** Web explorer shell. Two splits: horizontal between the construct tree and the file panes, vertical between the top row and the violations panel. Each split has a draggable resizer with an arrow toggle that collapses one side. */
 export function App(): JSX.Element {
   const [tree, setTree] = React.useState<TreeResponse | undefined>();
   const [violations, setViolations] = React.useState<ViolationsResponse | undefined>();
   const [error, setError] = React.useState<string | undefined>();
-  const [updatedAt, setUpdatedAt] = React.useState('—');
-
-  const load = React.useCallback(async () => {
-    try {
-      const [t, v] = await Promise.all([api.getTree(), api.getViolations()]);
-      setTree(t);
-      setViolations(v);
-      setUpdatedAt(new Date().toLocaleTimeString());
-      setError(undefined);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    }
-  }, []);
 
   React.useEffect(() => {
-    void load();
-  }, [load]);
+    Promise.all([api.getTree(), api.getViolations()])
+      .then(([t, v]) => {
+        setTree(t);
+        setViolations(v);
+        setError(undefined);
+      })
+      .catch((err) => setError(err instanceof Error ? err.message : String(err)));
+  }, []);
 
-  const [treeWidth, setTreeWidth] = React.useState(340);
-  const startResize = React.useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startWidth = treeWidth;
-    document.body.style.userSelect = 'none';
-    document.body.style.cursor = 'col-resize';
-    const onMove = (ev: MouseEvent) => {
-      setTreeWidth(Math.min(MAX_TREE_WIDTH, Math.max(MIN_TREE_WIDTH, startWidth + ev.clientX - startX)));
-    };
-    const onUp = () => {
-      document.body.style.userSelect = '';
-      document.body.style.cursor = '';
-      document.removeEventListener('mousemove', onMove);
-      document.removeEventListener('mouseup', onUp);
-    };
-    document.addEventListener('mousemove', onMove);
-    document.addEventListener('mouseup', onUp);
-  }, [treeWidth]);
+  // Vertical split: violations row's share of the page height (default 33%).
+  const vSplit = useSplit({ orientation: 'vertical', defaultFraction: 0.33, min: 0.15, max: 0.85 });
+  // Horizontal split inside the top row: file panes' share of that row's width (default 75%; tree gets the remaining 25%).
+  const hSplit = useSplit({ orientation: 'horizontal', defaultFraction: 0.75, min: 0.4, max: 0.85 });
 
   return (
-    <ContentLayout
-      header={<Header variant="h1" description={`last updated: ${updatedAt}`}>CDK Web Explorer</Header>}
-    >
-      <SpaceBetween size="l">
-        {error && <Box color="text-status-error">{error}</Box>}
-        <div style={SPLIT_ROW_STYLE}>
-          <div style={{ width: `${treeWidth}px`, flexShrink: 0, minWidth: 0 }}>
-            <Container header={<Header variant="h2">Construct Tree</Header>}>
-              <ResourceTree tree={tree} />
+    <div style={PAGE_STYLE} ref={vSplit.containerRef}>
+      <header style={TITLE_BLOCK_STYLE}>
+        <Header variant="h1" description="last updated: —">CDK Web Explorer</Header>
+      </header>
+      {error && <Box color="text-status-error">{error}</Box>}
+      <div style={topRowStyle(vSplit)} ref={hSplit.containerRef}>
+        <div style={treePaneStyle(hSplit)}>
+          {!hSplit.collapsed && (
+            <div style={GROW_STYLE}>
+              <Container fitHeight header={<Header variant="h2">Construct Tree</Header>}>
+                <ConstructTreeContent tree={tree} />
+              </Container>
+            </div>
+          )}
+        </div>
+        <Resizer split={hSplit} />
+        <div style={filesPaneStyle(hSplit)}>
+          <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+            <FilePane title="file 1" />
+            <FilePane title="file 2" />
+          </Grid>
+        </div>
+      </div>
+      <div style={bottomRowStyle(vSplit)}>
+        <Resizer split={vSplit} />
+        {!vSplit.collapsed && (
+          <div style={GROW_STYLE}>
+            <Container fitHeight header={<Header variant="h2">Violations</Header>}>
+              <ViolationsContent violations={violations} />
             </Container>
           </div>
-          <div style={RESIZE_HANDLE_STYLE} onMouseDown={startResize} role="separator" aria-orientation="vertical">
-            <div style={RESIZE_GRIP_STYLE} />
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-              <FilePane title="file 1" />
-              <FilePane title="file 2" />
-            </Grid>
-          </div>
-        </div>
-        <Container header={<Header variant="h2">Violations</Header>}>
-          <ViolationsContent violations={violations} />
-        </Container>
-      </SpaceBetween>
-    </ContentLayout>
+        )}
+      </div>
+    </div>
   );
 }
 
-function ResourceTree({ tree }: { readonly tree?: TreeResponse }): JSX.Element {
+function ConstructTreeContent({ tree }: { readonly tree?: TreeResponse }): JSX.Element {
   if (!tree) return <Spinner />;
   if (tree.status === 'not-synthesized') {
     return <Box color="text-status-inactive">No cloud assembly found. Run cdk synth first.</Box>;
@@ -100,15 +84,187 @@ function ViolationsContent({ violations }: { readonly violations?: ViolationsRes
   return <ViolationsPanel violations={violations.violations} reportError={violations.reportError} />;
 }
 
-const MIN_TREE_WIDTH = 220;
-const MAX_TREE_WIDTH = 720;
-const SPLIT_ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'stretch' };
-const RESIZE_HANDLE_STYLE: React.CSSProperties = {
-  flexShrink: 0,
-  width: '11px',
-  cursor: 'col-resize',
+interface SplitOptions {
+  /** 'horizontal' = the resizer moves left/right (separating columns). 'vertical' = the resizer moves up/down (separating rows). */
+  readonly orientation: 'horizontal' | 'vertical';
+  readonly defaultFraction: number;
+  readonly min: number;
+  readonly max: number;
+}
+
+interface Split extends SplitOptions {
+  /** Fraction the *trailing* pane (right column / bottom row) takes of its container; 0..1. */
+  readonly fraction: number;
+  readonly collapsed: boolean;
+  readonly toggleCollapsed: () => void;
+  readonly startDrag: (e: React.MouseEvent) => void;
+  readonly containerRef: React.RefObject<HTMLDivElement>;
+}
+
+/** Drives a resizable / collapsible split. Drag updates the fraction live; the arrow toggles full collapse of the trailing pane. */
+function useSplit(opts: SplitOptions): Split {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [fraction, setFraction] = React.useState(opts.defaultFraction);
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  const startDrag = React.useCallback((e: React.MouseEvent) => {
+    if (collapsed) return; // Drag while collapsed makes no sense; user must expand first via the arrow.
+    e.preventDefault();
+    const container = containerRef.current;
+    if (!container) return;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = opts.orientation === 'vertical' ? 'row-resize' : 'col-resize';
+    const onMove = (ev: MouseEvent) => {
+      const rect = container.getBoundingClientRect();
+      // Trailing pane share grows as the pointer moves toward the leading edge.
+      const frac = opts.orientation === 'vertical'
+        ? (rect.bottom - ev.clientY) / rect.height
+        : (rect.right - ev.clientX) / rect.width;
+      setFraction(Math.min(opts.max, Math.max(opts.min, frac)));
+    };
+    const onUp = () => {
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [collapsed, opts.orientation, opts.min, opts.max]);
+
+  const toggleCollapsed = React.useCallback(() => setCollapsed((c) => !c), []);
+
+  return { ...opts, fraction, collapsed, toggleCollapsed, startDrag, containerRef };
+}
+
+/** Thin strip pinned to the edge of the trailing pane. The whole strip is the drag handle; a centered arrow toggles collapse. */
+function Resizer({ split }: { readonly split: Split }): JSX.Element {
+  const isVertical = split.orientation === 'vertical';
+  // Arrow points the way the boundary travels on collapse, and flips once collapsed.
+  const arrow = isVertical
+    ? (split.collapsed ? '▲' : '▼')
+    : (split.collapsed ? '▶' : '◀');
+  const verb = isVertical
+    ? (split.collapsed ? 'Expand violations' : 'Collapse violations')
+    : (split.collapsed ? 'Expand construct tree' : 'Collapse construct tree');
+  return (
+    <div
+      style={resizerStyle(split)}
+      role="separator"
+      aria-orientation={isVertical ? 'horizontal' : 'vertical'}
+      onMouseDown={split.startDrag}
+    >
+      <button
+        type="button"
+        style={isVertical ? RESIZER_BUTTON_HORIZONTAL : RESIZER_BUTTON_VERTICAL}
+        title={verb}
+        aria-label={verb}
+        aria-expanded={!split.collapsed}
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={split.toggleCollapsed}
+      >
+        {arrow}
+      </button>
+    </div>
+  );
+}
+
+function topRowStyle(vSplit: Split): React.CSSProperties {
+  return {
+    display: 'flex',
+    minHeight: 0,
+    alignItems: 'stretch',
+    flexDirection: 'row',
+    flex: vSplit.collapsed ? '1 1 auto' : `${1 - vSplit.fraction} 1 0`,
+  };
+}
+
+function bottomRowStyle(vSplit: Split): React.CSSProperties {
+  return {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    flex: vSplit.collapsed ? '0 0 auto' : `${vSplit.fraction} 1 0`,
+  };
+}
+
+function treePaneStyle(hSplit: Split): React.CSSProperties {
+  return {
+    flex: hSplit.collapsed ? '0 0 0' : `0 0 ${(1 - hSplit.fraction) * 100}%`,
+    minWidth: 0,
+    minHeight: 0,
+    display: 'flex',
+  };
+}
+
+function filesPaneStyle(hSplit: Split): React.CSSProperties {
+  return {
+    flex: hSplit.collapsed ? '1 1 auto' : `0 0 ${hSplit.fraction * 100}%`,
+    minWidth: 0,
+    minHeight: 0,
+  };
+}
+
+function resizerStyle(split: Split): React.CSSProperties {
+  if (split.orientation === 'vertical') {
+    return {
+      flexShrink: 0,
+      height: split.collapsed ? '20px' : '10px',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      cursor: split.collapsed ? 'pointer' : 'row-resize',
+      position: 'relative',
+      marginBottom: split.collapsed ? 0 : '-4px',
+    };
+  }
+  return {
+    flexShrink: 0,
+    width: split.collapsed ? '20px' : '10px',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: split.collapsed ? 'pointer' : 'col-resize',
+    position: 'relative',
+    // Slide 4px left so the pill straddles the tree pane's border.
+    marginLeft: split.collapsed ? 0 : '-4px',
+  };
+}
+
+const PAGE_STYLE: React.CSSProperties = {
+  height: '100vh',
   display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'stretch',
+  flexDirection: 'column',
+  padding: '16px',
+  boxSizing: 'border-box',
+  overflow: 'hidden',
 };
-const RESIZE_GRIP_STYLE: React.CSSProperties = { width: '2px', background: '#d1d5db', borderRadius: '1px' };
+const TITLE_BLOCK_STYLE: React.CSSProperties = { flexShrink: 0, marginBottom: '12px' };
+/** Wraps a Cloudscape Container so it stretches to fill its flex parent (Container is intrinsically sized). */
+const GROW_STYLE: React.CSSProperties = { flex: '1 1 0', minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', width: '100%' };
+
+const RESIZER_BUTTON_BASE: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  border: '1px solid #d1d5db',
+  background: '#ffffff',
+  color: '#5f6b7a',
+  fontSize: '10px',
+  lineHeight: 1,
+  cursor: 'pointer',
+  zIndex: 1,
+  padding: 0,
+};
+const RESIZER_BUTTON_HORIZONTAL: React.CSSProperties = {
+  ...RESIZER_BUTTON_BASE,
+  width: '40px',
+  height: '14px',
+  borderRadius: '7px',
+};
+const RESIZER_BUTTON_VERTICAL: React.CSSProperties = {
+  ...RESIZER_BUTTON_BASE,
+  width: '14px',
+  height: '40px',
+  borderRadius: '7px',
+};

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -4,37 +4,111 @@ import ContentLayout from '@cloudscape-design/components/content-layout';
 import Grid from '@cloudscape-design/components/grid';
 import Header from '@cloudscape-design/components/header';
 import SpaceBetween from '@cloudscape-design/components/space-between';
+import Spinner from '@cloudscape-design/components/spinner';
 import * as React from 'react';
+import { api, type TreeResponse, type ViolationsResponse } from './api';
+import { ConstructTree } from './components/ConstructTree';
 import { FilePane } from './components/FilePane';
+import { ViolationsPanel } from './components/ViolationsPanel';
 
-/** Web explorer shell: Resource Tree (left), two file panes, Violations (bottom). Tree/violations are placeholders until the cloud-assembly reader is wired in. */
+/** Web explorer shell: Resource Tree (left), two file panes, Violations (bottom). */
 export function App(): JSX.Element {
+  const [tree, setTree] = React.useState<TreeResponse | undefined>();
+  const [violations, setViolations] = React.useState<ViolationsResponse | undefined>();
+  const [error, setError] = React.useState<string | undefined>();
+  const [updatedAt, setUpdatedAt] = React.useState('—');
+
+  const load = React.useCallback(async () => {
+    try {
+      const [t, v] = await Promise.all([api.getTree(), api.getViolations()]);
+      setTree(t);
+      setViolations(v);
+      setUpdatedAt(new Date().toLocaleTimeString());
+      setError(undefined);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  React.useEffect(() => {
+    void load();
+  }, [load]);
+
+  const [treeWidth, setTreeWidth] = React.useState(340);
+  const startResize = React.useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = treeWidth;
+    document.body.style.userSelect = 'none';
+    document.body.style.cursor = 'col-resize';
+    const onMove = (ev: MouseEvent) => {
+      setTreeWidth(Math.min(MAX_TREE_WIDTH, Math.max(MIN_TREE_WIDTH, startWidth + ev.clientX - startX)));
+    };
+    const onUp = () => {
+      document.body.style.userSelect = '';
+      document.body.style.cursor = '';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }, [treeWidth]);
+
   return (
     <ContentLayout
-      header={
-        <Header variant="h1" description="last updated: —">
-          CDK Web Explorer
-        </Header>
-      }
+      header={<Header variant="h1" description={`last updated: ${updatedAt}`}>CDK Web Explorer</Header>}
     >
       <SpaceBetween size="l">
-        <Grid gridDefinition={[{ colspan: 3 }, { colspan: 9 }]}>
-          <Container header={<Header variant="h2">Resource Tree</Header>}>
-            <Box color="text-status-inactive">
-              Construct tree appears here once the cloud-assembly reader is wired in.
-            </Box>
-          </Container>
-          <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
-            <FilePane title="file 1" />
-            <FilePane title="file 2" />
-          </Grid>
-        </Grid>
+        {error && <Box color="text-status-error">{error}</Box>}
+        <div style={SPLIT_ROW_STYLE}>
+          <div style={{ width: `${treeWidth}px`, flexShrink: 0, minWidth: 0 }}>
+            <Container header={<Header variant="h2">Construct Tree</Header>}>
+              <ResourceTree tree={tree} />
+            </Container>
+          </div>
+          <div style={RESIZE_HANDLE_STYLE} onMouseDown={startResize} role="separator" aria-orientation="vertical">
+            <div style={RESIZE_GRIP_STYLE} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Grid gridDefinition={[{ colspan: 6 }, { colspan: 6 }]}>
+              <FilePane title="file 1" />
+              <FilePane title="file 2" />
+            </Grid>
+          </div>
+        </div>
         <Container header={<Header variant="h2">Violations</Header>}>
-          <Box color="text-status-inactive">
-            Policy-validation violations appear here once the cloud-assembly reader is wired in.
-          </Box>
+          <ViolationsContent violations={violations} />
         </Container>
       </SpaceBetween>
     </ContentLayout>
   );
 }
+
+function ResourceTree({ tree }: { readonly tree?: TreeResponse }): JSX.Element {
+  if (!tree) return <Spinner />;
+  if (tree.status === 'not-synthesized') {
+    return <Box color="text-status-inactive">No cloud assembly found. Run cdk synth first.</Box>;
+  }
+  return <ConstructTree nodes={tree.tree} />;
+}
+
+function ViolationsContent({ violations }: { readonly violations?: ViolationsResponse }): JSX.Element {
+  if (!violations) return <Spinner />;
+  if (violations.status === 'not-synthesized') {
+    return <Box color="text-status-inactive">No cloud assembly found.</Box>;
+  }
+  return <ViolationsPanel violations={violations.violations} reportError={violations.reportError} />;
+}
+
+const MIN_TREE_WIDTH = 220;
+const MAX_TREE_WIDTH = 720;
+const SPLIT_ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'stretch' };
+const RESIZE_HANDLE_STYLE: React.CSSProperties = {
+  flexShrink: 0,
+  width: '11px',
+  cursor: 'col-resize',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'stretch',
+};
+const RESIZE_GRIP_STYLE: React.CSSProperties = { width: '2px', background: '#d1d5db', borderRadius: '1px' };

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -1,6 +1,24 @@
-import type { DirEntry, FilesResponse, FileResponse } from '../lib/web/protocol';
+import type {
+  DirEntry,
+  FilesResponse,
+  FileResponse,
+  TreeResponse,
+  ViolationsResponse,
+  WebConstructNode,
+  WebViolation,
+  WebViolationOccurrence,
+} from '../lib/web/protocol';
 
-export type { DirEntry, FilesResponse, FileResponse };
+export type {
+  DirEntry,
+  FilesResponse,
+  FileResponse,
+  TreeResponse,
+  ViolationsResponse,
+  WebConstructNode,
+  WebViolation,
+  WebViolationOccurrence,
+};
 
 async function getJson<T>(url: string): Promise<T> {
   const res = await fetch(url);
@@ -14,4 +32,6 @@ async function getJson<T>(url: string): Promise<T> {
 export const api = {
   listFiles: (dir = ''): Promise<FilesResponse> => getJson(`/api/files?dir=${encodeURIComponent(dir)}`),
   readFile: (filePath: string): Promise<FileResponse> => getJson(`/api/file?path=${encodeURIComponent(filePath)}`),
+  getTree: (): Promise<TreeResponse> => getJson('/api/tree'),
+  getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),
 };

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -29,9 +29,14 @@ async function getJson<T>(url: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+export interface AppInfoResponse {
+  readonly appDir: string;
+}
+
 export const api = {
   listFiles: (dir = ''): Promise<FilesResponse> => getJson(`/api/files?dir=${encodeURIComponent(dir)}`),
   readFile: (filePath: string): Promise<FileResponse> => getJson(`/api/file?path=${encodeURIComponent(filePath)}`),
   getTree: (): Promise<TreeResponse> => getJson('/api/tree'),
   getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),
+  getAppInfo: (): Promise<AppInfoResponse> => getJson('/api/info'),
 };

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
@@ -1,114 +1,72 @@
 import Box from '@cloudscape-design/components/box';
 import Icon from '@cloudscape-design/components/icon';
 import * as React from 'react';
+import { severityHexColor } from '../../lib/web/severity';
 import type { WebConstructNode } from '../api';
 
 interface ConstructTreeProps {
   readonly nodes: readonly WebConstructNode[];
+  readonly depth?: number;
 }
+
+/** Auto-expand the tree through this depth on load (0 = root), so stacks and their top-level constructs are visible without manual clicks. */
+const AUTO_EXPAND_DEPTH = 2;
 
 /**
  * Renders the construct hierarchy as a nested, indented list. Rows never spill
  * past the panel: long labels truncate with an ellipsis and the tree clips
- * horizontally. Nodes collapse via a caret (whole-row click). A node can be
- * renamed by double-clicking its label; the override is persisted to
- * localStorage and a revert control restores the default. Display-only.
+ * horizontally. Nodes collapse via a caret (whole-row click). Display-only.
  */
-export function ConstructTree({ nodes }: ConstructTreeProps): JSX.Element {
-  const names = React.useContext(TreeNamesContext);
+export function ConstructTree({ nodes, depth = 0 }: ConstructTreeProps): JSX.Element {
   if (nodes.length === 0) {
     return <Box color="text-status-inactive">No constructs.</Box>;
   }
   const list = (
     <ul style={LIST_STYLE}>
       {nodes.map((node) => (
-        <TreeNode key={node.path} node={node} />
+        <TreeNode key={node.path} node={node} depth={depth} />
       ))}
     </ul>
   );
-  // Root render (no surrounding provider): own the rename store + the clip box.
-  if (!names) {
-    return (
-      <TreeNamesProvider>
-        <div style={TREE_VIEWPORT_STYLE}>{list}</div>
-      </TreeNamesProvider>
-    );
-  }
-  return list;
+  // Root render: wrap once in the clipping viewport; nested calls return the bare list.
+  return depth === 0 ? <div style={TREE_VIEWPORT_STYLE}>{list}</div> : list;
 }
 
-function TreeNode({ node }: { readonly node: WebConstructNode }): JSX.Element {
-  const names = React.useContext(TreeNamesContext)!;
+function TreeNode({ node, depth }: { readonly node: WebConstructNode; readonly depth: number }): JSX.Element {
   const hasChildren = node.children.length > 0;
-  const [expanded, setExpanded] = React.useState(false);
-  const [editing, setEditing] = React.useState(false);
+  const [expanded, setExpanded] = React.useState(depth < AUTO_EXPAND_DEPTH);
 
-  const override = names.overrides[node.path];
-  const defaultLabel = friendlyName(node);
-  const label = override ?? defaultLabel;
-
-  const commit = (raw: string): void => {
-    const value = raw.trim();
-    if (value && value !== defaultLabel) {
-      names.rename(node.path, value);
-    } else {
-      names.reset(node.path);
-    }
-    setEditing(false);
-  };
+  const label = friendlyName(node);
+  const severity = node.highestSeverity;
+  const severityColor = severity ? severityHexColor(severity) : undefined;
 
   return (
     <li style={ITEM_STYLE}>
       <div
         style={hasChildren ? ROW_CLICKABLE_STYLE : ROW_STYLE}
-        onClick={hasChildren && !editing ? () => setExpanded((e) => !e) : undefined}
+        onClick={hasChildren ? () => setExpanded((e) => !e) : undefined}
         role={hasChildren ? 'button' : undefined}
         aria-expanded={hasChildren ? expanded : undefined}
       >
         {hasChildren ? <span style={CARET_STYLE}>{expanded ? '\u25be' : '\u25b8'}</span> : <span style={CARET_SPACER} />}
         <Icon name={hasChildren ? 'folder' : 'file'} variant="subtle" />
-        {editing ? (
-          <input
-            autoFocus
-            defaultValue={label}
-            style={EDIT_INPUT_STYLE}
-            onFocus={(e) => e.currentTarget.select()}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') commit(e.currentTarget.value);
-              else if (e.key === 'Escape') setEditing(false);
-            }}
-            onBlur={(e) => commit(e.currentTarget.value)}
-          />
-        ) : (
+        {severityColor && (
           <span
-            style={LABEL_STYLE}
-            title={`${node.path} (double-click to rename)`}
-            onDoubleClick={() => setEditing(true)}
-          >
-            {label}
-          </span>
+            style={{ ...SEVERITY_DOT_STYLE, background: severityColor }}
+            title={`${severity} violation on this construct`}
+            aria-label={`${severity} violation`}
+          />
         )}
-        {node.type && !editing && (
+        <span style={severityColor ? { ...LABEL_STYLE, color: severityColor } : LABEL_STYLE} title={node.path}>
+          {label}
+        </span>
+        {node.type && (
           <span style={TYPE_STYLE} title={node.type}>
             {friendlyType(node.type)}
           </span>
         )}
-        {override !== undefined && !editing && (
-          <button
-            type="button"
-            style={REVERT_BUTTON_STYLE}
-            title="Revert to default name"
-            aria-label="Revert to default name"
-            onClick={(e) => {
-              e.stopPropagation();
-              names.reset(node.path);
-            }}
-          >
-            {'\u21ba'}
-          </button>
-        )}
       </div>
-      {hasChildren && expanded && <ConstructTree nodes={node.children} />}
+      {hasChildren && expanded && <ConstructTree nodes={node.children} depth={depth + 1} />}
     </li>
   );
 }
@@ -126,49 +84,13 @@ function friendlyType(type: string): string {
   return type.replace(/^AWS::/, '').split('::').join(' ');
 }
 
-interface TreeNames {
-  readonly overrides: Readonly<Record<string, string>>;
-  readonly rename: (path: string, name: string) => void;
-  readonly reset: (path: string) => void;
-}
-
-const TreeNamesContext = React.createContext<TreeNames | null>(null);
-const NAME_OVERRIDES_KEY = 'cdk-explorer:tree-name-overrides';
-
-/** Holds user rename overrides (keyed by construct path) and persists them to localStorage. */
-function TreeNamesProvider({ children }: { readonly children: React.ReactNode }): JSX.Element {
-  const [overrides, setOverrides] = React.useState<Record<string, string>>(loadOverrides);
-  React.useEffect(() => {
-    window.localStorage.setItem(NAME_OVERRIDES_KEY, JSON.stringify(overrides));
-  }, [overrides]);
-  const api = React.useMemo<TreeNames>(
-    () => ({
-      overrides,
-      rename: (path, name) => setOverrides((o) => ({ ...o, [path]: name })),
-      reset: (path) =>
-        setOverrides((o) => {
-          if (!(path in o)) return o;
-          const next = { ...o };
-          delete next[path];
-          return next;
-        }),
-    }),
-    [overrides],
-  );
-  return <TreeNamesContext.Provider value={api}>{children}</TreeNamesContext.Provider>;
-}
-
-/** Read persisted overrides; tolerate absent or corrupt storage by starting empty. */
-function loadOverrides(): Record<string, string> {
-  try {
-    const raw = window.localStorage.getItem(NAME_OVERRIDES_KEY);
-    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
-  } catch {
-    return {};
-  }
-}
-
-const TREE_VIEWPORT_STYLE: React.CSSProperties = { overflowX: 'hidden', overflowY: 'auto', maxHeight: '60vh' };
+const TREE_VIEWPORT_STYLE: React.CSSProperties = { overflowX: 'hidden', overflowY: 'auto', height: '100%' };
+const SEVERITY_DOT_STYLE: React.CSSProperties = {
+  flexShrink: 0,
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+};
 const LIST_STYLE: React.CSSProperties = { listStyle: 'none', margin: 0, paddingLeft: '12px', borderLeft: '1px solid #e9ebed' };
 const ITEM_STYLE: React.CSSProperties = { padding: '2px 0' };
 const ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0, overflow: 'hidden' };
@@ -190,25 +112,6 @@ const TYPE_STYLE: React.CSSProperties = {
   paddingLeft: '8px',
   color: '#5f6b7a',
   fontSize: '12px',
-};
-const EDIT_INPUT_STYLE: React.CSSProperties = {
-  flex: '1 1 auto',
-  minWidth: 0,
-  font: 'inherit',
-  padding: '0 2px',
-  border: '1px solid #9ba7b4',
-  borderRadius: '2px',
-};
-const REVERT_BUTTON_STYLE: React.CSSProperties = {
-  flexShrink: 0,
-  marginLeft: '6px',
-  padding: 0,
-  border: 'none',
-  background: 'none',
-  cursor: 'pointer',
-  color: '#5f6b7a',
-  fontSize: '12px',
-  lineHeight: 1,
 };
 const CARET_STYLE: React.CSSProperties = {
   width: '12px',

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
@@ -1,0 +1,219 @@
+import Box from '@cloudscape-design/components/box';
+import Icon from '@cloudscape-design/components/icon';
+import * as React from 'react';
+import type { WebConstructNode } from '../api';
+
+interface ConstructTreeProps {
+  readonly nodes: readonly WebConstructNode[];
+}
+
+/**
+ * Renders the construct hierarchy as a nested, indented list. Rows never spill
+ * past the panel: long labels truncate with an ellipsis and the tree clips
+ * horizontally. Nodes collapse via a caret (whole-row click). A node can be
+ * renamed by double-clicking its label; the override is persisted to
+ * localStorage and a revert control restores the default. Display-only.
+ */
+export function ConstructTree({ nodes }: ConstructTreeProps): JSX.Element {
+  const names = React.useContext(TreeNamesContext);
+  if (nodes.length === 0) {
+    return <Box color="text-status-inactive">No constructs.</Box>;
+  }
+  const list = (
+    <ul style={LIST_STYLE}>
+      {nodes.map((node) => (
+        <TreeNode key={node.path} node={node} />
+      ))}
+    </ul>
+  );
+  // Root render (no surrounding provider): own the rename store + the clip box.
+  if (!names) {
+    return (
+      <TreeNamesProvider>
+        <div style={TREE_VIEWPORT_STYLE}>{list}</div>
+      </TreeNamesProvider>
+    );
+  }
+  return list;
+}
+
+function TreeNode({ node }: { readonly node: WebConstructNode }): JSX.Element {
+  const names = React.useContext(TreeNamesContext)!;
+  const hasChildren = node.children.length > 0;
+  const [expanded, setExpanded] = React.useState(false);
+  const [editing, setEditing] = React.useState(false);
+
+  const override = names.overrides[node.path];
+  const defaultLabel = friendlyName(node);
+  const label = override ?? defaultLabel;
+
+  const commit = (raw: string): void => {
+    const value = raw.trim();
+    if (value && value !== defaultLabel) {
+      names.rename(node.path, value);
+    } else {
+      names.reset(node.path);
+    }
+    setEditing(false);
+  };
+
+  return (
+    <li style={ITEM_STYLE}>
+      <div
+        style={hasChildren ? ROW_CLICKABLE_STYLE : ROW_STYLE}
+        onClick={hasChildren && !editing ? () => setExpanded((e) => !e) : undefined}
+        role={hasChildren ? 'button' : undefined}
+        aria-expanded={hasChildren ? expanded : undefined}
+      >
+        {hasChildren ? <span style={CARET_STYLE}>{expanded ? '\u25be' : '\u25b8'}</span> : <span style={CARET_SPACER} />}
+        <Icon name={hasChildren ? 'folder' : 'file'} variant="subtle" />
+        {editing ? (
+          <input
+            autoFocus
+            defaultValue={label}
+            style={EDIT_INPUT_STYLE}
+            onFocus={(e) => e.currentTarget.select()}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commit(e.currentTarget.value);
+              else if (e.key === 'Escape') setEditing(false);
+            }}
+            onBlur={(e) => commit(e.currentTarget.value)}
+          />
+        ) : (
+          <span
+            style={LABEL_STYLE}
+            title={`${node.path} (double-click to rename)`}
+            onDoubleClick={() => setEditing(true)}
+          >
+            {label}
+          </span>
+        )}
+        {node.type && !editing && (
+          <span style={TYPE_STYLE} title={node.type}>
+            {friendlyType(node.type)}
+          </span>
+        )}
+        {override !== undefined && !editing && (
+          <button
+            type="button"
+            style={REVERT_BUTTON_STYLE}
+            title="Revert to default name"
+            aria-label="Revert to default name"
+            onClick={(e) => {
+              e.stopPropagation();
+              names.reset(node.path);
+            }}
+          >
+            {'\u21ba'}
+          </button>
+        )}
+      </div>
+      {hasChildren && expanded && <ConstructTree nodes={node.children} />}
+    </li>
+  );
+}
+
+/** Friendlier default label: a generic CDK id ("Resource"/"Default") shows its resource type instead. */
+function friendlyName(node: WebConstructNode): string {
+  if ((node.id === 'Resource' || node.id === 'Default') && node.type) {
+    return friendlyType(node.type);
+  }
+  return node.id;
+}
+
+/** "AWS::DynamoDB::Table" -> "DynamoDB Table". */
+function friendlyType(type: string): string {
+  return type.replace(/^AWS::/, '').split('::').join(' ');
+}
+
+interface TreeNames {
+  readonly overrides: Readonly<Record<string, string>>;
+  readonly rename: (path: string, name: string) => void;
+  readonly reset: (path: string) => void;
+}
+
+const TreeNamesContext = React.createContext<TreeNames | null>(null);
+const NAME_OVERRIDES_KEY = 'cdk-explorer:tree-name-overrides';
+
+/** Holds user rename overrides (keyed by construct path) and persists them to localStorage. */
+function TreeNamesProvider({ children }: { readonly children: React.ReactNode }): JSX.Element {
+  const [overrides, setOverrides] = React.useState<Record<string, string>>(loadOverrides);
+  React.useEffect(() => {
+    window.localStorage.setItem(NAME_OVERRIDES_KEY, JSON.stringify(overrides));
+  }, [overrides]);
+  const api = React.useMemo<TreeNames>(
+    () => ({
+      overrides,
+      rename: (path, name) => setOverrides((o) => ({ ...o, [path]: name })),
+      reset: (path) =>
+        setOverrides((o) => {
+          if (!(path in o)) return o;
+          const next = { ...o };
+          delete next[path];
+          return next;
+        }),
+    }),
+    [overrides],
+  );
+  return <TreeNamesContext.Provider value={api}>{children}</TreeNamesContext.Provider>;
+}
+
+/** Read persisted overrides; tolerate absent or corrupt storage by starting empty. */
+function loadOverrides(): Record<string, string> {
+  try {
+    const raw = window.localStorage.getItem(NAME_OVERRIDES_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+const TREE_VIEWPORT_STYLE: React.CSSProperties = { overflowX: 'hidden', overflowY: 'auto', maxHeight: '60vh' };
+const LIST_STYLE: React.CSSProperties = { listStyle: 'none', margin: 0, paddingLeft: '12px', borderLeft: '1px solid #e9ebed' };
+const ITEM_STYLE: React.CSSProperties = { padding: '2px 0' };
+const ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0, overflow: 'hidden' };
+const ROW_CLICKABLE_STYLE: React.CSSProperties = { ...ROW_STYLE, cursor: 'pointer' };
+const LABEL_STYLE: React.CSSProperties = {
+  flex: '1 1 auto',
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  fontWeight: 500,
+};
+const TYPE_STYLE: React.CSSProperties = {
+  flex: '0 1 auto',
+  minWidth: 0,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+  paddingLeft: '8px',
+  color: '#5f6b7a',
+  fontSize: '12px',
+};
+const EDIT_INPUT_STYLE: React.CSSProperties = {
+  flex: '1 1 auto',
+  minWidth: 0,
+  font: 'inherit',
+  padding: '0 2px',
+  border: '1px solid #9ba7b4',
+  borderRadius: '2px',
+};
+const REVERT_BUTTON_STYLE: React.CSSProperties = {
+  flexShrink: 0,
+  marginLeft: '6px',
+  padding: 0,
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  color: '#5f6b7a',
+  fontSize: '12px',
+  lineHeight: 1,
+};
+const CARET_STYLE: React.CSSProperties = {
+  width: '12px',
+  flexShrink: 0,
+  fontSize: '10px',
+  lineHeight: 1,
+};
+const CARET_SPACER: React.CSSProperties = { display: 'inline-block', width: '12px', flexShrink: 0 };

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
@@ -39,6 +39,8 @@ function TreeNode({ node, depth }: { readonly node: WebConstructNode; readonly d
   const label = friendlyName(node);
   const severity = node.highestSeverity;
   const severityColor = severity ? severityHexColor(severity) : undefined;
+  const inherited = !severity ? node.inheritedSeverity : undefined;
+  const inheritedColor = inherited ? severityHexColor(inherited) : undefined;
 
   return (
     <li style={ITEM_STYLE}>
@@ -57,7 +59,7 @@ function TreeNode({ node, depth }: { readonly node: WebConstructNode; readonly d
             aria-label={`${severity} violation`}
           />
         )}
-        <span style={severityColor ? { ...LABEL_STYLE, color: severityColor } : LABEL_STYLE} title={node.path}>
+        <span style={labelStyle(severityColor, inheritedColor)} title={node.path}>
           {label}
         </span>
         {node.type && (
@@ -82,6 +84,12 @@ function friendlyName(node: WebConstructNode): string {
 /** "AWS::DynamoDB::Table" -> "DynamoDB Table". */
 function friendlyType(type: string): string {
   return type.replace(/^AWS::/, '').split('::').join(' ');
+}
+
+function labelStyle(severityColor: string | undefined, inheritedColor: string | undefined): React.CSSProperties {
+  if (severityColor) return { ...LABEL_STYLE, color: severityColor };
+  if (inheritedColor) return { ...LABEL_STYLE, color: inheritedColor, opacity: 0.7 };
+  return LABEL_STYLE;
 }
 
 const TREE_VIEWPORT_STYLE: React.CSSProperties = { overflowX: 'hidden', overflowY: 'auto', height: '100%' };

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
@@ -8,7 +8,6 @@ import type { WebViolation } from '../api';
 
 interface ViolationsPanelProps {
   readonly violations: readonly WebViolation[];
-  readonly reportError?: string;
 }
 
 /**
@@ -16,10 +15,7 @@ interface ViolationsPanelProps {
  * severity, each a collapsible row led by a colored severity indicator, with
  * the rule, affected-construct count, and plugin source.
  */
-export function ViolationsPanel({ violations, reportError }: ViolationsPanelProps): JSX.Element {
-  if (reportError) {
-    return <Box color="text-status-error">Validation report failed to load: {reportError}</Box>;
-  }
+export function ViolationsPanel({ violations }: ViolationsPanelProps): JSX.Element {
   if (violations.length === 0) {
     return <StatusIndicator type="success">No policy violations.</StatusIndicator>;
   }

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
@@ -66,7 +66,7 @@ function ViolationItem({ violation }: { readonly violation: WebViolation }): JSX
   );
 }
 
-function severityStyle(severity: string | undefined): React.CSSProperties {
+function severityStyle(severity: string): React.CSSProperties {
   return { color: severityHexColor(severity), fontWeight: 700 };
 }
 

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
@@ -1,7 +1,9 @@
 import Box from '@cloudscape-design/components/box';
+import ExpandableSection from '@cloudscape-design/components/expandable-section';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import StatusIndicator from '@cloudscape-design/components/status-indicator';
 import * as React from 'react';
+import { displaySeverity, severityHexColor, severityRank } from '../../lib/web/severity';
 import type { WebViolation } from '../api';
 
 interface ViolationsPanelProps {
@@ -33,77 +35,42 @@ export function ViolationsPanel({ violations, reportError }: ViolationsPanelProp
   );
 }
 
-const SCROLL_STYLE: React.CSSProperties = { maxHeight: '55vh', overflowY: 'auto' };
-
 function ViolationItem({ violation }: { readonly violation: WebViolation }): JSX.Element {
-  const [expanded, setExpanded] = React.useState(false);
+  const severity = displaySeverity(violation);
   const count = violation.occurrences.length;
   return (
-    <Box>
-      <button type="button" style={HEADER_STYLE} aria-expanded={expanded} onClick={() => setExpanded((e) => !e)}>
-        <span style={CARET_STYLE}>{expanded ? '\u25be' : '\u25b8'}</span>
-        <span style={severityStyle(displaySeverity(violation))}>[{displaySeverity(violation).toUpperCase()}]</span>
-        <span style={RULE_STYLE}>{violation.ruleName}</span>
-        <Box variant="span" color="text-status-inactive">
-          {count} {count === 1 ? 'construct' : 'constructs'} \u00b7 {violation.source}
-        </Box>
-      </button>
-      {expanded && (
-        <Box padding={{ left: 'xl', top: 'xxs' }}>
-          <SpaceBetween size="xxs">
-            <Box>{violation.description}</Box>
-            {violation.suggestedFix && <Box variant="small">Suggested fix: {violation.suggestedFix}</Box>}
-            {violation.occurrences.map((occ, i) => (
-              <Box key={`${occ.constructPath}:${i}`} variant="small" color="text-status-inactive">
-                {occ.constructPath}
-                {occ.logicalId ? ` \u2192 ${occ.logicalId}` : ''}
-                {occ.templateFile ? ` (${occ.templateFile})` : ''}
-              </Box>
-            ))}
-          </SpaceBetween>
-        </Box>
-      )}
-    </Box>
+    <ExpandableSection
+      variant="footer"
+      headerText={
+        <span style={HEADER_STYLE}>
+          <span style={severityStyle(severity)}>[{severity.toUpperCase()}]</span>
+          <span style={RULE_STYLE}>{violation.ruleName}</span>
+          <span style={META_STYLE}>
+            {count} {count === 1 ? 'construct' : 'constructs'} {'·'} {violation.source}
+          </span>
+        </span>
+      }
+    >
+      <SpaceBetween size="xxs">
+        <Box>{violation.description}</Box>
+        {violation.suggestedFix && <Box variant="small">Suggested fix: {violation.suggestedFix}</Box>}
+        {violation.occurrences.map((occ, i) => (
+          <Box key={`${occ.constructPath}:${i}`} variant="small" color="text-status-inactive">
+            {occ.constructPath}
+            {occ.logicalId ? ` → ${occ.logicalId}` : ''}
+            {occ.templateFile ? ` (${occ.templateFile})` : ''}
+          </Box>
+        ))}
+      </SpaceBetween>
+    </ExpandableSection>
   );
 }
 
-/** Lower-cased severity so 'Error'/'ERROR'/'error' all map (matching cdk validate). */
-function normalize(severity: string | undefined): string {
-  return (severity ?? '').toLowerCase();
-}
-
-/** Severity for display: a plugin's custom label, else the reported severity, else 'warning' (matching cdk validate's default for severity-less plugins like CfnGuard). */
-function displaySeverity(violation: WebViolation): string {
-  return violation.customSeverity ?? violation.severity ?? 'warning';
-}
-
-/** Severity text colors mirroring `cdk validate`'s scheme: fatal red, error orange, warning amber, info blue. */
-const SEVERITY_HEX: Record<string, string> = {
-  fatal: '#d91515',
-  error: '#e07700',
-  warning: '#8d6605',
-  info: '#0972d3',
-  custom: '#5f6b7a',
-};
 function severityStyle(severity: string | undefined): React.CSSProperties {
-  return { color: SEVERITY_HEX[normalize(severity)] ?? '#5f6b7a', fontWeight: 700 };
+  return { color: severityHexColor(severity), fontWeight: 700 };
 }
 
-const SEVERITY_RANK: Record<string, number> = { fatal: 0, error: 1, warning: 2, info: 3, custom: 4 };
-function severityRank(severity: string | undefined): number {
-  return SEVERITY_RANK[normalize(severity)] ?? 5;
-}
-
-const HEADER_STYLE: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '6px',
-  background: 'none',
-  border: 'none',
-  cursor: 'pointer',
-  padding: 0,
-  width: '100%',
-  textAlign: 'left',
-};
-const CARET_STYLE: React.CSSProperties = { width: '10px', fontSize: '10px', lineHeight: 1, color: 'inherit' };
+const SCROLL_STYLE: React.CSSProperties = { maxHeight: '100%', overflowY: 'auto' };
+const HEADER_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '8px' };
 const RULE_STYLE: React.CSSProperties = { fontWeight: 700 };
+const META_STYLE: React.CSSProperties = { color: '#5f6b7a', fontWeight: 400, fontSize: '12px' };

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
@@ -1,0 +1,109 @@
+import Box from '@cloudscape-design/components/box';
+import SpaceBetween from '@cloudscape-design/components/space-between';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import * as React from 'react';
+import type { WebViolation } from '../api';
+
+interface ViolationsPanelProps {
+  readonly violations: readonly WebViolation[];
+  readonly reportError?: string;
+}
+
+/**
+ * Renders policy-validation violations like a Problems panel: sorted by
+ * severity, each a collapsible row led by a colored severity indicator, with
+ * the rule, affected-construct count, and plugin source.
+ */
+export function ViolationsPanel({ violations, reportError }: ViolationsPanelProps): JSX.Element {
+  if (reportError) {
+    return <Box color="text-status-error">Validation report failed to load: {reportError}</Box>;
+  }
+  if (violations.length === 0) {
+    return <StatusIndicator type="success">No policy violations.</StatusIndicator>;
+  }
+  const sorted = [...violations].sort((a, b) => severityRank(displaySeverity(a)) - severityRank(displaySeverity(b)));
+  return (
+    <div style={SCROLL_STYLE}>
+      <SpaceBetween size="xs">
+        {sorted.map((violation, i) => (
+          <ViolationItem key={`${violation.source}:${violation.ruleName}:${i}`} violation={violation} />
+        ))}
+      </SpaceBetween>
+    </div>
+  );
+}
+
+const SCROLL_STYLE: React.CSSProperties = { maxHeight: '55vh', overflowY: 'auto' };
+
+function ViolationItem({ violation }: { readonly violation: WebViolation }): JSX.Element {
+  const [expanded, setExpanded] = React.useState(false);
+  const count = violation.occurrences.length;
+  return (
+    <Box>
+      <button type="button" style={HEADER_STYLE} aria-expanded={expanded} onClick={() => setExpanded((e) => !e)}>
+        <span style={CARET_STYLE}>{expanded ? '\u25be' : '\u25b8'}</span>
+        <span style={severityStyle(displaySeverity(violation))}>[{displaySeverity(violation).toUpperCase()}]</span>
+        <span style={RULE_STYLE}>{violation.ruleName}</span>
+        <Box variant="span" color="text-status-inactive">
+          {count} {count === 1 ? 'construct' : 'constructs'} \u00b7 {violation.source}
+        </Box>
+      </button>
+      {expanded && (
+        <Box padding={{ left: 'xl', top: 'xxs' }}>
+          <SpaceBetween size="xxs">
+            <Box>{violation.description}</Box>
+            {violation.suggestedFix && <Box variant="small">Suggested fix: {violation.suggestedFix}</Box>}
+            {violation.occurrences.map((occ, i) => (
+              <Box key={`${occ.constructPath}:${i}`} variant="small" color="text-status-inactive">
+                {occ.constructPath}
+                {occ.logicalId ? ` \u2192 ${occ.logicalId}` : ''}
+                {occ.templateFile ? ` (${occ.templateFile})` : ''}
+              </Box>
+            ))}
+          </SpaceBetween>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/** Lower-cased severity so 'Error'/'ERROR'/'error' all map (matching cdk validate). */
+function normalize(severity: string | undefined): string {
+  return (severity ?? '').toLowerCase();
+}
+
+/** Severity for display: a plugin's custom label, else the reported severity, else 'warning' (matching cdk validate's default for severity-less plugins like CfnGuard). */
+function displaySeverity(violation: WebViolation): string {
+  return violation.customSeverity ?? violation.severity ?? 'warning';
+}
+
+/** Severity text colors mirroring `cdk validate`'s scheme: fatal red, error orange, warning amber, info blue. */
+const SEVERITY_HEX: Record<string, string> = {
+  fatal: '#d91515',
+  error: '#e07700',
+  warning: '#8d6605',
+  info: '#0972d3',
+  custom: '#5f6b7a',
+};
+function severityStyle(severity: string | undefined): React.CSSProperties {
+  return { color: SEVERITY_HEX[normalize(severity)] ?? '#5f6b7a', fontWeight: 700 };
+}
+
+const SEVERITY_RANK: Record<string, number> = { fatal: 0, error: 1, warning: 2, info: 3, custom: 4 };
+function severityRank(severity: string | undefined): number {
+  return SEVERITY_RANK[normalize(severity)] ?? 5;
+}
+
+const HEADER_STYLE: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '6px',
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  padding: 0,
+  width: '100%',
+  textAlign: 'left',
+};
+const CARET_STYLE: React.CSSProperties = { width: '10px', fontSize: '10px', lineHeight: 1, color: 'inherit' };
+const RULE_STYLE: React.CSSProperties = { fontWeight: 700 };

--- a/packages/@aws-cdk/cdk-explorer/frontend/index.html
+++ b/packages/@aws-cdk/cdk-explorer/frontend/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>CDK Web Explorer</title>
     <link rel="stylesheet" href="./bundle.css" />
+    <style>
+      html, body, #root { height: 100%; margin: 0; }
+      body { overflow: hidden; }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -116,10 +116,8 @@ export interface WebViolation {
 /**
  * Response for `GET /api/policy-validation`. `not-synthesized` mirrors the tree
  * endpoint: no cloud assembly was found. When the assembly exists, `violations`
- * is the normalized list (empty when the report is clean or absent), and
- * `reportError` is set only when a report file was present but could not be
- * read or parsed (the tree endpoint is unaffected).
+ * is the normalized list (empty when the report is clean or absent).
  */
 export type ViolationsResponse =
-  | { readonly status: 'ok'; readonly violations: readonly WebViolation[]; readonly reportError?: string }
+  | { readonly status: 'ok'; readonly violations: readonly WebViolation[] }
   | { readonly status: 'not-synthesized' };

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -16,3 +16,103 @@ export interface FileResponse {
   readonly path: string;
   readonly content: string;
 }
+
+/**
+ * A construct's source location for the SPA. Mirrors the core `SourceLocation`
+ * but with `file` made app-relative (POSIX), so the client can feed it straight
+ * back into `/api/file`. Line and column are 1-based, or 0 when only the file
+ * is known.
+ */
+export interface WebSourceLocation {
+  /** Source file path relative to the app directory. POSIX separators. */
+  readonly file: string;
+  readonly line: number;
+  readonly column: number;
+}
+
+/**
+ * A construct tree node as served to the SPA. A trimmed, wire-stable view of
+ * the core `ConstructNode`: absolute source paths are relativized to the app
+ * directory and nothing internal leaks over the wire.
+ */
+export interface WebConstructNode {
+  /** Construct path, e.g. "MyStack/DataBucket". */
+  readonly path: string;
+  readonly id: string;
+  /** CFN resource type (e.g. "AWS::S3::Bucket"), if this construct is a resource. */
+  readonly type?: string;
+  /** CFN logical ID, if this construct maps to a resource. */
+  readonly logicalId?: string;
+  /**
+   * Path to the synthesized template that declares this construct's CFN
+   * resource, relative to the cloud assembly (`cdk.out`) directory, with POSIX
+   * separators. Usually a bare name like "MyStack.template.json", but includes
+   * the sub-assembly directory for staged stacks, e.g.
+   * "assembly-Prod/Prod-MyStack.template.json". Only set for CFN resources. The
+   * core's absolute path is relativized before it crosses the wire.
+   */
+  readonly templateFile?: string;
+  readonly sourceLocation?: WebSourceLocation;
+  readonly children: readonly WebConstructNode[];
+}
+
+/**
+ * Response for `GET /api/tree`. `not-synthesized` means no cloud assembly was
+ * found (the user has not run `cdk synth`)
+ */
+export type TreeResponse =
+  | { readonly status: 'ok'; readonly tree: readonly WebConstructNode[]; readonly warnings: readonly string[] }
+  | { readonly status: 'not-synthesized' };
+
+/**
+ * Severity exactly as reported by CDK policy validation. Unlike the LSP, which
+ * collapses these onto its three diagnostic levels, the SPA keeps the full set
+ * so the violations panel can distinguish (for example) fatal from error.
+ */
+export type WebViolationSeverity = 'fatal' | 'error' | 'warning' | 'info' | 'custom';
+
+/**
+ * A single construct that triggered a violation, joined to construct-tree data
+ * so the panel can navigate to the resource and its source.
+ */
+export interface WebViolationOccurrence {
+  /** Construct path of the offending construct, e.g. "MyStack/MyBucket". */
+  readonly constructPath: string;
+  /** CFN logical ID of the offending resource, if known. */
+  readonly logicalId?: string;
+  /**
+   * Template that declares the resource, relative to the cloud assembly
+   * (`cdk.out`) directory with POSIX separators (see {@link WebConstructNode.templateFile}).
+   */
+  readonly templateFile?: string;
+  /** Resolved user source location; absent for non-TypeScript apps. */
+  readonly sourceLocation?: WebSourceLocation;
+  /** JSON property paths within the resource that violate the rule. */
+  readonly propertyPaths?: readonly string[];
+}
+
+/** A policy-validation violation, normalized for the SPA. */
+export interface WebViolation {
+  readonly ruleName: string;
+  readonly description: string;
+  /** Severity as reported; absent for plugins (e.g. CfnGuard) that don't emit one. */
+  readonly severity?: WebViolationSeverity;
+  /** Plugin-specific label when `severity` is "custom". */
+  readonly customSeverity?: string;
+  /** Validation plugin that produced the violation. */
+  readonly source: string;
+  /** Suggested fix text, when the plugin provides one. */
+  readonly suggestedFix?: string;
+  readonly occurrences: readonly WebViolationOccurrence[];
+}
+
+/**
+ * Response for `GET /api/policy-validation`. `not-synthesized` mirrors the tree
+ * endpoint: no cloud assembly was found. When the assembly exists, `violations`
+ * is the normalized list (empty when the report is clean or absent), and
+ * `reportError` is set only when a report file was present but could not be
+ * read or parsed (the tree endpoint is unaffected).
+ */
+export type ViolationsResponse =
+  | { readonly status: 'ok'; readonly violations: readonly WebViolation[]; readonly reportError?: string }
+  | { readonly status: 'not-synthesized' };

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -53,6 +53,12 @@ export interface WebConstructNode {
    */
   readonly templateFile?: string;
   readonly sourceLocation?: WebSourceLocation;
+  /**
+   * Highest-severity policy-violation label affecting this construct. A folded
+   * default child's violations count toward its parent. Absent when the
+   * construct has no violation. Used to flag the node in the tree.
+   */
+  readonly highestSeverity?: string;
   readonly children: readonly WebConstructNode[];
 }
 
@@ -73,7 +79,8 @@ export type WebViolationSeverity = 'fatal' | 'error' | 'warning' | 'info' | 'cus
 
 /**
  * A single construct that triggered a violation, joined to construct-tree data
- * so the panel can navigate to the resource and its source.
+ * (resolved source location and template file) so a future navigation feature
+ * can link to the resource and its source.
  */
 export interface WebViolationOccurrence {
   /** Construct path of the offending construct, e.g. "MyStack/MyBucket". */

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -59,6 +59,12 @@ export interface WebConstructNode {
    * construct has no violation. Used to flag the node in the tree.
    */
   readonly highestSeverity?: string;
+  /**
+   * Highest severity inherited from any descendant. Set when a child (or
+   * deeper) has a violation but this node does not. Lets the tree color
+   * ancestor labels so users can drill down to the offending construct.
+   */
+  readonly inheritedSeverity?: string;
   readonly children: readonly WebConstructNode[];
 }
 

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -2,15 +2,16 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
 import type { PolicyValidationReportJson, ViolatingConstructJson } from '@aws-cdk/cloud-assembly-schema';
-import { type Router, type Express } from 'express';
+import { type Router, type Express, type Response } from 'express';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
 import type { DirEntry, TreeResponse, ViolationsResponse, WebConstructNode, WebSourceLocation, WebViolation, WebViolationOccurrence } from './protocol';
 import { resolveWithinRoot } from './safe-path';
-import { readAssembly as defaultReadAssembly, type AssemblyReadResult, type ConstructNode } from '../core/assembly-reader';
+import { classifyReportSeverity, displaySeverity, severityRank } from './severity';
+import { readAssembly as defaultReadAssembly, type AssemblyData, type AssemblyReadResult, type ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
 
-/** Largest file the viewer will return inline, to avoid streaming huge artifacts. */
+/** Largest file the viewer returns inline, to avoid buffering huge artifacts into memory and the response. */
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
 
 export interface ApiOptions {
@@ -85,32 +86,21 @@ export function createApiRouter(options: ApiOptions): Router {
   });
 
   router.get('/tree', (_req, res) => {
-    const result = readAssembly(assemblyDir);
-    if (result.status === 'not-found') {
-      const body: TreeResponse = { status: 'not-synthesized' };
-      return res.json(body);
-    }
-    if (result.status === 'error') {
-      return res.status(500).json({ error: result.message });
-    }
-    const tree = result.data.tree.map((node) => toWebNode(collapseDefaultChildren(node), assemblyDir, appDir));
-    const body: TreeResponse = { status: 'ok', tree, warnings: result.data.warnings };
-    return res.json(body);
+    withAssembly(readAssembly(assemblyDir), res, (data) => {
+      const severityByPath = highestSeverityByPath(data.violations);
+      const tree = data.tree.map((node) => toWebNode(node, severityByPath, assemblyDir, appDir));
+      const body: TreeResponse = { status: 'ok', tree, warnings: data.warnings };
+      res.json(body);
+    });
   });
 
   router.get('/policy-validation', (_req, res) => {
-    const result = readAssembly(assemblyDir);
-    if (result.status === 'not-found') {
-      const body: ViolationsResponse = { status: 'not-synthesized' };
-      return res.json(body);
-    }
-    if (result.status === 'error') {
-      return res.status(500).json({ error: result.message });
-    }
-    const index = ConstructIndex.fromTree(result.data.tree);
-    const violations = normalizeViolations(result.data.violations, index, assemblyDir, appDir);
-    const body: ViolationsResponse = { status: 'ok', violations, reportError: result.data.violationsError };
-    return res.json(body);
+    withAssembly(readAssembly(assemblyDir), res, (data) => {
+      const index = ConstructIndex.fromTree(data.tree);
+      const violations = normalizeViolations(data.violations, index, assemblyDir, appDir);
+      const body: ViolationsResponse = { status: 'ok', violations, reportError: data.violationsError };
+      res.json(body);
+    });
   });
 
   return router;
@@ -121,54 +111,102 @@ export function registerApi(app: Express, options: ApiOptions): void {
 }
 
 /**
- * Map a core construct node to its wire form. Absolute filesystem paths are
- * relativized to roots the client can resolve: `templateFile` to the cloud
- * assembly directory, `sourceLocation.file` to the app directory. A source
- * location that resolves outside the app directory is dropped, since
- * `/api/file` cannot serve it. Recurses over children.
+ * Read the cloud assembly and send the shared not-synthesized / error responses,
+ * invoking `onReady` with the assembly data only on success.
  */
-export function toWebNode(node: ConstructNode, assemblyDir: string, appDir: string): WebConstructNode {
-  return {
-    path: node.path,
-    id: node.id,
-    type: node.type,
-    logicalId: node.logicalId,
-    templateFile: node.templateFile ? toPosix(path.relative(assemblyDir, node.templateFile)) : undefined,
-    sourceLocation: toWebSourceLocation(node.sourceLocation, appDir),
-    children: node.children.map((child) => toWebNode(child, assemblyDir, appDir)),
-  };
+function withAssembly(
+  result: AssemblyReadResult,
+  res: Response,
+  onReady: (data: AssemblyData) => void,
+): void {
+  if (result.status === 'not-found') {
+    res.json({ status: 'not-synthesized' });
+    return;
+  }
+  if (result.status === 'error') {
+    res.status(500).json({ error: result.message });
+    return;
+  }
+  onReady(result.data);
 }
 
 /** Ids CDK gives a construct's synthetic default child (the L1 resource it wraps). */
 const DEFAULT_CHILD_IDS = new Set(['Resource', 'Default']);
 
 /**
- * Fold each construct's synthetic default child (the leaf L1 resource CDK names
- * "Resource" or "Default") up into its parent, so an L2 like `ItemsTable` shows
- * its CFN type directly instead of nesting a redundant `Resource` leaf. The
- * parent absorbs the child's CFN identity (type, logicalId, templateFile) and
- * the child is dropped. Only a leaf default child carrying a CFN type collapses,
- * so resources that nest further children are left intact. Recurses depth-first.
- *
- * Display-only: violation joining still keys off the full (uncollapsed) tree,
- * whose construct paths end in ".../Resource".
+ * Map a core construct node to its wire form, owning every transform the
+ * displayed tree needs:
+ * - Relativizes paths the client can't resolve (`templateFile` to the cloud
+ *   assembly, `sourceLocation.file` to the app dir; a source location outside
+ *   the app dir is dropped, since `/api/file` cannot serve it).
+ * - Folds a synthetic default child (the leaf L1 resource CDK names "Resource"
+ *   or "Default", carrying a CFN type) up into its parent, so an L2 like
+ *   `ItemsTable` shows its CFN type directly instead of nesting a redundant
+ *   leaf. Only a leaf default child with a type collapses; a resource that
+ *   nests further children is left intact.
+ * - Annotates each node with the highest severity of any violation on it,
+ *   folding an absorbed default child's severity into the parent so the dot
+ *   tracks the displayed node. Because the join happens here, the client never
+ *   re-derives the collapse rule.
+ * Recurses depth-first.
  */
-export function collapseDefaultChildren(node: ConstructNode): ConstructNode {
-  const children = node.children.map(collapseDefaultChildren);
+export function toWebNode(
+  node: ConstructNode,
+  severityByPath: ReadonlyMap<string, string>,
+  assemblyDir: string,
+  appDir: string,
+): WebConstructNode {
+  const children = node.children.map((child) => toWebNode(child, severityByPath, assemblyDir, appDir));
+  const ownSeverity = severityByPath.get(node.path);
   const defaultChild = children.find(
     (child) => DEFAULT_CHILD_IDS.has(child.id) && child.children.length === 0 && child.type !== undefined,
   );
   if (!defaultChild) {
-    return { ...node, children };
+    return {
+      path: node.path,
+      id: node.id,
+      type: node.type,
+      logicalId: node.logicalId,
+      templateFile: node.templateFile ? toPosix(path.relative(assemblyDir, node.templateFile)) : undefined,
+      sourceLocation: toWebSourceLocation(node.sourceLocation, appDir),
+      highestSeverity: ownSeverity,
+      children,
+    };
   }
   return {
-    ...node,
+    path: node.path,
+    id: node.id,
     type: defaultChild.type,
     logicalId: defaultChild.logicalId,
     templateFile: defaultChild.templateFile,
-    sourceLocation: node.sourceLocation ?? defaultChild.sourceLocation,
+    sourceLocation: toWebSourceLocation(node.sourceLocation, appDir) ?? defaultChild.sourceLocation,
+    highestSeverity: moreSevere(ownSeverity, defaultChild.highestSeverity),
     children: children.filter((child) => child !== defaultChild),
   };
+}
+
+/** Build a construct-path to highest-severity-label map from a (raw) validation report. */
+function highestSeverityByPath(report: PolicyValidationReportJson | undefined): Map<string, string> {
+  const byPath = new Map<string, string>();
+  for (const plugin of report?.pluginReports ?? []) {
+    for (const violation of plugin.violations ?? []) {
+      const label = displaySeverity(classifyReportSeverity(violation.severity, violation.customSeverity));
+      for (const vc of violation.violatingConstructs ?? []) {
+        const existing = byPath.get(vc.constructPath);
+        if (existing === undefined || severityRank(label) < severityRank(existing)) {
+          byPath.set(vc.constructPath, label);
+        }
+      }
+    }
+  }
+  return byPath;
+}
+
+/** The more severe of two severity labels (lower rank = more severe); undefined loses to any defined label. */
+function moreSevere(a: string | undefined, b: string | undefined): string | undefined {
+  if (a === undefined) return b;
+  if (b === undefined) return a;
+  return severityRank(a) <= severityRank(b) ? a : b;
 }
 
 /** Relativize a source location to the app dir, dropping any that escape it. */
@@ -181,10 +219,10 @@ function toWebSourceLocation(loc: SourceLocation | undefined, appDir: string): W
 
 /**
  * Normalize a policy-validation report into the SPA's flat violation model.
- * Each violating construct is joined to the construct tree (by path) so the
- * panel can navigate to the resource and its source: the resolved
- * `sourceLocation` and `cdk.out`-relative `templateFile` come from the tree
- * node when present, falling back to the report's own resource fields.
+ * Each violating construct is joined to the construct tree (by path): the
+ * resolved `sourceLocation` and `cdk.out`-relative `templateFile` come from the
+ * tree node when present, falling back to the report's own resource fields.
+ * These carry the data a future navigation feature would link from.
  */
 export function normalizeViolations(
   report: PolicyValidationReportJson | undefined,
@@ -193,14 +231,13 @@ export function normalizeViolations(
   appDir: string,
 ): WebViolation[] {
   return (report?.pluginReports ?? []).flatMap((plugin) =>
-    plugin.violations.map((violation) => ({
+    (plugin.violations ?? []).map((violation) => ({
       ruleName: violation.ruleName,
       description: violation.description,
-      severity: violation.severity,
-      customSeverity: violation.customSeverity,
+      ...classifyReportSeverity(violation.severity, violation.customSeverity),
       source: plugin.pluginName,
       suggestedFix: violation.suggestedFix,
-      occurrences: violation.violatingConstructs.map((vc) => toOccurrence(vc, index, assemblyDir, appDir)),
+      occurrences: (violation.violatingConstructs ?? []).map((vc) => toOccurrence(vc, index, assemblyDir, appDir)),
     })));
 }
 

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -98,7 +98,7 @@ export function createApiRouter(options: ApiOptions): Router {
     withAssembly(readAssembly(assemblyDir), res, (data) => {
       const index = ConstructIndex.fromTree(data.tree);
       const violations = normalizeViolations(data.violations, index, assemblyDir, appDir);
-      const body: ViolationsResponse = { status: 'ok', violations, reportError: data.violationsError };
+      const body: ViolationsResponse = { status: 'ok', violations };
       res.json(body);
     });
   });

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -26,7 +26,7 @@ export interface ApiOptions {
    * Reader for the cloud assembly. Injectable for tests; defaults to the real
    * `readAssembly` against {@link assemblyDir}.
    */
-  readonly readAssembly?: (assemblyDir: string) => AssemblyReadResult;
+  readonly readAssembly?: (assemblyDir: string) => AssemblyReadResult | Promise<AssemblyReadResult>;
 }
 
 export function createApiRouter(options: ApiOptions): Router {
@@ -37,6 +37,10 @@ export function createApiRouter(options: ApiOptions): Router {
 
   router.get('/health', (_req, res) => {
     res.json({ status: 'ok' });
+  });
+
+  router.get('/info', (_req, res) => {
+    res.json({ appDir });
   });
 
   router.get('/files', (req, res) => {
@@ -85,8 +89,8 @@ export function createApiRouter(options: ApiOptions): Router {
     return res.json({ path: toPosix(path.relative(appDir, resolved)), content: buffer.toString('utf-8') });
   });
 
-  router.get('/tree', (_req, res) => {
-    withAssembly(readAssembly(assemblyDir), res, (data) => {
+  router.get('/tree', async (_req, res) => {
+    withAssembly(await readAssembly(assemblyDir), res, (data) => {
       const severityByPath = highestSeverityByPath(data.violations);
       const tree = data.tree.map((node) => toWebNode(node, severityByPath, assemblyDir, appDir));
       const body: TreeResponse = { status: 'ok', tree, warnings: data.warnings };
@@ -94,8 +98,8 @@ export function createApiRouter(options: ApiOptions): Router {
     });
   });
 
-  router.get('/policy-validation', (_req, res) => {
-    withAssembly(readAssembly(assemblyDir), res, (data) => {
+  router.get('/policy-validation', async (_req, res) => {
+    withAssembly(await readAssembly(assemblyDir), res, (data) => {
       const index = ConstructIndex.fromTree(data.tree);
       const violations = normalizeViolations(data.violations, index, assemblyDir, appDir);
       const body: ViolationsResponse = { status: 'ok', violations };
@@ -162,6 +166,8 @@ export function toWebNode(
     (child) => DEFAULT_CHILD_IDS.has(child.id) && child.children.length === 0 && child.type !== undefined,
   );
   if (!defaultChild) {
+    const highestSeverity = ownSeverity;
+    const inheritedSeverity = highestSeverity ? undefined : worstChildSeverity(children);
     return {
       path: node.path,
       id: node.id,
@@ -169,10 +175,14 @@ export function toWebNode(
       logicalId: node.logicalId,
       templateFile: node.templateFile ? toPosix(path.relative(assemblyDir, node.templateFile)) : undefined,
       sourceLocation: toWebSourceLocation(node.sourceLocation, appDir),
-      highestSeverity: ownSeverity,
+      highestSeverity,
+      ...(inheritedSeverity && { inheritedSeverity }),
       children,
     };
   }
+  const highestSeverity = moreSevere(ownSeverity, defaultChild.highestSeverity);
+  const remainingChildren = children.filter((child) => child !== defaultChild);
+  const inheritedSeverity = highestSeverity ? undefined : worstChildSeverity(remainingChildren);
   return {
     path: node.path,
     id: node.id,
@@ -180,8 +190,9 @@ export function toWebNode(
     logicalId: defaultChild.logicalId,
     templateFile: defaultChild.templateFile,
     sourceLocation: toWebSourceLocation(node.sourceLocation, appDir) ?? defaultChild.sourceLocation,
-    highestSeverity: moreSevere(ownSeverity, defaultChild.highestSeverity),
-    children: children.filter((child) => child !== defaultChild),
+    highestSeverity,
+    ...(inheritedSeverity && { inheritedSeverity }),
+    children: remainingChildren,
   };
 }
 
@@ -207,6 +218,15 @@ function moreSevere(a: string | undefined, b: string | undefined): string | unde
   if (a === undefined) return b;
   if (b === undefined) return a;
   return severityRank(a) <= severityRank(b) ? a : b;
+}
+
+/** The worst severity across all children (direct or inherited). */
+function worstChildSeverity(children: readonly WebConstructNode[]): string | undefined {
+  let worst: string | undefined;
+  for (const child of children) {
+    worst = moreSevere(worst, child.highestSeverity ?? child.inheritedSeverity);
+  }
+  return worst;
 }
 
 /** Relativize a source location to the app dir, dropping any that escape it. */

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -1,10 +1,14 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
+import type { PolicyValidationReportJson, ViolatingConstructJson } from '@aws-cdk/cloud-assembly-schema';
 import { type Router, type Express } from 'express';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
-import type { DirEntry } from './protocol';
+import type { DirEntry, TreeResponse, ViolationsResponse, WebConstructNode, WebSourceLocation, WebViolation, WebViolationOccurrence } from './protocol';
 import { resolveWithinRoot } from './safe-path';
+import { readAssembly as defaultReadAssembly, type AssemblyReadResult, type ConstructNode } from '../core/assembly-reader';
+import type { SourceLocation } from '../core/source-resolver';
 
 /** Largest file the viewer will return inline, to avoid streaming huge artifacts. */
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
@@ -12,10 +16,22 @@ const MAX_FILE_BYTES = 2 * 1024 * 1024;
 export interface ApiOptions {
   /** Root of the CDK app; all file listing/reading is confined to this directory. */
   readonly appDir: string;
+  /**
+   * Cloud assembly directory the construct tree and violations are read from.
+   * Defaults to `<appDir>/cdk.out`.
+   */
+  readonly assemblyDir?: string;
+  /**
+   * Reader for the cloud assembly. Injectable for tests; defaults to the real
+   * `readAssembly` against {@link assemblyDir}.
+   */
+  readonly readAssembly?: (assemblyDir: string) => AssemblyReadResult;
 }
 
 export function createApiRouter(options: ApiOptions): Router {
   const appDir = canonicalDir(options.appDir);
+  const assemblyDir = options.assemblyDir ?? path.join(options.appDir, 'cdk.out');
+  const readAssembly = options.readAssembly ?? defaultReadAssembly;
   const router = express.Router();
 
   router.get('/health', (_req, res) => {
@@ -68,11 +84,144 @@ export function createApiRouter(options: ApiOptions): Router {
     return res.json({ path: toPosix(path.relative(appDir, resolved)), content: buffer.toString('utf-8') });
   });
 
+  router.get('/tree', (_req, res) => {
+    const result = readAssembly(assemblyDir);
+    if (result.status === 'not-found') {
+      const body: TreeResponse = { status: 'not-synthesized' };
+      return res.json(body);
+    }
+    if (result.status === 'error') {
+      return res.status(500).json({ error: result.message });
+    }
+    const tree = result.data.tree.map((node) => toWebNode(collapseDefaultChildren(node), assemblyDir, appDir));
+    const body: TreeResponse = { status: 'ok', tree, warnings: result.data.warnings };
+    return res.json(body);
+  });
+
+  router.get('/policy-validation', (_req, res) => {
+    const result = readAssembly(assemblyDir);
+    if (result.status === 'not-found') {
+      const body: ViolationsResponse = { status: 'not-synthesized' };
+      return res.json(body);
+    }
+    if (result.status === 'error') {
+      return res.status(500).json({ error: result.message });
+    }
+    const index = ConstructIndex.fromTree(result.data.tree);
+    const violations = normalizeViolations(result.data.violations, index, assemblyDir, appDir);
+    const body: ViolationsResponse = { status: 'ok', violations, reportError: result.data.violationsError };
+    return res.json(body);
+  });
+
   return router;
 }
 
 export function registerApi(app: Express, options: ApiOptions): void {
   app.use('/api', createApiRouter(options));
+}
+
+/**
+ * Map a core construct node to its wire form. Absolute filesystem paths are
+ * relativized to roots the client can resolve: `templateFile` to the cloud
+ * assembly directory, `sourceLocation.file` to the app directory. A source
+ * location that resolves outside the app directory is dropped, since
+ * `/api/file` cannot serve it. Recurses over children.
+ */
+export function toWebNode(node: ConstructNode, assemblyDir: string, appDir: string): WebConstructNode {
+  return {
+    path: node.path,
+    id: node.id,
+    type: node.type,
+    logicalId: node.logicalId,
+    templateFile: node.templateFile ? toPosix(path.relative(assemblyDir, node.templateFile)) : undefined,
+    sourceLocation: toWebSourceLocation(node.sourceLocation, appDir),
+    children: node.children.map((child) => toWebNode(child, assemblyDir, appDir)),
+  };
+}
+
+/** Ids CDK gives a construct's synthetic default child (the L1 resource it wraps). */
+const DEFAULT_CHILD_IDS = new Set(['Resource', 'Default']);
+
+/**
+ * Fold each construct's synthetic default child (the leaf L1 resource CDK names
+ * "Resource" or "Default") up into its parent, so an L2 like `ItemsTable` shows
+ * its CFN type directly instead of nesting a redundant `Resource` leaf. The
+ * parent absorbs the child's CFN identity (type, logicalId, templateFile) and
+ * the child is dropped. Only a leaf default child carrying a CFN type collapses,
+ * so resources that nest further children are left intact. Recurses depth-first.
+ *
+ * Display-only: violation joining still keys off the full (uncollapsed) tree,
+ * whose construct paths end in ".../Resource".
+ */
+export function collapseDefaultChildren(node: ConstructNode): ConstructNode {
+  const children = node.children.map(collapseDefaultChildren);
+  const defaultChild = children.find(
+    (child) => DEFAULT_CHILD_IDS.has(child.id) && child.children.length === 0 && child.type !== undefined,
+  );
+  if (!defaultChild) {
+    return { ...node, children };
+  }
+  return {
+    ...node,
+    type: defaultChild.type,
+    logicalId: defaultChild.logicalId,
+    templateFile: defaultChild.templateFile,
+    sourceLocation: node.sourceLocation ?? defaultChild.sourceLocation,
+    children: children.filter((child) => child !== defaultChild),
+  };
+}
+
+/** Relativize a source location to the app dir, dropping any that escape it. */
+function toWebSourceLocation(loc: SourceLocation | undefined, appDir: string): WebSourceLocation | undefined {
+  if (!loc) return undefined;
+  const file = toPosix(path.relative(appDir, loc.file));
+  if (file === '..' || file.startsWith('../')) return undefined;
+  return { file, line: loc.line, column: loc.column };
+}
+
+/**
+ * Normalize a policy-validation report into the SPA's flat violation model.
+ * Each violating construct is joined to the construct tree (by path) so the
+ * panel can navigate to the resource and its source: the resolved
+ * `sourceLocation` and `cdk.out`-relative `templateFile` come from the tree
+ * node when present, falling back to the report's own resource fields.
+ */
+export function normalizeViolations(
+  report: PolicyValidationReportJson | undefined,
+  index: ConstructIndex<ConstructNode>,
+  assemblyDir: string,
+  appDir: string,
+): WebViolation[] {
+  return (report?.pluginReports ?? []).flatMap((plugin) =>
+    plugin.violations.map((violation) => ({
+      ruleName: violation.ruleName,
+      description: violation.description,
+      severity: violation.severity,
+      customSeverity: violation.customSeverity,
+      source: plugin.pluginName,
+      suggestedFix: violation.suggestedFix,
+      occurrences: violation.violatingConstructs.map((vc) => toOccurrence(vc, index, assemblyDir, appDir)),
+    })));
+}
+
+/** Join one violating construct to its tree node, preferring resolved tree data. */
+function toOccurrence(
+  vc: ViolatingConstructJson,
+  index: ConstructIndex<ConstructNode>,
+  assemblyDir: string,
+  appDir: string,
+): WebViolationOccurrence {
+  const node = index.byPath(vc.constructPath);
+  const templateFile = node?.templateFile
+    ? toPosix(path.relative(assemblyDir, node.templateFile))
+    : vc.cloudFormationResource?.templatePath;
+  return {
+    constructPath: vc.constructPath,
+    logicalId: node?.logicalId ?? vc.cloudFormationResource?.logicalId,
+    templateFile,
+    sourceLocation: toWebSourceLocation(node?.sourceLocation, appDir),
+    propertyPaths: vc.cloudFormationResource?.propertyPaths,
+  };
 }
 
 function listDir(appDir: string, dir: string): DirEntry[] {

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -15,6 +15,11 @@ export interface WebServerOptions {
    * `process.cwd()`.
    */
   readonly appDir?: string;
+  /**
+   * Cloud assembly directory to read the construct tree and violations from.
+   * Defaults to `<appDir>/cdk.out`.
+   */
+  readonly assemblyDir?: string;
 }
 
 export interface WebServer {
@@ -36,20 +41,24 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 
   const app = express();
 
-  registerApi(app, { appDir });
+  registerApi(app, { appDir, assemblyDir: options.assemblyDir });
 
   // Unknown /api routes must return JSON 404, not fall through to the SPA.
   app.use('/api', (_req, res) => res.status(404).json({ error: 'unknown endpoint' }));
 
   // Serve the SPA from the embedded bundle (survives CLI bundling). Named assets
   // by path; any other GET falls back to index.html for client-side routing.
+  // The bundle filename is unversioned, so disable caching to ensure a rebuilt
+  // explorer is always picked up on reload rather than served stale by the browser.
   app.get('/:asset', (req, res, next) => {
     const asset = webAsset(req.params.asset);
     if (!asset) return next();
+    res.set('Cache-Control', 'no-store');
     return res.type(asset.contentType).send(asset.body);
   });
   app.get('*', (_req, res) => {
     const index = indexHtml();
+    res.set('Cache-Control', 'no-store');
     res.type(index.contentType).send(index.body);
   });
 

--- a/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
@@ -1,0 +1,67 @@
+/**
+ * Severity vocabulary for CDK policy violations, shared by the server (ranking
+ * violations onto construct-tree nodes) and the SPA (sorting and coloring the
+ * violations panel) so the rules live in exactly one place.
+ */
+
+import type { WebViolation, WebViolationSeverity } from './protocol';
+
+/** Severities CDK policy validation reports natively. */
+const KNOWN_SEVERITIES = new Set<string>(['fatal', 'error', 'warning', 'info', 'custom']);
+
+/**
+ * Classify a severity from a raw, unvalidated policy-validation report into the
+ * wire model. Known values and a missing severity pass through unchanged; a
+ * value outside the set is mapped to `custom`, keeping the raw value as the
+ * label, so a newer or non-conforming report can never produce a wire value
+ * that violates {@link WebViolationSeverity}.
+ */
+export function classifyReportSeverity(
+  severity: string | undefined,
+  customSeverity: string | undefined,
+): { readonly severity?: WebViolationSeverity; readonly customSeverity?: string } {
+  if (severity !== undefined && !KNOWN_SEVERITIES.has(severity)) {
+    return { severity: 'custom', customSeverity: customSeverity ?? severity };
+  }
+  return { severity: severity as WebViolationSeverity | undefined, customSeverity };
+}
+
+/** Lower-cased severity so 'Error'/'ERROR'/'error' all match (mirroring cdk validate). */
+function normalize(severity: string | undefined): string {
+  return (severity ?? '').toLowerCase();
+}
+
+/**
+ * Severity label for display: a plugin's custom label, else the reported
+ * severity, else 'warning' (cdk validate's default for severity-less plugins
+ * like CfnGuard).
+ */
+export function displaySeverity(violation: Pick<WebViolation, 'severity' | 'customSeverity'>): string {
+  return violation.customSeverity ?? violation.severity ?? 'warning';
+}
+
+const SEVERITY_RANK: Record<string, number> = { fatal: 0, error: 1, warning: 2, info: 3 };
+
+/**
+ * Sort rank for a severity label; lower sorts first. Custom and unrecognized
+ * labels rank just after `info`, matching cdk validate's handling of unknown
+ * severities.
+ */
+export function severityRank(severity: string | undefined): number {
+  return SEVERITY_RANK[normalize(severity)] ?? 4;
+}
+
+const SEVERITY_HEX: Record<string, string> = {
+  fatal: '#d91515',
+  error: '#e07700',
+  warning: '#8d6605',
+  info: '#0972d3',
+};
+
+/**
+ * Text color for a severity label, mirroring cdk validate (fatal red, error
+ * orange, warning amber, info blue); custom and unrecognized labels render gray.
+ */
+export function severityHexColor(severity: string | undefined): string {
+  return SEVERITY_HEX[normalize(severity)] ?? '#5f6b7a';
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
@@ -27,8 +27,8 @@ export function classifyReportSeverity(
 }
 
 /** Lower-cased severity so 'Error'/'ERROR'/'error' all match (mirroring cdk validate). */
-function normalize(severity: string | undefined): string {
-  return (severity ?? '').toLowerCase();
+function normalize(severity: string): string {
+  return severity.toLowerCase();
 }
 
 /**
@@ -47,7 +47,7 @@ const SEVERITY_RANK: Record<string, number> = { fatal: 0, error: 1, warning: 2, 
  * labels rank just after `info`, matching cdk validate's handling of unknown
  * severities.
  */
-export function severityRank(severity: string | undefined): number {
+export function severityRank(severity: string): number {
   return SEVERITY_RANK[normalize(severity)] ?? 4;
 }
 
@@ -62,6 +62,6 @@ const SEVERITY_HEX: Record<string, string> = {
  * Text color for a severity label, mirroring cdk validate (fatal red, error
  * orange, warning amber, info blue); custom and unrecognized labels render gray.
  */
-export function severityHexColor(severity: string | undefined): string {
+export function severityHexColor(severity: string): string {
   return SEVERITY_HEX[normalize(severity)] ?? '#5f6b7a';
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/severity.ts
@@ -10,11 +10,11 @@ import type { WebViolation, WebViolationSeverity } from './protocol';
 const KNOWN_SEVERITIES = new Set<string>(['fatal', 'error', 'warning', 'info', 'custom']);
 
 /**
- * Classify a severity from a raw, unvalidated policy-validation report into the
- * wire model. Known values and a missing severity pass through unchanged; a
- * value outside the set is mapped to `custom`, keeping the raw value as the
- * label, so a newer or non-conforming report can never produce a wire value
- * that violates {@link WebViolationSeverity}.
+ * Coerce a report's severity into the wire model. aws-cdk-lib already emits standard
+ * levels as-is and non-standard ones as `severity: 'custom'` with the raw label in
+ * `customSeverity`. Since we read the report as untyped JSON, this also folds any
+ * unrecognized `severity` string into `'custom'` (keeping the raw value as its label),
+ * so the result can never be a value outside {@link WebViolationSeverity}.
  */
 export function classifyReportSeverity(
   severity: string | undefined,

--- a/packages/@aws-cdk/cdk-explorer/test/web/normalize-violations.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/normalize-violations.test.ts
@@ -1,0 +1,127 @@
+import { ConstructIndex } from '@aws-cdk/cloud-assembly-api';
+import type { PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
+import type { ConstructNode } from '../../lib/core/assembly-reader';
+import { normalizeViolations } from '../../lib/web/routes';
+
+const ASSEMBLY_DIR = '/abs/cdk.out';
+const APP_DIR = '/abs/app';
+
+function makeNode(props: {
+  path: string;
+  id: string;
+  type?: string;
+  logicalId?: string;
+  templateFile?: string;
+  sourceLocation?: { file: string; line: number; column: number };
+  children?: ConstructNode[];
+}): ConstructNode {
+  return { ...props, children: props.children ?? [] };
+}
+
+function report(violatingConstructs: PolicyValidationReportJson['pluginReports'][number]['violations'][number]['violatingConstructs']): PolicyValidationReportJson {
+  return {
+    version: '1.0',
+    pluginReports: [
+      {
+        pluginName: 'cdk-validator',
+        conclusion: 'failure',
+        violations: [
+          {
+            ruleName: 'no-public-access',
+            description: 'S3 bucket should not allow public access',
+            severity: 'error',
+            suggestedFix: 'set blockPublicAccess',
+            violatingConstructs,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe('normalizeViolations', () => {
+  test('prefers resolved tree data over the report when the construct is in the index', () => {
+    const index = ConstructIndex.fromTree<ConstructNode>([
+      makeNode({
+        path: 'MyStack/Bucket',
+        id: 'Bucket',
+        type: 'AWS::S3::Bucket',
+        logicalId: 'Bucket123',
+        templateFile: `${ASSEMBLY_DIR}/MyStack.template.json`,
+        sourceLocation: { file: `${APP_DIR}/lib/stack.ts`, line: 12, column: 5 },
+      }),
+    ]);
+    const r = report([
+      {
+        constructPath: 'MyStack/Bucket',
+        cloudFormationResource: { templatePath: 'IGNORED.json', logicalId: 'IGNORED', propertyPaths: ['Properties.PublicAccessBlock'] },
+      },
+    ]);
+
+    const out = normalizeViolations(r, index, ASSEMBLY_DIR, APP_DIR);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      ruleName: 'no-public-access',
+      description: 'S3 bucket should not allow public access',
+      severity: 'error',
+      source: 'cdk-validator',
+      suggestedFix: 'set blockPublicAccess',
+    });
+    expect(out[0].occurrences[0]).toEqual({
+      constructPath: 'MyStack/Bucket',
+      logicalId: 'Bucket123',
+      templateFile: 'MyStack.template.json',
+      sourceLocation: { file: 'lib/stack.ts', line: 12, column: 5 },
+      propertyPaths: ['Properties.PublicAccessBlock'],
+    });
+  });
+
+  test('falls back to the report resource fields when the construct is not in the index', () => {
+    const index = ConstructIndex.fromTree<ConstructNode>([]);
+    const r = report([
+      {
+        constructPath: 'Other/X',
+        cloudFormationResource: { templatePath: 'Other.template.json', logicalId: 'X9', propertyPaths: ['P'] },
+      },
+    ]);
+
+    const occ = normalizeViolations(r, index, ASSEMBLY_DIR, APP_DIR)[0].occurrences[0];
+
+    expect(occ.constructPath).toBe('Other/X');
+    expect(occ.logicalId).toBe('X9');
+    expect(occ.templateFile).toBe('Other.template.json');
+    expect(occ.sourceLocation).toBeUndefined();
+    expect(occ.propertyPaths).toEqual(['P']);
+  });
+
+  test('leaves resource fields undefined when neither the index nor the report has them', () => {
+    const index = ConstructIndex.fromTree<ConstructNode>([]);
+    const occ = normalizeViolations(report([{ constructPath: 'Ghost' }]), index, ASSEMBLY_DIR, APP_DIR)[0].occurrences[0];
+    expect(occ.logicalId).toBeUndefined();
+    expect(occ.templateFile).toBeUndefined();
+    expect(occ.sourceLocation).toBeUndefined();
+    expect(occ.propertyPaths).toBeUndefined();
+  });
+
+  test('flattens violations across plugins', () => {
+    const index = ConstructIndex.fromTree<ConstructNode>([]);
+    const r: PolicyValidationReportJson = {
+      version: '1.0',
+      pluginReports: [
+        { pluginName: 'a', conclusion: 'failure', violations: [{ ruleName: 'r1', description: 'd1', severity: 'warning', violatingConstructs: [] }] },
+        { pluginName: 'b', conclusion: 'failure', violations: [{ ruleName: 'r2', description: 'd2', severity: 'fatal', customSeverity: 'BLOCKER', violatingConstructs: [] }] },
+      ],
+    };
+
+    const out = normalizeViolations(r, index, ASSEMBLY_DIR, APP_DIR);
+
+    expect(out).toHaveLength(2);
+    expect(out.map((v) => v.source)).toEqual(['a', 'b']);
+    expect(out[1]).toMatchObject({ severity: 'fatal', customSeverity: 'BLOCKER' });
+  });
+
+  test('returns an empty list for an undefined report', () => {
+    expect(normalizeViolations(undefined, ConstructIndex.fromTree<ConstructNode>([]), ASSEMBLY_DIR, APP_DIR)).toEqual([]);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import type { PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import request = require('supertest');
+import type { AssemblyReadResult, ConstructNode } from '../../lib/core/assembly-reader';
 import { createApiRouter } from '../../lib/web/routes';
 
 let appDir: string;
@@ -109,5 +111,154 @@ describe('symlink containment', () => {
     } finally {
       fs.rmSync(outside, { recursive: true, force: true });
     }
+  });
+});
+
+describe('GET /api/tree', () => {
+  /** Build an app whose /api router uses an injected assembly reader. */
+  function appWith(
+    readAssembly: (dir: string) => AssemblyReadResult,
+    opts: { assemblyDir?: string } = {},
+  ): express.Express {
+    const a = express();
+    a.use('/api', createApiRouter({ appDir, assemblyDir: opts.assemblyDir, readAssembly }));
+    return a;
+  }
+
+  test('maps a successful read into an ok TreeResponse with relativized paths', async () => {
+    const realAppDir = fs.realpathSync(appDir);
+    const reader = (dir: string): AssemblyReadResult => {
+      const node: ConstructNode = {
+        path: 'MyStack/Bucket',
+        id: 'Bucket',
+        type: 'AWS::S3::Bucket',
+        logicalId: 'Bucket123',
+        templateFile: path.join(dir, 'MyStack.template.json'),
+        sourceLocation: { file: path.join(realAppDir, 'lib', 'stack.ts'), line: 12, column: 5 },
+        children: [],
+      };
+      return { status: 'success', data: { tree: [node], warnings: ['heads up'] } };
+    };
+
+    const res = await request(appWith(reader)).get('/api/tree');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.warnings).toEqual(['heads up']);
+    expect(res.body.tree).toHaveLength(1);
+    expect(res.body.tree[0]).toMatchObject({
+      path: 'MyStack/Bucket',
+      logicalId: 'Bucket123',
+      templateFile: 'MyStack.template.json',
+      sourceLocation: { file: 'lib/stack.ts', line: 12, column: 5 },
+    });
+  });
+
+  test('returns not-synthesized (200) when no assembly is found', async () => {
+    const res = await request(appWith(() => ({ status: 'not-found' }))).get('/api/tree');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'not-synthesized' });
+  });
+
+  test('returns 500 when the read errors', async () => {
+    const res = await request(appWith(() => ({ status: 'error', message: 'bad manifest' }))).get('/api/tree');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'bad manifest' });
+  });
+
+  test('defaults the assembly dir to <appDir>/cdk.out', async () => {
+    let seen: string | undefined;
+    const reader = (dir: string): AssemblyReadResult => {
+      seen = dir;
+      return { status: 'not-found' };
+    };
+    await request(appWith(reader)).get('/api/tree');
+    expect(seen).toBe(path.join(appDir, 'cdk.out'));
+  });
+
+  test('honors an explicit assemblyDir override', async () => {
+    let seen: string | undefined;
+    const reader = (dir: string): AssemblyReadResult => {
+      seen = dir;
+      return { status: 'not-found' };
+    };
+    await request(appWith(reader, { assemblyDir: '/custom/out' })).get('/api/tree');
+    expect(seen).toBe('/custom/out');
+  });
+});
+
+describe('GET /api/policy-validation', () => {
+  function appWith(readAssembly: (dir: string) => AssemblyReadResult): express.Express {
+    const a = express();
+    a.use('/api', createApiRouter({ appDir, readAssembly }));
+    return a;
+  }
+
+  test('normalizes violations joined to the construct tree', async () => {
+    const realAppDir = fs.realpathSync(appDir);
+    const reader = (dir: string): AssemblyReadResult => {
+      const node: ConstructNode = {
+        path: 'MyStack/Bucket',
+        id: 'Bucket',
+        type: 'AWS::S3::Bucket',
+        logicalId: 'Bucket123',
+        templateFile: path.join(dir, 'MyStack.template.json'),
+        sourceLocation: { file: path.join(realAppDir, 'lib', 'stack.ts'), line: 7, column: 3 },
+        children: [],
+      };
+      const violations: PolicyValidationReportJson = {
+        version: '1.0',
+        pluginReports: [
+          {
+            pluginName: 'cdk-validator',
+            conclusion: 'failure',
+            violations: [
+              {
+                ruleName: 'no-public-access',
+                description: 'no public access',
+                severity: 'error',
+                violatingConstructs: [
+                  { constructPath: 'MyStack/Bucket', cloudFormationResource: { templatePath: 'x', logicalId: 'y', propertyPaths: ['Properties.Public'] } },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      return { status: 'success', data: { tree: [node], violations, warnings: [] } };
+    };
+
+    const res = await request(appWith(reader)).get('/api/policy-validation');
+
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.violations).toHaveLength(1);
+    expect(res.body.violations[0]).toMatchObject({ ruleName: 'no-public-access', severity: 'error', source: 'cdk-validator' });
+    expect(res.body.violations[0].occurrences[0]).toMatchObject({
+      constructPath: 'MyStack/Bucket',
+      logicalId: 'Bucket123',
+      templateFile: 'MyStack.template.json',
+      sourceLocation: { file: 'lib/stack.ts', line: 7, column: 3 },
+      propertyPaths: ['Properties.Public'],
+    });
+  });
+
+  test('returns not-synthesized (200) when no assembly is found', async () => {
+    const res = await request(appWith(() => ({ status: 'not-found' }))).get('/api/policy-validation');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'not-synthesized' });
+  });
+
+  test('returns 500 when the read errors', async () => {
+    const res = await request(appWith(() => ({ status: 'error', message: 'boom' }))).get('/api/policy-validation');
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'boom' });
+  });
+
+  test('surfaces reportError with an empty list when the report failed to load', async () => {
+    const reader = (): AssemblyReadResult => ({ status: 'success', data: { tree: [], violationsError: 'bad json', warnings: [] } });
+    const res = await request(appWith(reader)).get('/api/policy-validation');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ status: 'ok', violations: [], reportError: 'bad json' });
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -254,11 +254,4 @@ describe('GET /api/policy-validation', () => {
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'boom' });
   });
-
-  test('surfaces reportError with an empty list when the report failed to load', async () => {
-    const reader = (): AssemblyReadResult => ({ status: 'success', data: { tree: [], violationsError: 'bad json', warnings: [] } });
-    const res = await request(appWith(reader)).get('/api/policy-validation');
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok', violations: [], reportError: 'bad json' });
-  });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -64,4 +64,11 @@ describe('Web Server', () => {
     expect(res.headers.get('content-type')).toMatch(/application\/json/);
     expect((await res.json()).error).toBeDefined();
   });
+
+  test('serves the SPA index with Cache-Control: no-store so a rebuilt bundle is not served stale', async () => {
+    server = await startWebServer();
+    const res = await fetch(`${server.url}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/web/to-web-node.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/to-web-node.test.ts
@@ -1,8 +1,9 @@
 import type { ConstructNode } from '../../lib/core/assembly-reader';
-import { collapseDefaultChildren, toWebNode } from '../../lib/web/routes';
+import { toWebNode } from '../../lib/web/routes';
 
 const ASSEMBLY_DIR = '/abs/cdk.out';
 const APP_DIR = '/abs/app';
+const NO_SEVERITY = new Map<string, string>();
 
 function makeNode(props: {
   path: string;
@@ -20,6 +21,7 @@ describe('toWebNode', () => {
   test('relativizes a flat template to its bare name', () => {
     const web = toWebNode(
       makeNode({ path: 'S/B', id: 'B', logicalId: 'B123', templateFile: `${ASSEMBLY_DIR}/MyStack.template.json` }),
+      NO_SEVERITY,
       ASSEMBLY_DIR,
       APP_DIR,
     );
@@ -34,6 +36,7 @@ describe('toWebNode', () => {
         logicalId: 'S1',
         templateFile: `${ASSEMBLY_DIR}/assembly-Prod/Prod-MyStack.template.json`,
       }),
+      NO_SEVERITY,
       ASSEMBLY_DIR,
       APP_DIR,
     );
@@ -43,6 +46,7 @@ describe('toWebNode', () => {
   test('relativizes a source location inside the app dir', () => {
     const web = toWebNode(
       makeNode({ path: 'S/B', id: 'B', sourceLocation: { file: `${APP_DIR}/lib/stack.ts`, line: 12, column: 5 } }),
+      NO_SEVERITY,
       ASSEMBLY_DIR,
       APP_DIR,
     );
@@ -52,6 +56,7 @@ describe('toWebNode', () => {
   test('drops a source location that escapes the app dir', () => {
     const web = toWebNode(
       makeNode({ path: 'S/B', id: 'B', sourceLocation: { file: '/abs/other/lib.ts', line: 1, column: 1 } }),
+      NO_SEVERITY,
       ASSEMBLY_DIR,
       APP_DIR,
     );
@@ -59,7 +64,7 @@ describe('toWebNode', () => {
   });
 
   test('leaves template and source undefined for a non-resource, non-TS node', () => {
-    const web = toWebNode(makeNode({ path: 'S', id: 'S' }), ASSEMBLY_DIR, APP_DIR);
+    const web = toWebNode(makeNode({ path: 'S', id: 'S' }), NO_SEVERITY, ASSEMBLY_DIR, APP_DIR);
     expect(web.templateFile).toBeUndefined();
     expect(web.sourceLocation).toBeUndefined();
   });
@@ -67,6 +72,7 @@ describe('toWebNode', () => {
   test('passes through type and logicalId', () => {
     const web = toWebNode(
       makeNode({ path: 'S/B', id: 'B', type: 'AWS::S3::Bucket', logicalId: 'B123' }),
+      NO_SEVERITY,
       ASSEMBLY_DIR,
       APP_DIR,
     );
@@ -82,16 +88,26 @@ describe('toWebNode', () => {
         makeNode({ path: 'S/B', id: 'B', logicalId: 'B1', templateFile: `${ASSEMBLY_DIR}/S.template.json` }),
       ],
     });
-    const web = toWebNode(tree, ASSEMBLY_DIR, APP_DIR);
+    const web = toWebNode(tree, NO_SEVERITY, ASSEMBLY_DIR, APP_DIR);
     expect(web.children).toHaveLength(1);
     expect(web.children[0].path).toBe('S/B');
     expect(web.children[0].templateFile).toBe('S.template.json');
   });
+
+  test('annotates a node with its violation severity', () => {
+    const web = toWebNode(makeNode({ path: 'S/B', id: 'B' }), new Map([['S/B', 'error']]), ASSEMBLY_DIR, APP_DIR);
+    expect(web.highestSeverity).toBe('error');
+  });
+
+  test('leaves highestSeverity undefined when the node has no violation', () => {
+    const web = toWebNode(makeNode({ path: 'S/B', id: 'B' }), NO_SEVERITY, ASSEMBLY_DIR, APP_DIR);
+    expect(web.highestSeverity).toBeUndefined();
+  });
 });
 
-describe('collapseDefaultChildren', () => {
+describe('toWebNode default-child collapse', () => {
   test('folds a leaf "Resource" child into its parent', () => {
-    const collapsed = collapseDefaultChildren(
+    const web = toWebNode(
       makeNode({
         path: 'S/ItemsTable',
         id: 'ItemsTable',
@@ -105,27 +121,33 @@ describe('collapseDefaultChildren', () => {
           }),
         ],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(collapsed.type).toBe('AWS::DynamoDB::Table');
-    expect(collapsed.logicalId).toBe('ItemsTable0ABC');
-    expect(collapsed.templateFile).toBe(`${ASSEMBLY_DIR}/S.template.json`);
-    expect(collapsed.children).toHaveLength(0);
+    expect(web.type).toBe('AWS::DynamoDB::Table');
+    expect(web.logicalId).toBe('ItemsTable0ABC');
+    expect(web.templateFile).toBe('S.template.json');
+    expect(web.children).toHaveLength(0);
   });
 
   test('folds a leaf "Default" child too', () => {
-    const collapsed = collapseDefaultChildren(
+    const web = toWebNode(
       makeNode({
         path: 'S/Custom',
         id: 'Custom',
         children: [makeNode({ path: 'S/Custom/Default', id: 'Default', type: 'AWS::CloudFormation::CustomResource' })],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(collapsed.type).toBe('AWS::CloudFormation::CustomResource');
-    expect(collapsed.children).toHaveLength(0);
+    expect(web.type).toBe('AWS::CloudFormation::CustomResource');
+    expect(web.children).toHaveLength(0);
   });
 
   test('collapses each construct independently, keeping siblings', () => {
-    const collapsed = collapseDefaultChildren(
+    const web = toWebNode(
       makeNode({
         path: 'S/Bucket',
         id: 'Bucket',
@@ -140,16 +162,19 @@ describe('collapseDefaultChildren', () => {
           }),
         ],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(collapsed.type).toBe('AWS::S3::Bucket');
-    expect(collapsed.children).toHaveLength(1);
-    expect(collapsed.children[0].id).toBe('Policy');
-    expect(collapsed.children[0].type).toBe('AWS::S3::BucketPolicy');
-    expect(collapsed.children[0].children).toHaveLength(0);
+    expect(web.type).toBe('AWS::S3::Bucket');
+    expect(web.children).toHaveLength(1);
+    expect(web.children[0].id).toBe('Policy');
+    expect(web.children[0].type).toBe('AWS::S3::BucketPolicy');
+    expect(web.children[0].children).toHaveLength(0);
   });
 
   test('does not collapse a "Resource" child that has its own children', () => {
-    const collapsed = collapseDefaultChildren(
+    const web = toWebNode(
       makeNode({
         path: 'S/Weird',
         id: 'Weird',
@@ -162,40 +187,103 @@ describe('collapseDefaultChildren', () => {
           }),
         ],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(collapsed.type).toBeUndefined();
-    expect(collapsed.children).toHaveLength(1);
-    expect(collapsed.children[0].id).toBe('Resource');
+    expect(web.type).toBeUndefined();
+    expect(web.children).toHaveLength(1);
+    expect(web.children[0].id).toBe('Resource');
   });
 
   test('does not collapse a "Resource" child with no CFN type', () => {
-    const collapsed = collapseDefaultChildren(
+    const web = toWebNode(
       makeNode({ path: 'S/X', id: 'X', children: [makeNode({ path: 'S/X/Resource', id: 'Resource' })] }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(collapsed.type).toBeUndefined();
-    expect(collapsed.children).toHaveLength(1);
+    expect(web.type).toBeUndefined();
+    expect(web.children).toHaveLength(1);
   });
 
-  test('keeps the parent source location, falling back to the child when absent', () => {
-    const parentLoc = { file: '/abs/app/lib/s.ts', line: 5, column: 2 };
-    const childLoc = { file: '/abs/app/lib/s.ts', line: 99, column: 9 };
-    const kept = collapseDefaultChildren(
+  test('keeps the parent source location (relativized), falling back to the child when absent', () => {
+    const parentLoc = { file: `${APP_DIR}/lib/s.ts`, line: 5, column: 2 };
+    const childLoc = { file: `${APP_DIR}/lib/s.ts`, line: 99, column: 9 };
+    const kept = toWebNode(
       makeNode({
         path: 'S/T',
         id: 'T',
         sourceLocation: parentLoc,
         children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y', sourceLocation: childLoc })],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(kept.sourceLocation).toEqual(parentLoc);
+    expect(kept.sourceLocation).toEqual({ file: 'lib/s.ts', line: 5, column: 2 });
 
-    const fellBack = collapseDefaultChildren(
+    const fellBack = toWebNode(
       makeNode({
         path: 'S/T',
         id: 'T',
         children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y', sourceLocation: childLoc })],
       }),
+      NO_SEVERITY,
+      ASSEMBLY_DIR,
+      APP_DIR,
     );
-    expect(fellBack.sourceLocation).toEqual(childLoc);
+    expect(fellBack.sourceLocation).toEqual({ file: 'lib/s.ts', line: 99, column: 9 });
+  });
+
+  test("folds an absorbed default child's severity into the parent", () => {
+    const web = toWebNode(
+      makeNode({
+        path: 'S/T',
+        id: 'T',
+        children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y' })],
+      }),
+      new Map([['S/T/Resource', 'error']]),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.highestSeverity).toBe('error');
+    expect(web.children).toHaveLength(0);
+  });
+
+  test('takes the more severe of the parent and the absorbed child', () => {
+    const web = toWebNode(
+      makeNode({
+        path: 'S/T',
+        id: 'T',
+        children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y' })],
+      }),
+      new Map([['S/T', 'warning'], ['S/T/Resource', 'error']]),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.highestSeverity).toBe('error');
+  });
+
+  test("does not attribute an uncollapsed Resource child's severity to its parent", () => {
+    const web = toWebNode(
+      makeNode({
+        path: 'S/Weird',
+        id: 'Weird',
+        children: [
+          makeNode({
+            path: 'S/Weird/Resource',
+            id: 'Resource',
+            type: 'AWS::Some::Thing',
+            children: [makeNode({ path: 'S/Weird/Resource/Inner', id: 'Inner' })],
+          }),
+        ],
+      }),
+      new Map([['S/Weird/Resource', 'error']]),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.highestSeverity).toBeUndefined();
+    expect(web.children[0].highestSeverity).toBe('error');
   });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/web/to-web-node.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/to-web-node.test.ts
@@ -1,0 +1,201 @@
+import type { ConstructNode } from '../../lib/core/assembly-reader';
+import { collapseDefaultChildren, toWebNode } from '../../lib/web/routes';
+
+const ASSEMBLY_DIR = '/abs/cdk.out';
+const APP_DIR = '/abs/app';
+
+function makeNode(props: {
+  path: string;
+  id: string;
+  type?: string;
+  logicalId?: string;
+  templateFile?: string;
+  sourceLocation?: { file: string; line: number; column: number };
+  children?: ConstructNode[];
+}): ConstructNode {
+  return { ...props, children: props.children ?? [] };
+}
+
+describe('toWebNode', () => {
+  test('relativizes a flat template to its bare name', () => {
+    const web = toWebNode(
+      makeNode({ path: 'S/B', id: 'B', logicalId: 'B123', templateFile: `${ASSEMBLY_DIR}/MyStack.template.json` }),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.templateFile).toBe('MyStack.template.json');
+  });
+
+  test('keeps the sub-assembly directory for staged stacks', () => {
+    const web = toWebNode(
+      makeNode({
+        path: 'Prod/S',
+        id: 'S',
+        logicalId: 'S1',
+        templateFile: `${ASSEMBLY_DIR}/assembly-Prod/Prod-MyStack.template.json`,
+      }),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.templateFile).toBe('assembly-Prod/Prod-MyStack.template.json');
+  });
+
+  test('relativizes a source location inside the app dir', () => {
+    const web = toWebNode(
+      makeNode({ path: 'S/B', id: 'B', sourceLocation: { file: `${APP_DIR}/lib/stack.ts`, line: 12, column: 5 } }),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.sourceLocation).toEqual({ file: 'lib/stack.ts', line: 12, column: 5 });
+  });
+
+  test('drops a source location that escapes the app dir', () => {
+    const web = toWebNode(
+      makeNode({ path: 'S/B', id: 'B', sourceLocation: { file: '/abs/other/lib.ts', line: 1, column: 1 } }),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.sourceLocation).toBeUndefined();
+  });
+
+  test('leaves template and source undefined for a non-resource, non-TS node', () => {
+    const web = toWebNode(makeNode({ path: 'S', id: 'S' }), ASSEMBLY_DIR, APP_DIR);
+    expect(web.templateFile).toBeUndefined();
+    expect(web.sourceLocation).toBeUndefined();
+  });
+
+  test('passes through type and logicalId', () => {
+    const web = toWebNode(
+      makeNode({ path: 'S/B', id: 'B', type: 'AWS::S3::Bucket', logicalId: 'B123' }),
+      ASSEMBLY_DIR,
+      APP_DIR,
+    );
+    expect(web.type).toBe('AWS::S3::Bucket');
+    expect(web.logicalId).toBe('B123');
+  });
+
+  test('recurses over children', () => {
+    const tree = makeNode({
+      path: 'S',
+      id: 'S',
+      children: [
+        makeNode({ path: 'S/B', id: 'B', logicalId: 'B1', templateFile: `${ASSEMBLY_DIR}/S.template.json` }),
+      ],
+    });
+    const web = toWebNode(tree, ASSEMBLY_DIR, APP_DIR);
+    expect(web.children).toHaveLength(1);
+    expect(web.children[0].path).toBe('S/B');
+    expect(web.children[0].templateFile).toBe('S.template.json');
+  });
+});
+
+describe('collapseDefaultChildren', () => {
+  test('folds a leaf "Resource" child into its parent', () => {
+    const collapsed = collapseDefaultChildren(
+      makeNode({
+        path: 'S/ItemsTable',
+        id: 'ItemsTable',
+        children: [
+          makeNode({
+            path: 'S/ItemsTable/Resource',
+            id: 'Resource',
+            type: 'AWS::DynamoDB::Table',
+            logicalId: 'ItemsTable0ABC',
+            templateFile: `${ASSEMBLY_DIR}/S.template.json`,
+          }),
+        ],
+      }),
+    );
+    expect(collapsed.type).toBe('AWS::DynamoDB::Table');
+    expect(collapsed.logicalId).toBe('ItemsTable0ABC');
+    expect(collapsed.templateFile).toBe(`${ASSEMBLY_DIR}/S.template.json`);
+    expect(collapsed.children).toHaveLength(0);
+  });
+
+  test('folds a leaf "Default" child too', () => {
+    const collapsed = collapseDefaultChildren(
+      makeNode({
+        path: 'S/Custom',
+        id: 'Custom',
+        children: [makeNode({ path: 'S/Custom/Default', id: 'Default', type: 'AWS::CloudFormation::CustomResource' })],
+      }),
+    );
+    expect(collapsed.type).toBe('AWS::CloudFormation::CustomResource');
+    expect(collapsed.children).toHaveLength(0);
+  });
+
+  test('collapses each construct independently, keeping siblings', () => {
+    const collapsed = collapseDefaultChildren(
+      makeNode({
+        path: 'S/Bucket',
+        id: 'Bucket',
+        children: [
+          makeNode({ path: 'S/Bucket/Resource', id: 'Resource', type: 'AWS::S3::Bucket', logicalId: 'Bucket1' }),
+          makeNode({
+            path: 'S/Bucket/Policy',
+            id: 'Policy',
+            children: [
+              makeNode({ path: 'S/Bucket/Policy/Resource', id: 'Resource', type: 'AWS::S3::BucketPolicy', logicalId: 'Policy1' }),
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(collapsed.type).toBe('AWS::S3::Bucket');
+    expect(collapsed.children).toHaveLength(1);
+    expect(collapsed.children[0].id).toBe('Policy');
+    expect(collapsed.children[0].type).toBe('AWS::S3::BucketPolicy');
+    expect(collapsed.children[0].children).toHaveLength(0);
+  });
+
+  test('does not collapse a "Resource" child that has its own children', () => {
+    const collapsed = collapseDefaultChildren(
+      makeNode({
+        path: 'S/Weird',
+        id: 'Weird',
+        children: [
+          makeNode({
+            path: 'S/Weird/Resource',
+            id: 'Resource',
+            type: 'AWS::Some::Thing',
+            children: [makeNode({ path: 'S/Weird/Resource/Inner', id: 'Inner' })],
+          }),
+        ],
+      }),
+    );
+    expect(collapsed.type).toBeUndefined();
+    expect(collapsed.children).toHaveLength(1);
+    expect(collapsed.children[0].id).toBe('Resource');
+  });
+
+  test('does not collapse a "Resource" child with no CFN type', () => {
+    const collapsed = collapseDefaultChildren(
+      makeNode({ path: 'S/X', id: 'X', children: [makeNode({ path: 'S/X/Resource', id: 'Resource' })] }),
+    );
+    expect(collapsed.type).toBeUndefined();
+    expect(collapsed.children).toHaveLength(1);
+  });
+
+  test('keeps the parent source location, falling back to the child when absent', () => {
+    const parentLoc = { file: '/abs/app/lib/s.ts', line: 5, column: 2 };
+    const childLoc = { file: '/abs/app/lib/s.ts', line: 99, column: 9 };
+    const kept = collapseDefaultChildren(
+      makeNode({
+        path: 'S/T',
+        id: 'T',
+        sourceLocation: parentLoc,
+        children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y', sourceLocation: childLoc })],
+      }),
+    );
+    expect(kept.sourceLocation).toEqual(parentLoc);
+
+    const fellBack = collapseDefaultChildren(
+      makeNode({
+        path: 'S/T',
+        id: 'T',
+        children: [makeNode({ path: 'S/T/Resource', id: 'Resource', type: 'AWS::X::Y', sourceLocation: childLoc })],
+      }),
+    );
+    expect(fellBack.sourceLocation).toEqual(childLoc);
+  });
+});

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -16041,6 +16041,77 @@ Apache License
 
 ----------------
 
+** @jridgewell/resolve-uri@3.1.2 - https://www.npmjs.com/package/@jridgewell/resolve-uri/v/3.1.2 | MIT
+Copyright 2019 Justin Ridgewell <jridgewell@google.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+----------------
+
+** @jridgewell/sourcemap-codec@1.5.5 - https://www.npmjs.com/package/@jridgewell/sourcemap-codec/v/1.5.5 | MIT
+Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** @jridgewell/trace-mapping@0.3.31 - https://www.npmjs.com/package/@jridgewell/trace-mapping/v/0.3.31 | MIT
+Copyright 2024 Justin Ridgewell <justin@ridgewell.name>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** @nodelib/fs.scandir@2.1.5 - https://www.npmjs.com/package/@nodelib/fs.scandir/v/2.1.5 | MIT
 The MIT License (MIT)
 
@@ -27646,6 +27717,34 @@ SOFTWARE.
 
 ----------------
 
+** accepts@1.3.8 - https://www.npmjs.com/package/accepts/v/1.3.8 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** agent-base@7.1.4 - https://www.npmjs.com/package/agent-base/v/7.1.4 | MIT
 (The MIT License)
 
@@ -27753,6 +27852,32 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** array-flatten@1.1.1 - https://www.npmjs.com/package/array-flatten/v/1.1.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** ast-types@0.13.4 - https://www.npmjs.com/package/ast-types/v/0.13.4 | MIT
 Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
 
@@ -27812,6 +27937,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----------------
+
+** body-parser@1.20.5 - https://www.npmjs.com/package/body-parser/v/1.20.5 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -27905,6 +28058,86 @@ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PA
 PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
 FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** bytes@3.1.2 - https://www.npmjs.com/package/bytes/v/3.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015 Jed Watson <jed.watson@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** call-bind-apply-helpers@1.0.2 - https://www.npmjs.com/package/call-bind-apply-helpers/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** call-bound@1.0.4 - https://www.npmjs.com/package/call-bound/v/1.0.4 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -28012,6 +28245,121 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** content-disposition@0.5.4 - https://www.npmjs.com/package/content-disposition/v/0.5.4 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** content-type@1.0.5 - https://www.npmjs.com/package/content-type/v/1.0.5 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** convert-source-map@2.0.0 - https://www.npmjs.com/package/convert-source-map/v/2.0.0 | MIT
+Copyright 2013 Thorsten Lorenz. 
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** cookie-signature@1.0.7 - https://www.npmjs.com/package/cookie-signature/v/1.0.7 | MIT
+
+----------------
+
+** cookie@0.7.2 - https://www.npmjs.com/package/cookie/v/0.7.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** data-uri-to-buffer@6.0.2 - https://www.npmjs.com/package/data-uri-to-buffer/v/6.0.2 | MIT
 (The MIT License)
 
@@ -28035,6 +28383,30 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** debug@2.6.9 - https://www.npmjs.com/package/debug/v/2.6.9 | MIT
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the 'Software'), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 
 ----------------
 
@@ -28107,6 +28479,114 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** depd@2.0.0 - https://www.npmjs.com/package/depd/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2018 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** destroy@1.2.0 - https://www.npmjs.com/package/destroy/v/1.2.0 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2015-2022 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** dunder-proto@1.0.1 - https://www.npmjs.com/package/dunder-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** ee-first@1.1.1 - https://www.npmjs.com/package/ee-first/v/1.1.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** emoji-regex@8.0.0 - https://www.npmjs.com/package/emoji-regex/v/8.0.0 | MIT
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -28128,6 +28608,33 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** encodeurl@2.0.0 - https://www.npmjs.com/package/encodeurl/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -28154,6 +28661,113 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+----------------
+
+** es-define-property@1.0.1 - https://www.npmjs.com/package/es-define-property/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-errors@1.3.0 - https://www.npmjs.com/package/es-errors/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-object-atoms@1.1.1 - https://www.npmjs.com/package/es-object-atoms/v/1.1.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** escape-html@1.0.3 - https://www.npmjs.com/package/escape-html/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Tiancheng "Timothy" Gu
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -28258,6 +28872,33 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------
 
+** etag@1.8.1 - https://www.npmjs.com/package/etag/v/1.8.1 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** eventemitter3@4.0.7 - https://www.npmjs.com/package/eventemitter3/v/4.0.7 | MIT
 The MIT License (MIT)
 
@@ -28280,6 +28921,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+----------------
+
+** express@4.22.2 - https://www.npmjs.com/package/express/v/4.22.2 | MIT
+(The MIT License)
+
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -28458,6 +29128,33 @@ THE SOFTWARE.
 
 ----------------
 
+** finalhandler@1.3.2 - https://www.npmjs.com/package/finalhandler/v/1.3.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** find-up@4.1.0 - https://www.npmjs.com/package/find-up/v/4.1.0 | MIT
 MIT License
 
@@ -28468,6 +29165,61 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** forwarded@0.2.0 - https://www.npmjs.com/package/forwarded/v/0.2.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** fresh@0.5.2 - https://www.npmjs.com/package/fresh/v/0.5.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -28492,7 +29244,84 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ----------------
 
+** function-bind@1.1.2 - https://www.npmjs.com/package/function-bind/v/1.1.2 | MIT
+Copyright (c) 2013 Raynos.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+----------------
+
 ** get-caller-file@2.0.5 - https://www.npmjs.com/package/get-caller-file/v/2.0.5 | ISC
+
+----------------
+
+** get-intrinsic@1.3.0 - https://www.npmjs.com/package/get-intrinsic/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2020 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** get-proto@1.0.1 - https://www.npmjs.com/package/get-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2025 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 
@@ -28542,6 +29371,32 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** gopd@1.2.0 - https://www.npmjs.com/package/gopd/v/1.2.0 | MIT
+MIT License
+
+Copyright (c) 2022 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** graceful-fs@4.2.11 - https://www.npmjs.com/package/graceful-fs/v/4.2.11 | ISC
 The ISC License
 
@@ -28572,6 +29427,86 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** has-symbols@1.1.0 - https://www.npmjs.com/package/has-symbols/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2016 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** hasown@2.0.2 - https://www.npmjs.com/package/hasown/v/2.0.2 | MIT
+MIT License
+
+Copyright (c) Jordan Harband and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** http-errors@2.0.1 - https://www.npmjs.com/package/http-errors/v/2.0.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -28629,8 +29564,79 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** iconv-lite@0.4.24 - https://www.npmjs.com/package/iconv-lite/v/0.4.24 | MIT
+Copyright (c) 2011 Alexander Shtuchkin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
+** inherits@2.0.4 - https://www.npmjs.com/package/inherits/v/2.0.4 | ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+
+----------------
+
 ** ip-address@10.2.0 - https://www.npmjs.com/package/ip-address/v/10.2.0 | MIT
 Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** ipaddr.js@1.9.1 - https://www.npmjs.com/package/ipaddr.js/v/1.9.1 | MIT
+Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28903,6 +29909,87 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** math-intrinsics@1.1.0 - https://www.npmjs.com/package/math-intrinsics/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** media-typer@0.3.0 - https://www.npmjs.com/package/media-typer/v/0.3.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** merge-descriptors@1.0.3 - https://www.npmjs.com/package/merge-descriptors/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** merge2@1.4.1 - https://www.npmjs.com/package/merge2/v/1.4.1 | MIT
 The MIT License (MIT)
 
@@ -28929,10 +30016,121 @@ SOFTWARE.
 
 ----------------
 
+** methods@1.1.2 - https://www.npmjs.com/package/methods/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** micromatch@4.0.8 - https://www.npmjs.com/package/micromatch/v/4.0.8 | MIT
 The MIT License (MIT)
 
 Copyright (c) 2014-present, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** mime-db@1.52.0 - https://www.npmjs.com/package/mime-db/v/1.52.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime-types@2.1.35 - https://www.npmjs.com/package/mime-types/v/2.1.35 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime@1.6.0 - https://www.npmjs.com/package/mime/v/1.6.0 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -28981,6 +30179,10 @@ THE SOFTWARE.
 
 ----------------
 
+** ms@2.0.0 - https://www.npmjs.com/package/ms/v/2.0.0 | MIT
+
+----------------
+
 ** ms@2.1.3 - https://www.npmjs.com/package/ms/v/2.1.3 | MIT
 
 ----------------
@@ -29005,7 +30207,90 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** negotiator@0.6.3 - https://www.npmjs.com/package/negotiator/v/0.6.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** netmask@2.1.1 - https://www.npmjs.com/package/netmask/v/2.1.1 | MIT
+
+----------------
+
+** object-inspect@1.13.4 - https://www.npmjs.com/package/object-inspect/v/1.13.4 | MIT
+MIT License
+
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** on-finished@2.4.1 - https://www.npmjs.com/package/on-finished/v/2.4.1 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -29172,6 +30457,35 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** parseurl@1.3.3 - https://www.npmjs.com/package/parseurl/v/1.3.3 | MIT
+
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** path-exists@4.0.0 - https://www.npmjs.com/package/path-exists/v/4.0.0 | MIT
 MIT License
 
@@ -29182,6 +30496,32 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** path-to-regexp@0.1.13 - https://www.npmjs.com/package/path-to-regexp/v/0.1.13 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -29264,6 +30604,33 @@ THE SOFTWARE.
 
 ----------------
 
+** proxy-addr@2.0.7 - https://www.npmjs.com/package/proxy-addr/v/2.0.7 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** proxy-agent@6.5.0 - https://www.npmjs.com/package/proxy-agent/v/6.5.0 | MIT
 (The MIT License)
 
@@ -29315,6 +30682,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** qs@6.15.3 - https://www.npmjs.com/package/qs/v/6.15.3 | BSD-3-Clause
+
+----------------
+
 ** queue-microtask@1.2.3 - https://www.npmjs.com/package/queue-microtask/v/1.2.3 | MIT
 The MIT License (MIT)
 
@@ -29336,6 +30707,61 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** range-parser@1.2.1 - https://www.npmjs.com/package/range-parser/v/1.2.1 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** raw-body@2.5.3 - https://www.npmjs.com/package/raw-body/v/2.5.3 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -29458,6 +30884,58 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** safe-buffer@5.2.1 - https://www.npmjs.com/package/safe-buffer/v/5.2.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) Feross Aboukhadijeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** safer-buffer@2.1.2 - https://www.npmjs.com/package/safer-buffer/v/2.1.2 | MIT
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** semver@7.8.4 - https://www.npmjs.com/package/semver/v/7.8.4 | ISC
 The ISC License
 
@@ -29478,6 +30956,64 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** send@0.19.2 - https://www.npmjs.com/package/send/v/0.19.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2014-2022 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** serve-static@1.16.3 - https://www.npmjs.com/package/serve-static/v/1.16.3 | MIT
+(The MIT License)
+
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** set-blocking@2.0.0 - https://www.npmjs.com/package/set-blocking/v/2.0.0 | ISC
 Copyright (c) 2016, Contributors
 
@@ -29493,6 +31029,128 @@ LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** setprototypeof@1.2.0 - https://www.npmjs.com/package/setprototypeof/v/1.2.0 | ISC
+Copyright (c) 2015, Wes Todd
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** side-channel-list@1.0.1 - https://www.npmjs.com/package/side-channel-list/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-map@1.0.1 - https://www.npmjs.com/package/side-channel-map/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-weakmap@1.0.2 - https://www.npmjs.com/package/side-channel-weakmap/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel@1.1.1 - https://www.npmjs.com/package/side-channel/v/1.1.1 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -29639,6 +31297,34 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** statuses@2.0.2 - https://www.npmjs.com/package/statuses/v/2.0.2 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** string-width@4.2.3 - https://www.npmjs.com/package/string-width/v/4.2.3 | MIT
 MIT License
 
@@ -29736,6 +31422,32 @@ THE SOFTWARE.
 
 ----------------
 
+** toidentifier@1.0.1 - https://www.npmjs.com/package/toidentifier/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** tslib@2.8.1 - https://www.npmjs.com/package/tslib/v/2.8.1 | 0BSD
 Copyright (c) Microsoft Corporation.
 
@@ -29749,6 +31461,34 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+----------------
+
+** type-is@1.6.18 - https://www.npmjs.com/package/type-is/v/1.6.18 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -29773,6 +31513,165 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** unpipe@1.0.0 - https://www.npmjs.com/package/unpipe/v/1.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** utils-merge@1.0.1 - https://www.npmjs.com/package/utils-merge/v/1.0.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Jared Hanson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vary@1.1.2 - https://www.npmjs.com/package/vary/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vscode-jsonrpc@8.2.0 - https://www.npmjs.com/package/vscode-jsonrpc/v/8.2.0 | MIT
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vscode-jsonrpc@8.2.1 - https://www.npmjs.com/package/vscode-jsonrpc/v/8.2.1 | MIT
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vscode-languageserver-protocol@3.17.5 - https://www.npmjs.com/package/vscode-languageserver-protocol/v/3.17.5 | MIT
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vscode-languageserver-types@3.17.5 - https://www.npmjs.com/package/vscode-languageserver-types/v/3.17.5 | MIT
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vscode-languageserver@9.0.1 - https://www.npmjs.com/package/vscode-languageserver/v/9.0.1 | MIT
+Copyright (c) Microsoft Corporation
+
+All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------


### PR DESCRIPTION
Adds two read-only views to the `cdk explore` web UI.

- **Construct tree** (`GET /api/tree`): the synthesized construct hierarchy. Each
  node is flagged with the highest severity of any policy violation on it, so
  problem areas are visible at a glance.
- **Policy-validation panel** (`GET /api/policy-validation`): violations grouped
  by rule, sorted by severity, labeled with the originating plugin.

The server reads the cloud assembly in `cdk.out` and returns a wire-stable,
app-relative view. The backend owns the full transform from core construct node
to displayed node, including default-child collapse and the per-node
highest-severity join, so the frontend renders without re-deriving any of it.


## Out of scope 

- Navigation between a construct, its synthesized template, and its source. The
  wire model already carries `templateFile` and `sourceLocation`, but no 
  navigation UI yet.
- Frontend tests (adds deps, so future PR)

frontend:
<img width="1505" height="857" alt="Screenshot 2026-07-01 at 11 32 09 AM" src="https://github.com/user-attachments/assets/0086cdf4-175b-49a4-917e-ebb6bdf44f9d" />



### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
