### PR TITLE
chore(cli): `CliIoHost` listeners can set level handle and requests

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -5,7 +5,7 @@ import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import type { HotswapResult, IIoHost, IoMessage, IoMessageCode, IoMessageLevel, IoRequest, ToolkitAction } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as promptly from 'promptly';
-import type { IoHelper, ActivityPrinterProps, IActivityPrinter, IoMessageMaker, IoDefaultMessages } from '../../../lib/api-private';
+import type { IoHelper, ActivityPrinterProps, IActivityPrinter, IoMessageMaker, IoRequestMaker, IoDefaultMessages } from '../../../lib/api-private';
 import { asIoHelper, IO, isMessageRelevantForLevel, CurrentActivityPrinter, HistoryActivityPrinter } from '../../../lib/api-private';
 import type { Context } from '../../api/context';
 import { StackActivityProgress } from '../../commands/deploy';
@@ -135,6 +135,16 @@ export interface MessageListenerResult {
    * @default false
    */
   readonly preventDefault?: boolean;
+
+  /**
+   * For requests only: answer the request with this value so the host does not
+   * prompt the user (and writes nothing). Ignored for plain notifications. The
+   * presence of the key is what matters, so `false`/`0`/`''` are valid answers.
+   * Use the `respond`/`respondOnce` helpers for the common case.
+   *
+   * @default - this listener does not answer the request
+   */
+  readonly respond?: unknown;
 }
 
 /**
@@ -442,7 +452,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    *   myCount += msg.data.stacks.length;
    * });
    */
