### PR TITLE
fix(cli): a declined `cdk destroy` now returns exit code 1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -249,6 +249,7 @@ Integration tests require AWS credentials and run against real accounts. During 
 - Error messages: lowercase, no period, include the wrong value, explain what to change
 - Never catch and swallow errors — CDK errors are unrecoverable
 - Validate inputs eagerly — fail fast with clear messages
+- Confirmation prompts: a declined confirmation must exit non-zero and fail soft. See [`packages/aws-cdk/docs/confirmation-prompts.md`](./packages/aws-cdk/docs/confirmation-prompts.md)
 
 ### AWS SDK Usage
 
@@ -334,6 +335,7 @@ When changing observable CLI behavior:
 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | Getting started, prerequisites, integration test process |
 | [`packages/aws-cdk/CONTRIBUTING.md`](./packages/aws-cdk/CONTRIBUTING.md) | CLI-specific: command definitions, bundling, source maps |
 | [`packages/@aws-cdk-testing/cli-integ/README.md`](./packages/@aws-cdk-testing/cli-integ/README.md) | Integration test suites, regression testing, patching |
+| [`packages/aws-cdk/docs/confirmation-prompts.md`](./packages/aws-cdk/docs/confirmation-prompts.md) | How declined confirmation prompts must behave (exit code, soft fail) |
 | [`.projenrc.ts`](./.projenrc.ts) | Monorepo configuration (all project settings) |
 
 ## Environment Setup

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-interactive.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/destroy/cdk-destroy-interactive.integtest.ts
@@ -9,8 +9,10 @@ integTest('cdk destroy prompts the user for confirmation', withDefaultFixture(as
   await fixture.cdkDeploy(stackName);
 
   fixture.log(`Destroying stack ${fullStackName} and declining prompt`);
-  await fixture.cdkDestroy(stackName, {
+  const output = await fixture.cdkDestroy(stackName, {
     force: false,
+    // Declining the confirmation aborts the command with a non-zero exit code.
+    allowErrExit: true,
     interact: [
       { prompt: /Are you sure you want to delete/, input: 'no' },
     ],
@@ -19,6 +21,9 @@ integTest('cdk destroy prompts the user for confirmation', withDefaultFixture(as
       FORCE_COLOR: '0',
     },
   });
+
+  // the decline is reported softly, not as a crash
+  expect(output).toContain('Deletion cancelled');
 
   // assert we didn't destroy the stack
   const stack = await fixture.aws.cloudFormation.send(new DescribeStacksCommand({ StackName: fullStackName }));

--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
@@ -6,7 +6,7 @@ import type { IECRClient, IS3Client, SDK, SdkProvider } from '../aws-auth/privat
 import { DEFAULT_TOOLKIT_STACK_NAME, ToolkitInfo } from '../toolkit-info';
 import { ProgressPrinter } from './progress-printer';
 import { ActiveAssetCache, BackgroundStackRefresh, refreshStacks } from './stack-refresh';
-import { ToolkitError } from '../../toolkit/toolkit-error';
+import { ToolkitError, AbortError } from '../../toolkit/toolkit-error';
 import { IO, type IoHelper } from '../io/private';
 import { Mode } from '../plugin';
 
@@ -760,7 +760,7 @@ export class GarbageCollector {
       const yes = ['y', 'yes'];
       const all = ['a', 'all', 'delete-all'];
       if (!response || ![...yes, ...all].includes(response.toLowerCase())) {
-        throw new ToolkitError('DeletionAborted', 'Deletion aborted by user');
+        throw new AbortError('DeletionAborted', 'Garbage collection cancelled');
       } else if (all.includes(response.toLowerCase())) {
         this.confirm = false;
       }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit-error.ts
@@ -2,6 +2,7 @@ import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 
 const TOOLKIT_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.ToolkitError');
 const AUTHENTICATION_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.AuthenticationError');
+const ABORT_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.AbortError');
 const DEPLOYMENT_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.DeploymentError');
 const ASSEMBLY_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.AssemblyError');
 const CONTEXT_PROVIDER_ERROR_SYMBOL = Symbol.for('@aws-cdk/toolkit-lib.ContextProviderError');
@@ -23,6 +24,13 @@ export class ToolkitError extends Error {
    */
   public static isAuthenticationError(x: any): x is AuthenticationError {
     return ToolkitError.isToolkitError(x) && AUTHENTICATION_ERROR_SYMBOL in x;
+  }
+
+  /**
+   * Determines if a given error is an instance of AbortError.
+   */
+  public static isAbortError(x: any): x is AbortError {
+    return ToolkitError.isToolkitError(x) && ABORT_ERROR_SYMBOL in x;
   }
 
   /**
@@ -92,6 +100,28 @@ export class AuthenticationError extends ToolkitError {
     super(errorCode, message, 'authentication');
     Object.setPrototypeOf(this, AuthenticationError.prototype);
     Object.defineProperty(this, AUTHENTICATION_ERROR_SYMBOL, { value: true });
+  }
+}
+
+/**
+ * Represents an abort of an operation because the user declined a confirmation.
+ *
+ * This is not a failure of the toolkit: the user was asked a question and chose
+ * not to proceed. It carries a per-action error code (for example
+ * `DeployAborted`) so the reason stays specific, while `isAbortError` lets
+ * consumers detect a user-initiated abort without matching on messages. The
+ * default message, `Operation cancelled`, is a sensible generic for any action.
+ */
+export class AbortError extends ToolkitError {
+  /**
+   * Denotes the source of the error as user.
+   */
+  public readonly source = 'user';
+
+  constructor(errorCode: string, message: string = 'Operation cancelled') {
+    super(errorCode, message, 'abort');
+    Object.setPrototypeOf(this, AbortError.prototype);
+    Object.defineProperty(this, ABORT_ERROR_SYMBOL, { value: true });
   }
 }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -27,7 +27,7 @@ import * as fs from 'fs-extra';
 import { NonInteractiveIoHost } from './non-interactive-io-host';
 import type { ToolkitServices } from './private';
 import { assemblyFromSource } from './private';
-import { ToolkitError } from './toolkit-error';
+import { ToolkitError, AbortError } from './toolkit-error';
 import type { DeployResult, DestroyResult, FeatureFlag, MinimumSeverity, RollbackResult } from './types';
 import type {
   BootstrapEnvironments,
@@ -935,7 +935,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
           if (prepareResult?.changeSet?.ChangeSetName) {
             await deployments.cleanupChangeSet(stack, prepareResult.changeSet.ChangeSetName);
           }
-          throw new ToolkitError('DeployAborted', 'Aborted by user');
+          throw new AbortError('DeployAborted', 'Deployment cancelled');
         }
       }
 
@@ -986,7 +986,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
                 concurrency,
               }));
               if (!confirmed) {
-                throw new ToolkitError('RollbackAborted', 'Aborted by user');
+                throw new AbortError('RollbackAborted', 'Rollback cancelled');
               }
 
               // Perform a rollback
@@ -1012,7 +1012,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
                 concurrency,
               }));
               if (!confirmed) {
-                throw new ToolkitError('ReplacementRollbackAborted', 'Aborted by user');
+                throw new AbortError('ReplacementRollbackAborted', 'Rollback cancelled');
               }
 
               // Go around through the 'while' loop again but switch rollback to true.
