### PR TITLE
fix: changeset-based diff is not showing changes caused by SSM parameters

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1615,6 +1615,7 @@ const cliInteg = configureProject(
       sdkDep('@aws-sdk/client-s3'),
       sdkDep('@aws-sdk/client-sns'),
       sdkDep('@aws-sdk/client-sso'),
+      sdkDep('@aws-sdk/client-ssm'),
       sdkDep('@aws-sdk/client-sts'),
       sdkDep('@aws-sdk/client-secrets-manager'),
       sdkDep('@aws-sdk/credential-providers'),

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,6 +225,8 @@ bin/run-suite -a cli-integ-tests -t 'test name substring'
 
 Integration tests require AWS credentials and run against real accounts. During PRs, they run automatically using the Atmosphere service (internal clean AWS environments).
 
+**MUST: one `integTest` per file.** Each integration test lives in its own `*.integtest.ts` file containing exactly one `integTest(...)` call. Do not group multiple `integTest` calls in a single file. The file name should describe the scenario (e.g. `cdk-cdk-diff---method-change-set-detects-ssm-parameter-driven-changes.integtest.ts`). The runner discovers and parallelizes tests by file, so combining tests in one file serializes them and breaks isolation.
+
 ## Code Style
 
 ### General Rules

--- a/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
+++ b/packages/@aws-cdk-testing/cli-integ/.projen/deps.json
@@ -185,6 +185,11 @@
       "type": "runtime"
     },
     {
+      "name": "@aws-sdk/client-ssm",
+      "version": "^3",
+      "type": "runtime"
+    },
+    {
       "name": "@aws-sdk/client-sso",
       "version": "^3",
       "type": "runtime"

--- a/packages/@aws-cdk-testing/cli-integ/lib/aws.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/aws.ts
@@ -20,6 +20,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { SecretsManagerClient } from '@aws-sdk/client-secrets-manager';
 import { SNSClient } from '@aws-sdk/client-sns';
+import { SSMClient } from '@aws-sdk/client-ssm';
 import { SSOClient } from '@aws-sdk/client-sso';
 import { AssumeRoleCommand, STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
 import { fromIni, fromNodeProviderChain } from '@aws-sdk/credential-providers';
@@ -51,6 +52,7 @@ export class AwsClients {
   public readonly ecrPublic: ECRPUBLICClient;
   public readonly ecs: ECSClient;
   public readonly sso: SSOClient;
+  public readonly ssm: SSMClient;
   public readonly sns: SNSClient;
   public readonly iam: IAMClient;
   public readonly lambda: LambdaClient;
@@ -76,6 +78,7 @@ export class AwsClients {
     this.ecrPublic = new ECRPUBLICClient({ ...this.config, region: 'us-east-1' /* public gallery is only available in us-east-1 */ });
     this.ecs = new ECSClient(this.config);
     this.sso = new SSOClient(this.config);
+    this.ssm = new SSMClient(this.config);
     this.sns = new SNSClient(this.config);
     this.iam = new IAMClient(this.config);
     this.lambda = new LambdaClient(this.config);

--- a/packages/@aws-cdk-testing/cli-integ/package.json
+++ b/packages/@aws-cdk-testing/cli-integ/package.json
@@ -80,6 +80,7 @@
     "@aws-sdk/client-s3": "^3",
     "@aws-sdk/client-secrets-manager": "^3",
     "@aws-sdk/client-sns": "^3",
+    "@aws-sdk/client-ssm": "^3",
     "@aws-sdk/client-sso": "^3",
     "@aws-sdk/client-sts": "^3",
     "@aws-sdk/credential-providers": "^3",

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
@@ -85,6 +85,26 @@ class NoticesStack extends cdk.Stack {
   }
 }
 
+// Names an SQS queue after the *value* of an SSM parameter, resolved at deploy time via a
+// `AWS::SSM::Parameter::Value<String>` CloudFormation parameter (i.e. StringParameter.valueForStringParameter).
+// The synthesized template is identical regardless of the parameter's value, so a template-only
+// diff cannot detect a change. This is used to verify that `cdk diff --method=change-set` surfaces
+// changes that only a CloudFormation change set knows about. See aws/aws-cdk-cli#641.
+class SsmResolveQueueStack extends cdk.Stack {
+  constructor(parent, id, props) {
+    super(parent, id, props);
+    const parameterName = process.env.SSM_PARAMETER_NAME || '/cdk-integ/ssm-resolve-queue/placeholder';
+    const queueName = ssm.StringParameter.valueForStringParameter(this, parameterName);
+    // Optional ordinary (template-visible) change, used to exercise the "mixed" case where a
+    // resource has both a template-detected change and a change-set-only change. See #641.
+    const waitTime = process.env.SSM_RESOLVE_QUEUE_WAIT_TIME;
+    new sqs.Queue(this, 'Queue', {
+      queueName,
+      receiveMessageWaitTime: waitTime ? cdk.Duration.seconds(Number(waitTime)) : undefined,
+    });
+  }
+}
+
 class SsoPermissionSetNoPolicy extends Stack {
   constructor(scope, id) {
     super(scope, id);
@@ -1077,6 +1097,9 @@ switch (stackSet) {
     new ConsumingStack(app, `${stackPrefix}-order-consuming`, { providingStack: providing });
 
     new MissingSSMParameterStack(app, `${stackPrefix}-missing-ssm-parameter`, { env: defaultEnv });
+
+    // Queue whose name is resolved from an SSM parameter at deploy time (see aws/aws-cdk-cli#641)
+    new SsmResolveQueueStack(app, `${stackPrefix}-ssm-resolve-queue`, { env: defaultEnv });
 
     new LambdaStack(app, `${stackPrefix}-lambda`);
 

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-detects-ssm-parameter-driven-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-detects-ssm-parameter-driven-changes.integtest.ts
@@ -1,0 +1,57 @@
+import { DeleteParameterCommand, PutParameterCommand } from '@aws-sdk/client-ssm';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+/**
+ * Regression test for https://github.com/aws/aws-cdk-cli/issues/641
+ *
+ * When a resource's name (or any property) is resolved at deploy time from an SSM parameter,
+ * the synthesized CloudFormation template is identical regardless of the parameter's value.
+ * A template-only diff therefore reports "no differences", but the change set that
+ * `--method=change-set` creates *does* know the value changed.
+ *
+ * This test deploys a queue whose name comes from an SSM parameter, changes the parameter
+ * out-of-band, and asserts that the change-set diff surfaces the (replacing) change while the
+ * template-only diff does not.
+ */
+integTest(
+  'cdk diff --method=change-set detects SSM-parameter-driven changes that template diff misses',
+  withDefaultFixture(async (fixture) => {
+    const parameterName = `/cdk-integ/${fixture.randomString}/queue-name`;
+    const queueNameV1 = `cdktest-${fixture.randomString}-q1`;
+    const queueNameV2 = `cdktest-${fixture.randomString}-q2`;
+    const stackName = fixture.fullStackName('ssm-resolve-queue');
+
+    // GIVEN - an SSM parameter with an initial value, and a deployed stack that names its queue after it
+    await fixture.aws.ssm.send(new PutParameterCommand({
+      Name: parameterName,
+      Type: 'String',
+      Value: queueNameV1,
+    }));
+    fixture.aws.addCleanup(() => fixture.aws.ssm.send(new DeleteParameterCommand({ Name: parameterName })));
+
+    await fixture.cdkDeploy('ssm-resolve-queue', {
+      modEnv: { SSM_PARAMETER_NAME: parameterName },
+    });
+
+    // WHEN - the SSM parameter value changes out-of-band (the CDK app/template is unchanged)
+    await fixture.aws.ssm.send(new PutParameterCommand({
+      Name: parameterName,
+      Type: 'String',
+      Value: queueNameV2,
+      Overwrite: true,
+    }));
+
+    // THEN - a template-only diff sees nothing, because the template is byte-for-byte identical
+    const templateDiff = await fixture.cdk(['diff', '--method=template', stackName], {
+      modEnv: { SSM_PARAMETER_NAME: parameterName },
+    });
+    expect(templateDiff).toContain('There were no differences');
+
+    // ...but the change-set diff surfaces the queue change (a replacement, since QueueName is immutable)
+    const changeSetDiff = await fixture.cdk(['diff', '--method=change-set', stackName], {
+      modEnv: { SSM_PARAMETER_NAME: parameterName },
+    });
+    expect(changeSetDiff).not.toContain('There were no differences');
+    expect(changeSetDiff).toContain('AWS::SQS::Queue');
+  }),
+);

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-surfaces-change-set-only-changes-alongside-template-changes.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-cdk-diff---method-change-set-surfaces-change-set-only-changes-alongside-template-changes.integtest.ts
@@ -1,0 +1,51 @@
+import { DeleteParameterCommand, PutParameterCommand } from '@aws-sdk/client-ssm';
+import { integTest, withDefaultFixture } from '../../../lib';
+
+/**
+ * Regression test for https://github.com/aws/aws-cdk-cli/issues/641 (the "mixed" case).
+ *
+ * A single resource has BOTH a template-visible change (ReceiveMessageWaitTimeSeconds) AND a change
+ * that only the change set knows about (QueueName, resolved at deploy time from an SSM parameter).
+ * The change-set diff must surface both - in particular it must not let the visible change hide the
+ * (replacing) hidden change.
+ */
+integTest(
+  'cdk diff --method=change-set surfaces change-set-only changes alongside template changes on the same resource',
+  withDefaultFixture(async (fixture) => {
+    const parameterName = `/cdk-integ/${fixture.randomString}/queue-name-mixed`;
+    const queueNameV1 = `cdktest-${fixture.randomString}-m1`;
+    const queueNameV2 = `cdktest-${fixture.randomString}-m2`;
+    const stackName = fixture.fullStackName('ssm-resolve-queue');
+
+    // GIVEN - deployed with an initial SSM value and an initial receive-wait-time
+    await fixture.aws.ssm.send(new PutParameterCommand({
+      Name: parameterName,
+      Type: 'String',
+      Value: queueNameV1,
+    }));
+    fixture.aws.addCleanup(() => fixture.aws.ssm.send(new DeleteParameterCommand({ Name: parameterName })));
+
+    await fixture.cdkDeploy('ssm-resolve-queue', {
+      modEnv: { SSM_PARAMETER_NAME: parameterName, SSM_RESOLVE_QUEUE_WAIT_TIME: '10' },
+    });
+
+    // WHEN - the SSM value changes out-of-band (queue name -> replacement, only in the change set)
+    await fixture.aws.ssm.send(new PutParameterCommand({
+      Name: parameterName,
+      Type: 'String',
+      Value: queueNameV2,
+      Overwrite: true,
+    }));
+
+    // ...and the template also changes the receive-wait-time (a normal, template-visible update)
+    const diff = await fixture.cdk(['diff', '--method=change-set', stackName], {
+      modEnv: { SSM_PARAMETER_NAME: parameterName, SSM_RESOLVE_QUEUE_WAIT_TIME: '20' },
+    });
+
+    // THEN - both the template-visible change and the change-set-only change are reported
+    expect(diff).not.toContain('There were no differences');
+    expect(diff).toContain('AWS::SQS::Queue');
+    expect(diff).toContain('ReceiveMessageWaitTimeSeconds'); // template-detected update
+    expect(diff).toContain('QueueName'); // change-set-only replacement
+  }),
+);

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff-template.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff-template.ts
@@ -51,15 +51,36 @@ export function fullDiff(
   changeSet?: DescribeChangeSetOutput,
   isImport?: boolean,
 ): types.TemplateDiff {
-  normalize(currentTemplate);
-  normalize(newTemplate);
-  const theDiff = diffTemplate(currentTemplate, newTemplate);
+  // `normalize` mutates the templates it is given (it sorts `DependsOn` arrays and rewrites
+  // `Fn::GetAtt` short form, among other things). We must not mutate the caller's objects,
+  // because they may be reused for other purposes (e.g. `cdk import` reuses the deployed
+  // template as the base for the IMPORT change set, and a reordered `DependsOn` there is
+  // rejected by CloudFormation as a "modification" to a non-imported resource).
+  // So we normalize copies and diff those.
+  const currentTemplateCopy = deepCopy(currentTemplate);
+  const newTemplateCopy = deepCopy(newTemplate);
+  normalize(currentTemplateCopy);
+  normalize(newTemplateCopy);
+  const theDiff = diffTemplate(currentTemplateCopy, newTemplateCopy);
   if (changeSet) {
     // These methods mutate the state of theDiff, using the changeSet.
     const changeSetDiff = new TemplateAndChangeSetDiffMerger({ changeSet });
-    theDiff.resources.forEachDifference((logicalId: string, change: types.ResourceDifference) =>
-      changeSetDiff.overrideDiffResourceChangeImpactWithChangeSetChangeImpact(logicalId, change),
-    );
+
+    // Capture the resources the template diff knows about *before* we start
+    // mutating their change impacts. Resources that are already part of the
+    // template diff are handled by the override path below; resources that are
+    // only known to the change set (e.g. a property that resolves to a different
+    // value at deploy time, such as an SSM parameter or a CloudFormation dynamic
+    // reference) are added afterwards.
+    const resourcesInTemplateDiff = new Set(theDiff.resources.logicalIds);
+
+    theDiff.resources.forEachDifference((logicalId: string, change: types.ResourceDifference) => {
+      changeSetDiff.overrideDiffResourceChangeImpactWithChangeSetChangeImpact(logicalId, change);
+      // For resources the template diff already found, also surface any *additional* property
+      // changes that only the change set knows about (e.g. a deploy-time-resolved property).
+      changeSetDiff.addChangeSetPropertiesNotInTemplateDiff(logicalId, change);
+    });
+    changeSetDiff.addChangeSetResourcesNotInTemplateDiff(theDiff.resources, resourcesInTemplateDiff);
     changeSetDiff.addImportInformationFromChangeset(theDiff.resources);
   } else if (isImport) {
     makeAllResourceChangesImports(theDiff);

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
@@ -1,10 +1,12 @@
 // The SDK is only used to reference `DescribeChangeSetOutput`, so the SDK is added as a devDependency.
 // The SDK should not make network calls here
-import type { DescribeChangeSetOutput as DescribeChangeSet, ResourceChangeDetail as RCD } from '@aws-sdk/client-cloudformation';
+import type { DescribeChangeSetOutput as DescribeChangeSet, ResourceChange as RC, ResourceChangeDetail as RCD } from '@aws-sdk/client-cloudformation';
+import { diffResource } from '../diff';
 import * as types from '../diff/types';
 
 export type DescribeChangeSetOutput = DescribeChangeSet;
 type ChangeSetResourceChangeDetail = RCD;
+type ChangeSetResourceChange = RC;
 
 interface TemplateAndChangeSetDiffMergerOptions {
   /*
@@ -134,6 +136,280 @@ export class TemplateAndChangeSetDiffMerger {
     });
   }
 
+  /**
+   * Adds property changes that the change set reports for a resource that the template diff already
+   * surfaced, but that the template diff did not pick up on its own.
+   *
+   * Without this, a resource that has an ordinary (textual) change to one property would hide a
+   * second change to a *different* property that is only resolved at deploy time (e.g. a property
+   * whose value comes from an SSM parameter or a CloudFormation dynamic reference). That hidden
+   * change might even be a replacement, so silently dropping it is exactly the class of bug that
+   * issue #641 is about - just on a resource that happens to also have a visible change.
+   *
+   * This complements `addChangeSetResourcesNotInTemplateDiff`, which handles resources that are
+   * entirely absent from the template diff.
+   *
+   * @param logicalId - the logical ID of the resource (already present in the template diff)
+   * @param change - the resource difference to augment (mutated in place)
+   */
+  public addChangeSetPropertiesNotInTemplateDiff(logicalId: string, change: types.ResourceDifference) {
+    // Same guard as the impact-refinement path: the change set describes the post-transform
+    // resource for SAM, so its property information does not line up with the template.
+    // `resourceType` getter throws if the type changed, so check that first.
+    if ((change.resourceTypeChanged === true) || change.resourceType?.includes('AWS::Serverless')) {
+      return;
+    }
+
+    const propertyReplacementModes = this.changeSetResources[logicalId]?.propertyReplacementModes;
+    if (!propertyReplacementModes) {
+      return;
+    }
+
+    const resourceChange = this.findResourceChange(logicalId);
+
+    for (const [propertyName, { replacementMode }] of Object.entries(propertyReplacementModes)) {
+      // Properties the template diff already flagged are owned by the impact-refinement path.
+      if (propertyName in change.propertyUpdates) {
+        continue;
+      }
+
+      const changeImpact = changeImpactForReplacementMode(replacementMode);
+      if (changeImpact === undefined) {
+        // The change set does not actually consider this a (meaningful) change.
+        continue;
+      }
+
+      const { oldValue, newValue } = this.changeSetPropertyValues(resourceChange, propertyName);
+      const propertyDiff = new types.PropertyDifference<any>(oldValue, newValue, { changeImpact });
+      propertyDiff.isDifferent = true;
+      change.setPropertyChange(propertyName, propertyDiff);
+    }
+  }
+
+  /**
+   * Adds resources to the template diff that the change set reports as changing, but that the
+   * template diff did not surface on its own.
+   *
+   * This happens when the local template is byte-for-byte identical between the current and
+   * target state, yet a value that is only resolved at deploy time changes - for example an
+   * SSM parameter referenced through `AWS::SSM::Parameter::Value<...>` or a CloudFormation
+   * dynamic reference (`{{resolve:ssm:...}}`). CloudFormation detects these in the change set
+   * even though a pure template diff cannot, so we synthesize a `ResourceDifference` from the
+   * change set's before/after data.
+   *
+   * @param resourceDiffs - the resource differences to add to (mutated in place)
+   * @param resourcesInTemplateDiff - the logical IDs that the template diff already reported as
+   *   changed, captured *before* any change-set overrides were applied. Those resources are
+   *   owned by the override path and are skipped here so we never clobber more accurate
+   *   template-derived information with change-set-only data.
+   */
+  public addChangeSetResourcesNotInTemplateDiff(
+    resourceDiffs: types.DifferenceCollection<types.Resource, types.ResourceDifference>,
+    resourcesInTemplateDiff: Set<string>,
+  ) {
+    for (const resourceChange of this.changeSet?.Changes ?? []) {
+      const rc = resourceChange.ResourceChange;
+      const logicalId = rc?.LogicalResourceId;
+      if (!rc || !logicalId) {
+        continue;
+      }
+
+      // Additions, removals and imports are already reflected in the template diff (a new or
+      // deleted resource shows up textually), or are handled by the dedicated import path. We
+      // only need to synthesize changes for modifications that are invisible to a textual diff.
+      if (rc.Action !== 'Modify') {
+        continue;
+      }
+
+      // The template diff already produced a difference for this resource, so the override path
+      // is responsible for it. Don't replace it with change-set-only data.
+      if (resourcesInTemplateDiff.has(logicalId)) {
+        continue;
+      }
+
+      // CFN applies the SAM transform before creating the changeset, so changeset entries for
+      // SAM resources describe the transformed (e.g. Lambda) resource and won't line up with the
+      // SAM resource in the template. Skip them to avoid rendering a bogus diff.
+      if (rc.ResourceType?.includes('AWS::Serverless')) {
+        continue;
+      }
+
+      const resourceDiff = this.resourceDifferenceFromChangeSetResource(rc);
+      if (resourceDiff?.isDifferent) {
+        resourceDiffs.set(logicalId, resourceDiff);
+      }
+    }
+  }
+
+  /**
+   * Build a `ResourceDifference` purely from a change set's `ResourceChange`.
+   *
+   * Prefers the rich `BeforeContext`/`AfterContext` (the full resource definition before and
+   * after the change, included when the change set is described with `IncludePropertyValues`),
+   * and falls back to the per-property `BeforeValue`/`AfterValue` carried in the change details.
+   *
+   * @returns the synthesized difference, or `undefined` if there is not enough information to
+   *   build a meaningful before/after comparison.
+   */
+  private resourceDifferenceFromChangeSetResource(rc: ChangeSetResourceChange): types.ResourceDifference | undefined {
+    const resourceType = rc.ResourceType;
+
+    let oldResource: types.Resource | undefined;
+    let newResource: types.Resource | undefined;
+
+    const oldFromContext = this.parseResourceContext(rc.BeforeContext, resourceType);
+    const newFromContext = this.parseResourceContext(rc.AfterContext, resourceType);
+    if (oldFromContext !== undefined && newFromContext !== undefined) {
+      oldResource = oldFromContext;
+      newResource = newFromContext;
+    } else {
+      // The full before/after context was not requested/returned; reconstruct the resource
+      // from the individual property changes instead.
+      const fromDetails = this.resourcesFromChangeDetails(rc, resourceType);
+      oldResource = fromDetails.oldResource;
+      newResource = fromDetails.newResource;
+    }
+
+    if (oldResource === undefined || newResource === undefined) {
+      return undefined;
+    }
+
+    const resourceDiff = diffResource(oldResource, newResource, rc.LogicalResourceId);
+
+    // Refine the change impact (replacement vs. update) using the change set, exactly like we do
+    // for resources that originate from the template diff.
+    this.overrideDiffResourceChangeImpactWithChangeSetChangeImpact(rc.LogicalResourceId!, resourceDiff);
+
+    return resourceDiff;
+  }
+
+  /**
+   * Parse a change set `BeforeContext`/`AfterContext` into a resource object.
+   *
+   * The context is the resource's definition (Properties, Metadata, etc.) but does *not* include
+   * the resource `Type`, so we splice it back in (using the change set's reported type) to allow
+   * the diff machinery to compare like-for-like and look up replacement information.
+   */
+  private parseResourceContext(context: string | object | undefined, resourceType: string | undefined): types.Resource | undefined {
+    if (context === undefined || context === null) {
+      return undefined;
+    }
+
+    let parsed: any;
+    if (typeof context === 'string') {
+      try {
+        parsed = JSON.parse(context);
+      } catch {
+        return undefined;
+      }
+    } else {
+      parsed = context;
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) {
+      return undefined;
+    }
+
+    return {
+      Type: resourceType ?? TemplateAndChangeSetDiffMerger.UNKNOWN_RESOURCE_TYPE,
+      ...parsed,
+    };
+  }
+
+  /**
+   * Reconstruct (partial) before/after resource definitions from the per-property change details.
+   *
+   * This is the fallback used when `BeforeContext`/`AfterContext` are not available (for example
+   * when the change set was described without `IncludePropertyValues`). Only properties that
+   * carry a before or after value contribute to the reconstructed resources.
+   */
+  private resourcesFromChangeDetails(
+    rc: ChangeSetResourceChange,
+    resourceType: string | undefined,
+  ): { oldResource: types.Resource | undefined; newResource: types.Resource | undefined } {
+    const oldProperties: types.PropertyMap = {};
+    const newProperties: types.PropertyMap = {};
+    let hasData = false;
+
+    for (const detail of rc.Details ?? []) {
+      const target = detail.Target;
+      if (target?.Attribute !== 'Properties' || !target.Name) {
+        continue;
+      }
+      if (target.BeforeValue !== undefined) {
+        oldProperties[target.Name] = tryJsonParse(target.BeforeValue);
+        hasData = true;
+      }
+      if (target.AfterValue !== undefined) {
+        newProperties[target.Name] = tryJsonParse(target.AfterValue);
+        hasData = true;
+      }
+    }
+
+    if (!hasData) {
+      return { oldResource: undefined, newResource: undefined };
+    }
+
+    const type = resourceType ?? TemplateAndChangeSetDiffMerger.UNKNOWN_RESOURCE_TYPE;
+    return {
+      oldResource: { Type: type, Properties: oldProperties },
+      newResource: { Type: type, Properties: newProperties },
+    };
+  }
+
+  /**
+   * Find the raw `ResourceChange` for a given logical ID in the change set.
+   */
+  private findResourceChange(logicalId: string): ChangeSetResourceChange | undefined {
+    for (const resourceChange of this.changeSet?.Changes ?? []) {
+      if (resourceChange.ResourceChange?.LogicalResourceId === logicalId) {
+        return resourceChange.ResourceChange;
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Determine the before/after value of a single property from the change set.
+   *
+   * Prefers the per-property `BeforeValue`/`AfterValue` carried in the change details, then the
+   * `BeforeContext`/`AfterContext` resource snapshots, and finally falls back to empty-object
+   * placeholders so the property still renders as a change (with the impact derived from the
+   * change set) even when no concrete values were returned.
+   */
+  private changeSetPropertyValues(
+    resourceChange: ChangeSetResourceChange | undefined,
+    propertyName: string,
+  ): { oldValue: any; newValue: any } {
+    let oldValue: any;
+    let newValue: any;
+
+    for (const detail of resourceChange?.Details ?? []) {
+      const target = detail.Target;
+      if (target?.Attribute === 'Properties' && target.Name === propertyName) {
+        if (target.BeforeValue !== undefined) {
+          oldValue = tryJsonParse(target.BeforeValue);
+        }
+        if (target.AfterValue !== undefined) {
+          newValue = tryJsonParse(target.AfterValue);
+        }
+      }
+    }
+
+    if (oldValue === undefined) {
+      oldValue = contextProperties(resourceChange?.BeforeContext)?.[propertyName];
+    }
+    if (newValue === undefined) {
+      newValue = contextProperties(resourceChange?.AfterContext)?.[propertyName];
+    }
+
+    // PropertyDifference requires at least one defined side; use a placeholder otherwise.
+    return {
+      oldValue: oldValue !== undefined ? oldValue : {},
+      newValue: newValue !== undefined ? newValue : {},
+    };
+  }
+
   public addImportInformationFromChangeset(resourceDiffs: types.DifferenceCollection<types.Resource, types.ResourceDifference>) {
     const imports = this.findResourceImports();
     resourceDiffs.forEachDifference((logicalId: string, change: types.ResourceDifference) => {
@@ -153,4 +429,57 @@ export class TemplateAndChangeSetDiffMerger {
 
     return importedResourceLogicalIds;
   }
+}
+
+/**
+ * Parse a change set property value as JSON, falling back to the raw value.
+ *
+ * Change set property values (e.g. `BeforeValue`/`AfterValue`) are always strings. Some of them
+ * are serialized JSON (such as an IAM `PolicyDocument`), while others are plain scalars. Parsing
+ * lets us compare structured values structurally; if parsing fails we keep the original string.
+ */
+function tryJsonParse(value: string): any {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Map a change set replacement mode to the corresponding diff `ResourceImpact`.
+ *
+ * Returns `undefined` when the change set does not consider the property a (meaningful) change.
+ */
+function changeImpactForReplacementMode(replacementMode: types.ReplacementModes | undefined): types.ResourceImpact | undefined {
+  switch (replacementMode) {
+    case 'Always':
+      return types.ResourceImpact.WILL_REPLACE;
+    case 'Never':
+      return types.ResourceImpact.WILL_UPDATE;
+    case 'Conditionally':
+      return types.ResourceImpact.MAY_REPLACE;
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Parse the `Properties` block out of a change set `BeforeContext`/`AfterContext` snapshot.
+ */
+function contextProperties(context: string | object | undefined): { [name: string]: any } | undefined {
+  if (context === undefined || context === null) {
+    return undefined;
+  }
+  let parsed: any;
+  if (typeof context === 'string') {
+    try {
+      parsed = JSON.parse(context);
+    } catch {
+      return undefined;
+    }
+  } else {
+    parsed = context;
+  }
+  return parsed && typeof parsed === 'object' ? parsed.Properties : undefined;
 }

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
@@ -396,6 +396,23 @@ export class DifferenceCollection<V, T extends IDifference<V>> {
     delete this.diffs[logicalId];
   }
 
+  /**
+   * Whether a difference (changed or not) is tracked for the given logical ID.
+   *
+   * Note this is different from `logicalIds`, which only returns IDs that have
+   * an actual change. A logical ID may be present here with a "no-op" difference.
+   */
+  public has(logicalId: string): boolean {
+    return this.diffs[logicalId] !== undefined;
+  }
+
+  /**
+   * Set (or replace) the difference tracked for the given logical ID.
+   */
+  public set(logicalId: string, diff: T): void {
+    this.diffs[logicalId] = diff;
+  }
+
   public get logicalIds(): string[] {
     return Object.keys(this.changes);
   }

--- a/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
@@ -560,6 +560,472 @@ describe('fullDiff tests that include changeset', () => {
     expect(differences.resources.differenceCount).toBe(1);
     expect(differences.resources.get('BucketResource')?.changeImpact === ResourceImpact.WILL_IMPORT);
   });
+
+  describe('changeset-only resource changes (issue #641)', () => {
+    // A resource whose local template is byte-for-byte identical between current and target,
+    // but whose deploy-time-resolved value (e.g. an SSM parameter) changed. The template diff
+    // sees nothing; only the change set knows about the change.
+    const ssmBackedQueueTemplate = {
+      Parameters: {
+        QueueNameParam: {
+          Type: 'AWS::SSM::Parameter::Value<String>',
+          Default: '/cdk/test/queue-name-param',
+        },
+      },
+      Resources: {
+        Queue: {
+          Type: 'AWS::SQS::Queue',
+          Properties: {
+            QueueName: { Ref: 'QueueNameParam' },
+          },
+        },
+      },
+    };
+
+    test('a replacement-causing change known only to the change set is surfaced', () => {
+      // GIVEN current === new (the CDK app did not change; only the external SSM value did)
+      const currentTemplate = JSON.parse(JSON.stringify(ssmBackedQueueTemplate));
+      const newTemplate = JSON.parse(JSON.stringify(ssmBackedQueueTemplate));
+
+      // WHEN
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Queue',
+              ResourceType: 'AWS::SQS::Queue',
+              Replacement: 'True',
+              Scope: ['Properties'],
+              Details: [
+                {
+                  Target: { Attribute: 'Properties', Name: 'QueueName', RequiresRecreation: 'Always' },
+                  Evaluation: 'Static',
+                  ChangeSource: 'ParameterReference',
+                },
+              ],
+              BeforeContext: '{"Properties":{"QueueName":"old-queue-name"}}',
+              AfterContext: '{"Properties":{"QueueName":"new-queue-name"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN
+      expect(differences.resources.differenceCount).toBe(1);
+      const queueDiff = differences.resources.get('Queue');
+      expect(queueDiff.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+      expect(queueDiff.propertyUpdates.QueueName.oldValue).toBe('old-queue-name');
+      expect(queueDiff.propertyUpdates.QueueName.newValue).toBe('new-queue-name');
+    });
+
+    test('an update-only change known only to the change set is surfaced as WILL_UPDATE', () => {
+      // GIVEN
+      const ssmParamTemplate = {
+        Resources: {
+          mySsmParameter: {
+            Type: 'AWS::SSM::Parameter',
+            Properties: { Type: 'String', Value: { Ref: 'SomeParam' } },
+          },
+        },
+      };
+      const currentTemplate = JSON.parse(JSON.stringify(ssmParamTemplate));
+      const newTemplate = JSON.parse(JSON.stringify(ssmParamTemplate));
+
+      // WHEN
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'mySsmParameter',
+              ResourceType: 'AWS::SSM::Parameter',
+              Replacement: 'False',
+              Scope: ['Properties'],
+              Details: [
+                {
+                  Target: { Attribute: 'Properties', Name: 'Value', RequiresRecreation: 'Never' },
+                  Evaluation: 'Static',
+                  ChangeSource: 'DirectModification',
+                },
+              ],
+              BeforeContext: '{"Properties":{"Type":"String","Value":"old"}}',
+              AfterContext: '{"Properties":{"Type":"String","Value":"new"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN
+      expect(differences.resources.differenceCount).toBe(1);
+      expect(differences.resources.get('mySsmParameter').changeImpact).toBe(ResourceImpact.WILL_UPDATE);
+    });
+
+    test('falls back to per-property Before/After values when no Before/AfterContext is present', () => {
+      // GIVEN
+      const currentTemplate = JSON.parse(JSON.stringify(ssmBackedQueueTemplate));
+      const newTemplate = JSON.parse(JSON.stringify(ssmBackedQueueTemplate));
+
+      // WHEN - no BeforeContext/AfterContext, only Details carry the values
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Queue',
+              ResourceType: 'AWS::SQS::Queue',
+              Replacement: 'True',
+              Scope: ['Properties'],
+              Details: [
+                {
+                  Target: {
+                    Attribute: 'Properties',
+                    Name: 'QueueName',
+                    RequiresRecreation: 'Always',
+                    BeforeValue: 'old-queue-name',
+                    AfterValue: 'new-queue-name',
+                  },
+                  Evaluation: 'Static',
+                  ChangeSource: 'ParameterReference',
+                },
+              ],
+            },
+          },
+        ],
+      });
+
+      // THEN
+      expect(differences.resources.differenceCount).toBe(1);
+      const queueDiff = differences.resources.get('Queue');
+      expect(queueDiff.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+      expect(queueDiff.propertyUpdates.QueueName.oldValue).toBe('old-queue-name');
+      expect(queueDiff.propertyUpdates.QueueName.newValue).toBe('new-queue-name');
+    });
+
+    test('does not add a change set resource that the template diff already covers', () => {
+      // GIVEN the template itself changes QueueName
+      const currentTemplate = {
+        Resources: {
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'first' } },
+        },
+      };
+      const newTemplate = {
+        Resources: {
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'second' } },
+        },
+      };
+
+      // WHEN - the change set also reports the change, with (different) context values
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Queue',
+              ResourceType: 'AWS::SQS::Queue',
+              Replacement: 'True',
+              Scope: ['Properties'],
+              Details: [
+                {
+                  Target: { Attribute: 'Properties', Name: 'QueueName', RequiresRecreation: 'Always' },
+                  Evaluation: 'Static',
+                  ChangeSource: 'DirectModification',
+                },
+              ],
+              BeforeContext: '{"Properties":{"QueueName":"context-old"}}',
+              AfterContext: '{"Properties":{"QueueName":"context-new"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN - exactly one difference, using the template's values (not clobbered by the change set context)
+      expect(differences.resources.differenceCount).toBe(1);
+      const queueDiff = differences.resources.get('Queue');
+      expect(queueDiff.propertyUpdates.QueueName.oldValue).toBe('first');
+      expect(queueDiff.propertyUpdates.QueueName.newValue).toBe('second');
+      expect(queueDiff.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+    });
+
+    test('does not add Add/Remove/Import change set actions as synthesized changes', () => {
+      // GIVEN identical templates
+      const template = {
+        Resources: {
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' } } },
+        },
+      };
+
+      // WHEN the change set only carries non-Modify actions for a resource not in the diff
+      const differences = fullDiff(JSON.parse(JSON.stringify(template)), JSON.parse(JSON.stringify(template)), {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Add',
+              LogicalResourceId: 'SomethingElse',
+              ResourceType: 'AWS::SQS::Queue',
+              AfterContext: '{"Properties":{"QueueName":"x"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN
+      expect(differences.resources.differenceCount).toBe(0);
+    });
+
+    test('skips SAM resources reported by the change set', () => {
+      // GIVEN identical templates with a SAM resource
+      const template = {
+        Resources: {
+          ServerlessFunction: {
+            Type: 'AWS::Serverless::Function',
+            Properties: { CodeUri: 's3://bucket/handler.zip' },
+          },
+        },
+      };
+
+      // WHEN the change set reports the (transformed) resource as Serverless
+      const differences = fullDiff(JSON.parse(JSON.stringify(template)), JSON.parse(JSON.stringify(template)), {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'ServerlessFunction',
+              ResourceType: 'AWS::Serverless::Function',
+              Replacement: 'False',
+              Details: [],
+              BeforeContext: '{"Properties":{"CodeUri":"s3://bucket/old.zip"}}',
+              AfterContext: '{"Properties":{"CodeUri":"s3://bucket/new.zip"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN - SAM resources are not synthesized from the change set
+      expect(differences.resources.differenceCount).toBe(0);
+    });
+
+    test('does not add a change set resource when there is no before/after data to diff', () => {
+      // GIVEN identical templates
+      const template = {
+        Resources: {
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' } } },
+        },
+      };
+
+      // WHEN the change set has a Modify with no usable values
+      const differences = fullDiff(JSON.parse(JSON.stringify(template)), JSON.parse(JSON.stringify(template)), {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Queue',
+              ResourceType: 'AWS::SQS::Queue',
+              Replacement: 'False',
+              Details: [],
+            },
+          },
+        ],
+      });
+
+      // THEN
+      expect(differences.resources.differenceCount).toBe(0);
+    });
+
+    test('surfaces a change set change for a resource present-but-unchanged in the template diff', () => {
+      // GIVEN one resource changes textually (forcing the Resources section to differ),
+      // while a second resource is identical in the template but changed per the change set.
+      const currentTemplate = {
+        Resources: {
+          Bucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'old-bucket' } },
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' } } },
+        },
+      };
+      const newTemplate = {
+        Resources: {
+          Bucket: { Type: 'AWS::S3::Bucket', Properties: { BucketName: 'new-bucket' } },
+          Queue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' } } },
+        },
+      };
+
+      // WHEN
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Bucket',
+              ResourceType: 'AWS::S3::Bucket',
+              Replacement: 'False',
+              Details: [
+                {
+                  Target: { Attribute: 'Properties', Name: 'BucketName', RequiresRecreation: 'Never' },
+                  Evaluation: 'Static',
+                  ChangeSource: 'DirectModification',
+                },
+              ],
+            },
+          },
+          {
+            Type: 'Resource',
+            ResourceChange: {
+              Action: 'Modify',
+              LogicalResourceId: 'Queue',
+              ResourceType: 'AWS::SQS::Queue',
+              Replacement: 'True',
+              Details: [
+                {
+                  Target: { Attribute: 'Properties', Name: 'QueueName', RequiresRecreation: 'Always' },
+                  Evaluation: 'Static',
+                  ChangeSource: 'ParameterReference',
+                },
+              ],
+              BeforeContext: '{"Properties":{"QueueName":"old-queue-name"}}',
+              AfterContext: '{"Properties":{"QueueName":"new-queue-name"}}',
+            },
+          },
+        ],
+      });
+
+      // THEN - both the textual change (Bucket) and the change-set-only change (Queue) are present
+      expect(differences.resources.differenceCount).toBe(2);
+      expect(differences.resources.get('Queue').changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+      expect(differences.resources.get('Queue').propertyUpdates.QueueName.newValue).toBe('new-queue-name');
+    });
+  });
+
+  describe('changeset-only property changes on a resource already in the template diff (issue #641)', () => {
+    // A resource that has an ordinary (textual) change to one property, while a *second* property
+    // changes only via a deploy-time value (e.g. an SSM parameter) that the template diff cannot see.
+    test('adds the change-set-only property (a hidden replacement) alongside the template change', () => {
+      // GIVEN - the template changes ReceiveMessageWaitTimeSeconds (10 -> 20); QueueName is an
+      // unchanged Ref in the template, but the change set reports it changing (and replacing).
+      const currentTemplate = {
+        Parameters: {
+          SsmParameterValuetestbugreportC9: { Type: 'AWS::SSM::Parameter::Value<String>', Default: 'x' },
+        },
+        Resources: {
+          Queue: utils.sqsQueueWithArgs({ waitTime: 10 }),
+        },
+      };
+      const newTemplate = {
+        Parameters: {
+          SsmParameterValuetestbugreportC9: { Type: 'AWS::SSM::Parameter::Value<String>', Default: 'x' },
+        },
+        Resources: {
+          Queue: utils.sqsQueueWithArgs({ waitTime: 20 }),
+        },
+      };
+
+      // WHEN
+      const differences = fullDiff(currentTemplate, newTemplate, {
+        Changes: [
+          utils.queueFromChangeset({ beforeContextWaitTime: '10', afterContextWaitTime: '20' }),
+        ],
+      });
+
+      // THEN - exactly one changed resource, with BOTH properties surfaced
+      expect(differences.resources.differenceCount).toBe(1);
+      const queue = differences.resources.get('Queue');
+
+      // template-detected change
+      expect(queue.propertyUpdates.ReceiveMessageWaitTimeSeconds.changeImpact).toBe(ResourceImpact.WILL_UPDATE);
+
+      // change-set-only change
+      expect(queue.propertyUpdates.QueueName).toBeDefined();
+      expect(queue.propertyUpdates.QueueName.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+      expect(queue.propertyUpdates.QueueName.oldValue).toBe('newValuechangedddd');
+      expect(queue.propertyUpdates.QueueName.newValue).toBe('newValuesdflkja');
+
+      // resource-level impact is the worst of the two
+      expect(queue.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+    });
+  });
+
+  describe('fullDiff does not mutate its input templates (issue #1575)', () => {
+    test('DependsOn array order on the input is preserved (not sorted)', () => {
+      // GIVEN a resource with a multi-element DependsOn whose natural order is not alphabetical
+      const currentTemplate = {
+        Resources: {
+          Function: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {},
+            DependsOn: ['FnServiceRoleDefaultPolicy', 'FnServiceRole'],
+          },
+        },
+      };
+      const newTemplate = {
+        Resources: {
+          Function: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {},
+            DependsOn: ['FnServiceRoleDefaultPolicy', 'FnServiceRole'],
+          },
+        },
+      };
+      const currentClone = JSON.parse(JSON.stringify(currentTemplate));
+      const newClone = JSON.parse(JSON.stringify(newTemplate));
+
+      // WHEN
+      fullDiff(currentTemplate, newTemplate);
+
+      // THEN - the caller's objects are untouched, in particular the DependsOn order
+      expect(currentTemplate).toEqual(currentClone);
+      expect(newTemplate).toEqual(newClone);
+      expect(currentTemplate.Resources.Function.DependsOn).toEqual(['FnServiceRoleDefaultPolicy', 'FnServiceRole']);
+    });
+
+    test('Fn::GetAtt short form on the input is not rewritten to an array', () => {
+      // GIVEN
+      const currentTemplate = {
+        Resources: { Bucket: { Type: 'AWS::S3::Bucket', Properties: {} } },
+        Outputs: { Arn: { Value: { 'Fn::GetAtt': 'Bucket.Arn' } } },
+      };
+      const newTemplate = JSON.parse(JSON.stringify(currentTemplate));
+
+      // WHEN
+      fullDiff(currentTemplate, newTemplate);
+
+      // THEN
+      expect(currentTemplate.Outputs.Arn.Value['Fn::GetAtt']).toBe('Bucket.Arn');
+    });
+
+    test('the diff is still computed correctly while leaving inputs intact', () => {
+      // GIVEN DependsOn reordering should be treated as no change, even though we no longer mutate
+      const currentTemplate = {
+        Resources: {
+          Bucket: {
+            Type: 'AWS::S3::Bucket',
+            DependsOn: ['B', 'A'],
+          },
+        },
+      };
+      const newTemplate = {
+        Resources: {
+          Bucket: {
+            Type: 'AWS::S3::Bucket',
+            DependsOn: ['A', 'B'],
+          },
+        },
+      };
+
+      // WHEN
+      const differences = fullDiff(currentTemplate, newTemplate);
+
+      // THEN - no semantic difference, and inputs are preserved
+      expect(differences.resources.differenceCount).toBe(0);
+      expect(currentTemplate.Resources.Bucket.DependsOn).toEqual(['B', 'A']);
+      expect(newTemplate.Resources.Bucket.DependsOn).toEqual(['A', 'B']);
+    });
+  });
 });
 
 describe('method tests', () => {
@@ -989,6 +1455,132 @@ describe('method tests', () => {
       // THEN
       expect(queue.changeImpact).toBe('WILL_ORPHAN');
       expect(queue.isDifferent).toBe(true);
+    });
+  });
+
+  describe('addChangeSetPropertiesNotInTemplateDiff', () => {
+    test('adds a change-set-only property with the impact derived from the change set', () => {
+      // GIVEN - a resource already in the template diff (Other changed), plus a change-set-only
+      // QueueName replacement that the template diff did not see.
+      const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
+        changeSet: {},
+        changeSetResources: {
+          Queue: {
+            resourceWasReplaced: true,
+            resourceType: 'AWS::SQS::Queue',
+            propertyReplacementModes: {
+              QueueName: { replacementMode: 'Always' },
+            },
+          },
+        },
+      });
+      const queue = new ResourceDifference(
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' }, Other: 'a' } },
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: { Ref: 'P' }, Other: 'b' } },
+        {
+          resourceType: { oldType: 'AWS::SQS::Queue', newType: 'AWS::SQS::Queue' },
+          propertyDiffs: { Other: new PropertyDifference<string>('a', 'b', { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          otherDiffs: {},
+        },
+      );
+
+      // WHEN
+      templateAndChangeSetDiffMerger.addChangeSetPropertiesNotInTemplateDiff('Queue', queue);
+
+      // THEN
+      expect(queue.propertyUpdates.QueueName).toBeDefined();
+      expect(queue.propertyUpdates.QueueName.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+      expect(queue.propertyUpdates.QueueName.isDifferent).toBe(true);
+      expect(queue.changeImpact).toBe(ResourceImpact.WILL_REPLACE);
+    });
+
+    test('does not clobber a property already present in the template diff', () => {
+      // GIVEN
+      const existing = new PropertyDifference<string>('a', 'b', { changeImpact: ResourceImpact.WILL_UPDATE });
+      const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
+        changeSet: {},
+        changeSetResources: {
+          Queue: {
+            resourceWasReplaced: false,
+            resourceType: 'AWS::SQS::Queue',
+            propertyReplacementModes: {
+              QueueName: { replacementMode: 'Always' },
+            },
+          },
+        },
+      });
+      const queue = new ResourceDifference(
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'a' } },
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'b' } },
+        {
+          resourceType: { oldType: 'AWS::SQS::Queue', newType: 'AWS::SQS::Queue' },
+          propertyDiffs: { QueueName: existing },
+          otherDiffs: {},
+        },
+      );
+
+      // WHEN
+      templateAndChangeSetDiffMerger.addChangeSetPropertiesNotInTemplateDiff('Queue', queue);
+
+      // THEN - the existing template-derived diff is untouched (impact not promoted to replace)
+      expect(queue.propertyUpdates.QueueName).toBe(existing);
+      expect(queue.propertyUpdates.QueueName.changeImpact).toBe(ResourceImpact.WILL_UPDATE);
+    });
+
+    test('skips SAM resources (changeset describes the transformed resource)', () => {
+      // GIVEN
+      const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
+        changeSet: {},
+        changeSetResources: {
+          Fn: {
+            resourceWasReplaced: false,
+            resourceType: 'AWS::Serverless::Function',
+            propertyReplacementModes: {
+              CodeUri: { replacementMode: 'Always' },
+            },
+          },
+        },
+      });
+      const fn = new ResourceDifference(
+        { Type: 'AWS::Serverless::Function', Properties: { CodeUri: 'a' } },
+        { Type: 'AWS::Serverless::Function', Properties: { CodeUri: 'a' } },
+        {
+          resourceType: { oldType: 'AWS::Serverless::Function', newType: 'AWS::Serverless::Function' },
+          propertyDiffs: {},
+          otherDiffs: {},
+        },
+      );
+
+      // WHEN
+      templateAndChangeSetDiffMerger.addChangeSetPropertiesNotInTemplateDiff('Fn', fn);
+
+      // THEN - nothing added
+      expect(fn.propertyUpdates.CodeUri).toBeUndefined();
+      expect(fn.isDifferent).toBe(false);
+    });
+
+    test('does nothing when the resource is not in the change set', () => {
+      // GIVEN
+      const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
+        changeSet: {},
+        changeSetResources: {},
+      });
+      const queue = new ResourceDifference(
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'a' } },
+        { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'b' } },
+        {
+          resourceType: { oldType: 'AWS::SQS::Queue', newType: 'AWS::SQS::Queue' },
+          propertyDiffs: { QueueName: new PropertyDifference<string>('a', 'b', { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          otherDiffs: {},
+        },
+      );
+
+      // WHEN
+      templateAndChangeSetDiffMerger.addChangeSetPropertiesNotInTemplateDiff('Queue', queue);
+
+      // THEN - unchanged
+      expect(Object.keys(queue.propertyUpdates)).toEqual(['QueueName']);
+      expect(queue.propertyUpdates.QueueName.changeImpact).toBe(ResourceImpact.WILL_UPDATE);
     });
   });
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -39,11 +39,12 @@ async function describeChangeSet(
   cfn: ICloudFormationClient,
   stackNameOrArn: string,
   changeSetNameOrArn: string,
-  { fetchAll }: { fetchAll: boolean },
+  { fetchAll, includePropertyValues }: { fetchAll: boolean; includePropertyValues?: boolean },
 ): Promise<DescribeChangeSetCommandOutput> {
   const response = await cfn.describeChangeSet({
     StackName: stackNameOrArn,
     ChangeSetName: changeSetNameOrArn,
+    IncludePropertyValues: includePropertyValues,
   });
 
   // If fetchAll is true, traverse all pages from the change set description.
@@ -52,6 +53,7 @@ async function describeChangeSet(
       StackName: response.StackId ?? stackNameOrArn,
       ChangeSetName: response.ChangeSetId ?? changeSetNameOrArn,
       NextToken: response.NextToken,
+      IncludePropertyValues: includePropertyValues,
     });
 
     // Consolidate the changes
