### PR TITLE
feat(integ-runner): emit versions to metrics on CodeBuild

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -2,6 +2,7 @@
 import * as path from 'path';
 import * as jest from 'jest';
 import * as yargs from 'yargs';
+import { emitVersionsEmf } from '../emf';
 import { RunnerCliNpmSource } from '../package-sources/cli-npm-source';
 import { RunnerCliRepoSource } from '../package-sources/cli-repo-source';
 import { autoFindRepoRoot } from '../package-sources/find-root';
@@ -10,7 +11,6 @@ import { RunnerLibraryNpmSource } from '../package-sources/library-npm-source';
 import { RunnerLibraryPreinstalledSource } from '../package-sources/library-preinstalled-source';
 import type { IRunnerSource, ITestCliSource, ITestLibrarySource } from '../package-sources/source';
 import { serializeSources } from '../package-sources/subprocess';
-import { emitVersionsEmf } from '../emf';
 
 const CLI_PACKAGE_NAME = 'aws-cdk';
 const CDK_ASSETS_PACKAGE_NAME = 'cdk-assets';

--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -10,6 +10,7 @@ import { RunnerLibraryNpmSource } from '../package-sources/library-npm-source';
 import { RunnerLibraryPreinstalledSource } from '../package-sources/library-preinstalled-source';
 import type { IRunnerSource, ITestCliSource, ITestLibrarySource } from '../package-sources/source';
 import { serializeSources } from '../package-sources/subprocess';
+import { emitVersionsEmf } from '../emf';
 
 const CLI_PACKAGE_NAME = 'aws-cdk';
 const CDK_ASSETS_PACKAGE_NAME = 'cdk-assets';
@@ -241,6 +242,19 @@ async function main() {
       cdkAssets,
     });
 
+    if (process.env.CODEBUILD_BUILD_ID) {
+      // Emitting here is sliiiightly going to mess up the output of the test run, but since this is
+      // CodeBuild not too many people are going to look at it probably. Ultimately we only want these
+      // metrics into CloudWatch.
+      emitVersionsEmf({
+        cli: cli.version,
+        library: library.version,
+        toolkitLib: toolkitLib.version,
+        cdkAssets: cdkAssets.version,
+        tests: thisPackageVersion(),
+      });
+    }
+
     const jestConfig = path.resolve(__dirname, '..', '..', 'resources', 'integ.jest.config.js');
 
     // Flip a flag to indicate we're testing CDK itself. Some parts of CDK behave more thoroughly
@@ -311,3 +325,4 @@ main().catch(e => {
   console.error(e);
   process.exitCode = 1;
 });
+

