### PR TITLE
feat(toolkit-lib): register message codes for dependency-stack selection lines

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -167,6 +167,8 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_ASSEMBLY_I0150` | Indicates the use of a pre-synthesized cloud assembly directory | `debug` | n/a |
 | `CDK_ASSEMBLY_I0300` | An info message emitted by a Context Provider | `info` | {@link ContextProviderMessageSource} |
 | `CDK_ASSEMBLY_I0301` | A debug message emitted by a Context Provider | `debug` | {@link ContextProviderMessageSource} |
+| `CDK_ASSEMBLY_I0400` | Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion) | `info` | n/a |
+| `CDK_ASSEMBLY_I0401` | Stacks added to the selection because they are dependent on selected stacks (downstream expansion) | `info` | n/a |
 | `CDK_ASSEMBLY_I9999` | Annotations emitted by the cloud assembly | `info` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_W9999` | Warnings emitted by the cloud assembly | `warn` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_E9999` | Errors emitted by the cloud assembly | `error` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |

--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -64,6 +64,8 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_TOOLKIT_W0100` | Credential plugin warnings | `warn` | n/a |
 | `CDK_TOOLKIT_I1000` | Provides synthesis times. | `info` | {@link Operation} |
 | `CDK_TOOLKIT_I1001` | Cloud Assembly synthesis is starting | `trace` | {@link StackSelectionDetails} |
+| `CDK_TOOLKIT_I1002` | Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion) | `info` | n/a |
+| `CDK_TOOLKIT_I1003` | Stacks added to the selection because they are dependent on the selected stacks (downstream expansion) | `info` | n/a |
 | `CDK_TOOLKIT_I1901` | Provides stack data | `result` | {@link StackAndAssemblyData} |
 | `CDK_TOOLKIT_I1902` | Successfully deployed stacks | `result` | {@link AssemblyData} |
 | `CDK_TOOLKIT_I2901` | Provides details on the selected stacks and their dependencies | `result` | {@link StackDetailsPayload} |
@@ -167,8 +169,6 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_ASSEMBLY_I0150` | Indicates the use of a pre-synthesized cloud assembly directory | `debug` | n/a |
 | `CDK_ASSEMBLY_I0300` | An info message emitted by a Context Provider | `info` | {@link ContextProviderMessageSource} |
 | `CDK_ASSEMBLY_I0301` | A debug message emitted by a Context Provider | `debug` | {@link ContextProviderMessageSource} |
-| `CDK_ASSEMBLY_I0400` | Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion) | `info` | n/a |
-| `CDK_ASSEMBLY_I0401` | Stacks added to the selection because they are dependent on selected stacks (downstream expansion) | `info` | n/a |
 | `CDK_ASSEMBLY_I9999` | Annotations emitted by the cloud assembly | `info` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_W9999` | Warnings emitted by the cloud assembly | `warn` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |
 | `CDK_ASSEMBLY_E9999` | Errors emitted by the cloud assembly | `error` | [cxapi.SynthesisMessage](https://docs.aws.amazon.com/cdk/api/v2/docs/@aws-cdk_cx-api.SynthesisMessage.html) |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
@@ -149,7 +149,7 @@ async function includeDownstreamStacks(
   } while (madeProgress);
 
   if (added.length > 0) {
-    await ioHelper.notify(IO.CDK_ASSEMBLY_I0401.msg(`Including depending stacks: ${chalk.bold(added.join(', '))}`));
+    await ioHelper.notify(IO.CDK_TOOLKIT_I1003.msg(`Including depending stacks: ${chalk.bold(added.join(', '))}`));
   }
 }
 
@@ -181,6 +181,6 @@ async function includeUpstreamStacks(
   }
 
   if (added.length > 0) {
-    await ioHelper.notify(IO.CDK_ASSEMBLY_I0400.msg(`Including dependency stacks: ${chalk.bold(added.join(', '))}`));
+    await ioHelper.notify(IO.CDK_TOOLKIT_I1002.msg(`Including dependency stacks: ${chalk.bold(added.join(', '))}`));
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
@@ -4,6 +4,7 @@ import { isMatch as picomatch } from 'picomatch';
 import { StackCollection } from './stack-collection';
 import { flatten } from '../../util';
 import type { IoHelper } from '../io/private/io-helper';
+import { IO } from '../io/private/messages';
 
 export interface IStackAssembly {
   /**
@@ -148,7 +149,7 @@ async function includeDownstreamStacks(
   } while (madeProgress);
 
   if (added.length > 0) {
-    await ioHelper.defaults.info(`Including depending stacks: ${chalk.bold(added.join(', '))}`);
+    await ioHelper.notify(IO.CDK_ASSEMBLY_I0401.msg(`Including depending stacks: ${chalk.bold(added.join(', '))}`));
   }
 }
 
@@ -180,6 +181,6 @@ async function includeUpstreamStacks(
   }
 
   if (added.length > 0) {
-    await ioHelper.defaults.info(`Including dependency stacks: ${chalk.bold(added.join(', '))}`);
+    await ioHelper.notify(IO.CDK_ASSEMBLY_I0400.msg(`Including dependency stacks: ${chalk.bold(added.join(', '))}`));
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -57,6 +57,14 @@ export const IO = {
     description: 'Cloud Assembly synthesis is starting',
     interface: 'StackSelectionDetails',
   }),
+  CDK_TOOLKIT_I1002: make.info({
+    code: 'CDK_TOOLKIT_I1002',
+    description: 'Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion)',
+  }),
+  CDK_TOOLKIT_I1003: make.info({
+    code: 'CDK_TOOLKIT_I1003',
+    description: 'Stacks added to the selection because they are dependent on the selected stacks (downstream expansion)',
+  }),
   CDK_TOOLKIT_I1901: make.result<StackAndAssemblyData>({
     code: 'CDK_TOOLKIT_I1901',
     description: 'Provides stack data',
@@ -606,14 +614,6 @@ export const IO = {
     code: 'CDK_ASSEMBLY_I0301',
     description: 'A debug message emitted by a Context Provider',
     interface: 'ContextProviderMessageSource',
-  }),
-  CDK_ASSEMBLY_I0400: make.info({
-    code: 'CDK_ASSEMBLY_I0400',
-    description: 'Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion)',
-  }),
-  CDK_ASSEMBLY_I0401: make.info({
-    code: 'CDK_ASSEMBLY_I0401',
-    description: 'Stacks added to the selection because they are dependent on selected stacks (downstream expansion)',
   }),
 
   // Assembly Annotations

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -607,6 +607,14 @@ export const IO = {
     description: 'A debug message emitted by a Context Provider',
     interface: 'ContextProviderMessageSource',
   }),
+  CDK_ASSEMBLY_I0400: make.info({
+    code: 'CDK_ASSEMBLY_I0400',
+    description: 'Stacks added to the selection because they are dependencies of the selected stacks (upstream expansion)',
+  }),
+  CDK_ASSEMBLY_I0401: make.info({
+    code: 'CDK_ASSEMBLY_I0401',
+    description: 'Stacks added to the selection because they are dependent on selected stacks (downstream expansion)',
+  }),
 
   // Assembly Annotations
   CDK_ASSEMBLY_I9999: make.info<cxapi.SynthesisMessage>({


### PR DESCRIPTION
This PR adds message codes to two stack-selection lines:

- `CDK_TOOLKIT_I1002` — "Including dependency stacks" (upstream)
- `CDK_TOOLKIT_I1002` — "Including depending stacks" (downstream)

They were emitted without a code, so integrators couldn't target them. Text is unchanged.

#1663  will use these codes to suppress the lines for `cdk list`.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
