### PR TITLE
fix(integ-runner): stack traces are in golden snapshot manifest

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
@@ -18,9 +18,9 @@ import { NoManifestError } from './private/integ-manifest';
 const DESTRUCTIVE_CHANGES = '!!DESTRUCTIVE_CHANGES:';
 
 /**
- * Options for creating an integration test runner
+ * Options for creating an integ helper
  */
-export interface IntegRunnerOptions {
+export interface CdkIntegHelperOptions {
   /**
    * Information about the test to run
    */
@@ -83,16 +83,33 @@ export interface IntegRunnerOptions {
 }
 
 /**
- * The different components of a test name
+ * Whether to synthesize the actual snapshot with lookups enabled or not.
+ *
+ * If either `true` or `false`, we send context in or not while synthesizing,
+ * and if the generated snapshot test definition requests a different value we
+ * will synth again.
+ *
+ * For `dont-care`, we do send in the context but we never resynth.
  */
+export type LegacyEnableLookups = true | false | 'dont-care';
+
 /**
- * Represents an Integration test runner
+ * Class with some helper routines for running CDK snapshots and integration tests.
  */
-export abstract class IntegRunner {
+export class CdkIntegHelper {
   /**
-   * The directory where the snapshot will be stored
+   * Factory method to create an instance of the CdkIntegHelper.
+   *
+   * Hiding the constructor to prevent inheritance.
    */
-  public readonly snapshotDir: string;
+  public static create(options: CdkIntegHelperOptions) {
+    return new CdkIntegHelper(options);
+  }
+
+  /**
+   * The directory where the golden snapshot will be stored
+   */
+  public readonly goldenSnapshotDir: string;
 
   /**
    * An instance of the CDK  CLI
@@ -109,29 +126,29 @@ export abstract class IntegRunner {
    *
    * Path to the integ test source file, relative to `this.directory`.
    */
-  protected readonly cdkApp: string;
+  public readonly cdkApp: string;
 
   /**
    * The path where the `cdk.context.json` file
    * will be created
    */
-  protected readonly cdkContextPath: string;
+  public readonly cdkContextPath: string;
 
   /**
    * The working directory that the integration tests will be
    * executed from
    */
-  protected readonly directory: string;
+  public readonly directory: string;
 
   /**
    * The test to run
    */
-  protected readonly test: IntegTest;
+  private readonly test: IntegTest;
 
   /**
    * Default options to pass to the CDK CLI
    */
-  protected readonly defaultArgs: DefaultCdkOptions = {
+  public readonly defaultArgs: DefaultCdkOptions = {
     pathMetadata: false,
     assetMetadata: false,
     versionReporting: false,
@@ -142,28 +159,32 @@ export abstract class IntegRunner {
    *
    * Relative to cwd.
    */
-  protected readonly cdkOutDir: string;
+  public readonly cdkOutDir: string;
 
   /**
    * The profile to use for the CDK CLI calls
    */
-  protected readonly profile?: string;
+  public readonly profile?: string;
 
   /**
    * Show output from the integ test run.
    */
-  protected readonly showOutput: boolean;
+  private readonly showOutput: boolean;
 
-  protected _destructiveChanges?: DestructiveChange[];
+  public _destructiveChanges?: DestructiveChange[];
   private legacyContext?: Record<string, any>;
   private _expectedTestSuite?: IntegTestSuite | LegacyIntegTestSuite;
-  private _actualTestSuite?: IntegTestSuite | LegacyIntegTestSuite;
+  private _actualSnapshot?: SnapshotAndTestDefinition;
+  private _legacyEnableLookups?: LegacyEnableLookups;
 
-  constructor(options: IntegRunnerOptions) {
+  /**
+   * Private constructor to prevent inheritance.
+   */
+  private constructor(options: CdkIntegHelperOptions) {
     this.test = options.test;
     this.directory = this.test.directory;
     this.testName = this.test.testName;
-    this.snapshotDir = this.test.snapshotDir;
+    this.goldenSnapshotDir = this.test.snapshotDir;
     this.cdkContextPath = path.join(this.directory, 'cdk.context.json');
     this.profile = options.profile;
     this.showOutput = options.showOutput ?? false;
@@ -176,10 +197,12 @@ export abstract class IntegRunner {
   }
 
   /**
-   * Return the list of expected (i.e. existing) test cases for this integration test
+   * Configure the legacy enableLookups value to use when generating the actual snapshot.
+   *
+   * Must be set before using snapshot methods.
    */
-  public async expectedTests(): Promise<{ [testName: string]: TestCase } | undefined> {
-    return (await this.expectedTestSuite())?.testSuite;
+  public configureLegacyEnableLookups(enableLookups: LegacyEnableLookups): void {
+    this._legacyEnableLookups = enableLookups;
   }
 
   /**
@@ -194,47 +217,105 @@ export abstract class IntegRunner {
    * existing "expected" snapshot
    * This will synth and then load the integration test manifest
    */
-  public async generateActualSnapshot(): Promise<IntegTestSuite | LegacyIntegTestSuite> {
+  private async generateActualSnapshot(): Promise<SnapshotAndTestDefinition> {
+    await this.synthActualSnapshot(this.cdkOutDir);
+    const manifest = await this.loadManifest(this.cdkOutDir);
+    return {
+      testDefinition: manifest,
+      snapshotDirectory: this.cdkOutDir,
+    };
+  }
+
+  /**
+   * Synth the actual application to the given directory, for purposes of generating/validating a snapshot
+   *
+   * `legacyEnableLookups` is to preserve historical behavior for a while:
+   * traditionally, the application would only be seeded with context if
+   * `enableLookups` was true, and this information would come from the test
+   * definition.
+   *
+   * - Since the test definition comes from inside the app, this requires a
+   *   synth just to get the test definition, and then another synth to generate
+   *   the actual snapshot with the correct context, which is time consuming.
+   * - Given that the context is fixed and fake, it could always have been passed.
+   *
+   * However, the snapshot contents themselves depend on the context flag, and changing
+   * this behavior now invalidates all snapshots everywhere, which is annoying for upgrading.
+   *
+   * So we will use the behavior from the GOLDEN SNAPSHOT's test definition to
+   * determine whether to pass the context, and if the new actual snapshot has a
+   * different value for `enableLookups`, we will throw away the old snapshot and synth again.
+   */
+  private async synthActualSnapshot(outputDirectory: string): Promise<void> {
+    if (this._legacyEnableLookups === undefined) {
+      throw new Error('Must call configureLegacyEnableLookups before generating snapshots');
+    }
+
     await this.cdk.synth({
       app: this.cdkApp,
-      // we don't know the "actual" context yet (this method is what generates it) so just
-      // use the "expected" context. This is only run in order to read the manifest
-      context: this.getContext((await this.expectedTestSuite())?.synthContext),
+      context: this.getContext(this._legacyEnableLookups !== false ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
-      output: path.relative(this.directory, this.cdkOutDir),
+      output: path.relative(this.directory, outputDirectory),
     });
-    const manifest = await this.loadManifest(this.cdkOutDir);
-    // after we load the manifest remove the tmp snapshot
-    // so that it doesn't mess up the real snapshot created later
-    this.cleanup();
-    return manifest;
+  }
+
+  public actualSynthReproCommand() {
+    // Show the command necessary to repro this
+    const envSet = Object.entries(DEFAULT_SYNTH_OPTIONS.env).map(([k, v]) => `${k}='${v}'`);
+    const envCmd = envSet.length > 0 ? ['env', ...envSet] : [];
+
+    return [
+      ...envCmd,
+      'cdk',
+      'synth',
+      '-a',
+      `'${this.cdkApp}'`,
+      '-o',
+      `'${this.cdkOutDir}'`,
+      ...Object.entries(this.getContext(DEFAULT_SYNTH_OPTIONS.context)).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : []),
+    ];
   }
 
   /**
    * Returns true if a snapshot already exists for this test
    */
   public hasSnapshot(): boolean {
-    return fs.existsSync(this.snapshotDir);
+    return fs.existsSync(this.goldenSnapshotDir);
   }
 
   /**
    * The test suite from the existing snapshot
    */
-  protected async expectedTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite | undefined> {
+  public async expectedTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite | undefined> {
     if (!this._expectedTestSuite && this.hasSnapshot()) {
       this._expectedTestSuite = await this.loadManifest();
     }
     return this._expectedTestSuite;
   }
 
+  public async actualSnapshot(): Promise<SnapshotAndTestDefinition> {
+    if (!this._actualSnapshot) {
+      this._actualSnapshot = await this.generateActualSnapshot();
+
+      // Check if the enableLookups value has changed between the golden
+      // snapshot and the actual snapshot. If it has, we need to re-synth the
+      // actual snapshot with the new enableLookups value.
+      //
+      // See `synthActualSnapshot` for a description of why this is necessary.
+      const actualEnableLookups = this._actualSnapshot.testDefinition.enableLookups ?? false;
+      if (actualEnableLookups !== this._legacyEnableLookups && this._legacyEnableLookups !== 'dont-care') {
+        this.configureLegacyEnableLookups(actualEnableLookups);
+        this._actualSnapshot = await this.generateActualSnapshot();
+      }
+    }
+    return this._actualSnapshot;
+  }
+
   /**
    * The test suite from the new "actual" snapshot
    */
-  protected async actualTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite> {
-    if (!this._actualTestSuite) {
-      this._actualTestSuite = await this.generateActualSnapshot();
-    }
-    return this._actualTestSuite;
+  private async actualTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite> {
+    return (await this.actualSnapshot()).testDefinition;
   }
 
   /**
@@ -244,8 +325,8 @@ export abstract class IntegRunner {
    * from the cloud assembly. If it doesn't exist, then we fallback to the
    * "legacy mode" and create a manifest from pragma
    */
-  protected async loadManifest(dir?: string): Promise<IntegTestSuite | LegacyIntegTestSuite> {
-    const manifest = dir ?? this.snapshotDir;
+  public async loadManifest(dir?: string): Promise<IntegTestSuite | LegacyIntegTestSuite> {
+    const manifest = dir ?? this.goldenSnapshotDir;
     try {
       const testSuite = IntegTestSuite.fromPath(manifest);
       return testSuite;
@@ -281,11 +362,13 @@ export abstract class IntegRunner {
     }
   }
 
-  protected cleanup(): void {
+  public cleanup(): void {
     const cdkOutPath = this.cdkOutDir;
     if (fs.existsSync(cdkOutPath)) {
       fs.removeSync(cdkOutPath);
     }
+    // Clear cache
+    this._actualSnapshot = undefined;
   }
 
   /**
@@ -317,15 +400,15 @@ export abstract class IntegRunner {
    * disabled and then delete assets that relate to that stack. It does that
    * by reading the asset manifest for the stack and deleting the asset source
    */
-  protected async removeAssetsFromSnapshot(): Promise<void> {
+  private async removeAssetsFromSnapshot(): Promise<void> {
     const stacks = (await this.actualTestSuite()).getStacksWithoutUpdateWorkflow() ?? [];
-    const manifest = AssemblyManifestReader.fromPath(this.snapshotDir);
+    const manifest = AssemblyManifestReader.fromPath(this.goldenSnapshotDir);
     const assets = flatten(stacks.map(stack => {
       return manifest.getAssetLocationsForStack(stack) ?? [];
     }));
 
     assets.forEach(asset => {
-      const fileName = path.join(this.snapshotDir, asset);
+      const fileName = path.join(this.goldenSnapshotDir, asset);
       if (fs.existsSync(fileName)) {
         if (fs.lstatSync(fileName).isDirectory()) {
           fs.removeSync(fileName);
@@ -341,10 +424,10 @@ export abstract class IntegRunner {
    * These are a cache of the asset zips, but we are fine with
    * re-zipping on deploy
    */
-  protected removeAssetsCacheFromSnapshot(): void {
-    const files = fs.readdirSync(this.snapshotDir);
+  private removeAssetsCacheFromSnapshot(): void {
+    const files = fs.readdirSync(this.goldenSnapshotDir);
     files.forEach(file => {
-      const fileName = path.join(this.snapshotDir, file);
+      const fileName = path.join(this.goldenSnapshotDir, file);
       if (fs.lstatSync(fileName).isDirectory() && file === '.cache') {
         fs.emptyDirSync(fileName);
         fs.rmdirSync(fileName);
@@ -362,23 +445,18 @@ export abstract class IntegRunner {
    * If lookups are disabled (which means the stack is env agnostic) then just copy
    * the assembly that was output by the deployment
    */
-  protected async createSnapshot(): Promise<void> {
-    if (fs.existsSync(this.snapshotDir)) {
-      fs.removeSync(this.snapshotDir);
+  public async createSnapshot(): Promise<void> {
+    if (fs.existsSync(this.goldenSnapshotDir)) {
+      fs.removeSync(this.goldenSnapshotDir);
     }
 
-    const actualTestSuite = await this.actualTestSuite();
+    // TODO: If we're clever, we should be able to reuse the snapshot that was
+    // generated during the test invalidation check and avoid the below synth.
+    // But that gets run in a completely different lifecycle and it might not
+    // exist. We're not dealing with that just yet.
+    await this.synthActualSnapshot(this.goldenSnapshotDir);
 
-    // if lookups are enabled then we need to synth again
-    // using dummy context and save that as the snapshot
-    await this.cdk.synth({
-      app: this.cdkApp,
-      context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
-      env: DEFAULT_SYNTH_OPTIONS.env,
-      output: path.relative(this.directory, this.snapshotDir),
-    });
-
-    await this.cleanupSnapshot();
+    await this.cleanupGoldenSnapshot();
   }
 
   /**
@@ -386,11 +464,11 @@ export abstract class IntegRunner {
    * Anytime the snapshot needs to be modified after creation
    * the logic should live here.
    */
-  private async cleanupSnapshot(): Promise<void> {
-    if (fs.existsSync(this.snapshotDir)) {
+  private async cleanupGoldenSnapshot(): Promise<void> {
+    if (fs.existsSync(this.goldenSnapshotDir)) {
       await this.removeAssetsFromSnapshot();
       this.removeAssetsCacheFromSnapshot();
-      const assembly = AssemblyManifestReader.fromPath(this.snapshotDir);
+      const assembly = AssemblyManifestReader.fromPath(this.goldenSnapshotDir);
       assembly.cleanManifest();
       assembly.recordTrace(this.renderTraceData());
     }
@@ -401,19 +479,22 @@ export abstract class IntegRunner {
     // the next time
     const actualTestSuite = await this.actualTestSuite();
     if (actualTestSuite.type === 'legacy-test-suite') {
-      (actualTestSuite as LegacyIntegTestSuite).saveManifest(this.snapshotDir, this.legacyContext);
+      (actualTestSuite as LegacyIntegTestSuite).saveManifest(this.goldenSnapshotDir, this.legacyContext);
     }
   }
 
-  protected getContext(additionalContext?: Record<string, any>): Record<string, any> {
+  public getContext(additionalContext?: Record<string, any>): Record<string, any> {
     return {
       ...currentlyRecommendedAwsCdkLibFlags(),
       ...this.legacyContext,
       ...additionalContext,
 
+      // Don't record creation stack traces in the snapshot, since they just take up space and are never deterministic.
+      'aws:cdk:disable-creation-stack-traces': true,
+
       // We originally had PLANNED to set this to ['aws', 'aws-cn'], but due to a programming mistake
       // it was set to everything. In this PR, set it to everything to not mess up all the snapshots.
-      ['@aws-cdk/core:target-partitions']: undefined,
+      '@aws-cdk/core:target-partitions': undefined,
 
       /* ---------------- THE FUTURE LIVES BELOW----------------------------
       // Restricting to these target partitions makes most service principals synthesize to
@@ -484,4 +565,9 @@ export const DEFAULT_SYNTH_OPTIONS = {
  */
 export function currentlyRecommendedAwsCdkLibFlags() {
   return recommendedFlagsFile;
+}
+
+export interface SnapshotAndTestDefinition {
+  readonly testDefinition: IntegTestSuite | LegacyIntegTestSuite;
+  readonly snapshotDirectory: string;
 }

--- a/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
@@ -95,6 +95,13 @@ export type LegacyEnableLookups = true | false | 'dont-care';
 
 /**
  * Class with some helper routines for running CDK snapshots and integration tests.
+ *
+ * A "golden snapshot" is the snapshot that is stored permanently in version
+ * control, that new runs are compared against (stored in a directory named
+ * `<test-name>.snapshot`).
+ *
+ * This is as opposed to other snapshots, which can be generated for example
+ * temporarily in a temporary directory, to compare agains the golden snapshot.
  */
 export class CdkIntegHelper {
   /**

--- a/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
@@ -6,7 +6,7 @@ import { ToolkitLibRunnerEngine } from '../engines/toolkit-lib';
  *
  * Only the toolkit-lib engine is supported.
  */
-export function makeEngine(options: CdkIntegHelperOptions): ToolkitLibRunnerEngine {
+export function makeEngine(options: EngineOptions): ToolkitLibRunnerEngine {
   return new ToolkitLibRunnerEngine({
     workingDirectory: options.test.directory,
     showOutput: options.showOutput,
@@ -17,3 +17,5 @@ export function makeEngine(options: CdkIntegHelperOptions): ToolkitLibRunnerEngi
     caBundlePath: options.caBundlePath,
   });
 }
+
+export type EngineOptions = Pick<CdkIntegHelperOptions, 'test' | 'showOutput' | 'env' | 'region' | 'profile' | 'proxy' | 'caBundlePath'>;

--- a/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/engine.ts
@@ -1,4 +1,4 @@
-import type { IntegRunnerOptions } from './runner-base';
+import type { CdkIntegHelperOptions } from './cdk-integ-helper';
 import { ToolkitLibRunnerEngine } from '../engines/toolkit-lib';
 
 /**
@@ -6,7 +6,7 @@ import { ToolkitLibRunnerEngine } from '../engines/toolkit-lib';
  *
  * Only the toolkit-lib engine is supported.
  */
-export function makeEngine(options: IntegRunnerOptions): ToolkitLibRunnerEngine {
+export function makeEngine(options: CdkIntegHelperOptions): ToolkitLibRunnerEngine {
   return new ToolkitLibRunnerEngine({
     workingDirectory: options.test.directory,
     showOutput: options.showOutput,

--- a/packages/@aws-cdk/integ-runner/lib/runner/index.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/index.ts
@@ -1,4 +1,4 @@
-export * from './runner-base';
+export * from './cdk-integ-helper';
 export * from './integ-test-suite';
 export * from './integ-test-runner';
 export * from './snapshot-test-runner';

--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -5,8 +5,8 @@ import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
 import * as fs from 'fs-extra';
 import * as workerpool from 'workerpool';
-import type { IntegRunnerOptions } from './runner-base';
-import { IntegRunner } from './runner-base';
+import type { CdkIntegHelperOptions } from './cdk-integ-helper';
+import { CdkIntegHelper } from './cdk-integ-helper';
 import type * as cdk from '../engines/cdk-interface';
 import * as logger from '../logger';
 import { chunks, exec, execWithSubShell, promiseWithResolvers, renderCommand } from '../utils';
@@ -118,10 +118,35 @@ export interface RunOptions extends CommonOptions {
  * An integration test runner that orchestrates executing
  * integration tests
  */
-export class IntegTestRunner extends IntegRunner {
-  constructor(options: IntegRunnerOptions, destructiveChanges?: DestructiveChange[]) {
-    super(options);
-    this._destructiveChanges = destructiveChanges;
+export class IntegTestRunner {
+  private readonly helper: CdkIntegHelper;
+  constructor(options: CdkIntegHelperOptions, destructiveChanges?: DestructiveChange[]) {
+    this.helper = CdkIntegHelper.create(options);
+    this.helper._destructiveChanges = destructiveChanges;
+
+    // We need to have given this a value, but we don't actually care about it initially,
+    // because we only synth to get the test definition.
+    // FIXME: This is unfortunate -- in order to start running the test "for real" we
+    // already have created a real snapshot with the real test definition, but we've thrown
+    // that away already. So we need to synth again just to get the test definition, AGAIN.
+    //
+    // We will rewrite this later when it comes time to generate the actual
+    // golden snapshot, to match the requested value in the test definition.
+    this.helper.configureLegacyEnableLookups('dont-care');
+  }
+
+  /**
+   * Compatibility shim with old API
+   */
+  public get testName() {
+    return this.helper.testName;
+  }
+
+  /**
+   * Compatibility shim with old API
+   */
+  private async actualTestSuite() {
+    return (await this.helper.actualSnapshot()).testDefinition;
   }
 
   public async actualTests(): Promise<{ [testName: string]: TestCase } | undefined> {
@@ -129,8 +154,8 @@ export class IntegTestRunner extends IntegRunner {
     // We don't want new tests written in the legacy mode.
     // If there is no existing snapshot _and_ this is a legacy
     // test then point the user to the new `IntegTest` construct
-    if (!this.hasSnapshot() && actualTestSuite.type === 'legacy-test-suite') {
-      throw new Error(`${this.testName} is a new test. Please use the IntegTest construct ` +
+    if (!this.helper.hasSnapshot() && actualTestSuite.type === 'legacy-test-suite') {
+      throw new Error(`${this.helper.testName} is a new test. Please use the IntegTest construct ` +
         'to configure the test\n' +
         'https://github.com/aws/aws-cdk/tree/main/packages/%40aws-cdk/integ-tests-alpha',
       );
@@ -140,8 +165,8 @@ export class IntegTestRunner extends IntegRunner {
   }
 
   public createCdkContextJson(): void {
-    if (!fs.existsSync(this.cdkContextPath)) {
-      fs.writeFileSync(this.cdkContextPath, JSON.stringify({
+    if (!fs.existsSync(this.helper.cdkContextPath)) {
+      fs.writeFileSync(this.helper.cdkContextPath, JSON.stringify({
         watch: { },
       }, undefined, 2));
     }
@@ -152,9 +177,9 @@ export class IntegTestRunner extends IntegRunner {
    * Fails fast if the snapshot does not exist at the given ref.
    */
   private checkoutSnapshotAtRef(ref: string): void {
-    const gitCwd = path.dirname(this.snapshotDir);
+    const gitCwd = path.dirname(this.helper.goldenSnapshotDir);
     const git = ['git', '-C', gitCwd];
-    const relativeSnapshotDir = path.relative(gitCwd, this.snapshotDir);
+    const relativeSnapshotDir = path.relative(gitCwd, this.helper.goldenSnapshotDir);
 
     try {
       exec([...git, 'checkout', ref, '--', relativeSnapshotDir]);
@@ -181,11 +206,11 @@ export class IntegTestRunner extends IntegRunner {
 
     for (let i = 0; i < totalTags; i++) {
       const tag = tags[i];
-      logger.highlight(`${this.testName}/${testCaseName}: deploying tag ${tag} (${i + 1}/${totalTags})`);
+      logger.highlight(`${this.helper.testName}/${testCaseName}: deploying tag ${tag} (${i + 1}/${totalTags})`);
 
       this.checkoutSnapshotAtRef(tag);
 
-      const expectedTestSuite = await this.expectedTestSuite();
+      const expectedTestSuite = await this.helper.expectedTestSuite();
       if (!expectedTestSuite || !(testCaseName in expectedTestSuite.testSuite)) {
         throw new Error(
           `Test case '${testCaseName}' does not exist in snapshot at tag '${tag}'`,
@@ -193,12 +218,12 @@ export class IntegTestRunner extends IntegRunner {
       }
 
       const expectedTestCase = expectedTestSuite.testSuite[testCaseName];
-      const deployResult = await this.cdk.deploy({
+      const deployResult = await this.helper.cdk.deploy({
         ...deployArgs,
         stacks: expectedTestCase.stacks,
         ...expectedTestCase?.cdkCommandOptions?.deploy?.args,
-        context: this.getContext(expectedTestCase?.cdkCommandOptions?.deploy?.args?.context),
-        app: path.relative(this.directory, this.snapshotDir),
+        context: this.helper.getContext(expectedTestCase?.cdkCommandOptions?.deploy?.args?.context),
+        app: path.relative(this.helper.directory, this.helper.goldenSnapshotDir),
         lookups: expectedTestSuite?.enableLookups,
       });
 
@@ -216,7 +241,7 @@ export class IntegTestRunner extends IntegRunner {
       }
     }
 
-    logger.highlight(`${this.testName}/${testCaseName}: deploying current branch (final)`);
+    logger.highlight(`${this.helper.testName}/${testCaseName}: deploying current branch (final)`);
   }
 
   /**
@@ -236,7 +261,7 @@ export class IntegTestRunner extends IntegRunner {
     // @see https://git-scm.com/docs/git#Documentation/git.txt--Cltpathgt
     // This way we are guaranteed to operate under the correct git repo, even
     // when executing integ-runner from outside the repo under test.
-    const gitCwd = path.dirname(this.snapshotDir);
+    const gitCwd = path.dirname(this.helper.goldenSnapshotDir);
     const git = ['git', '-C', gitCwd];
 
     // https://git-scm.com/docs/git-merge-base
@@ -253,7 +278,7 @@ export class IntegTestRunner extends IntegRunner {
     } catch (e) {
       logger.warning('%s\n%s',
         'Could not determine git origin branch.',
-        `You need to manually checkout the snapshot directory ${this.snapshotDir}` +
+        `You need to manually checkout the snapshot directory ${this.helper.goldenSnapshotDir}` +
         'from the merge-base (https://git-scm.com/docs/git-merge-base)',
       );
       logger.warning('error: %s', formatError(e));
@@ -262,14 +287,14 @@ export class IntegTestRunner extends IntegRunner {
     // if we found the base branch then get the merge-base (most recent common commit)
     // and checkout the snapshot using that commit
     if (baseBranch) {
-      const relativeSnapshotDir = path.relative(gitCwd, this.snapshotDir);
+      const relativeSnapshotDir = path.relative(gitCwd, this.helper.goldenSnapshotDir);
 
       const checkoutCommand = [...git, 'checkout', [...git, 'merge-base', 'HEAD', baseBranch], '--', relativeSnapshotDir];
       try {
         execWithSubShell(checkoutCommand);
       } catch (e) {
         logger.warning('%s\n%s',
-          `Could not checkout snapshot directory '${this.snapshotDir}'. Please verify the following command completes correctly:`,
+          `Could not checkout snapshot directory '${this.helper.goldenSnapshotDir}'. Please verify the following command completes correctly:`,
           renderCommand(checkoutCommand),
           '',
         );
@@ -296,14 +321,14 @@ export class IntegTestRunner extends IntegRunner {
     try {
       await this.watch(
         {
-          ...this.defaultArgs,
+          ...this.helper.defaultArgs,
           deploymentMethod: {
             method: 'hotswap',
             fallback: {
               method: 'change-set',
             },
           },
-          profile: this.profile,
+          profile: this.helper.profile,
           requireApproval: RequireApproval.NEVER,
           traceLogs: enableForVerbosityLevel(2) ?? false,
           verbose: enableForVerbosityLevel(3),
@@ -336,6 +361,16 @@ export class IntegTestRunner extends IntegRunner {
     if (!actualTestCase) {
       throw new Error(`Did not find test case name '${options.testCaseName}' in '${Object.keys(actualTestSuite.testSuite)}'`);
     }
+
+    // Ideally we would force `enableLookups` to `true`, always, because that's what we would like to converge on for the snapshots.
+    //
+    // HOWEVER!
+    //
+    // In order to do that, to validate the snapshot correctly we need to match what's in `integ.json`. In order to ratchet
+    // that value to `true`, we would need to rewrite `integ.json` to have `enableLookups: true`. We don't currently
+    // have code to reliably rewrite that file, so we just leave the value at whatever the test requested.
+    this.helper.configureLegacyEnableLookups(actualTestSuite.enableLookups ?? false);
+
     const clean = options.clean ?? true;
     const updateWorkflowEnabled = (options.updateWorkflow ?? true)
       && (actualTestCase.stackUpdateWorkflow ?? true);
@@ -349,8 +384,8 @@ export class IntegTestRunner extends IntegRunner {
       if (!options.dryRun && (actualTestCase.cdkCommandOptions?.deploy?.enabled ?? true)) {
         assertionResults = await this.deploy(
           {
-            ...this.defaultArgs,
-            profile: this.profile,
+            ...this.helper.defaultArgs,
+            profile: this.helper.profile,
             requireApproval: RequireApproval.NEVER,
             verbose: enableForVerbosityLevel(3),
             debug: enableForVerbosityLevel(4),
@@ -366,7 +401,7 @@ export class IntegTestRunner extends IntegRunner {
       // only create the snapshot if there are no failed assertion results
       // (i.e. no failures)
       if (!Object.values(assertionResults ?? {}).some(result => result.status === 'fail')) {
-        await this.createSnapshot();
+        await this.helper.createSnapshot();
       }
     } catch (e) {
       throw e;
@@ -374,21 +409,21 @@ export class IntegTestRunner extends IntegRunner {
       if (!options.dryRun) {
         if (clean && (actualTestCase.cdkCommandOptions?.destroy?.enabled ?? true)) {
           await this.destroy(options.testCaseName, {
-            ...this.defaultArgs,
-            profile: this.profile,
+            ...this.helper.defaultArgs,
+            profile: this.helper.profile,
             all: true,
             force: true,
-            app: this.cdkApp,
-            output: path.relative(this.directory, this.cdkOutDir),
+            app: this.helper.cdkApp,
+            output: path.relative(this.helper.directory, this.helper.cdkOutDir),
             ...actualTestCase.cdkCommandOptions?.destroy?.args,
-            context: this.getContext(actualTestCase.cdkCommandOptions?.destroy?.args?.context),
+            context: this.helper.getContext(actualTestCase.cdkCommandOptions?.destroy?.args?.context),
             roleArn: options.roleArn ?? actualTestCase.cdkCommandOptions?.destroy?.args?.roleArn,
             verbose: enableForVerbosityLevel(3),
             debug: enableForVerbosityLevel(4),
           });
         }
       }
-      this.cleanup();
+      this.helper.cleanup();
     }
     return assertionResults;
   }
@@ -402,18 +437,18 @@ export class IntegTestRunner extends IntegRunner {
       if (actualTestCase.hooks?.preDestroy) {
         actualTestCase.hooks.preDestroy.forEach(cmd => {
           exec(chunks(cmd), {
-            cwd: path.dirname(this.snapshotDir),
+            cwd: path.dirname(this.helper.goldenSnapshotDir),
           });
         });
       }
-      await this.cdk.destroy({
+      await this.helper.cdk.destroy({
         ...destroyArgs,
       });
 
       if (actualTestCase.hooks?.postDestroy) {
         actualTestCase.hooks.postDestroy.forEach(cmd => {
           exec(chunks(cmd), {
-            cwd: path.dirname(this.snapshotDir),
+            cwd: path.dirname(this.helper.goldenSnapshotDir),
           });
         });
       }
@@ -431,7 +466,7 @@ export class IntegTestRunner extends IntegRunner {
     if (actualTestCase.hooks?.preDeploy) {
       actualTestCase.hooks.preDeploy.forEach(cmd => {
         exec(chunks(cmd), {
-          cwd: path.dirname(this.snapshotDir),
+          cwd: path.dirname(this.helper.goldenSnapshotDir),
         });
       });
     }
@@ -442,13 +477,13 @@ export class IntegTestRunner extends IntegRunner {
         ...actualTestCase.stacks,
         ...actualTestCase.assertionStack ? [actualTestCase.assertionStack] : [],
       ],
-      output: path.relative(this.directory, this.cdkOutDir),
-      outputsFile: path.relative(this.directory, path.join(this.cdkOutDir, 'assertion-results.json')),
+      output: path.relative(this.helper.directory, this.helper.cdkOutDir),
+      outputsFile: path.relative(this.helper.directory, path.join(this.helper.cdkOutDir, 'assertion-results.json')),
       ...actualTestCase?.cdkCommandOptions?.deploy?.args,
       context: {
-        ...this.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
+        ...this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
       },
-      app: this.cdkApp,
+      app: this.helper.cdkApp,
     };
     const destroyMessage = {
       additionalMessages: [
@@ -456,7 +491,7 @@ export class IntegTestRunner extends IntegRunner {
         `  ${[
           ...process.env.AWS_REGION ? [`AWS_REGION=${process.env.AWS_REGION}`] : [],
           'cdk destroy',
-          `-a '${this.cdkApp}'`,
+          `-a '${this.helper.cdkApp}'`,
           watchArgs.stacks.join(' '),
           `--profile ${watchArgs.profile}`,
         ].join(' ')}`,
@@ -471,9 +506,9 @@ export class IntegTestRunner extends IntegRunner {
           'Repro:',
           `  ${[
             'cdk synth',
-            `-a '${this.cdkApp}'`,
-            `-o '${this.cdkOutDir}'`,
-            ...Object.entries(this.getContext()).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : []),
+            `-a '${this.helper.cdkApp}'`,
+            `-o '${this.helper.cdkOutDir}'`,
+            ...Object.entries(this.helper.getContext()).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : []),
             watchArgs.stacks.join(' '),
             `--outputs-file ${watchArgs.outputsFile}`,
             `--profile ${watchArgs.profile}`,
@@ -483,9 +518,9 @@ export class IntegTestRunner extends IntegRunner {
       });
     }
 
-    const assertionResults = path.join(this.cdkOutDir, 'assertion-results.json');
-    const watcher = chokidar.watch([this.cdkOutDir], {
-      cwd: this.directory,
+    const assertionResults = path.join(this.helper.cdkOutDir, 'assertion-results.json');
+    const watcher = chokidar.watch([this.helper.cdkOutDir], {
+      cwd: this.helper.directory,
     });
     watcher.on('all', (event: EventName, file: string) => {
       if (!isFileEvent(event)) {
@@ -498,7 +533,7 @@ export class IntegTestRunner extends IntegRunner {
         if (actualTestCase.hooks?.postDeploy) {
           actualTestCase.hooks.postDeploy.forEach(cmd => {
             exec(chunks(cmd), {
-              cwd: path.dirname(this.snapshotDir),
+              cwd: path.dirname(this.helper.goldenSnapshotDir),
             });
           });
         }
@@ -538,7 +573,7 @@ export class IntegTestRunner extends IntegRunner {
 
     const { promise: waiter, resolve } = promiseWithResolvers<number | null>();
 
-    await this.cdk.watch(watchArgs, {
+    await this.helper.cdk.watch(watchArgs, {
       // if `-v` (or above) is passed then stream the logs
       onStdout: (message) => {
         if (verbosity > 0) {
@@ -579,7 +614,7 @@ export class IntegTestRunner extends IntegRunner {
       if (actualTestCase.hooks?.preDeploy) {
         actualTestCase.hooks.preDeploy.forEach(cmd => {
           exec(chunks(cmd), {
-            cwd: path.dirname(this.snapshotDir),
+            cwd: path.dirname(this.helper.goldenSnapshotDir),
           });
         });
       }
@@ -587,34 +622,34 @@ export class IntegTestRunner extends IntegRunner {
       if (updateFromTags && updateFromTags.length > 0) {
         // Tag-sequence update workflow: deploy each tag's snapshot in order
         await this.deployFromTags(deployArgs, testCaseName, updateFromTags, allowDeleteFailures);
-      } else if (updateWorkflowEnabled && this.hasSnapshot()) {
+      } else if (updateWorkflowEnabled && this.helper.hasSnapshot()) {
         // Normal merge-base update workflow
-        const expectedTestSuite = await this.expectedTestSuite();
+        const expectedTestSuite = await this.helper.expectedTestSuite();
         if (expectedTestSuite && testCaseName in expectedTestSuite?.testSuite) {
           this.checkoutSnapshot();
           const expectedTestCase = expectedTestSuite.testSuite[testCaseName];
-          await this.cdk.deploy({
+          await this.helper.cdk.deploy({
             ...deployArgs,
             stacks: expectedTestCase.stacks,
             ...expectedTestCase?.cdkCommandOptions?.deploy?.args,
-            context: this.getContext(expectedTestCase?.cdkCommandOptions?.deploy?.args?.context),
-            app: path.relative(this.directory, this.snapshotDir),
+            context: this.helper.getContext(expectedTestCase?.cdkCommandOptions?.deploy?.args?.context),
+            app: path.relative(this.helper.directory, this.helper.goldenSnapshotDir),
             lookups: expectedTestSuite?.enableLookups,
           });
         }
       }
       // now deploy the "actual" test.
       // This is the stack update if the update workflow ran above.
-      const actualDeployResult = await this.cdk.deploy({
+      const actualDeployResult = await this.helper.cdk.deploy({
         ...deployArgs,
         lookups: (await this.actualTestSuite()).enableLookups,
         stacks: [
           ...actualTestCase.stacks,
         ],
-        output: path.relative(this.directory, this.cdkOutDir),
+        output: path.relative(this.helper.directory, this.helper.cdkOutDir),
         ...actualTestCase?.cdkCommandOptions?.deploy?.args,
-        context: this.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
-        app: this.cdkApp,
+        context: this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
+        app: this.helper.cdkApp,
       });
 
       if (actualDeployResult.deleteFailures.length > 0) {
@@ -638,32 +673,32 @@ export class IntegTestRunner extends IntegRunner {
       // assertions instead of failing at the first failed assertion
       // combining it with the above deployment would prevent any replacement updates
       if (actualTestCase.assertionStack) {
-        await this.cdk.deploy({
+        await this.helper.cdk.deploy({
           ...deployArgs,
           lookups: (await this.actualTestSuite()).enableLookups,
           stacks: [
             actualTestCase.assertionStack,
           ],
           rollback: false,
-          output: path.relative(this.directory, this.cdkOutDir),
+          output: path.relative(this.helper.directory, this.helper.cdkOutDir),
           ...actualTestCase?.cdkCommandOptions?.deploy?.args,
-          outputsFile: path.relative(this.directory, path.join(this.cdkOutDir, 'assertion-results.json')),
-          context: this.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
-          app: this.cdkApp,
+          outputsFile: path.relative(this.helper.directory, path.join(this.helper.cdkOutDir, 'assertion-results.json')),
+          context: this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
+          app: this.helper.cdkApp,
         });
       }
 
       if (actualTestCase.hooks?.postDeploy) {
         actualTestCase.hooks.postDeploy.forEach(cmd => {
           exec(chunks(cmd), {
-            cwd: path.dirname(this.snapshotDir),
+            cwd: path.dirname(this.helper.goldenSnapshotDir),
           });
         });
       }
 
       if (actualTestCase.assertionStack && actualTestCase.assertionStackName) {
         return this.processAssertionResults(
-          path.join(this.cdkOutDir, 'assertion-results.json'),
+          path.join(this.helper.cdkOutDir, 'assertion-results.json'),
           actualTestCase.assertionStackName,
           actualTestCase.assertionStack,
         );

--- a/packages/@aws-cdk/integ-runner/lib/runner/private/cloud-assembly.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/private/cloud-assembly.ts
@@ -152,7 +152,7 @@ export class AssemblyManifestReader {
   /**
    * Return a list of asset artifacts for a given stack
    */
-  public getAssetManifestsForStack(stackId: string): AssetManifest[] {
+  private getAssetManifestsForStack(stackId: string): AssetManifest[] {
     return Object.values(this.manifest.artifacts ?? {})
       .filter(artifact =>
         artifact.type === ArtifactType.ASSET_MANIFEST && (artifact.properties as AssetManifestProperties)?.file === `${stackId}.assets.json`)

--- a/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
@@ -5,9 +5,9 @@ import { StringDecoder } from 'string_decoder';
 import { UNKNOWN_REGION } from '@aws-cdk/cloud-assembly-api';
 import type { ResourceDifference } from '@aws-cdk/cloudformation-diff';
 import { fullDiff, formatDifferences, ResourceImpact } from '@aws-cdk/cloudformation-diff';
+import type { CdkIntegHelperOptions } from './cdk-integ-helper';
+import { CdkIntegHelper } from './cdk-integ-helper';
 import { AssemblyManifestReader } from './private/cloud-assembly';
-import type { IntegRunnerOptions } from './runner-base';
-import { IntegRunner, DEFAULT_SYNTH_OPTIONS } from './runner-base';
 import type { Diagnostic, DestructiveChange, SnapshotVerificationOptions } from '../workers/common';
 import { DiagnosticReason } from '../workers/common';
 
@@ -34,17 +34,29 @@ interface SnapshotAssembly {
  * Runner for snapshot tests. This handles orchestrating
  * the validation of the integration test snapshots
  */
-export class IntegSnapshotRunner extends IntegRunner {
-  constructor(options: Omit<IntegRunnerOptions, 'region'>) {
-    super({
+export class IntegSnapshotRunner {
+  private readonly helper: CdkIntegHelper;
+  constructor(options: Omit<CdkIntegHelperOptions, 'region'>) {
+    this.helper = CdkIntegHelper.create({
       ...options,
       region: UNKNOWN_REGION,
     });
   }
 
+  public hasSnapshot() {
+    return this.helper.hasSnapshot();
+  }
+
+  public actualTests() {
+    return this.helper.actualTests();
+  }
+
+  public dontCareAboutLegacyLookupsForTests() {
+    this.helper.configureLegacyEnableLookups('dont-care');
+  }
+
   /**
-   * Synth the integration tests and compare the templates
-   * to the existing snapshot.
+   * Synth the CDK app and compare the templates to the existing snapshot.
    *
    * @returns any diagnostics and any destructive changes
    */
@@ -54,25 +66,16 @@ export class IntegSnapshotRunner extends IntegRunner {
   }> {
     let doClean = true;
     try {
-      const expectedTestSuite = await this.expectedTestSuite();
-      const actualTestSuite = await this.actualTestSuite();
-      const expectedSnapshotAssembly = this.getSnapshotAssembly(this.snapshotDir, expectedTestSuite?.stacks);
+      // Read the "expected" snapshot
+      const expectedTestSuite = await this.helper.expectedTestSuite();
+      const expectedSnapshotAssembly = this.getSnapshotAssembly(this.helper.goldenSnapshotDir, expectedTestSuite?.stacks);
 
-      // synth the integration test
-      // FIXME: ideally we should not need to run this again if
-      // the cdkOutDir exists already, but for some reason generateActualSnapshot
-      // generates an incorrect snapshot and I have no idea why so synth again here
-      // to produce the "correct" snapshot
-      const env = DEFAULT_SYNTH_OPTIONS.env;
-      await this.cdk.synth({
-        app: this.cdkApp,
-        context: this.getContext(actualTestSuite.enableLookups ? DEFAULT_SYNTH_OPTIONS.context : {}),
-        env,
-        output: path.relative(this.directory, this.cdkOutDir),
-      });
+      // Configure settings from the golden snapshot
+      this.helper.configureLegacyEnableLookups(expectedTestSuite?.enableLookups ?? false);
 
       // read the "actual" snapshot
-      const actualSnapshotAssembly = this.getSnapshotAssembly(this.cdkOutDir, actualTestSuite.stacks);
+      const actualSnapshot = await this.helper.actualSnapshot();
+      const actualSnapshotAssembly = this.getSnapshotAssembly(this.helper.cdkOutDir, actualSnapshot.testDefinition.stacks);
 
       // diff the existing snapshot (expected) with the integration test (actual)
       const diagnostics = await this.diffAssembly(expectedSnapshotAssembly, actualSnapshotAssembly);
@@ -83,21 +86,16 @@ export class IntegSnapshotRunner extends IntegRunner {
 
         if (options.retain) {
           additionalMessages.push(
-            `(Failure retained) Expected: ${path.relative(process.cwd(), this.snapshotDir)}`,
-            `                   Actual:   ${path.relative(process.cwd(), this.cdkOutDir)}`,
+            `(Failure retained) Expected: ${path.relative(process.cwd(), this.helper.goldenSnapshotDir)}`,
+            `                   Actual:   ${path.relative(process.cwd(), this.helper.cdkOutDir)}`,
           ),
           doClean = false;
         }
 
         if (options.verbose) {
-          // Show the command necessary to repro this
-          const envSet = Object.entries(env).map(([k, v]) => `${k}='${v}'`);
-          const envCmd = envSet.length > 0 ? ['env', ...envSet] : [];
-
           additionalMessages.push(
             'Repro:',
-            `  ${[...envCmd, 'cdk synth', `-a '${this.cdkApp}'`, `-o '${this.cdkOutDir}'`, ...Object.entries(this.getContext()).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : [])].join(' ')}`,
-
+            `  ${this.helper.actualSynthReproCommand().join(' ')}`,
           );
         }
 
@@ -112,7 +110,7 @@ export class IntegSnapshotRunner extends IntegRunner {
       throw e;
     } finally {
       if (doClean) {
-        this.cleanup();
+        this.helper.cleanup();
       }
     }
   }
@@ -155,7 +153,7 @@ export class IntegSnapshotRunner extends IntegRunner {
    * @returns a list of resource types or undefined if none are found
    */
   private async getAllowedDestroyTypesForStack(stackId: string): Promise<string[] | undefined> {
-    for (const testCase of Object.values((await this.actualTests()) ?? {})) {
+    for (const testCase of Object.values((await this.helper.actualTests()) ?? {})) {
       if (testCase.stacks.includes(stackId)) {
         return testCase.allowDestroy;
       }
@@ -183,7 +181,7 @@ export class IntegSnapshotRunner extends IntegRunner {
       for (const templateId of Object.keys(stack.templates)) {
         if (!actual[stackId]?.templates[templateId]) {
           failures.push({
-            testName: this.testName,
+            testName: this.helper.testName,
             stackName: templateId,
             reason: DiagnosticReason.SNAPSHOT_FAILED,
             message: `${templateId} exists in snapshot, but not in actual`,
@@ -198,7 +196,7 @@ export class IntegSnapshotRunner extends IntegRunner {
       // that does not exist in the current snapshot
         if (!expected[stackId]?.templates[templateId]) {
           failures.push({
-            testName: this.testName,
+            testName: this.helper.testName,
             stackName: templateId,
             reason: DiagnosticReason.SNAPSHOT_FAILED,
             message: `${templateId} does not exist in snapshot, but does in actual`,
@@ -206,7 +204,7 @@ export class IntegSnapshotRunner extends IntegRunner {
           continue;
         } else {
           const config = {
-            diffAssets: (await this.actualTestSuite()).getOptionsForStack(stackId)?.diffAssets,
+            diffAssets: (await this.helper.actualSnapshot()).testDefinition.getOptionsForStack(stackId)?.diffAssets,
           };
           let actualTemplate = actual[stackId].templates[templateId];
           let expectedTemplate = expected[stackId].templates[templateId];
@@ -259,7 +257,7 @@ export class IntegSnapshotRunner extends IntegRunner {
               reason: DiagnosticReason.SNAPSHOT_FAILED,
               message: writable.data,
               stackName: templateId,
-              testName: this.testName,
+              testName: this.helper.testName,
               config,
             });
           }

--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -110,7 +110,6 @@ export class MockCdkProvider {
     const results = await integTest.testSnapshot();
 
     // THEN
-    expect(this.mocks.synth).toHaveBeenCalledTimes(2);
     expect(this.mocks.synth).toHaveBeenCalledWith({
       env: expect.objectContaining({
         CDK_INTEG_ACCOUNT: '12345678',

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -553,7 +553,6 @@ describe('IntegTest runIntegTests', () => {
     });
 
     expect(removeSyncMock.mock.calls).toEqual([
-      ['test/test-data/cdk-integ.out.xxxxx.test-with-snapshot-assets.js.snapshot'],
       ['test/test-data/xxxxx.test-with-snapshot-assets.js.snapshot'],
       [
         'test/test-data/xxxxx.test-with-snapshot-assets.js.snapshot/asset.be270bbdebe0851c887569796e3997437cca54ce86893ed94788500448e92824',

--- a/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
@@ -1,20 +1,7 @@
-import { LegacyIntegTestSuite } from '../../lib/runner';
+import { CdkIntegHelper, LegacyIntegTestSuite } from '../../lib/runner';
 import { IntegTest } from '../../lib/runner/integration-tests';
 import { ManifestLoadError } from '../../lib/runner/private/integ-manifest';
-import { IntegRunner } from '../../lib/runner/runner-base';
 import { testDataPath } from '../helpers';
-
-// Create a concrete implementation of IntegRunner for testing
-class TestIntegRunner extends IntegRunner {
-  public async runIntegTestCase(): Promise<void> {
-    // No-op for testing
-  }
-
-  // Expose protected method for testing
-  public async testLoadManifest(dir?: string) {
-    return this.loadManifest(dir);
-  }
-}
 
 describe('IntegRunner manifest error handling', () => {
   let mockCdk: any;
@@ -49,7 +36,7 @@ describe('IntegRunner manifest error handling', () => {
   test('loadManifest throws ManifestLoadError when manifest is invalid', async () => {
     // GIVEN
     const invalidManifestDir = testDataPath('invalid-integ-manifest');
-    const runner = new TestIntegRunner({
+    const runner = CdkIntegHelper.create({
       cdk: mockCdk,
       test: new IntegTest({
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
@@ -60,13 +47,13 @@ describe('IntegRunner manifest error handling', () => {
     });
 
     // WHEN / THEN
-    await expect(runner.testLoadManifest(invalidManifestDir)).rejects.toThrow(ManifestLoadError);
+    await expect(runner.loadManifest(invalidManifestDir)).rejects.toThrow(ManifestLoadError);
   });
 
   test('loadManifest falls back to legacy mode when manifest does not exist', async () => {
     // GIVEN
     const nonExistentDir = testDataPath('non-existent-dir');
-    const runner = new TestIntegRunner({
+    const runner = CdkIntegHelper.create({
       cdk: mockCdk,
       test: new IntegTest({
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
@@ -77,7 +64,7 @@ describe('IntegRunner manifest error handling', () => {
     });
 
     // WHEN
-    const result = await runner.testLoadManifest(nonExistentDir);
+    const result = await runner.loadManifest(nonExistentDir);
 
     // THEN
     expect(result instanceof LegacyIntegTestSuite).toBe(true);

--- a/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/snapshot-test-runner.test.ts
@@ -186,6 +186,7 @@ describe('IntegTest runSnapshotTests', () => {
         }),
         integOutDir: 'does/not/exist',
       });
+      integTest.dontCareAboutLegacyLookupsForTests();
 
       // THEN
       expect(await integTest.actualTests()).toEqual(expect.objectContaining({
@@ -208,6 +209,7 @@ describe('IntegTest runSnapshotTests', () => {
         }),
         integOutDir: 'does/not/exist',
       });
+      integTest.dontCareAboutLegacyLookupsForTests();
 
       // THEN
       expect(await integTest.actualTests()).toEqual(expect.objectContaining({


### PR DESCRIPTION
The golden snapshots contain stack trace information captured by the AWS CDK Library. This PR sets a context flag to ask the CDK Library to not do that.

Upon diving into this code, I got an itch I couldn't resist, so I refactored it *a lot* (and still in the middle of doing more):

- Both snapshot validator and test runner inherited from some base class (`IntegRunner`) that they only inherited from to get access to some helper functions. Renamed this class to `CdkIntegHelper` and used composition instead of inheritance to make these routines available in the other "runners".
- The tests do an awful lot of `synth`ing just to get at the test definition information that is *inside* of the CDK app. In this change, we at least remove one instance of `synths`: when a snapshot is being checked for invalidation, we used to do 2 `synths` but are now doing just 1 (mostly). The reason was `enableLookups`, see below.
- Snapshot generation logic is now more centralized; other synths (actual deployments do *another* synth just to get the test definition, even though we just got it from snapshot invalidation) could potentially be refactored and deduplicated in the future, but haven't done so yet. Plus there is still a lot of code duplication that we could probably move into the helper.

enableLookups
-------------

This setting is slightly weird: it is supposed to control whether the app can/is going to do context lookups.

If this is enabled, the integ runner passes fake context to the golden snapshot generator, and if it's not enabled, it doesn't.

The problem is that the value of this flag is determined by the CDK app, and we must already have decided on its value before we invoke the CDK app. This is a dependency that is hard to shake, and the reason the original code did 2 synths: one to get the value of `enableLookups`, then another one to do the "actual" synth.

Since the golden snapshot lookups are always faked, we could have always passed the context and have been fine. The problem is that the fake context affects the generated templates (for example: the number of subnets in a VPC is affected by these settings), so we can't wholesale change this setting now for all future runs, because it would cause snapshot invalidations.

So what we will do instead is read the `enableLookups` value from the golden snapshot settings, and use the same value to do the new snapshot synthesis. If after synthesizing we find out that we guessed wrong, we synth again with the right setting. This should almost never be the case.

We can ratchet to a future in which this setting is always turned on and the code that deals with backwards compatibility is removed, but for that we need to be able to change `integ.json` from the integ runner, and we don't have code to do that right now. This will be an exercise for the future.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