--- a/packages/@aws-cdk-testing/cli-integ/lib/emf.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/emf.ts
@@ -8,6 +8,7 @@
  * automatically emit metric data from these fields.
  */
 export function emitVersionsEmf(versions: Versions) {
+  // eslint-disable-next-line no-console
   console.log(JSON.stringify(createVersionsEmf(versions)));
 }
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/emf.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/emf.ts
@@ -1,0 +1,63 @@
+/**
+ * Emit an EMF event with the versions of the CLI, library, toolkit-lib and cdk-assets that were used to run the tests.
+ *
+ * The version numbers are first scalarized so that they can be graphed, and the CodeBuild Project Name is used as
+ * a dimension to keep different test runs in the same account separate.
+ *
+ * The way EMF works, if CloudWatch sees a log message like this it will
+ * automatically emit metric data from these fields.
+ */
+export function emitVersionsEmf(versions: Versions) {
+  console.log(JSON.stringify(createVersionsEmf(versions)));
+}
+
+export function createVersionsEmf(versions: Versions) {
+  const emf = {
+    _aws: {
+      Timestamp: Date.now(),
+      CloudWatchMetrics: [{
+        Namespace: 'CDK/CLIInteg',
+        Dimensions: [['ProjectName']],
+        Metrics: [
+          { Name: 'CliVersion' },
+          { Name: 'LibraryVersion' },
+          { Name: 'ToolkitLibVersion' },
+          { Name: 'CdkAssetsVersion' },
+          { Name: 'TestsVersion' },
+        ],
+      }],
+    },
+    // Dimensions
+    ProjectName: process.env.CODEBUILD_BUILD_ID?.split(':')[0] ?? 'unknown',
+    // Metrics
+    CliVersion: scalarizeVersion(versions.cli),
+    LibraryVersion: scalarizeVersion(versions.library),
+    ToolkitLibVersion: scalarizeVersion(versions.toolkitLib),
+    CdkAssetsVersion: scalarizeVersion(versions.cdkAssets),
+    TestsVersion: scalarizeVersion(versions.tests),
+  };
+
+  return emf;
+
+  function scalarizeVersion(version: string): number {
+    const parts = version.match(/(\d+)\.(\d+)\.(\d+)/);
+    if (!parts) {
+      return 0;
+    }
+
+    const vs = parts.slice(1).map(p => parseInt(p, 10));
+
+    // This gives 4 digits for the minor version (necessary for the CLI), and 1 digit for the patch version
+    return vs[0] * 100000
+      + (vs[1] % 10000) * 10
+      + vs[2] % 10;
+  }
+}
+
+export interface Versions {
+  readonly cli: string;
+  readonly library: string;
+  readonly toolkitLib: string;
+  readonly cdkAssets: string;
+  readonly tests: string;
+}

--- a/packages/@aws-cdk-testing/cli-integ/test/emf.test.ts
+++ b/packages/@aws-cdk-testing/cli-integ/test/emf.test.ts
@@ -1,4 +1,4 @@
-import { createVersionsEmf } from "../lib/emf";
+import { createVersionsEmf } from '../lib/emf';
 
 process.env.CODEBUILD_BUILD_ID = 'test-project:1234567890';
 

--- a/packages/@aws-cdk-testing/cli-integ/test/emf.test.ts
+++ b/packages/@aws-cdk-testing/cli-integ/test/emf.test.ts
@@ -1,0 +1,47 @@
+import { createVersionsEmf } from "../lib/emf";
+
+process.env.CODEBUILD_BUILD_ID = 'test-project:1234567890';
+
+// Do not be weirded out by _ inside the numbers. They have no semantic meaning.
+// You would usually use them as 1000s separators, but here I'm using them to make the version components
+// easier to see.
+
+test('EMF conversion', () => {
+  const emf = createVersionsEmf({
+    cli: '2.1128.1 (npm)',
+    library: 'aws-cdk-lib@2.260.0',
+    toolkitLib: '@aws-cdk/toolkit-lib@latest',
+    cdkAssets: 'latest (npm)',
+    tests: '3.33.2',
+  });
+
+  expect(emf).toEqual(expect.objectContaining({
+    CliVersion: 2_1128_1,
+    LibraryVersion: 2_0260_0,
+    ToolkitLibVersion: 0,
+    CdkAssetsVersion: 0,
+    TestsVersion: 3_0033_2,
+    ProjectName: 'test-project',
+  }));
+});
+
+test('overflow doesnt spill over into next version component', () => {
+  const emf = createVersionsEmf({
+    cli: '2.1128.1-rc.99',
+    library: 'aws-cdk-lib@2.260.666',
+    toolkitLib: '1.123123.1',
+    cdkAssets: 'v2',
+    tests: 'v3',
+  });
+
+  expect(emf).toEqual(expect.objectContaining({
+    // RC is ignored
+    CliVersion: 2_1128_1,
+
+    // .666 is modulo'ed to .6
+    LibraryVersion: 2_0260_6,
+
+    // .123123. is modulo'ed to 3123
+    ToolkitLibVersion: 1_3123_1,
+  }));
+});


### PR DESCRIPTION
When we detect that we are running on CodeBuild, scalarize the versions and use EMF to emit them as metrics to CloudWatch. This will allow us to easily correlate version changes with behavior changes in the same graph.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
