### PR TITLE
feat(integ-runner): context is loaded from integ.context.json or cdk.json

### DIFF
--- a/packages/@aws-cdk/integ-runner/README.md
+++ b/packages/@aws-cdk/integ-runner/README.md
@@ -172,7 +172,7 @@ Tests:    1 failed, 9 total
 Error: Some snapshot tests failed!
 To re-run failed tests run: integ-runner --update-on-failed
     at main (packages/@aws-cdk/integ-runner/lib/cli.js:90:15)
-error Command failed with exit code 1. 
+error Command failed with exit code 1.
 ```
 
 To re-run the integration test for the failed tests you would then run:
@@ -227,7 +227,7 @@ By default, integration tests are run with the "update workflow" enabled. This c
 If an existing snapshot is being updated, the integration test runner will first deploy the existing snapshot and then perform a stack update
 with the new changes. This is to test for cases where an update would cause a breaking change only on a stack update.
 
-> **Important:** The update workflow (both `--update-workflow` and `--update-from-tags`) only works 
+> **Important:** The update workflow (both `--update-workflow` and `--update-from-tags`) only works
 > with **environment-agnostic** snapshots. A snapshot is environment-agnostic when its templates do
 > not embed specific account IDs or regions. Tests that use context lookups (e.g., VPC or AZ
 > providers) store dummy resolved values in their snapshots — these are fine for diffing but can
@@ -364,3 +364,22 @@ integ-runner --help
 ```
 
 To use a different config file, provide the `--config` command-line option.
