### PR TITLE
fix: read templates off the LSP event loop

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/codelens.ts
@@ -13,17 +13,22 @@ export const OPEN_RESOURCE_COMMAND = 'cdkExplorer.openResource';
  * sourceLocation matches fileUri, group by line and emit one lens per line
  * summarising the CFN resources produced there.
  */
-export function codeLensesForFile(index: ConstructIndex<ConstructNode>, fileUri: string): CodeLens[] {
+export async function codeLensesForFile(index: ConstructIndex<ConstructNode>, fileUri: string): Promise<CodeLens[]> {
   const matches = [...index]
     .filter((node) => isResourceOnFile(node, fileUri))
     .map((node) => ({ line: node.sourceLocation.line, node }));
 
   // Multiple resources can map to one line when an L2 construct fans out
-  // (e.g. an L2 producing a primary resource + auxiliary resources).
-  return [...groupBy(matches, (m) => m.line)].map(([line, group]) => ({
-    range: lineRange(line),
-    command: commandFor(group.map((m) => m.node)),
-  }));
+  // (e.g. an L2 producing a primary resource + auxiliary resources). Resolve
+  // sequentially so the number of concurrent reads never grows with app size.
+  const lenses: CodeLens[] = [];
+  for (const [line, group] of groupBy(matches, (m) => m.line)) {
+    lenses.push({
+      range: lineRange(line),
+      command: await commandFor(group.map((m) => m.node)),
+    });
+  }
+  return lenses;
 }
 
 /**
@@ -42,11 +47,15 @@ interface ResourceChoice {
  * client opens directly (one) or via a picker (several). Unresolvable resources
  * are dropped; a line where none resolve stays title-only.
  */
-function commandFor(nodes: readonly ResourceConstruct[]): Command {
+async function commandFor(nodes: readonly ResourceConstruct[]): Promise<Command> {
   const title = titleFor(nodes);
-  const choices = nodes
-    .map((node) => ({ label: node.type, description: friendlyName(node.path), target: resourceTarget(node) }))
-    .filter((choice): choice is ResourceChoice => choice.target !== undefined);
+  const choices: ResourceChoice[] = [];
+  for (const node of nodes) {
+    const target = await resourceTarget(node);
+    if (target !== undefined) {
+      choices.push({ label: node.type, description: friendlyName(node.path), target });
+    }
+  }
   if (choices.length === 0) {
     return { title, command: '' };
   }

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -73,8 +73,8 @@ export interface LspHandlers {
   onInitialize(params: InitializeParams): InitializeResult;
   onInitialized(): void;
   onDidSaveTextDocument(params: DidSaveTextDocumentParams): void;
-  onCodeLens(params: CodeLensParams): CodeLens[];
-  onDefinition(params: DefinitionParams): Location | undefined;
+  onCodeLens(params: CodeLensParams): Promise<CodeLens[]>;
+  onDefinition(params: DefinitionParams): Promise<Location | undefined>;
   onShutdown(): void;
 }
 
@@ -223,7 +223,7 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
     onCodeLens(params) {
       return codeLensesForFile(cachedIndex, params.textDocument.uri);
     },
-    onDefinition(params) {
+    async onDefinition(params) {
       // Only synthesized templates link back to source, and only file: URIs are
       // readable. Check the scheme before fileURLToPath, which throws on other
       // schemes (untitled:, git:, diff views).
@@ -234,7 +234,7 @@ export function createLspHandlers(options: LspHandlerOptions = {}): LspHandlers 
       const filePath = fileURLToPath(uri);
       let templateText: string;
       try {
-        templateText = fs.readFileSync(filePath, 'utf-8');
+        templateText = await fs.promises.readFile(filePath, 'utf-8');
       } catch {
         return undefined;
       }

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -23,13 +23,13 @@ export interface ResourceTarget {
  * Returns `undefined` when the node is not navigable: no resolved template, the
  * template cannot be read, it does not parse, or the logical id is absent.
  */
-export function resourceTarget(node: { templateFile?: string; logicalId: string }): ResourceTarget | undefined {
+export async function resourceTarget(node: { templateFile?: string; logicalId: string }): Promise<ResourceTarget | undefined> {
   if (node.templateFile === undefined) {
     return undefined;
   }
   let templateText: string;
   try {
-    templateText = fs.readFileSync(node.templateFile, 'utf-8');
+    templateText = await fs.promises.readFile(node.templateFile, 'utf-8');
   } catch {
     return undefined;
   }

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/codelens.test.ts
@@ -24,11 +24,11 @@ interface CommandChoice {
 }
 
 describe('codeLensesForFile', () => {
-  test('returns no lenses when tree is empty', () => {
-    expect(codeLensesForFile(ConstructIndex.fromTree([]), URI)).toEqual([]);
+  test('returns no lenses when tree is empty', async () => {
+    expect(await codeLensesForFile(ConstructIndex.fromTree([]), URI)).toEqual([]);
   });
 
-  test('returns no lenses for non-resource wrapper nodes (no logicalId)', () => {
+  test('returns no lenses for non-resource wrapper nodes (no logicalId)', async () => {
     // L2 wrapper: has sourceLocation but no logicalId/cfnType — they live on
     // its `Resource` child. Wrappers shouldn't get their own lens.
     const tree = [node({
@@ -36,10 +36,10 @@ describe('codeLensesForFile', () => {
       sourceLocation: { file: FILE, line: 12, column: 5 },
       // logicalId/type intentionally omitted
     })];
-    expect(codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toEqual([]);
+    expect(await codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toEqual([]);
   });
 
-  test('emits one lens per resource on its source line', () => {
+  test('emits one lens per resource on its source line', async () => {
     const tree = [node({
       path: 'Stack1/MyBucket/Resource',
       logicalId: 'MyBucketF68F3FF0',
@@ -47,7 +47,7 @@ describe('codeLensesForFile', () => {
       sourceLocation: { file: FILE, line: 12, column: 5 },
     })];
 
-    const lenses = codeLensesForFile(ConstructIndex.fromTree(tree), URI);
+    const lenses = await codeLensesForFile(ConstructIndex.fromTree(tree), URI);
     expect(lenses).toHaveLength(1);
     expect(lenses[0].range).toEqual({
       start: { line: 11, character: 0 },
@@ -56,7 +56,7 @@ describe('codeLensesForFile', () => {
     expect(lenses[0].command?.title).toBe('Creates AWS::S3::Bucket');
   });
 
-  test('groups multiple resources on the same source line into one lens', () => {
+  test('groups multiple resources on the same source line into one lens', async () => {
     // L2 like Bucket can produce Bucket + BucketPolicy + Key, all anchored
     // to the same `new s3.Bucket(...)` line. One lens, listing all.
     const tree = [
@@ -80,12 +80,12 @@ describe('codeLensesForFile', () => {
       }),
     ];
 
-    const lenses = codeLensesForFile(ConstructIndex.fromTree(tree), URI);
+    const lenses = await codeLensesForFile(ConstructIndex.fromTree(tree), URI);
     expect(lenses).toHaveLength(1);
     expect(lenses[0].command?.title).toBe('Creates 3 resources: AWS::S3::Bucket, AWS::S3::BucketPolicy, AWS::KMS::Key');
   });
 
-  test('emits separate lenses for resources on different lines', () => {
+  test('emits separate lenses for resources on different lines', async () => {
     const tree = [
       node({
         path: 'Stack1/A',
@@ -101,12 +101,12 @@ describe('codeLensesForFile', () => {
       }),
     ];
 
-    const lenses = codeLensesForFile(ConstructIndex.fromTree(tree), URI);
+    const lenses = await codeLensesForFile(ConstructIndex.fromTree(tree), URI);
     expect(lenses).toHaveLength(2);
     expect(lenses.map((l) => l.range.start.line).sort((a, b) => a - b)).toEqual([9, 19]);
   });
 
-  test('filters out resources from other files', () => {
+  test('filters out resources from other files', async () => {
     const tree = [
       node({
         path: 'Stack1/A',
@@ -125,15 +125,15 @@ describe('codeLensesForFile', () => {
     const index = ConstructIndex.fromTree(tree);
     // Each query returns only the resource defined in that file, which proves the
     // URI filter selects by file rather than returning everything for any query.
-    const onThisFile = codeLensesForFile(index, URI);
+    const onThisFile = await codeLensesForFile(index, URI);
     expect(onThisFile).toHaveLength(1);
     expect(onThisFile[0].command?.title).toBe('Creates AWS::S3::Bucket');
-    const onOtherFile = codeLensesForFile(index, OTHER_URI);
+    const onOtherFile = await codeLensesForFile(index, OTHER_URI);
     expect(onOtherFile).toHaveLength(1);
     expect(onOtherFile[0].command?.title).toBe('Creates AWS::SQS::Queue');
   });
 
-  test('walks descendants — finds resources nested under wrappers', () => {
+  test('walks descendants — finds resources nested under wrappers', async () => {
     const tree = [
       node({
         path: 'Stack1',
@@ -155,12 +155,12 @@ describe('codeLensesForFile', () => {
       }),
     ];
 
-    const lenses = codeLensesForFile(ConstructIndex.fromTree(tree), URI);
+    const lenses = await codeLensesForFile(ConstructIndex.fromTree(tree), URI);
     expect(lenses).toHaveLength(1);
     expect(lenses[0].command?.title).toContain('AWS::S3::Bucket');
   });
 
-  test('omits resources without sourceLocation (non-TS apps)', () => {
+  test('omits resources without sourceLocation (non-TS apps)', async () => {
     const tree = [node({
       path: 'Stack1/MyBucket/Resource',
       logicalId: 'MyBucketF68F3FF0',
@@ -168,10 +168,10 @@ describe('codeLensesForFile', () => {
       // sourceLocation omitted — non-TS app
     })];
 
-    expect(codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toEqual([]);
+    expect(await codeLensesForFile(ConstructIndex.fromTree(tree), URI)).toEqual([]);
   });
 
-  test('a single resource with a resolvable template gets a clickable openResource command', () => {
+  test('a single resource with a resolvable template gets a clickable openResource command', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
     const templateFile = path.join(dir, 'Stack1.template.json');
     fs.writeFileSync(templateFile, JSON.stringify({ Resources: { MyBucketF68F3FF0: { Type: 'AWS::S3::Bucket' } } }, null, 2));
@@ -184,7 +184,7 @@ describe('codeLensesForFile', () => {
         sourceLocation: { file: FILE, line: 12, column: 5 },
       })];
 
-      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      const lens = (await codeLensesForFile(ConstructIndex.fromTree(tree), URI))[0];
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
       const choices = (lens.command!.arguments as CommandChoice[][])[0];
       expect(choices).toHaveLength(1);
@@ -200,7 +200,7 @@ describe('codeLensesForFile', () => {
     }
   });
 
-  test('a multi-resource line carries all resolvable resources as choices', () => {
+  test('a multi-resource line carries all resolvable resources as choices', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
     const templateFile = path.join(dir, 'Stack1.template.json');
     fs.writeFileSync(templateFile, JSON.stringify({
@@ -212,7 +212,7 @@ describe('codeLensesForFile', () => {
         node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile, sourceLocation: { file: FILE, line: 12, column: 5 } }),
       ];
 
-      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      const lens = (await codeLensesForFile(ConstructIndex.fromTree(tree), URI))[0];
       const uri = pathToFileURL(templateFile).toString();
       expect(lens.command?.command).toBe(OPEN_RESOURCE_COMMAND);
       const choices = (lens.command!.arguments as CommandChoice[][])[0];
@@ -229,18 +229,18 @@ describe('codeLensesForFile', () => {
     }
   });
 
-  test('a multi-resource line with no resolvable templates stays title-only', () => {
+  test('a multi-resource line with no resolvable templates stays title-only', async () => {
     const tree = [
       node({ path: 'Stack1/B/Resource', logicalId: 'B1', type: 'AWS::S3::Bucket', templateFile: '/no/such.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
       node({ path: 'Stack1/B/Policy', logicalId: 'B2', type: 'AWS::S3::BucketPolicy', templateFile: '/no/such.json', sourceLocation: { file: FILE, line: 12, column: 5 } }),
     ];
 
-    const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+    const lens = (await codeLensesForFile(ConstructIndex.fromTree(tree), URI))[0];
     expect(lens.command?.command).toBe('');
     expect(lens.command?.arguments).toBeUndefined();
   });
 
-  test('a single resource whose id is missing from the template degrades to title-only', () => {
+  test('a single resource whose id is missing from the template degrades to title-only', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'codelens-'));
     const templateFile = path.join(dir, 'Stack1.template.json');
     fs.writeFileSync(templateFile, JSON.stringify({ Resources: { SomethingElse: { Type: 'AWS::S3::Bucket' } } }, null, 2));
@@ -253,7 +253,7 @@ describe('codeLensesForFile', () => {
         sourceLocation: { file: FILE, line: 12, column: 5 },
       })];
 
-      const lens = codeLensesForFile(ConstructIndex.fromTree(tree), URI)[0];
+      const lens = (await codeLensesForFile(ConstructIndex.fromTree(tree), URI))[0];
       expect(lens.command?.command).toBe('');
     } finally {
       fs.rmSync(dir, { recursive: true, force: true });

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -232,7 +232,7 @@ describe('LSP Server', () => {
     expect(client.published[0].diagnostics).toHaveLength(1);
   });
 
-  test('responds to codeLens with resources for the requested file', () => {
+  test('responds to codeLens with resources for the requested file', async () => {
     const stackTs = '/p/lib/stack.ts';
     const stackUri = pathToFileURL(stackTs).toString();
 
@@ -259,7 +259,7 @@ describe('LSP Server', () => {
 
     initializeClient(client, { applicationDir: '/p' });
 
-    const lenses = client.handlers.onCodeLens({
+    const lenses = await client.handlers.onCodeLens({
       textDocument: { uri: stackUri },
     });
 
@@ -348,7 +348,7 @@ describe('LSP Server', () => {
     expect(client.watcherClosed).toHaveBeenCalledTimes(1);
   });
 
-  test('onDefinition resolves a template position back to construct source', () => {
+  test('onDefinition resolves a template position back to construct source', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-def-'));
     const templateFile = path.join(dir, 'Stack1.template.json');
     const text = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
@@ -376,7 +376,7 @@ describe('LSP Server', () => {
 
       const uri = pathToFileURL(templateFile).toString();
       const position = TextDocument.create(uri, 'json', 0, text).positionAt(text.indexOf('AWS::S3::Bucket'));
-      const target = client.handlers.onDefinition({ textDocument: { uri }, position });
+      const target = await client.handlers.onDefinition({ textDocument: { uri }, position });
 
       expect(target?.uri).toBe(pathToFileURL('/p/lib/stack.ts').toString());
       expect(target?.range.start).toEqual({ line: 4, character: 2 }); // 1-based (5,3) -> 0-based
@@ -385,21 +385,21 @@ describe('LSP Server', () => {
     }
   });
 
-  test('onDefinition returns undefined for a non-template document', () => {
+  test('onDefinition returns undefined for a non-template document', async () => {
     const client = createTestClient();
     initializeClient(client, { applicationDir: '/p' });
-    const target = client.handlers.onDefinition({
+    const target = await client.handlers.onDefinition({
       textDocument: { uri: pathToFileURL('/p/lib/stack.ts').toString() },
       position: { line: 0, character: 0 },
     });
     expect(target).toBeUndefined();
   });
 
-  test('onDefinition returns undefined (does not throw) for a non-file URI', () => {
+  test('onDefinition returns undefined (does not throw) for a non-file URI', async () => {
     const client = createTestClient();
     initializeClient(client, { applicationDir: '/p' });
     expect(
-      client.handlers.onDefinition({
+      await client.handlers.onDefinition({
         textDocument: { uri: 'untitled:Untitled-1' },
         position: { line: 0, character: 0 },
       }),

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/template-locator.test.ts
@@ -57,7 +57,7 @@ describe('resourceTarget', () => {
     return undefined;
   };
 
-  test('resolves a resource node to its template uri and block range', () => {
+  test('resolves a resource node to its template uri and block range', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
@@ -66,7 +66,7 @@ describe('resourceTarget', () => {
     const node = find(result.data.tree, 'Stack1/MyBucket/Resource')!;
     const templateFile = path.join(dir!, 'Stack1.template.json');
 
-    const target = resourceTarget(node)!;
+    const target = (await resourceTarget(node))!;
     expect(target.uri).toBe(pathToFileURL(templateFile).toString());
     // The range spans the resource block (not a zero-width cursor) and re-parses to it.
     const text = fs.readFileSync(templateFile, 'utf-8');
@@ -74,30 +74,30 @@ describe('resourceTarget', () => {
     expect(sliceParse(text, target.range)).toEqual(JSON.parse(text).Resources.MyBucketF68F3FF0);
   });
 
-  test('returns undefined for a node without a resolved templateFile', () => {
-    expect(resourceTarget({ templateFile: undefined, logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
+  test('returns undefined for a node without a resolved templateFile', async () => {
+    expect(await resourceTarget({ templateFile: undefined, logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
   });
 
-  test('returns undefined when the logical id is not in the resolved template', () => {
+  test('returns undefined when the logical id is not in the resolved template', async () => {
     dir = buildFlatAssembly({
       stacks: [{ id: 'Stack1', resources: [{ id: 'MyBucket', logicalId: 'MyBucketF68F3FF0', cfnType: 'AWS::S3::Bucket' }] }],
     });
-    expect(resourceTarget({ templateFile: path.join(dir, 'Stack1.template.json'), logicalId: 'GhostId' })).toBeUndefined();
+    expect(await resourceTarget({ templateFile: path.join(dir, 'Stack1.template.json'), logicalId: 'GhostId' })).toBeUndefined();
   });
 
-  test('returns undefined (does not throw) when the template can no longer be read', () => {
-    expect(resourceTarget({ templateFile: '/no/such/template.json', logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
+  test('returns undefined (does not throw) when the template can no longer be read', async () => {
+    expect(await resourceTarget({ templateFile: '/no/such/template.json', logicalId: 'MyBucketF68F3FF0' })).toBeUndefined();
   });
 
-  test('resolves the definition block, not Ref/DependsOn occurrences of the same id', () => {
+  test('resolves the definition block, not Ref/DependsOn occurrences of the same id', async () => {
     const written = writeTemplate(TEMPLATE);
     dir = written.dir;
     // MyBucketF68F3FF0 is defined once and also referenced; the block must be the definition.
-    const target = resourceTarget({ templateFile: written.file, logicalId: 'MyBucketF68F3FF0' })!;
+    const target = (await resourceTarget({ templateFile: written.file, logicalId: 'MyBucketF68F3FF0' }))!;
     expect(sliceParse(TEMPLATE, target.range)).toEqual({ Type: 'AWS::S3::Bucket' });
   });
 
-  test('does not match a logical id that is a prefix of a longer key', () => {
+  test('does not match a logical id that is a prefix of a longer key', async () => {
     const contents = JSON.stringify(
       {
         Resources: {
@@ -111,7 +111,7 @@ describe('resourceTarget', () => {
     const written = writeTemplate(contents);
     dir = written.dir;
     // The shorter id must resolve to its own (distinct) block, not the longer-named sibling.
-    const target = resourceTarget({ templateFile: written.file, logicalId: 'MyBucket' })!;
+    const target = (await resourceTarget({ templateFile: written.file, logicalId: 'MyBucket' }))!;
     expect(sliceParse(contents, target.range)).toEqual({ Type: 'AWS::S3::Bucket', Properties: { BucketName: 'short' } });
   });
 });


### PR DESCRIPTION
Convert the two synchronous template reads on the LSP request paths (onDefinition and the CodeLens provider) to fs.promises, continuing the async direction from #1631. 

resourceTarget, codeLensesForFile, and commandFor are now async and read sequentially, so the number of concurrent reads never grows with app size. The LspHandlers interface widens onCodeLens and onDefinition to return Promises; the connection wiring passes the Promise through unchanged.

readAssembly and the source-map reads stay synchronous: they run at startup and on watch events, not per request, and convert-source-map takes a synchronous reader.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