@@ -102,7 +104,7 @@ export async function waitForChangeSetReport(
   ioHelper: IoHelper,
   stackNameOrArn: string,
   changeSetNameOrArn: string,
-  { fetchAll, diagnoser }: { fetchAll: boolean; diagnoser: CloudFormationStackDiagnoser },
+  { fetchAll, diagnoser, includePropertyValues }: { fetchAll: boolean; diagnoser: CloudFormationStackDiagnoser; includePropertyValues?: boolean },
 ): Promise<ChangeSetReport> {
   const stackDisplayName = stackNameFromArn(stackNameOrArn);
   const changeSetDisplayName = changeSetNameFromArn(changeSetNameOrArn);
@@ -110,6 +112,7 @@ export async function waitForChangeSetReport(
   const ret = await waitFor(async () => {
     const description = await describeChangeSet(cfn, stackNameOrArn, changeSetNameOrArn, {
       fetchAll,
+      includePropertyValues,
     });
 
     if (description.Status === 'CREATE_PENDING' || description.Status === 'CREATE_IN_PROGRESS') {
@@ -145,9 +148,12 @@ export async function waitForChangeSet(
   ioHelper: IoHelper,
   stackNameOrArn: string,
   changeSetNameOrArn: string,
-  { fetchAll, diagnoser }: { fetchAll: boolean; diagnoser: CloudFormationStackDiagnoser },
+  { fetchAll, diagnoser, includePropertyValues }: { fetchAll: boolean; diagnoser: CloudFormationStackDiagnoser; includePropertyValues?: boolean },
 ): Promise<DescribeChangeSetCommandOutput> {
-  const { description, diagnosis } = await waitForChangeSetReport(cfn, ioHelper, stackNameOrArn, changeSetNameOrArn, { fetchAll, diagnoser });
+  const { description, diagnosis } = await waitForChangeSetReport(
+    cfn, ioHelper, stackNameOrArn, changeSetNameOrArn,
+    { fetchAll, diagnoser, includePropertyValues },
+  );
   if (diagnosis.type !== 'no-problem') {
     throwDeploymentErrorFromDiagnosis(diagnosis);
   }
@@ -405,6 +411,11 @@ async function createChangeSetAndCleanup(
     {
       fetchAll: options.willExecute,
       diagnoser: options.diagnoser,
+      // Ask CloudFormation to include the before/after property values and resource contexts
+      // in the change set description. This is what lets `cdk diff` surface changes that are
+      // invisible to a pure template diff (e.g. an SSM parameter or dynamic reference whose
+      // resolved value changed even though the local template did not).
+      includePropertyValues: true,
     },
   );
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -305,7 +305,14 @@ export class ResourceImporter {
    * Return the current template, with the given resources added to it
    */
   private async currentTemplateWithAdditions(additions: ImportableResource[]): Promise<any> {
-    const template = await this.currentTemplate();
+    // Build the IMPORT change-set template from a *copy* of the deployed template. We must not
+    // mutate the cached deployed template: it is also referenced as the "old template" by the
+    // diff formatter returned from `discoverImportableResources`, and `fullDiff` (which it runs)
+    // already had a history of mutating its inputs. Reusing/mutating the cached object risks
+    // leaking changes - the import additions, or normalizations such as sorted `DependsOn`
+    // arrays - into the submitted change set, which CloudFormation rejects as modifications to
+    // resources that are not being imported. See https://github.com/aws/aws-cdk-cli/issues/1575.
+    const template = structuredClone(await this.currentTemplate());
     if (!template.Resources) {
       template.Resources = {};
     }

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -492,6 +492,32 @@ describe('diff', () => {
       });
     });
 
+    test('ChangeSet diff describes the change set with IncludePropertyValues so deploy-time-only changes are surfaced', async () => {
+      // GIVEN - an existing stack
+      jest.spyOn(deployments.Deployments.prototype, 'stackExists').mockResolvedValue(true);
+      mockCloudFormationClient.on(DescribeStacksCommand).resolves({
+        Stacks: [{ StackName: 'Stack1', StackStatus: 'CREATE_COMPLETE', CreationTime: new Date() }],
+      });
+      mockSSMClient.on(GetParameterCommand).resolves({ Parameter: { Value: '99' } });
+      mockCloudFormationClient.on(CreateChangeSetCommand).resolves({ Id: 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/cdk-diff' });
+      mockCloudFormationClient.on(DescribeChangeSetCommand).resolves({
+        Status: 'CREATE_COMPLETE',
+        Changes: [],
+      });
+
+      // WHEN
+      const cx = await cdkOutFixture(toolkit, 'stack-with-bucket');
+      await toolkit.diff(cx, {
+        stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+        method: DiffMethod.ChangeSet({ fallbackToTemplate: false }),
+      });
+
+      // THEN - the change set was described requesting property values (BeforeContext/AfterContext)
+      const describeCalls = mockCloudFormationClient.commandCalls(DescribeChangeSetCommand);
+      expect(describeCalls.length).toBeGreaterThan(0);
+      expect(describeCalls.some(call => (call.args[0].input as any).IncludePropertyValues === true)).toBe(true);
+    });
+
     test('ChangeSet diff treats DELETE_IN_PROGRESS stack as non-existent', async () => {
       // GIVEN - stack is in DELETE_IN_PROGRESS (from a previous diff cleanup)
       jest.spyOn(deployments.Deployments.prototype, 'stackExists').mockResolvedValue(true);

--- a/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/resource-import/import.test.ts
@@ -3,6 +3,7 @@ import {
   GetTemplateSummaryCommand,
   StackStatus,
 } from '@aws-sdk/client-cloudformation';
+import * as yaml from 'yaml';
 import { Deployments } from '../../../lib/api/deployments';
 import type { ImportMap, ResourceImporterProps } from '../../../lib/api/resource-import';
 import { ResourceImporter } from '../../../lib/api/resource-import';
@@ -225,9 +226,76 @@ test('asks human to confirm automatic import if identifier is in template', asyn
   });
 });
 
+test('issue 1575: importing resources does not mutate the cached deployed template', async () => {
+  // GIVEN a deployed stack with no resources, importing MyQueue
+  givenCurrentStack(STACK_WITH_QUEUE.stackName, { Resources: {} });
+  const importer = new ResourceImporter(STACK_WITH_QUEUE, props);
+
+  const first = await importer.discoverImportableResources();
+  const importMap: ImportMap = {
+    importResources: first.additions,
+    resourceMap: { MyQueue: { QueueName: 'TheQueueName' } },
+  };
+
+  // WHEN we run the import (which builds the import template from the cached deployed template)
+  await advanceTime(importer.importResourcesFromMap(importMap));
+
+  // THEN the cached deployed template must be untouched: MyQueue is still reported as a brand-new
+  // addition on a subsequent discovery (it would not be if the import had added it to the cache).
+  const second = await importer.discoverImportableResources();
+  expect(second.additions).toEqual([
+    expect.objectContaining({ logicalId: 'MyQueue' }),
+  ]);
+});
+
+test('issue 1575: IMPORT change set preserves DependsOn order of non-imported resources', async () => {
+  // GIVEN a deployed stack containing a resource whose DependsOn is NOT in alphabetical order.
+  // (A CDK L2 Lambda reliably produces this: [ ...ServiceRoleDefaultPolicy, ...ServiceRole ].)
+  const naturalOrder = ['MyFnServiceRoleDefaultPolicy', 'MyFnServiceRole'];
+  const existingResource = () => ({
+    Type: 'AWS::SQS::Queue',
+    Properties: { QueueName: 'ExistingQueue' },
+    DependsOn: [...naturalOrder],
+  });
+
+  const stackToImportInto = testStack({
+    stackName: 'StackImport1575',
+    template: {
+      Resources: {
+        Existing: existingResource(),
+        MyQueue: { Type: 'AWS::SQS::Queue', Properties: { QueueName: 'TheQueueName' } },
+      },
+    },
+  });
+
+  givenCurrentStack(stackToImportInto.stackName, {
+    Resources: {
+      Existing: existingResource(),
+    },
+  });
+
+  const importer = new ResourceImporter(stackToImportInto, props);
+  const { additions } = await importer.discoverImportableResources();
+  const importMap: ImportMap = {
+    importResources: additions,
+    resourceMap: {
+      MyQueue: { QueueName: 'TheQueueName' },
+    },
+  };
+
+  // WHEN
+  await advanceTime(importer.importResourcesFromMap(importMap));
+
+  // THEN - the submitted IMPORT template keeps the deployed (natural) DependsOn order, so the
+  // non-imported `Existing` resource is byte-for-byte unchanged and not flagged as "modified".
+  const calls = mockCloudFormationClient.commandCalls(CreateChangeSetCommand);
+  expect(calls.length).toBeGreaterThan(0);
+  const submittedTemplate = yaml.parse((calls[calls.length - 1].args[0].input as any).TemplateBody);
+  expect(submittedTemplate.Resources.Existing.DependsOn).toEqual(naturalOrder);
+});
+
 test('importing resources from migrate strips cdk metadata and outputs', async () => {
   // GIVEN
-
   const MyQueue = {
     Type: 'AWS::SQS::Queue',
     Properties: {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,6 +22,7 @@ __metadata:
     "@aws-sdk/client-s3": "npm:^3"
     "@aws-sdk/client-secrets-manager": "npm:^3"
     "@aws-sdk/client-sns": "npm:^3"
+    "@aws-sdk/client-ssm": "npm:^3"
     "@aws-sdk/client-sso": "npm:^3"
     "@aws-sdk/client-sts": "npm:^3"
     "@aws-sdk/credential-providers": "npm:^3"


### PR DESCRIPTION
**`cdk diff --method=change-set` now correctly reports deploy-time-only changes (#641).** When a property is resolved at deploy time (e.g. an SSM `AWS::SSM::Parameter::Value<...>` or a CloudFormation dynamic reference), the template is unchanged but the deployed value isn't — `cdk diff` used to say "There were no differences" before a deploy that actually changed/replaced the resource. The diff now reads the change set's before/after data (via `IncludePropertyValues`) and surfaces these changes, both on resources missing from the template diff and as extra properties on resources that already have visible changes.

This supersedes the reverted aws/aws-cdk#30093, which crashed on SAM/transform stacks; this version builds from the change set's own data with a defined type and guards transformed resources, so that crash cannot recur.

**`cdk import` no longer fails with "modified resources … not being imported" (#1575).** `fullDiff()` mutated its input (sorting `DependsOn`); `cdk import` reused that object as the change-set base, so the reorder leaked in and CloudFormation rejected untouched resources. `fullDiff()` is now side-effect free and the importer builds from a copy.

Fixes #641
Fixes #1575

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