-  public on<T>(code: IoMessageMaker<T>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
+  public on<T>(code: IoMessageMaker<T> | IoRequestMaker<T, any>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
     return this.addMessageListener(code.code, { once: false, fn: listener as MessageListenerFn });
   }
 
@@ -464,8 +474,30 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    * Like `on`, but the listener is automatically removed after it has been
    * invoked once.
    */
-  public once<T>(code: IoMessageMaker<T>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
+  public once<T>(code: IoMessageMaker<T> | IoRequestMaker<T, any>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
     return this.addMessageListener(code.code, { once: true, fn: listener as MessageListenerFn });
+  }
+
+  /**
+   * Answer a request (by its code) on the user's behalf with a fixed value, so
+   * the host does not prompt and writes nothing. Syntactic sugar for an `on`
+   * listener returning `{ respond: value }`; for conditional answers or to also
+   * reword the question, use `on`/`once` directly. Returns a function that
+   * removes the responder again.
+   *
+   * @example
+   * // Under --force, auto-confirm the destroy prompt without prompting.
+   * const dispose = ioHost.respond(IO.CDK_TOOLKIT_I7010, true);
+   */
+  public respond<T, U>(code: IoRequestMaker<T, U>, value: U): () => void {
+    return this.addMessageListener(code.code, { once: false, fn: () => ({ respond: value }) });
+  }
+
+  /**
+   * Like `respond`, but the answer is given only once and then removed.
+   */
+  public respondOnce<T, U>(code: IoRequestMaker<T, U>, value: U): () => void {
+    return this.addMessageListener(code.code, { once: true, fn: () => ({ respond: value }) });
   }
 
   /**
@@ -484,7 +516,11 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    * const dispose = ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) =>
    *   serializeStructure(msg.data.stacks, true));
    */
-  public rewrite<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string, level?: IoMessageLevel): () => void {
+  public rewrite<T>(
+    code: IoMessageMaker<T> | IoRequestMaker<T, any>,
+    formatter: (msg: IoMessage<T>) => string,
+    level?: IoMessageLevel,
+  ): () => void {
     return this.on(code, (msg) => ({ message: formatter(msg), ...(level !== undefined ? { level } : {}) }));
   }
 
@@ -492,7 +528,11 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    * Like `rewrite`, but the formatter is automatically removed after it has
    * been applied once.
    */
-  public rewriteOnce<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string, level?: IoMessageLevel): () => void {
+  public rewriteOnce<T>(
+    code: IoMessageMaker<T> | IoRequestMaker<T, any>,
+    formatter: (msg: IoMessage<T>) => string,
+    level?: IoMessageLevel,
+  ): () => void {
     return this.once(code, (msg) => ({ message: formatter(msg), ...(level !== undefined ? { level } : {}) }));
   }
 
@@ -515,16 +555,23 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
   /**
    * Run all registered listeners for a message's code, in registration order.
    *
-   * A listener may update the message text (which is passed on to subsequent
-   * listeners and the rest of the pipeline) and/or request that the default
-   * processing be skipped. `once` listeners are removed after they have run.
+   * A listener may update the message text/level (passed on to subsequent
+   * listeners and the rest of the pipeline), prevent the default processing, or
+   * (for requests) answer it. `once` listeners are removed after they have run.
    *
-   * Returns the (possibly text-updated) message and whether any listener
-   * prevented the default processing.
+   * Returns the (possibly updated) message, whether the default processing was
+   * prevented, and whether a listener answered the request (and with what).
    */
-  private applyMessageListeners(msg: IoMessage<unknown>): { message: IoMessage<unknown>; preventDefault: boolean } {
+  private applyMessageListeners(msg: IoMessage<unknown>): {
+    message: IoMessage<unknown>;
+    preventDefault: boolean;
+    responded: boolean;
+    response: unknown;
+  } {
     let current = msg;
     let preventDefault = false;
+    let responded = false;
+    let response: unknown;
 
     const listeners = msg.code ? this.messageListeners.get(msg.code) : undefined;
     if (listeners && listeners.length > 0) {
@@ -549,11 +596,15 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
           if (result.preventDefault) {
             preventDefault = true;
           }
+          if ('respond' in result) {
+            responded = true;
+            response = result.respond;
+          }
         }
       }
     }
 
-    return { message: current, preventDefault };
+    return { message: current, preventDefault, responded, response };
   }
 
   /**
@@ -582,6 +633,15 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       return;
     }
 
+    this.writeMessage(message);
+  }
+
+  /**
+   * Write a (already listener-processed) message to its target stream, honoring
+   * the log level and corked-logging buffer. Shared by `notify` and the
+   * non-prompting `requestResponse` path.
+   */
+  private writeMessage(message: IoMessage<unknown>): void {
     if (!isMessageRelevantForLevel(message, this.logLevel)) {
       return;
     }
@@ -687,13 +747,24 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
   /**
    * Notifies the host of a message that requires a response.
    *
-   * If the host does not return a response the suggested
-   * default response from the input message will be used.
+   * Registered listeners run first: a listener may reword the question (its text
+   * or level) or answer it outright via `respond` (e.g. `--force` auto-confirms
+   * a destroy). If no listener answers and the host cannot prompt, the suggested
+   * default response is used.
    */
   public async requestResponse<DataType, ResponseType>(msg: IoRequest<DataType, ResponseType>): Promise<ResponseType> {
+    // Listeners run exactly once here (so we don't go back through `notify`):
+    // they may answer the request, or reword/relevel the question shown below.
+    const applied = this.applyMessageListeners(msg);
+    if (applied.responded) {
+      return applied.response as ResponseType;
+    }
+    // The (possibly reworded) text/level to present to the user.
+    const question = applied.message.message;
+
     // If the request cannot be prompted for by the CliIoHost, we just accept the default
     if (!isPromptableRequest(msg)) {
-      await this.notify(msg);
+      this.writeMessage(applied.message);
       return msg.defaultResponse;
     }
 
@@ -722,18 +793,18 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       if (this.autoRespond) {
         // respond with yes to all confirmations
         if (isConfirmationPrompt(msg)) {
-          await this.notify({
+          await this.writeMessage({
             ...msg,
-            message: `${chalk.cyan(msg.message)} (auto-confirmed)`,
+            message: `${chalk.cyan(question)} (auto-confirmed)`,
           });
           return true;
         }
 
         // respond with the default for all other messages
         if (msg.defaultResponse) {
-          await this.notify({
+          await this.writeMessage({
             ...msg,
-            message: `${chalk.cyan(msg.message)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,
+            message: `${chalk.cyan(question)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,
           });
           return msg.defaultResponse;
         }
@@ -752,7 +823,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       // Basic confirmation prompt
       // We treat all requests with a boolean response as confirmation prompts
       if (isConfirmationPrompt(msg)) {
-        const confirmed = await promptly.confirm(`${chalk.cyan(msg.message)} (y/n)`);
+        const confirmed = await promptly.confirm(`${chalk.cyan(question)} (y/n)`);
         if (!confirmed) {
           throw new ToolkitError('AbortedByUser', 'Aborted by user');
         }
@@ -762,7 +833,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       // Asking for a specific value
       const prompt = extractPromptInfo(msg);
       const desc = responseDescription ?? prompt.default;
-      const answer = await promptly.prompt(`${chalk.cyan(msg.message)}${desc ? ` (${desc})` : ''}`, {
+      const answer = await promptly.prompt(`${chalk.cyan(question)}${desc ? ` (${desc})` : ''}`, {
         default: prompt.default,
         trim: true,
       });

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -106,9 +106,9 @@ export type TargetStream = 'stdout' | 'stderr' | 'drop';
 /**
  * The result a message listener may return to influence how a message is handled.
  *
- * A listener can only update the message _text_; it cannot change any other
- * field of the message (such as its `code`), which keeps the code-keyed
- * listener registry valid.
+ * A listener may update the message _text_ and/or its _level_; it cannot change
+ * any other field of the message (such as its `code`), which keeps the
+ * code-keyed listener registry valid.
  */
 export interface MessageListenerResult {
   /**
@@ -117,6 +117,17 @@ export interface MessageListenerResult {
    * @default - the message text is left unchanged
    */
   readonly message?: string;
+
+  /**
+   * Override the level of this message.
+   *
+   * The new level is used for both verbosity filtering and stream selection, so
+   * this can move a message between stdout/stderr (e.g. downgrade a `result` to
+   * `info`). The `code` is intentionally left unchanged.
+   *
+   * @default - the message level is left unchanged
+   */
+  readonly level?: IoMessageLevel;
 
   /**
    * Skip the default processing of the message, i.e. do not write it to a stream.
@@ -462,23 +473,27 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    * given code. This lets a caller define _how_ a toolkit message is presented
    * without the IoHost needing to know about it.
    *
-   * Syntactic sugar for an `on` listener that returns `{ message }`. Returns a
-   * function that removes the formatter again.
+   * Optionally pass a `level` to also override the message's level (which moves
+   * it between stdout/stderr and changes verbosity filtering). For the rarer
+   * case of overriding only the level, use `on`/`once` returning `{ level }`.
+   *
+   * Syntactic sugar for an `on` listener that returns `{ message, level? }`.
+   * Returns a function that removes the formatter again.
    *
    * @example
    * const dispose = ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) =>
    *   serializeStructure(msg.data.stacks, true));
    */
-  public rewrite<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string): () => void {
-    return this.on(code, (msg) => ({ message: formatter(msg) }));
+  public rewrite<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string, level?: IoMessageLevel): () => void {
+    return this.on(code, (msg) => ({ message: formatter(msg), ...(level !== undefined ? { level } : {}) }));
   }
 
   /**
    * Like `rewrite`, but the formatter is automatically removed after it has
    * been applied once.
    */
-  public rewriteOnce<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string): () => void {
-    return this.once(code, (msg) => ({ message: formatter(msg) }));
+  public rewriteOnce<T>(code: IoMessageMaker<T>, formatter: (msg: IoMessage<T>) => string, level?: IoMessageLevel): () => void {
+    return this.once(code, (msg) => ({ message: formatter(msg), ...(level !== undefined ? { level } : {}) }));
   }
 
   /**
@@ -527,6 +542,9 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
         if (result) {
           if (result.message !== undefined) {
             current = { ...current, message: result.message };
+          }
+          if (result.level !== undefined) {
+            current = { ...current, level: result.level };
           }
           if (result.preventDefault) {
             preventDefault = true;

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -228,6 +228,27 @@ describe('CliIoHost', () => {
       expect(mockStdout).toHaveBeenCalledWith('second\n');
     });
 
+    test('rewrite() can also override the level, moving the message between streams', async () => {
+      // A result-level message normally goes to stdout; rewriting it to info
+      // (and changing the text) sends it to stderr in non-CI mode.
+      track(ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${msg.message}`, 'info'));
+
+      await ioHost.notify(listMessage('first'));
+
+      expect(mockStderr).toHaveBeenCalledWith('rewritten:first\n');
+      expect(mockStdout).not.toHaveBeenCalled();
+    });
+
+    test('on() can override only the level, leaving the text unchanged', async () => {
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, () => ({ level: 'info' })));
+
+      await ioHost.notify(listMessage('first'));
+
+      // text unchanged, but routed to stderr because it is now info-level
+      expect(mockStderr).toHaveBeenCalledWith('first\n');
+      expect(mockStdout).not.toHaveBeenCalled();
+    });
+
     test('the returned dispose function removes the listener', async () => {
       const observed: string[] = [];
       const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -860,6 +860,63 @@ describe('CliIoHost', () => {
       })).rejects.toThrow('but concurrency is greater than 1');
     });
 
+    describe('request listeners', () => {
+      function confirmRequest(message = 'Are you sure?'): IoRequest<any, boolean> {
+        return plainMessage({
+          time: new Date(),
+          level: 'info',
+          action: 'destroy',
+          code: 'CDK_TOOLKIT_I7010',
+          message,
+          defaultResponse: false,
+        }) as IoRequest<any, boolean>;
+      }
+
+      test('respond() answers a request without prompting or printing', async () => {
+        const dispose = ioHost.respond(IO.CDK_TOOLKIT_I7010, true);
+
+        const response = await ioHost.requestResponse(confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStdout).not.toHaveBeenCalled();
+        dispose();
+      });
+
+      test('respondOnce() answers only the first request, then defers to the prompt', async () => {
+        const dispose = ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+
+        const first = await ioHost.requestResponse(confirmRequest());
+        const second = await requestResponse('y', confirmRequest());
+
+        expect(first).toBe(true);
+        expect(second).toBe(true);
+        // only the second request prompted; the first was answered silently
+        expect(mockStdout).toHaveBeenCalledWith(chalk.cyan('Are you sure?') + ' (y/n) ');
+        dispose();
+      });
+
+      test('a listener can reword the question that is prompted', async () => {
+        const dispose = ioHost.rewrite(IO.CDK_TOOLKIT_I7010, () => 'Really delete everything?');
+
+        const response = await requestResponse('y', confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStdout).toHaveBeenCalledWith(chalk.cyan('Really delete everything?') + ' (y/n) ');
+        dispose();
+      });
+
+      test('the returned dispose function removes the responder', async () => {
+        const dispose = ioHost.respond(IO.CDK_TOOLKIT_I7010, true);
+        dispose();
+
+        // responder gone, so the host prompts as usual
+        const response = await requestResponse('y', confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStdout).toHaveBeenCalledWith(chalk.cyan('Are you sure?') + ' (y/n) ');
+      });
+    });
+
     describe('boolean', () => {
       test('respond "yes" to a confirmation prompt', async () => {
         const response = await requestResponse('y', plainMessage({


### PR DESCRIPTION
Two small `CliIoHost` listener capabilities that the upcoming `cdk destroy` reroute needs. Both extend the existing `on`/`once`/`rewrite` family and change no command behavior on their own.

1. Rewrite listeners can override a message's level. A listener result may now carry a `level`, and `rewrite`/`rewriteOnce` take an optional third argument to set it. The level drives verbosity filtering and stream selection, so this lets a rerouted command re-categorize a message the action emits (for example, present a `result` as a plain `info` status line) without the action knowing. Level-only changes use `on`/`once` returning `{ level }`.

2. Listeners handle requests too. Requests now flow through the same listener pipeline as notifications, so `on`/`once`/`rewrite`/`rewriteOnce` also accept request codes. A listener can reword a question (or change its level), or answer it via a `respond` value so the host neither prompts nor prints. `respond(code, value)` and `respondOnce(code, value)` are sugar for the common "just answer it" case. This is how `cdk destroy --force` will confirm silently once it is routed through toolkit-lib.

Builds on the IoHost recording groundwork from #1661.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
