### PR TITLE
feat: support source tracing for python

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -44,24 +44,27 @@ export class SourceMapResolver {
   /**
    * Resolve the user source location from a creation stack trace (the frames
    * produced by toolkit-lib's findCreationStackTrace). Returns undefined when
-   * there's no trace (non-TS apps) or every frame is a skip-placeholder
-   * (framework-only call sites).
+   * there's no trace or no frame resolves to an in-root user source file.
    */
   public async resolveFrames(frames: readonly string[] | undefined): Promise<SourceLocation | undefined> {
     if (!frames) return undefined;
 
-    // aws-cdk-lib's renderCallStackJustMyCode (in node_modules/aws-cdk-lib/core/
-    // lib/stack-trace.js) pre-filters node_modules/node:internal frames into
-    // skip-placeholder lines. Those don't match FRAME_RE, so the first frame
-    // that parses IS the user call site.
+    // Scan for the first frame that is a supported source file inside the
+    // project. For TypeScript apps aws-cdk-lib's renderCallStackJustMyCode
+    // pre-filters framework frames into non-parsing placeholders, so the user
+    // .ts is first. For jsii host languages (Python/Java) the trace instead
+    // carries real aws-cdk-lib and jsii-kernel .js frames (in a temp dir,
+    // outside the root) ahead of the user's .py/.java frame, so we skip past
+    // unsupported-or-out-of-root frames rather than stop at the first one.
     for (const frame of frames) {
       const parsed = parseFrame(frame);
       if (!parsed) continue;
-      if (!isSupportedSourceFile(parsed.file)) return undefined;
+      const kind = sourceKind(parsed.file);
+      if (!kind) continue;
       // The frame's file path is assembly-derived and attacker-influenceable.
       // Never read or surface a location outside the project.
-      if (!(await isWithinRoot(this.projectRoot, parsed.file))) return undefined;
-      return this.mapJsToOriginalSource(parsed);
+      if (!(await isWithinRoot(this.projectRoot, parsed.file))) continue;
+      return kind === 'host' ? normalizeHostFrame(parsed) : this.mapJsToOriginalSource(parsed);
     }
     return undefined;
   }
@@ -140,21 +143,38 @@ export class SourceMapResolver {
     }
   }
 }
-const SUPPORTED_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js'] as const;
+// TypeScript/JavaScript frames go through source-map resolution (.js -> .ts).
+const TS_JS_EXTENSIONS = ['.ts', '.tsx', '.js'] as const;
+// jsii host-language frames (Python/Java) already point at user source; they
+// need no source map, only column normalization. .go/.cs are deferred until
+// their jsii runtimes send host stack traces over the wire.
+const HOST_LANGUAGE_EXTENSIONS = ['.py', '.java'] as const;
 
-function isSupportedSourceFile(file: string): boolean {
-  return SUPPORTED_SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext));
+function sourceKind(file: string): 'tsjs' | 'host' | undefined {
+  if (TS_JS_EXTENSIONS.some((ext) => file.endsWith(ext))) return 'tsjs';
+  if (HOST_LANGUAGE_EXTENSIONS.some((ext) => file.endsWith(ext))) return 'host';
+  return undefined;
 }
 
