### PR TITLE
chore: asset zip output depends on the machine timezone

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -717,7 +717,7 @@ const tools = defineTools({
   tools: {
     zip: {
       deps: ['yazl@^3.3.1', 'fast-glob@^3.3.3'],
-      devDeps: ['@types/yazl', 'jszip'],
+      devDeps: ['@types/yazl', 'jszip', 'timezone-mock'],
     },
   },
 });

--- a/packages/@aws-cdk/private-tools/.projen/deps.json
+++ b/packages/@aws-cdk/private-tools/.projen/deps.json
@@ -93,6 +93,10 @@
       "type": "build"
     },
     {
+      "name": "timezone-mock",
+      "type": "build"
+    },
+    {
       "name": "ts-jest",
       "type": "build"
     },

--- a/packages/@aws-cdk/private-tools/.projen/tasks.json
+++ b/packages/@aws-cdk/private-tools/.projen/tasks.json
@@ -39,7 +39,7 @@
       },
       "steps": [
         {
-          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/jest,@types/yazl,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,jszip,nx,projen,ts-jest"
+          "exec": "yarn dlx npm-check-updates@20 --upgrade --target=minor --cooldown=3 --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@cdklabs/eslint-plugin,@types/jest,@types/yazl,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,jszip,nx,projen,timezone-mock,ts-jest"
         }
       ]
     },

--- a/packages/@aws-cdk/private-tools/lib/zip/index.ts
+++ b/packages/@aws-cdk/private-tools/lib/zip/index.ts
@@ -5,10 +5,23 @@ import { globSync } from 'fast-glob';
 import { ZipFile } from 'yazl';
 
 /**
- * Fixed epoch used for every entry so that equal content yields an equal
- * zip (deterministic output, stable content hash).
+ * The fixed timestamp applied to every entry so that equal content yields an
+ * equal zip (deterministic output, stable content hash).
+ *
+ * It is built lazily (per call) from *local* date components rather than from a
+ * UTC instant (e.g. `new Date('1980-01-01T00:00:00Z')`). yazl derives the ZIP
+ * "DOS" timestamp from the local-time fields of this `Date`, so local
+ * components yield the same DOS value (1980-01-01 00:00:00) on every machine
+ * regardless of its timezone. Constructing it lazily (instead of as a
+ * module-load constant) means it reflects the process timezone at call time,
+ * which keeps the behavior identical in production while remaining observable
+ * to tests that simulate a timezone. Combined with `forceDosTimestamp`, the
+ * produced archive is byte-for-byte identical across timezones, which the asset
+ * hashing relies on.
  */