@@ -1393,7 +1393,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         motivation: 'User confirmation is needed before orphaning resources',
       }));
     if (!confirmed) {
-      throw new ToolkitError('OrphanAborted', 'Aborted by user');
+      throw new AbortError('OrphanAborted', 'Orphaning cancelled');
     }
 
     const result = await plan.execute();

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit-error.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/toolkit-error.test.ts
@@ -1,4 +1,4 @@
-import { AssemblyError, AuthenticationError, ContextProviderError, NoResultsFoundError, ToolkitError } from '../../lib/toolkit/toolkit-error';
+import { AssemblyError, AuthenticationError, ContextProviderError, NoResultsFoundError, ToolkitError, AbortError } from '../../lib/toolkit/toolkit-error';
 
 describe('toolkit error', () => {
   let toolkitError = new ToolkitError('TestError', 'Test toolkit error');
@@ -8,6 +8,7 @@ describe('toolkit error', () => {
   let assemblyError = AssemblyError.withStacks('Test authentication error', []);
   let assemblyCauseError = AssemblyError.withCause('Test authentication error', new Error('other error'));
   let noResultsError = new NoResultsFoundError('Test no results error');
+  let abortError = new AbortError('TestAborted');
 
   test('types are correctly assigned', async () => {
     expect(toolkitError.type).toBe('toolkit');
@@ -16,6 +17,7 @@ describe('toolkit error', () => {
     expect(assemblyCauseError.type).toBe('assembly');
     expect(contextProviderError.type).toBe('context-provider');
     expect(noResultsError.type).toBe('context-provider');
+    expect(abortError.type).toBe('abort');
   });
 
   test('isToolkitError works', () => {
@@ -38,6 +40,18 @@ describe('toolkit error', () => {
 
     expect(ToolkitError.isAuthenticationError(toolkitError)).toBe(false);
     expect(ToolkitError.isAuthenticationError(authError)).toBe(true);
+  });
+
+  test('isAbortError works', () => {
+    expect(abortError.source).toBe('user');
+    expect(abortError.name).toBe('TestAborted');
+    expect(abortError.message).toBe('Operation cancelled');
+
+    expect(ToolkitError.isAbortError(abortError)).toBe(true);
+    expect(ToolkitError.isToolkitError(abortError)).toBe(true);
+
+    expect(ToolkitError.isAbortError(toolkitError)).toBe(false);
+    expect(ToolkitError.isAbortError(authError)).toBe(false);
   });
 
   describe('isAssemblyError works', () => {

--- a/packages/aws-cdk/docs/confirmation-prompts.md
+++ b/packages/aws-cdk/docs/confirmation-prompts.md
@@ -1,0 +1,79 @@
+# Confirmation Prompts
+
+This document defines how the CLI must behave when a user declines a confirmation
+prompt (answers "no" to a question like "Are you sure you want to delete ...?",
+"Perform import?", or "Do you want to accept these changes?").
+
+This is a convention. Apply it to every command that asks for confirmation, so
+that declining behaves the same way everywhere.
+
+## The rule
+
+**Declining a confirmation exits non-zero and fails soft.**
+
+These are two independent decisions:
+
+1. **Exit code: non-zero.** The exit code answers a single question: did the
+   operation the user asked for happen? When the user declines, it did not, so
+   the command exits non-zero, the same as any other "the requested change did
+   not occur" outcome.
+2. **Presentation: soft.** A decline is an expected, user-initiated outcome, not
+   a defect. It must print a single clear line (no stack trace, no "internal
+   error" framing) and must not be counted as a crash or error in telemetry. It
+   is tagged as a user abort.
+
+In short: the exit code reflects "did the thing happen" (no, so non-zero); soft
+vs hard reflects "is this a bug" (no, so soft).
+
+## Why non-zero
+
+- **Post-condition.** The user asked to deploy, destroy, import, or apply. It did
+  not happen. The exit code should reflect the resulting state, not whose choice
+  caused it.
+- **Chaining safety.** Shell chains such as `cdk deploy && ./promote.sh` must not
+  continue when the deploy did not happen. This applies in interactive terminals
+  too, where developers routinely use `&&`. A non-zero exit short-circuits the
+  chain; exit 0 would let the next step run as if the operation succeeded.
+- **Ecosystem convention.** Comparable infrastructure tools do the same. For
+  example `terraform apply` answered "no" prints "Apply cancelled" and exits
+  non-zero, and `apt` answered "n" prints "Abort." and exits non-zero. Declining
+  a prompt is also equivalent to pressing Ctrl-C at the prompt, which is
+  non-zero.
+
+A confirmation prompt only appears in interactive use. In a non-interactive
+context the CLI cannot ask, so the prompt path is already an error (see below).
+That means the non-zero rule keeps the interactive decline consistent with the
+non-interactive case: in both, the operation did not happen.
+
+## How to implement it
+
+The `IoHost` does not decide whether to abort. `requestResponse` returns the
+user's answer (including `false` for a declined confirmation) and never throws on
+a decline. Each command owns the decline and reacts to a `false` answer by
+throwing an `AbortError`:
+
+```ts
+const confirmed = await ioHelper.requestResponse(IO.SOME_CONFIRMATION.req(question));
+if (!confirmed) {
+  throw new AbortError('SomethingAborted');
+}
+```
+
+`AbortError` is a dedicated `ToolkitError` subclass (`AbortError.isAbortError(x)`)
+that marks a user-initiated abort. It still carries a per-action error code (for
+example `DeployAborted`, `RollbackAborted`) so the reason stays clear in output
+and telemetry, while the marker gives the CLI one reliable way to detect a
+decline without matching on messages.
+
+The default message is `Operation cancelled`, a safe generic fallback. Prefer a
+specific message in the form `<Operation> cancelled` (sentence case, no trailing
+period), for example `Deployment cancelled` or `Import cancelled`, so the output
+names what was cancelled.
+
+The CLI's top-level error handler detects `AbortError` and applies the policy
+above: a non-zero exit, a soft presentation (the message only, no stack trace or
+"error" framing), and a user-abort telemetry tag rather than a crash.
+
+Do not let the `IoHost` throw an abort on the command's behalf, do not swallow a
+decline into an exit-0 return, and do not signal a decline with a plain
+`ToolkitError` that the handler cannot distinguish from a real failure.

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -5,7 +5,7 @@ import type { IManifestEntry } from '@aws-cdk/cdk-assets-lib';
 import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import { RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { ConfirmationRequest, DeploymentMethod, DiagnoseOptions, PublishAssetsOptions, ToolkitAction, ToolkitOptions, UnstableFeature, ValidateOptions } from '@aws-cdk/toolkit-lib';
-import { PermissionChangeType, Toolkit, ToolkitError } from '@aws-cdk/toolkit-lib';
+import { PermissionChangeType, Toolkit, ToolkitError, AbortError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
@@ -821,8 +821,7 @@ export class CdkToolkit {
       await ioHelper.defaults.info(formattedDiff);
       const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('Perform import?', { motivation: 'Confirm import with pending drift' }));
       if (!confirmed) {
-        await ioHelper.defaults.info('Import cancelled.');
-        return;
+        throw new AbortError('ImportAborted', 'Import cancelled');
       }
     }
 
@@ -920,14 +919,9 @@ export class CdkToolkit {
     if (!options.force) {
       const motivation = 'Destroying stacks is an irreversible action';
       const question = `Are you sure you want to delete: ${chalk.blue(stacks.stackArtifacts.map((s) => s.hierarchicalId).join(', '))}`;
-      try {
-        await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req(question, { motivation }));
-      } catch (err: unknown) {
-        if (!ToolkitError.isToolkitError(err) || err.message != 'Aborted by user') {
-          throw err; // unexpected error
-        }
-        await ioHelper.notify(IO.CDK_TOOLKIT_E7010.msg(err.message));
-        return;
+      const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req(question, { motivation }));
+      if (!confirmed) {
+        throw new AbortError('DestroyAborted', 'Deletion cancelled');
       }
     }
 
@@ -2064,9 +2058,15 @@ function buildParameterMap(
 async function askUserConfirmation(
   ioHost: CliIoHost,
   req: ActionLessRequest<ConfirmationRequest, boolean>,
+  abortErrorCode: string,
+  abortMessage: string,
 ) {
   await ioHost.withCorkedLogging(async () => {
-    await ioHost.asIoHelper().requestResponse(req);
+    // The IoHost returns the answer rather than aborting; abort here on decline.
+    const confirmed = await ioHost.asIoHelper().requestResponse(req);
+    if (!confirmed) {
+      throw new AbortError(abortErrorCode, abortMessage);
+    }
   });
 }
 
@@ -2311,6 +2311,8 @@ class WorkGraphDeploymentActions implements WorkGraphActions {
               permissionChangeType: securityDiff.permissionChangeType,
               templateDiffs: formatter.diffs,
             }),
+            'DeployAborted',
+            'Deployment cancelled',
           );
         } catch (e) {
           if (prepareResult?.changeSet?.ChangeSetName) {
@@ -2379,6 +2381,8 @@ class WorkGraphDeploymentActions implements WorkGraphActions {
                   motivation,
                   concurrency: this.options.concurrency,
                 }),
+                'RollbackAborted',
+                'Rollback cancelled',
               );
             }
 
@@ -2406,6 +2410,8 @@ class WorkGraphDeploymentActions implements WorkGraphActions {
                   concurrency: this.options.concurrency,
                   motivation,
                 }),
+                'ReplacementRollbackAborted',
+                'Rollback cancelled',
               );
             }
 

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */ // yargs
 import * as cxapi from '@aws-cdk/cx-api';
 import type { ChangeSetDeployment, DeploymentMethod, DirectDeployment, StackSelector as LibStackSelector } from '@aws-cdk/toolkit-lib';
-import { ExpandStackSelection, StackSelectionStrategy, ToolkitError, Toolkit } from '@aws-cdk/toolkit-lib';
+import { ExpandStackSelection, StackSelectionStrategy, ToolkitError, Toolkit, AbortError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import { guessLanguage } from '../util';
 import { CdkToolkit, AssetBuildTime } from './cdk-toolkit';
@@ -893,9 +893,15 @@ export function cli(args: string[] = process.argv.slice(2)) {
       }
     })
     .catch(async (err) => {
+      // The user declined a confirmation. This is an expected outcome, not a crash, so present it softly/
+      // We still exit non-zero so the operation is reported as not completed.
+      const soft = AbortError.isAbortError(err);
+
       // Log the stack trace if we're on a developer workstation. Otherwise this will be into a minified
       // file and the printed code line and stack trace are huge and useless.
-      prettyPrintError(err, isDeveloperBuildVersion());
+      const debug = isDeveloperBuildVersion();
+
+      prettyPrintError(err, { debug, soft });
       error = {
         name: cdkCliErrorName(err),
       };

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -768,7 +768,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       return msg.defaultResponse;
     }
 
-    const response = await this.withCorkedLogging(async (): Promise<string | number | true> => {
+    const response = await this.withCorkedLogging(async (): Promise<string | number | boolean> => {
       // prepare prompt data
       // @todo this format is not defined anywhere, probably should be
       const data: {
@@ -822,12 +822,11 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
 
       // Basic confirmation prompt
       // We treat all requests with a boolean response as confirmation prompts
+      // The IoHost never aborts on a "no": it returns the answer and lets the
+      // calling action decide what to do (so abort handling is consistent
+      // across actions).
       if (isConfirmationPrompt(msg)) {
-        const confirmed = await promptly.confirm(`${chalk.cyan(question)} (y/n)`);
-        if (!confirmed) {
-          throw new ToolkitError('AbortedByUser', 'Aborted by user');
-        }
-        return confirmed;
+        return promptly.confirm(`${chalk.cyan(question)} (y/n)`);
       }
 
       // Asking for a specific value

--- a/packages/aws-cdk/lib/cli/pretty-print-error.ts
+++ b/packages/aws-cdk/lib/cli/pretty-print-error.ts
@@ -2,11 +2,17 @@
 import * as chalk from 'chalk';
 
 /* c8 ignore start */
-export function prettyPrintError(error: unknown, debug = false) {
+export function prettyPrintError(error: unknown, options: { soft?: boolean; debug?: boolean } = {}) {
   const err = ensureError(error);
-  console.error(chalk.red(err.message));
+  const debug = options.debug ?? false;
+  const soft = options.soft ?? false;
 
-  if (err.cause) {
+  // A soft error (for example a user-declined confirmation) is an expected outcome, not a crash.
+  // Present the message less scary.
+  const errorPaint = soft ? chalk.yellow : chalk.red;
+
+  console.error(errorPaint(err.message));
+  if (err.cause && !soft) {
     const cause = ensureError(err.cause);
     console.error(chalk.yellow(cause.message));
     printTrace(cause, debug);

--- a/packages/aws-cdk/lib/commands/flags/operations.ts
+++ b/packages/aws-cdk/lib/commands/flags/operations.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
 import { formatTable } from '@aws-cdk/cloudformation-diff';
 import type { FeatureFlag, Toolkit } from '@aws-cdk/toolkit-lib';
-import { CdkAppMultiContext, MemoryContext, DiffMethod } from '@aws-cdk/toolkit-lib';
+import { CdkAppMultiContext, MemoryContext, DiffMethod, AbortError } from '@aws-cdk/toolkit-lib';
 import * as chalk from 'chalk';
 import * as fs from 'fs-extra';
 import PQueue from 'p-queue';
@@ -366,13 +366,13 @@ export class FlagOperations {
       defaultResponse: false,
     });
 
-    if (userAccepted) {
-      await this.modifyValues(flagNames, params);
-      await this.ioHelper.defaults.info('Flag value(s) updated successfully.');
-    } else {
-      await this.ioHelper.defaults.info('Operation cancelled');
+    if (!userAccepted) {
+      await this.cleanupTempDirectories();
+      throw new AbortError('FlagsAborted', 'Flag update cancelled');
     }
 
+    await this.modifyValues(flagNames, params);
+    await this.ioHelper.defaults.info('Flag value(s) updated successfully.');
     await this.cleanupTempDirectories();
   }
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -114,7 +114,7 @@ let cloudExecutable: MockCloudExecutable;
 let ioHost = CliIoHost.instance();
 let ioHelper = asIoHelper(ioHost, 'deploy');
 let notifySpy = jest.spyOn(ioHost, 'notify');
-let requestSpy = jest.spyOn(ioHost, 'requestResponse');
+let requestSpy = jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true);
 
 beforeEach(async () => {
   jest.resetAllMocks();
@@ -147,6 +147,10 @@ beforeEach(async () => {
   ioHelper = asIoHelper(ioHost, 'deploy');
   ioHost.isCI = false;
   notifySpy = jest.spyOn(ioHost, 'notify');
+  // Confirmation prompts are answered "yes" by default; the IoHost returns the
+  // answer (it no longer throws on decline), so the action decides. Tests that
+  // exercise a decline override this with `false`.
+  requestSpy = jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true);
 });
 
 function defaultToolkitSetup() {
@@ -261,7 +265,7 @@ describe('deploy', () => {
 
   test('any-change approval shows stack diff when there are no security changes', async () => {
     const toolkit = defaultToolkitSetup();
-    requestSpy = jest.spyOn(ioHost, 'requestResponse');
+    requestSpy = jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true);
     await toolkit.deploy({
       selector: { patterns: ['Test-Stack-A-Display-Name'] },
       deploymentMethod: { method: 'change-set' },
@@ -505,7 +509,7 @@ describe('deploy', () => {
         deployments: mockCfnDeployments,
       });
 
-      requestSpy = jest.spyOn(ioHost, 'requestResponse');
+      requestSpy = jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true);
 
       // WHEN — ANYCHANGE would normally prompt for approval, but a no-op change
       // set means there is nothing for the user to approve.
@@ -574,8 +578,8 @@ describe('deploy', () => {
         changeSet: { Status: 'CREATE_COMPLETE', Changes: [{ Type: 'Resource' }], ChangeSetName: 'my-change-set', $metadata: {} },
       });
 
-      // Reject approval
-      requestSpy.mockRejectedValue(new Error('Aborted by user'));
+      // Reject approval: the IoHost returns false and the deploy aborts itself.
+      requestSpy.mockResolvedValue(false);
 
       const cdkToolkit = new CdkToolkit({
         ioHost,
@@ -590,7 +594,7 @@ describe('deploy', () => {
         selector: { patterns: ['Test-Stack-A-Display-Name'] },
         requireApproval: RequireApproval.ANYCHANGE,
         deploymentMethod: { method: 'change-set' },
-      })).rejects.toThrow(/Aborted/);
+      })).rejects.toThrow(/Deployment cancelled/);
 
       // THEN
       expect(mockCfnDeployments.cleanupChangeSet).toHaveBeenCalledWith(

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -932,16 +932,17 @@ describe('CliIoHost', () => {
         expect(response).toBe(true);
       });
 
-      test('respond "no" to a confirmation prompt', async () => {
-        await expect(() => requestResponse('n', plainMessage({
+      test('respond "no" to a confirmation prompt returns false (the IoHost does not abort)', async () => {
+        const response = await requestResponse('n', plainMessage({
           time: new Date(),
           level: 'info',
           action: 'synth',
           code: 'CDK_TOOLKIT_I0001',
           message: 'Continue?',
           defaultResponse: true,
-        }))).rejects.toThrow('Aborted by user');
+        }));
 
+        expect(response).toBe(false);
         expect(mockStdout).toHaveBeenCalledWith(chalk.cyan('Continue?') + ' (y/n) ');
       });
     });
@@ -1115,15 +1116,17 @@ describe('CliIoHost', () => {
         expect(response).toEqual(true);
       });
 
-      test('require approval by default - respond no', async () => {
-        await expect(() => requestResponse('n', plainMessage({
+      test('require approval by default - respond no returns false', async () => {
+        const response = await requestResponse('n', plainMessage({
           time: new Date(),
           level: 'info',
           action: 'synth',
           code: 'CDK_TOOLKIT_I5060',
           message: 'test message',
           defaultResponse: true,
-        }))).rejects.toThrow('Aborted by user');
+        }));
+
+        expect(response).toBe(false);
       });
 
       test('never require approval', async () => {

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_CDK_TOOLKIT_E7010_and_destroys_nothing_when_the_user_declines.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_CDK_TOOLKIT_E7010_and_destroys_nothing_when_the_user_declines.ndjson
@@ -1,4 +1,0 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"request","action":"none","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":{"error":"AbortedByUser"}}
-{"seq":3,"type":"notify","action":"none","level":"error","code":"CDK_TOOLKIT_E7010","message":"Aborted by user"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_with_an_AbortError_and_destroys_nothing_when_the_user_declines.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_with_an_AbortError_and_destroys_nothing_when_the_user_declines.ndjson
@@ -1,0 +1,3 @@
+{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"request","action":"none","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":false}

--- a/packages/aws-cdk/test/commands/destroy.test.ts
+++ b/packages/aws-cdk/test/commands/destroy.test.ts
@@ -1,4 +1,4 @@
-import { ToolkitError } from '@aws-cdk/toolkit-lib';
+import { ToolkitError, AbortError } from '@aws-cdk/toolkit-lib';
 import { Deployments } from '../../lib/api';
 import type { DestroyStackOptions } from '../../lib/api/deployments';
 import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
@@ -160,17 +160,19 @@ describe('force: false (confirmation prompt)', () => {
     expect(cloudFormation.destroyStack).toHaveBeenCalledTimes(1);
   });
 
-  test('aborts (CDK_TOOLKIT_E7010) and destroys nothing when the user declines', async () => {
-    // The IoHost throws AbortedByUser when the user declines a confirmation.
-    jest.spyOn(ioHost, 'requestResponse').mockImplementation((() => {
-      throw new ToolkitError('AbortedByUser', 'Aborted by user');
-    }) as any);
+  test('aborts with an AbortError and destroys nothing when the user declines', async () => {
+    // The IoHost returns the answer; declining is `false` and the command aborts
+    // by throwing an AbortError (non-zero exit, presented softly by the CLI).
+    jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(false as any);
 
-    await toolkit.destroy({
+    const error = await toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },
       exclusively: true,
       force: false,
-    });
+    }).catch((e) => e);
+
+    expect(AbortError.isAbortError(error)).toBe(true);
+    expect(error.name).toBe('DestroyAborted');
 
     // Aborted before any destroy happened.
     expect(cloudFormation.destroyStack).not.toHaveBeenCalled();

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -419,15 +419,12 @@ describe('processFlagsCommand', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     expect(mockToolkit.fromCdkApp).toHaveBeenCalledTimes(2);
     expect(mockToolkit.synth).toHaveBeenCalledTimes(2);
     expect(mockToolkit.diff).toHaveBeenCalled();
     expect(requestResponseSpy).toHaveBeenCalled();
-
-    const plainTextOutput = output();
-    expect(plainTextOutput).toContain('Operation cancelled');
 
     await cleanupCdkJsonFile(cdkJsonPath);
     requestResponseSpy.mockRestore();
@@ -474,7 +471,7 @@ describe('processFlagsCommand', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     const finalContent = await fs.promises.readFile(cdkJsonPath, 'utf-8');
     const finalJson = JSON.parse(finalContent);
@@ -486,9 +483,6 @@ describe('processFlagsCommand', () => {
     expect(mockToolkit.synth).toHaveBeenCalledTimes(2);
     expect(mockToolkit.diff).toHaveBeenCalled();
     expect(requestResponseSpy).toHaveBeenCalled();
-
-    const plainTextOutput = output();
-    expect(plainTextOutput).toContain('Operation cancelled');
 
     await cleanupCdkJsonFile(cdkJsonPath);
     requestResponseSpy.mockRestore();
@@ -1229,7 +1223,7 @@ describe('CLI context parameters', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit, cliContextValues);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     // Get the first call's context store and verify it contains merged context
     // fromCdkApp(app, { contextStore: ..., outdir: ... }) was called
@@ -1274,7 +1268,7 @@ describe('CLI context parameters', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit, cliContextValues);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     // Get the first call's context store and verify it contains merged context
     // fromCdkApp(app, { contextStore: ..., outdir: ... }) was called
@@ -1322,7 +1316,7 @@ describe('setSafeFlags', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     const plainTextOutput = output();
     expect(plainTextOutput).toContain('Repeated synths with ts-node will type-check the application on every synth. Add --transpileOnly to cdk.json\'s "app" command to make this operation faster.');
@@ -1348,7 +1342,7 @@ describe('setSafeFlags', () => {
     };
 
     const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
-    await flagOperations.processFlagsCommand();
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
 
     const plainTextOutput = output();
     expect(plainTextOutput).toContain('Repeated synths with ts-node will type-check the application on every synth. Add --transpileOnly to cdk.json\'s "app" command to make this operation faster.');


### PR DESCRIPTION
Declining a confirmation prompt was inconsistent: `cdk destroy` exited 0 while other commands exited non-zero, some "no" answers showed a generic error messages, others a more specific one. Now declining any prompt behaves the same way: the command stops with a short, command-specific message and a non-zero exit code, shown as a notice rather than a red error.

### Before

<img width="477" height="90" alt="image" src="https://github.com/user-attachments/assets/9a5ad28e-1b46-4514-b59e-e3bd362e6b49" />


### After

<img width="653" height="89" alt="image" src="https://github.com/user-attachments/assets/882dcf4d-e199-4081-9844-ae52b478afa8" />


## User-facing changes

When you answer "no" to a confirmation:

- `cdk deploy`: `Deployment cancelled`
- `cdk destroy`: `Deletion cancelled` (now exits non-zero; previously exited 0)
- `cdk import`: `Import cancelled`
- `cdk rollback`: `Rollback cancelled`
- `cdk orphan`: `Orphaning cancelled`
- `cdk gc`: `Garbage collection cancelled`
- `cdk flags`: `Flag update cancelled` (now also cleans up its temporary files)

## Technical details

This changes the responsibility of who owns throwing exceptions. Previously we had this centralized inside the CLI's `CliIoHost`. However this was inconsistent with how `toolkit-lib` and _some_ other code paths worked. Now the `CliIoHost` no longer aborts on a declined confirmation; it returns the answer and it is the command's responsibility to throw (or do something else).

This is more consistent for a commands, since `requestResponse` always _seemed_ like it would return a response. Commands can now check the response and act accordingly. This also allows for more specific errors and messages to be thrown.

- `cdk destroy` no longer emits `CDK_TOOLKIT_E7010`.
- The reported error name (and telemetry) is now command-specific (`DeployAborted`, `DestroyAborted`, `ImportAborted`, `RollbackAborted`, `ReplacementRollbackAborted`, `OrphanAborted`, `DeletionAborted`, `FlagsAborted`) instead of the generic `AbortedByUser`.
- toolkit-lib: new exported `AbortError` (a `ToolkitError` subclass, `AbortError.isAbortError(x)`, default message `Operation cancelled`). `deploy`, `rollback`, `orphan`, and `gc` throw it on decline; the message text changes to `<Operation> cancelled` while the error code is unchanged.
- The convention is documented in `packages/aws-cdk/docs/confirmation-prompts.md`.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