-// renderCallStackJustMyCode emits frames as "    at <name> (<file>:<line>:<col>)".
-// Anchoring on "(" avoids capturing the leading "at " into the file group.
-const FRAME_RE = /\(([^()\s][^()]*?):(\d+):(\d+)\)\s*$/;
+// jsii host frames are already source-space, but their columns are 0-indexed
+// (and 0 when unavailable, e.g. Python). SourceLocation is 1-based, so shift;
+// 0 -> 1 lands at the start of the line, the safe default.
+function normalizeHostFrame(loc: SourceLocation): SourceLocation {
+  return { file: loc.file, line: loc.line, column: loc.column + 1 };
+}
+
+// V8 frames are "<name> (<file>:<line>:<col>)". jsii host-language frames
+// (aws-cdk-lib's formatExternalFrame) omit the column when it's unavailable
+// (the common Python/Java case), emitting "<name> (<file>:<line>)", so the
+// column group is optional. Anchoring on "(" avoids capturing a leading "at ".
+const FRAME_RE = /\(([^()\s][^()]*?):(\d+)(?::(\d+))?\)\s*$/;
 
 function parseFrame(frame: string): SourceLocation | undefined {
   const m = FRAME_RE.exec(frame);
   if (!m) return undefined;
   const line = Number(m[2]);
-  const column = Number(m[3]);
+  // Host frames may omit the column; treat absent as 0 (unavailable).
+  const column = m[3] !== undefined ? Number(m[3]) : 0;
   if (!Number.isFinite(line) || !Number.isFinite(column)) return undefined;
   return { file: m[1], line, column };
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -150,7 +150,7 @@ function sourceKind(file: string): 'tsjs' | 'host' | undefined {
   return undefined;
 }
 
-// Host frame columns are 0-indexed (0 = unavailable); SourceLocation is 1-based.
+// Treat the host column as 1-based; jsii sends 0 when unavailable, so clamp 0 to line start.
 function normalizeHostFrame(loc: SourceLocation): SourceLocation {
   return { file: loc.file, line: loc.line, column: Math.max(1, loc.column) };
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -49,13 +49,9 @@ export class SourceMapResolver {
   public async resolveFrames(frames: readonly string[] | undefined): Promise<SourceLocation | undefined> {
     if (!frames) return undefined;
 
-    // Scan for the first frame that is a supported source file inside the
-    // project. For TypeScript apps aws-cdk-lib's renderCallStackJustMyCode
-    // pre-filters framework frames into non-parsing placeholders, so the user
-    // .ts is first. For jsii host languages (Python/Java) the trace instead
-    // carries real aws-cdk-lib and jsii-kernel .js frames (in a temp dir,
-    // outside the root) ahead of the user's .py/.java frame, so we skip past
-    // unsupported-or-out-of-root frames rather than stop at the first one.
+    // First in-root, supported-source frame wins. Host-language traces carry
+    // framework .js frames (outside the root) ahead of the user's .py/.java
+    // frame, so skip past them rather than stop at the first parsed frame.
     for (const frame of frames) {
       const parsed = parseFrame(frame);
       if (!parsed) continue;
@@ -145,9 +141,7 @@ export class SourceMapResolver {
 }
 // TypeScript/JavaScript frames go through source-map resolution (.js -> .ts).
 const TS_JS_EXTENSIONS = ['.ts', '.tsx', '.js'] as const;
-// jsii host-language frames (Python/Java) already point at user source; they
-// need no source map, only column normalization. .go/.cs are deferred until
-// their jsii runtimes send host stack traces over the wire.
+// jsii host-language frames already point at user source (no source map needed).
 const HOST_LANGUAGE_EXTENSIONS = ['.py', '.java'] as const;
 
 function sourceKind(file: string): 'tsjs' | 'host' | undefined {
@@ -156,17 +150,13 @@ function sourceKind(file: string): 'tsjs' | 'host' | undefined {
   return undefined;
 }
 
-// jsii host frames are already source-space, but their columns are 0-indexed
-// (and 0 when unavailable, e.g. Python). SourceLocation is 1-based, so shift;
-// 0 -> 1 lands at the start of the line, the safe default.
+// Host frame columns are 0-indexed (0 = unavailable); SourceLocation is 1-based.
 function normalizeHostFrame(loc: SourceLocation): SourceLocation {
   return { file: loc.file, line: loc.line, column: loc.column + 1 };
 }
 
-// V8 frames are "<name> (<file>:<line>:<col>)". jsii host-language frames
-// (aws-cdk-lib's formatExternalFrame) omit the column when it's unavailable
-// (the common Python/Java case), emitting "<name> (<file>:<line>)", so the
-// column group is optional. Anchoring on "(" avoids capturing a leading "at ".
+// "<name> (<file>:<line>[:<col>])"; host frames omit the column when
+// unavailable, so it's optional. Anchoring on "(" avoids a leading "at ".
 const FRAME_RE = /\(([^()\s][^()]*?):(\d+)(?::(\d+))?\)\s*$/;
 
 function parseFrame(frame: string): SourceLocation | undefined {

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -50,7 +50,7 @@ export class SourceMapResolver {
     if (!frames) return undefined;
 
     // First in-root, supported-source frame wins. Host-language traces carry
-    // framework .js frames (outside the root) ahead of the user's .py/.java
+    // framework .js frames (outside the root) ahead of the user's .py
     // frame, so skip past them rather than stop at the first parsed frame.
     for (const frame of frames) {
       const parsed = parseFrame(frame);
@@ -142,7 +142,7 @@ export class SourceMapResolver {
 // TypeScript/JavaScript frames go through source-map resolution (.js -> .ts).
 const TS_JS_EXTENSIONS = ['.ts', '.tsx', '.js'] as const;
 // jsii host-language frames already point at user source (no source map needed).
-const HOST_LANGUAGE_EXTENSIONS = ['.py', '.java'] as const;
+const HOST_LANGUAGE_EXTENSIONS = ['.py'] as const;
 
 function sourceKind(file: string): 'tsjs' | 'host' | undefined {
   if (TS_JS_EXTENSIONS.some((ext) => file.endsWith(ext))) return 'tsjs';

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-resolver.ts
@@ -152,7 +152,7 @@ function sourceKind(file: string): 'tsjs' | 'host' | undefined {
 
 // Host frame columns are 0-indexed (0 = unavailable); SourceLocation is 1-based.
 function normalizeHostFrame(loc: SourceLocation): SourceLocation {
-  return { file: loc.file, line: loc.line, column: loc.column + 1 };
+  return { file: loc.file, line: loc.line, column: Math.max(1, loc.column) };
 }
 
 // "<name> (<file>:<line>[:<col>])"; host frames omit the column when

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
@@ -89,9 +89,7 @@ function anchorViolation(
   const loc = resolveLocation(constructPath, index);
   if ('reason' in loc) return loc;
 
-  // Anchor to whatever user source the resolver produced (.ts/.tsx for TS apps,
-  // .py/.java for jsii host-language apps). The resolver owns which files are
-  // valid sources; here we just turn the location into a range.
+  // Resolver already vetted the source file; just turn the location into a range.
   return { uri: pathToFileURL(loc.file).toString(), range: toRange(loc) };
 }
 

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
@@ -27,7 +27,7 @@ export interface MapViolationsResult {
 
 /**
  * Convert a validation report into LSP diagnostics keyed by file URI.
- * Violations we can't anchor to a TypeScript source location are dropped
+ * Violations we can't anchor to a source location are dropped
  * (with a reason) rather than thrown.
  */
 export function mapViolationsToDiagnostics(
@@ -77,7 +77,7 @@ function resolveLocation(
   if (!constructPath) return { reason: 'violation has no construct path' };
   const node = index.byPath(constructPath);
   if (!node) return { reason: 'not found in the construct tree' };
-  if (!node.sourceLocation) return { reason: 'no source location (non-TypeScript app or framework-only trace)' };
+  if (!node.sourceLocation) return { reason: 'no source location (framework-only trace or unresolved source)' };
   return node.sourceLocation;
 }
 
@@ -89,14 +89,10 @@ function anchorViolation(
   const loc = resolveLocation(constructPath, index);
   if ('reason' in loc) return loc;
 
-  // We only surface diagnostics for TypeScript sources for now.
-  if (!isTypeScript(loc.file)) return { reason: `source file is not TypeScript: ${loc.file}` };
-
+  // Anchor to whatever user source the resolver produced (.ts/.tsx for TS apps,
+  // .py/.java for jsii host-language apps). The resolver owns which files are
+  // valid sources; here we just turn the location into a range.
   return { uri: pathToFileURL(loc.file).toString(), range: toRange(loc) };
-}
-
-function isTypeScript(file: string): boolean {
-  return file.endsWith('.ts') || file.endsWith('.tsx');
 }
 
 /**

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/template-locator.ts
@@ -51,7 +51,7 @@ export async function resourceTarget(node: { templateFile?: string; logicalId: s
  * `index` (matched by both `templateFile` and `logicalId`, since logical ids are
  * only unique within a template), and returns its source location as a zero-width
  * range. Undefined when the offset is not inside a resource, no construct owns it,
- * or the construct has no source location (for example a non-TypeScript app).
+ * or the construct has no source location (for example a framework-only trace).
  */
 export function sourceTargetAtTemplateOffset(
   index: ConstructIndex<ConstructNode>,

--- a/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
@@ -96,10 +96,11 @@ describe('SourceMapResolver.resolveFrames', () => {
     });
   });
 
-  test('normalizes an explicit (non-zero) host column to 1-based', async () => {
-    // When a host frame does carry a column it is 0-indexed; shift to 1-based.
+  test('preserves an explicit (non-zero) host column', async () => {
+    // A real host column is already 1-based, so it is kept as-is. Only the 0
+    // "unavailable" sentinel is clamped to the start of the line.
     expect(await resolver.resolveFrames(['f (/project/stacks/data_stack.py:31:8)'])).toEqual({
-      file: '/project/stacks/data_stack.py', line: 31, column: 9,
+      file: '/project/stacks/data_stack.py', line: 31, column: 8,
     });
   });
 

--- a/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/source-resolver.test.ts
@@ -66,8 +66,45 @@ describe('SourceMapResolver.resolveFrames', () => {
     });
   });
 
-  test('returns undefined for a non-TypeScript (host-language) frame', async () => {
-    expect(await resolver.resolveFrames(['    at <module> (/project/app/my_stack.py:42:5)'])).toBeUndefined();
+  test('resolves a Python host frame in the real released format (placeholders + no-column .py)', async () => {
+    // Verbatim shape from aws-cdk-lib 2.260.0 / jsii 1.137.0: kernel frames are
+    // collapsed to non-parsing placeholders, and host frames carry no column
+    // (jsii's Python runtime sends column 0, which formatExternalFrame omits).
+    const frames = [
+      '...jsii runtime, node internals...',
+      '(no user code in 10 frames, use --stack-trace-limit to capture more)',
+      '__init__ (/project/stacks/network_stack.py:42)',
+      '<module> (/project/app.py:10)',
+    ];
+    // No column -> 1-based start of line.
+    expect(await resolver.resolveFrames(frames)).toEqual({
+      file: '/project/stacks/network_stack.py',
+      line: 42,
+      column: 1,
+    });
+  });
+
+  test('skips out-of-root .js frames to reach the first in-root .py frame', async () => {
+    // Robustness: if raw jsii/aws-cdk-lib .js frames appear (outside the root)
+    // ahead of the user frame, skip them rather than give up.
+    const frames = [
+      'Kernel._Kernel_create (/private/var/folders/qw/T/tmpiqvf63c1/lib/program.js:1:61273)',
+      '__init__ (/project/stacks/network_stack.py:42)',
+    ];
+    expect(await resolver.resolveFrames(frames)).toEqual({
+      file: '/project/stacks/network_stack.py', line: 42, column: 1,
+    });
+  });
+
+  test('normalizes an explicit (non-zero) host column to 1-based', async () => {
+    // When a host frame does carry a column it is 0-indexed; shift to 1-based.
+    expect(await resolver.resolveFrames(['f (/project/stacks/data_stack.py:31:8)'])).toEqual({
+      file: '/project/stacks/data_stack.py', line: 31, column: 9,
+    });
+  });
+
+  test('drops a host frame whose file escapes the project root', async () => {
+    expect(await resolver.resolveFrames(['<module> (/etc/evil.py:1)'])).toBeUndefined();
   });
 });
 

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/diagnostics.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/diagnostics.test.ts
@@ -156,13 +156,16 @@ describe('mapViolationsToDiagnostics', () => {
     expect(dropped[0].reason).toContain('no source location');
   });
 
-  test('drops violations whose source file is not TypeScript', () => {
-    const tree = indexOf(nodeWithLocation('S/X', '/p/lib/x.py', 1, 1));
+  test('anchors a violation to a Python (host-language) source file', () => {
+    const tree = indexOf(nodeWithLocation('S/X', '/p/stacks/x.py', 31, 1));
     const report = reportWith({ ruleName: 'r', severity: 'error', paths: ['S/X'] });
 
     const { byUri, dropped } = mapViolationsToDiagnostics(report, tree);
-    expect(byUri.size).toBe(0);
-    expect(dropped[0].reason).toContain('not TypeScript');
+    expect(dropped).toHaveLength(0);
+    expect(byUri.size).toBe(1);
+    const [uri, diags] = [...byUri.entries()][0];
+    expect(uri).toContain('x.py');
+    expect(diags[0].range.start).toEqual({ line: 30, character: 0 });
   });
 
   test('anchors at the top of the file when line/column are unknown', () => {


### PR DESCRIPTION
Add utilities to source resolver to parse jsii host-language creation-stack frames for Python, and drop the TypeScript-only diagnostics gate. Go-to-definition (source → template, and reverse) and policy-violation diagnostics now work for Python apps, not just TypeScript.

Requires synthing with `JSII_HOST_STACK_TRACES=1` (opt-in; jsii 1.137+ / aws-cdk-lib 2.260+). Auto-enabling it for LSP-triggered synth is a follow-up.  Java support separated into new PR due to FQN path parsing complexities. 

Example: 
<img width="819" height="568" alt="Screenshot 2026-06-25 at 1 30 10 PM" src="https://github.com/user-attachments/assets/c20a136e-656f-47b2-a15f-71a585645ba0" />


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