-const EPOCH = new Date('1980-01-01T00:00:00.000Z');
+function epoch(): Date {
+  return new Date(1980, 0, 1, 0, 0, 0);
+}
 
 /**
  * Receives informational messages (e.g. retries on EPERM on Windows).
@@ -57,7 +70,10 @@ export function zipString(fileName: string, rawString: string): Promise<Buffer> 
     zip.outputStream.on('end', () => resolve(Buffer.concat(buffers)));
 
     zip.addBuffer(Buffer.from(rawString), fileName, {
-      mtime: EPOCH, // reset date to get the same hash for the same content
+      mtime: epoch(), // reset date to get the same hash for the same content
+      // Only emit the DOS timestamp (no UTC "universal time" extended field),
+      // so the archive bytes do not depend on the machine's timezone.
+      forceDosTimestamp: true,
     });
     zip.end();
   });
@@ -93,8 +109,11 @@ function writeZipFile(directory: string, outputFile: string): Promise<void> {
       // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
       const [data, stat] = await Promise.all([fs.readFile(fullPath), fs.stat(fullPath)]);
       zip.addBuffer(data, file, {
-        mtime: EPOCH, // reset dates to get the same hash for the same content
+        mtime: epoch(), // reset dates to get the same hash for the same content
         mode: stat.mode,
+        // Only emit the DOS timestamp (no UTC "universal time" extended field),
+        // so the archive bytes do not depend on the machine's timezone.
+        forceDosTimestamp: true,
       });
     }
 

--- a/packages/@aws-cdk/private-tools/package.json
+++ b/packages/@aws-cdk/private-tools/package.json
@@ -51,6 +51,7 @@
     "nx": "^22.7.5",
     "prettier": "^2.8",
     "projen": "^0.99.73",
+    "timezone-mock": "^1.4.3",
     "ts-jest": "^29.4.11",
     "typescript": "5.9"
   },

--- a/packages/@aws-cdk/private-tools/test/zip/zip.test.ts
+++ b/packages/@aws-cdk/private-tools/test/zip/zip.test.ts
@@ -5,6 +5,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { promisify } from 'util';
 import * as jszip from 'jszip';
+import * as timezoneMock from 'timezone-mock';
 import { zipDirectory, zipString } from '../../lib/zip';
 
 const exec = promisify(_exec);
@@ -151,5 +152,54 @@ describe('zipString', () => {
     const a = await zipString('f.txt', 'same');
     const b = await zipString('f.txt', 'same');
     expect(contentHash(a)).toEqual(contentHash(b));
+  });
+});
+
+describe('timezone independence (regression)', () => {
+  // Regression guard: the produced archive must be byte-for-byte identical and
+  // its entry dates must reset to the fixed epoch regardless of the machine's
+  // timezone. A previous implementation derived the entry timestamp from a UTC
+  // instant, which yazl re-encodes using *local* time components, so archives
+  // built in a non-UTC timezone (e.g. Australia/Adelaide, +09:30) came out with
+  // shifted timestamps and different bytes — breaking cross-machine asset
+  // hashing.
+  //
+  // `timezone-mock` patches the global `Date` to simulate a zone. Because the
+  // epoch is built lazily inside `zipString`, simulating the zone around the
+  // call is enough — no module reloading is needed (and reloading would crash
+  // yazl, which builds out-of-range `Date`s at module load that timezone-mock
+  // rejects). Jest fake timers cannot be used here: they mock the clock, not
+  // the timezone offset.
+  afterEach(() => {
+    timezoneMock.unregister();
+  });
+
+  async function zipUnderTimezone(zone: timezoneMock.TimeZone): Promise<{ hash: string; date: string }> {
+    let buffer: Buffer;
+    timezoneMock.register(zone);
+    try {
+      buffer = await zipString('hello.txt', 'hello world');
+    } finally {
+      timezoneMock.unregister();
+    }
+    // Read back with the real Date so the decoded date is interpreted consistently.
+    const date = (await jszip.loadAsync(buffer)).files['hello.txt'].date.toISOString();
+    return { hash: contentHash(buffer), date };
+  }
+
+  test('resets dates and produces identical bytes across timezones', async () => {
+    const utc = await zipUnderTimezone('UTC');
+    const adelaide = await zipUnderTimezone('Australia/Adelaide'); // +09:30 (half-hour offset)
+    const pacific = await zipUnderTimezone('US/Pacific'); // negative offset
+
+    // The readable entry date is always the fixed epoch ...
+    for (const result of [utc, adelaide, pacific]) {
+      expect(result.date).toBe('1980-01-01T00:00:00.000Z');
+    }
+
+    // ... and the raw archive bytes are identical regardless of timezone, so
+    // asset hashes stay stable across machines.
+    expect(adelaide.hash).toBe(utc.hash);
+    expect(pacific.hash).toBe(utc.hash);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,6 +428,7 @@ __metadata:
     nx: "npm:^22.7.5"
     prettier: "npm:^2.8"
     projen: "npm:^0.99.73"
+    timezone-mock: "npm:^1.4.3"
     ts-jest: "npm:^29.4.11"
     typescript: "npm:5.9"
     yazl: "npm:^3.3.1"
@@ -17461,6 +17462,13 @@ __metadata:
   version: 2.3.8
   resolution: "through@npm:2.3.8"
   checksum: 10c0/4b09f3774099de0d4df26d95c5821a62faee32c7e96fb1f4ebd54a2d7c11c57fe88b0a0d49cf375de5fee5ae6bf4eb56dbbf29d07366864e2ee805349970d3cc
+  languageName: node
+  linkType: hard
+
+"timezone-mock@npm:^1.4.3":
+  version: 1.4.3
+  resolution: "timezone-mock@npm:1.4.3"
+  checksum: 10c0/984e52f711553c8fdc6ad23d756a3518981b9460048d0eec8d670cbe9457ba25217d2dc298af6cf56c5a61ff8f0db745b8170918cda4c6d30fad78d308a75050
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
CDK produces deterministic ZIP archives for file assets so that identical content always yields the same asset hash, no matter which machine ran the synth. The refactor in #1654 made that output depend on the machine's timezone: assets zipped on a non-UTC machine (for example Australia/Adelaide, +09:30) hashed differently than the same content zipped under UTC. For teams building from different timezones this shows up as spurious diffs and unnecessary re-deployments.

This restores timezone-independent output, so identical content always produces an identical archive again. A regression test covers UTC and non-UTC offsets to keep it that way.

Marking as `chore` since the previous change was not released yet and this PR does not need to appear in the release notes.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
