### PR TITLE
feat(cli-integ): control jest max workers with an env variable

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/run-suite.ts
@@ -108,6 +108,9 @@ async function main() {
         alias: 'w',
         describe: 'Specifies the maximum number of workers the worker-pool will spawn for running tests. We use a sensible default for running cli integ tests.',
         type: 'string',
+        // makes it easier to control from the outside and mitigate
+        // resource utilization issues on codebuild.
+        default: process.env.JEST_MAX_WORKERS,
         requiresArg: true,
       })
       .options('shard', {


### PR DESCRIPTION
Makes the integ test maxWorkers easier to control from the outside to mitigate / investigate resource utilization issues on CodeBuild. When unset, the config file's maxWorkers() calculation still applies.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