+
+## Dealing with context and Feature Flags
+
+By default, `integ-runner` will use the most recent recommended set of feature
+flags. This has the consequence that when you upgrade `integ-runner`, the
+feature flag set may change and affect your generated snapshots, requiring a
+snapshot update.
+
+If your test directory has an `integ.context.json` file or `cdk.json` file
+upstream from the test, context values from those files will be used and
+completely replace the built-in flags. This makes sure that your context stays
+the same, even if you upgrade `integ-runner`. It also gives you the ability
+to change a context value for all tests at once. If there are multiple files
+they will not be merged: the closest file to the test will be used.
+
+If `integ.context.json` is found, it is expected to be a one-level dictionary of
+context keys to values. If `cdk.json` is found, its `"context"` key will be used
+as a dictionary of context keys and values (same as the file that typically
+controls a CDK app's context and feature flags).

--- a/packages/@aws-cdk/integ-runner/README.md
+++ b/packages/@aws-cdk/integ-runner/README.md
@@ -377,7 +377,8 @@ upstream from the test, context values from those files will be used and
 completely replace the built-in flags. This makes sure that your context stays
 the same, even if you upgrade `integ-runner`. It also gives you the ability
 to change a context value for all tests at once. If there are multiple files
-they will not be merged: the closest file to the test will be used.
+they will not be merged: the closest file to the test will be used, with
+`integ.context.json` taking precedence over `cdk.json`.
 
 If `integ.context.json` is found, it is expected to be a one-level dictionary of
 context keys to values. If `cdk.json` is found, its `"context"` key will be used

--- a/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
@@ -14,6 +14,7 @@ import type { ManifestTrace } from './private/cloud-assembly';
 import { AssemblyManifestReader } from './private/cloud-assembly';
 import type { DestructiveChange } from '../workers/common';
 import { NoManifestError } from './private/integ-manifest';
+import type { CdkContext } from './private/test-specific-context';
 
 const DESTRUCTIVE_CHANGES = '!!DESTRUCTIVE_CHANGES:';
 
@@ -185,6 +186,13 @@ export class CdkIntegHelper {
   private _legacyEnableLookups?: LegacyEnableLookups;
 
   /**
+   * Fields that require an async context to initialize.
+   */
+  private _asyncMembers?: {
+    testSpecificContext?: CdkContext;
+  };
+
+  /**
    * Private constructor to prevent inheritance.
    */
   private constructor(options: CdkIntegHelperOptions) {
@@ -204,6 +212,29 @@ export class CdkIntegHelper {
   }
 
   /**
+   * Async initialization; copy information from an async context into variables so we can access them synchronously later.
+   *
+   * We call this automatically in all public async members, but if a consumer wants to access this context synchronously
+   * without calling an async members first, it needs to call this.
+   */
+  public async asyncInitialize(): Promise<void> {
+    if (this._asyncMembers) {
+      return;
+    }
+
+    this._asyncMembers = {
+      testSpecificContext: await this.test.testSpecificContext(),
+    };
+  }
+
+  private get asyncMembers(): NonNullable<CdkIntegHelper['_asyncMembers']> {
+    if (!this._asyncMembers) {
+      throw new Error('Async context not initialized. Call asyncInitialize() first.');
+    }
+    return this._asyncMembers;
+  }
+
+  /**
    * Configure the legacy enableLookups value to use when generating the actual snapshot.
    *
    * Must be set before using snapshot methods.
@@ -216,6 +247,7 @@ export class CdkIntegHelper {
    * Return the list of actual (i.e. new) test cases for this integration test
    */
   public async actualTests(): Promise<{ [testName: string]: TestCase } | undefined> {
+    await this.asyncInitialize();
     return (await this.actualTestSuite()).testSuite;
   }
 
@@ -260,7 +292,7 @@ export class CdkIntegHelper {
 
     await this.cdk.synth({
       app: this.cdkApp,
-      context: this.getContext(this._legacyEnableLookups !== false ? DEFAULT_SYNTH_OPTIONS.context : {}),
+      context: await this.getContext(this._legacyEnableLookups !== false ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
       output: path.relative(this.directory, outputDirectory),
     });
@@ -294,6 +326,7 @@ export class CdkIntegHelper {
    * The test suite from the existing snapshot
    */
   public async expectedTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite | undefined> {
+    await this.asyncInitialize();
     if (!this._expectedTestSuite && this.hasSnapshot()) {
       this._expectedTestSuite = await this.loadManifest();
     }
@@ -301,6 +334,7 @@ export class CdkIntegHelper {
   }
 
   public async actualSnapshot(): Promise<SnapshotAndTestDefinition> {
+    await this.asyncInitialize();
     if (!this._actualSnapshot) {
       this._actualSnapshot = await this.generateActualSnapshot();
 
@@ -333,6 +367,7 @@ export class CdkIntegHelper {
    * "legacy mode" and create a manifest from pragma
    */
   public async loadManifest(dir?: string): Promise<IntegTestSuite | LegacyIntegTestSuite> {
+    await this.asyncInitialize();
     const manifest = dir ?? this.goldenSnapshotDir;
     try {
       const testSuite = IntegTestSuite.fromPath(manifest);
@@ -453,6 +488,7 @@ export class CdkIntegHelper {
    * the assembly that was output by the deployment
    */
   public async createSnapshot(): Promise<void> {
+    await this.asyncInitialize();
     if (fs.existsSync(this.goldenSnapshotDir)) {
       fs.removeSync(this.goldenSnapshotDir);
     }
@@ -491,8 +527,13 @@ export class CdkIntegHelper {
   }
 
   public getContext(additionalContext?: Record<string, any>): Record<string, any> {
+    // Load the test-specific context (from `integ.context.json` or `cdk.json#context`), if any.
+    // If not found, use the built-in current feature flags (at the risk of newer feature flags changing
+    // the snapshots).
+    const featureFlags = this.asyncMembers.testSpecificContext ?? currentlyRecommendedAwsCdkLibFlags();
+
     return {
-      ...currentlyRecommendedAwsCdkLibFlags(),
+      ...featureFlags,
       ...this.legacyContext,
       ...additionalContext,
 

--- a/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as fs from 'fs-extra';
+import { findTestSpecificContext } from './private/test-specific-context';
 
 const CDK_OUTDIR_PREFIX = 'cdk-integ.out';
 
@@ -139,6 +140,17 @@ export class IntegTest {
       this.testName,
       this.absoluteFileName,
     ].includes(name);
+  }
+
+  /**
+   * Search for a test-specific context file and return its contents if it exists.
+   *
+   * If `undefined`, no test-specific context could be found. Test-specific context
+   * will be taken from either `integ.context.json` if found, or otherwise
+   * `cdk.json#context` if not found, upstream from the test.
+   */
+  public async testSpecificContext(): Promise<Record<string, unknown> | undefined> {
+    return findTestSpecificContext(this.fileName);
   }
 }
 

--- a/packages/@aws-cdk/integ-runner/lib/runner/private/test-specific-context.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/private/test-specific-context.ts
@@ -1,0 +1,54 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+
+const INTEG_CONTEXT_JSON_FILE = 'integ.context.json';
+const CDK_JSON_FILE = 'cdk.json';
+
+export type CdkContext = Record<string, unknown>;
+
+const CONTEXT_CACHE = new Map<string, CdkContext | undefined>();
+
+export async function findTestSpecificContext(directory: string): Promise<CdkContext | undefined> {
+  const existing = CONTEXT_CACHE.get(directory);
+  if (existing) {
+    return existing;
+  }
+
+  let maybeContext: CdkContext | undefined;
+
+  // Try to load `integ.context.json`
+  if (maybeContext === undefined) {
+    const contextFile = path.join(directory, INTEG_CONTEXT_JSON_FILE);
+    maybeContext = await tryReadJsonFile(contextFile) as CdkContext | undefined;
+  }
+
+  // Try to load `cdk.json#context`
+  if (maybeContext === undefined) {
+    const cdkJsonFile = path.join(directory, CDK_JSON_FILE);
+    let maybeCdkJson = await tryReadJsonFile(cdkJsonFile) as { context?: CdkContext } | undefined;
+    maybeContext = maybeCdkJson?.context;
+  }
+
+  // Try to load from parent directory
+  if (maybeContext === undefined) {
+    const parentDir = path.dirname(directory);
+    if (parentDir !== directory) {
+      maybeContext = await findTestSpecificContext(parentDir);
+    }
+  }
+
+  CONTEXT_CACHE.set(directory, maybeContext);
+  return maybeContext;
+}
+
+async function tryReadJsonFile(filePath: string): Promise<unknown | undefined> {
+  try {
+    const content = await fs.readFile(filePath, { encoding: 'utf-8' });
+    return JSON.parse(content);
+  } catch (e: any) {
+    if (e.code === 'ENOENT' || e.code === 'ENOTDIR') {
+      return undefined;
+    }
+    throw e;
+  }
+}

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-helper.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-helper.test.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { CdkIntegHelper } from '../../lib/runner';
+import { IntegTest } from '../../lib/runner/integration-tests';
+
+let mockCdk: any;
+let tempDir: string;
+
+beforeEach(async () => {
+  mockCdk = {
+    synthesize: jest.fn(),
+    deploy: jest.fn(),
+    destroy: jest.fn(),
+  };
+
+  tempDir = await fs.mkdtemp('cdk-integ-helper-test-');
+});
+
+afterEach(async () => {
+  await fs.rm(tempDir, { recursive: true, force: true });
+});
+
+test('can read context from integ.context.json in the same directory', async () => {
+  // GIVEN
+  await writeJson(path.join(tempDir, 'integ.context.json'), {
+    key: 'value',
+  });
+  const helper = await makeHelper('test.js');
+
+  // WHEN / THEN
+  expect(helper.getContext()).toMatchObject({ key: 'value' });
+});
+
+test('can read context from cdk.json in the same directory', async () => {
+  // GIVEN
+  await writeJson(path.join(tempDir, 'cdk.json'), {
+    context: {
+      key: 'value',
+    },
+  });
+  const helper = await makeHelper('test.js');
+
+  // WHEN / THEN
+  expect(helper.getContext()).toMatchObject({ key: 'value' });
+});
+
+test('integ.context.json takes precedence over cdk.json', async () => {
+  // GIVEN
+  await writeJson(path.join(tempDir, 'cdk.json'), {
+    context: {
+      cdkJsonKey: 'cdkJsonValue',
+    },
+  });
+  await writeJson(path.join(tempDir, 'integ.context.json'), {
+    integJsonKey: 'integJsonValue',
+  });
+  const helper = await makeHelper('test.js');
+
+  // WHEN / THEN
+  expect(helper.getContext()).toMatchObject({ integJsonKey: 'integJsonValue' });
+  expect(helper.getContext()).not.toMatchObject({ cdkJsonKey: 'cdkJsonValue' });
+});
+
+test('can read context from parent directory', async () => {
+  // GIVEN
+  await writeJson(path.join(tempDir, 'integ.context.json'), {
+    integJsonKey: 'integJsonValue',
+  });
+  const helper = await makeHelper('subdir/test.js');
+
+  // WHEN / THEN
+  expect(helper.getContext()).toMatchObject({ integJsonKey: 'integJsonValue' });
+});
+
+async function makeHelper(relativePath: string) {
+  const ret = CdkIntegHelper.create({
+    cdk: mockCdk,
+    test: new IntegTest({
+      fileName: path.join(tempDir, relativePath),
+      discoveryRoot: tempDir,
+    }),
+    showOutput: true,
+    region: 'eu-west-1',
+  });
+  await ret.asyncInitialize();
+  return ret;
+}
+
+async function writeJson(filePath: string, data: any): Promise<void> {
+  const jsonString = JSON.stringify(data, null, 2);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, jsonString, 'utf-8');
+}

--- a/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
@@ -3,7 +3,7 @@ import { IntegTest } from '../../lib/runner/integration-tests';
 import { ManifestLoadError } from '../../lib/runner/private/integ-manifest';
 import { testDataPath } from '../helpers';
 
-describe('IntegRunner manifest error handling', () => {
+describe('CdkIntegHelper manifest error handling', () => {
   let mockCdk: any;
 
   beforeEach(() => {


### PR DESCRIPTION
It used to be that the context if integ tests could not be controlled very well, and the feature flags would float with the version of `aws-cdk-lib` that the runner was built against.

We change this to make the flags in `integ.context.json` or `cdk.json` take precedence to the floating behavior: when found, those will be loaded and configured instead.

This makes integ tests stable during `integ-runner` upgrades, and gives a single place where context flags for 100s of tests can be controlled easily.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
