### PR TITLE
chore(toolkit-lib): stop action tests resolving real AWS credentials

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/mock-sdk.ts
@@ -204,3 +204,42 @@ export function mockResolvedEnvironment(): Environment {
     name: 'aws://123456789/bermuda-triangle-1337',
   };
 }
+
+/**
+ * Spy on `SdkProvider` so that tests never resolve real (ambient) AWS credentials.
+ *
+ * Tests that construct a real `Toolkit` get a real `SdkProvider` backed by the
+ * default AWS credential provider chain. Any code path that resolves base
+ * credentials — environment access (`accessStackFor...`), asset build/publish,
+ * etc. — will then read the developer's `~/.aws/config` and may spawn
+ * `credential_process` helpers (AWS SSO, Isengard, aws-vault, ...). That makes
+ * unit tests slow, flaky, or hang, and reaches out to the network from what
+ * should be a hermetic unit test.
+ *
+ * This installs the standard set of spies that keep the real `SdkProvider`
+ * hermetic: every SDK it hands out is a `MockSdk` (whose clients are the
+ * `aws-sdk-client-mock` clients), and credential/partition resolution short
+ * circuits without touching the ambient environment.
+ *
+ * Call it from `beforeEach()`, after `jest.restoreAllMocks()`:
+ *
+ * ```ts
+ * beforeEach(() => {
+ *   jest.restoreAllMocks();
+ *   restoreSdkMocksToDefault();
+ *   setDefaultSTSMocks();
+ *   mockSdkProvider();
+ * });
+ * ```
+ *
+ * @returns the installed jest spies, in case a test needs to customize them
+ */
+export function mockSdkProvider() {
+  const makeSdk = jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+  const forEnvironment = jest.spyOn(SdkProvider.prototype, 'forEnvironment').mockResolvedValue({
+    sdk: new MockSdk(),
+    didAssumeRole: false,
+  });
+  const baseCredentialsPartition = jest.spyOn(SdkProvider.prototype, 'baseCredentialsPartition').mockResolvedValue('aws');
+  return { makeSdk, forEnvironment, baseCredentialsPartition };
+}

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -3,15 +3,12 @@ import { CreateChangeSetCommand, DeleteStackCommand, DescribeChangeSetCommand, D
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import * as chalk from 'chalk';
 import { DiffMethod } from '../../lib/actions/diff';
-import * as awsauth from '../../lib/api/aws-auth/private';
 import { StackSelectionStrategy } from '../../lib/api/cloud-assembly';
 import * as deployments from '../../lib/api/deployments';
 import * as cfnApi from '../../lib/api/deployments/cfn-api';
 import { Toolkit } from '../../lib/toolkit';
 import { cdkOutFixture, disposableCloudAssemblySource, TestIoHost } from '../_helpers';
-import { mockCloudFormationClient, MockSdk, mockSSMClient, restoreSdkMocksToDefault, setDefaultSTSMocks } from '../_helpers/mock-sdk';
-
-jest.setTimeout(20_000);
+import { mockCloudFormationClient, mockSSMClient, mockSdkProvider, restoreSdkMocksToDefault, setDefaultSTSMocks } from '../_helpers/mock-sdk';
 
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
@@ -24,7 +21,9 @@ beforeEach(() => {
   toolkit = new Toolkit({ ioHost });
 
   // Some default implementations
-  jest.spyOn(awsauth.SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+  // Keep the real SdkProvider hermetic: hand out MockSdks and never resolve
+  // ambient credentials (which can spawn `credential_process` helpers and hang).
+  mockSdkProvider();
 
   jest.spyOn(deployments.Deployments.prototype, 'readCurrentTemplateWithNestedStacks').mockResolvedValue({
     deployedRootTemplate: {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/drift.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/drift.test.ts
@@ -1,9 +1,8 @@
 import { DescribeStackDriftDetectionStatusCommand, DescribeStackResourceDriftsCommand, DetectStackDriftCommand } from '@aws-sdk/client-cloudformation';
-import * as awsauth from '../../lib/api/aws-auth/private';
 import { StackSelectionStrategy } from '../../lib/api/cloud-assembly';
 import { Toolkit } from '../../lib/toolkit';
 import { builderFixture, TestIoHost } from '../_helpers';
-import { mockCloudFormationClient, MockSdk, restoreSdkMocksToDefault, setDefaultSTSMocks } from '../_helpers/mock-sdk';
+import { mockCloudFormationClient, mockSdkProvider, restoreSdkMocksToDefault, setDefaultSTSMocks } from '../_helpers/mock-sdk';
 
 let ioHost: TestIoHost;
 let toolkit: Toolkit;
@@ -16,7 +15,8 @@ beforeEach(() => {
   toolkit = new Toolkit({ ioHost });
 
   // Some default implementations
-  jest.spyOn(awsauth.SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+  // Keep the real SdkProvider hermetic and avoid resolving ambient credentials.
+  mockSdkProvider();
 });
 
 describe('drift', () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/refactor.test.ts
@@ -8,16 +8,13 @@ import {
 } from '@aws-sdk/client-cloudformation';
 import { GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { type RefactorOptions, StackSelectionStrategy, Toolkit } from '../../lib';
-import { SdkProvider } from '../../lib/api/aws-auth/private';
 import { builderFixture, TestIoHost } from '../_helpers';
-import { mockCloudFormationClient, MockSdk, mockSTSClient } from '../_helpers/mock-sdk';
-
-jest.setTimeout(20_000);
+import { mockCloudFormationClient, mockSTSClient, mockSdkProvider } from '../_helpers/mock-sdk';
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost, unstableFeatures: ['refactor'] });
 
-jest.spyOn(SdkProvider.prototype, '_makeSdk').mockReturnValue(new MockSdk());
+mockSdkProvider();
 
 beforeEach(() => {
   ioHost.notifySpy.mockClear();


### PR DESCRIPTION
Makes the `diff`, `drift`, and `refactor` action tests reliable and fast for everyone by ensuring they never touch real AWS credentials. Until now these tests could read a developer's local AWS config and trigger a credential helper if configured, which made them slow, flaky, and prone to timing out on some machines while passing fine on CI. After this change they run in milliseconds regardless of the local environment.

### Details

The tests construct a real `Toolkit`, so they use a real `SdkProvider`. Some of the paths they exercise (stack environment access, asset build/publish) resolve base credentials, which falls through to the default AWS credential provider chain and spawns any configured `credential_process`. That helper often reaches out to the network and takes seconds per call, so a single test could rack up many seconds of latency.

To fix this at the source rather than per test, a reusable `mockSdkProvider()` helper is added to the shared `mock-sdk` test helper. It keeps the real `SdkProvider` hermetic: every SDK it hands out is a `MockSdk`, and credential and partition resolution short circuit without touching the ambient environment. The three affected suites now use it in place of their ad-hoc `_makeSdk` spies, which did not cover the credential-resolution paths. With the slowness gone, the inflated 20s per-file Jest timeouts in `diff` and `refactor` are also removed in favour of the global default.

This is test-only and does not change any shipped behaviour.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
