### PR TITLE
chore(cli): async and predicate-based CliIoHost message listeners

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/message-maker.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/message-maker.ts
@@ -118,6 +118,11 @@ export interface IoRequestMaker<T, U> extends MessageInfo {
     : [U] extends [boolean]
       ? (message: string, data: T) => ActionLessRequest<T, U>
       : (message: string, data: T, defaultResponse: U) => ActionLessRequest<T, U>;
+
+  /**
+   * Returns whether the given `IoMessage` instance matches this request definition
+   */
+  is(x: IoMessage<unknown>): x is IoMessage<T>;
 }
 
 /**
@@ -137,6 +142,7 @@ function request<T = AbsentData, U = ImpossibleType>(level: IoMessageLevel, deta
     ...details,
     level,
     req: maker as any,
+    is: (m): m is IoMessage<T> => m.code === details.code,
   };
 }
 
@@ -166,5 +172,6 @@ export function question<T>(details: CodeInfo): IoRequestMaker<T, string> {
     ...details,
     level,
     req: maker as any,
+    is: (m): m is IoMessage<T> => m.code === details.code,
   };
 }

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -130,41 +130,96 @@ export interface MessageListenerResult {
   readonly level?: IoMessageLevel;
 
   /**
-   * Skip the default processing of the message, i.e. do not write it to a stream.
+   * Skip the default handling of the message.
+   *
+   * For a notification this means it is not written to a stream. For a request
+   * it stops processing entirely: the user is not prompted, nothing is written,
+   * and the request resolves with its (possibly `respond`-overridden) default
+   * response.
    *
    * @default false
    */
   readonly preventDefault?: boolean;
 
   /**
-   * For requests only: answer the request with this value so the host does not
-   * prompt the user (and writes nothing). Ignored for plain notifications. The
-   * presence of the key is what matters, so `false`/`0`/`''` are valid answers.
-   * Use the `respond`/`respondOnce` helpers for the common case.
+   * For requests only: the value to resolve the request with. It is folded into
+   * the request's default response and skips the prompt (the request is treated
+   * as not promptable). The question is still written unless `preventDefault` is
+   * also set. Ignored for plain notifications.
    *
-   * @default - this listener does not answer the request
+   * The presence of the key is what matters, so `false`/`0`/`''` are valid
+   * answers. Use the `respond`/`respondOnce` helpers for the common case.
+   *
+   * @default - this listener does not supply a response
    */
   readonly respond?: unknown;
 }
 
 /**
- * A registered message listener. Its return value (if any) may update the
- * message text and/or prevent the default processing.
+ * What a message listener may return: nothing, a `MessageListenerResult`, or a
+ * `Promise` of either.
+ *
+ * Listeners may be async. The host awaits each listener before running the
+ * next, so registration order — and the cumulative effect on the message — is
+ * preserved regardless of whether listeners are sync or async.
  */
-type MessageListenerFn = (msg: IoMessage<any>) => void | MessageListenerResult;
+export type MessageListenerResultOrPromise = void | MessageListenerResult | Promise<void | MessageListenerResult>;
+
+/**
+ * A registered message listener. Its return value (if any) may update the
+ * message text and/or prevent the default processing. It may be async.
+ */
+type MessageListenerFn = (msg: IoMessage<any>) => MessageListenerResultOrPromise;
 interface MessageListener {
   readonly once: boolean;
   readonly fn: MessageListenerFn;
+  /**
+   * Decides which messages this listener applies to. For a listener registered
+   * with a maker this matches by `code`; for one registered with a predicate it
+   * is the predicate itself.
+   */
+  readonly matches: (msg: IoMessage<unknown>) => boolean;
+  /**
+   * Whether this is one of the host's own internal listeners (e.g. stack-activity
+   * routing). Internal listeners are not removed by `removeAllListeners`.
+   *
+   * @default false - a user listener registered via `on`/`once`/`rewrite`/`respond`
+   */
+  readonly internal?: boolean;
 }
 
 /**
- * How an IoHost processed a single notified message.
+ * Selects which messages a listener applies to.
+ *
+ * Either a message/request *maker* — the listener fires for messages with that
+ * maker's `code` (the original behavior) — or a custom *predicate* over the
+ * message. A maker's `.is` type guard (e.g. `IO.CDK_TOOLKIT_I7010.is`) is a
+ * convenient predicate, but any `(msg) => boolean` works (e.g. to match a family
+ * of codes, or on the message level).
+ */
+export type MessageSelector<T> =
+  | IoMessageMaker<T>
+  | IoRequestMaker<T, any>
+  | ((msg: IoMessage<any>) => boolean);
+
+/**
+ * How an IoHost processed a single message or request.
  *
  * This describes the message *as the host handled it*, which can differ from
- * what was emitted: listeners may rewrite the text or level, or prevent it from
- * being written at all.
+ * what was emitted: listeners may rewrite the text or level, prevent it from
+ * being written at all, or (for requests) answer it on the user's behalf.
+ *
+ * Both notifications (`notify`) and requests (`requestResponse`) are reported,
+ * so an observer sees the complete, ordered stream the host handled. Use
+ * `type` to tell them apart.
  */
 export interface IoMessageObservation {
+  /**
+   * Whether this observation describes a plain notification (`notify`) or a
+   * request that asked for a response (`requestResponse`).
+   */
+  readonly type: 'notify' | 'request';
+
   /**
    * The message exactly as it was emitted to the host (before any listeners).
    */
@@ -177,7 +232,8 @@ export interface IoMessageObservation {
 
   /**
    * Whether a listener prevented this message from being written, i.e. the user
-   * would not see it.
+   * would not see it. Always `false` for requests (a request is reported once
+   * it has been resolved, regardless of how it was answered).
    */
   readonly dropped: boolean;
 }
@@ -193,9 +249,11 @@ export interface IoMessageObservation {
  */
 export interface ObservableIoHost {
   /**
-   * Register an observer that is invoked for every notified message with the
-   * disposition the host computed for it. Returns a function that removes the
-   * observer again.
+   * Register an observer that is invoked for every message the host handles —
+   * both notifications and requests — with the disposition the host computed
+   * for it (its effective form after listeners and whether it was dropped). For
+   * a request, the resolved answer is the effective message's `defaultResponse`.
+   * Returns a function that removes the observer again.
    */
   observeMessages(observer: (observation: IoMessageObservation) => void): () => void;
 }
@@ -272,8 +330,9 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
   private corkedCounter = 0;
   private readonly corkedLoggingBuffer: IoMessage<unknown>[] = [];
 
-  // Message listeners, keyed by message code. See `on`/`once`/`rewrite`/`rewriteOnce`.
-  private readonly messageListeners = new Map<IoMessageCode, MessageListener[]>();
+  // Message listeners in registration order. Each carries a matcher (by code,
+  // or a custom predicate). See `on`/`once`/`rewrite`/`respond`.
+  private readonly messageListeners: MessageListener[] = [];
 
   // Observers of how messages are handled (see ObservableIoHost / observeMessages).
   private readonly messageObservers = new Set<(observation: IoMessageObservation) => void>();
@@ -444,22 +503,38 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    *
    * The listener may return a `MessageListenerResult` to update the message
    * text and/or prevent the default processing (writing it to a stream);
-   * returning nothing leaves the message untouched. Returns a function that
-   * removes the listener again.
+   * returning nothing leaves the message untouched. The listener may be async
+   * (return a `Promise`); the host awaits it before processing the message
+   * further. Returns a function that removes the listener again.
    *
    * @example
-   * const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+   * const dispose = ioHost.on(IO.CDK_TOOLKIT_I2901, async (msg) => {
    *   myCount += msg.data.stacks.length;
+   *   await persist(myCount);
    * });
+   *
+   * @example
+   * // Match with a custom predicate instead of a code, e.g. a maker's `.is`:
+   * const dispose = ioHost.on(IO.CDK_TOOLKIT_I7010.is, (msg) => ({ respond: true }));
    */
-  public on<T>(code: IoMessageMaker<T> | IoRequestMaker<T, any>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
-    return this.addMessageListener(code.code, { once: false, fn: listener as MessageListenerFn });
+  public on<T>(
+    selector: IoMessageMaker<T> | IoRequestMaker<T, any> | ((msg: IoMessage<any>) => msg is IoMessage<T>),
+    listener: (msg: IoMessage<T>) => MessageListenerResultOrPromise,
+  ): () => void;
+  public on(
+    predicate: (msg: IoMessage<any>) => boolean,
+    listener: (msg: IoMessage<unknown>) => MessageListenerResultOrPromise,
+  ): () => void;
+  public on(selector: MessageSelector<any>, listener: MessageListenerFn): () => void {
+    return this.addMessageListener({ once: false, fn: listener, matches: messageMatcher(selector) });
   }
 
   /**
-   * Register an observer that is invoked for every notified message with the
-   * disposition the host computed for it (its effective form after listeners,
-   * and whether it was dropped). Returns a function that removes the observer.
+   * Register an observer that is invoked for every message the host handles —
+   * both notifications and requests — with the disposition the host computed
+   * for it (its effective form after listeners and whether it was dropped). For
+   * a request, the resolved answer is the effective message's `defaultResponse`.
+   * Returns a function that removes the observer.
    *
    * @see ObservableIoHost
    */
@@ -474,30 +549,63 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    * Like `on`, but the listener is automatically removed after it has been
    * invoked once.
    */
-  public once<T>(code: IoMessageMaker<T> | IoRequestMaker<T, any>, listener: (msg: IoMessage<T>) => void | MessageListenerResult): () => void {
-    return this.addMessageListener(code.code, { once: true, fn: listener as MessageListenerFn });
+  public once<T>(
+    selector: IoMessageMaker<T> | IoRequestMaker<T, any> | ((msg: IoMessage<any>) => msg is IoMessage<T>),
+    listener: (msg: IoMessage<T>) => MessageListenerResultOrPromise,
+  ): () => void;
+  public once(
+    predicate: (msg: IoMessage<any>) => boolean,
+    listener: (msg: IoMessage<unknown>) => MessageListenerResultOrPromise,
+  ): () => void;
+  public once(selector: MessageSelector<any>, listener: MessageListenerFn): () => void {
+    return this.addMessageListener({ once: true, fn: listener, matches: messageMatcher(selector) });
+  }
+
+  /**
+   * Remove every message listener registered via `on`/`once`/`rewrite`/`respond`.
+   *
+   * The host's own internal listeners (such as stack-activity routing) are kept,
+   * so the host keeps working afterwards. Message observers registered via
+   * `observeMessages` are a separate mechanism and are not affected.
+   *
+   * This is mainly useful for tests that share the singleton host and need to
+   * reset listener state between cases (a leftover listener would otherwise
+   * leak into the next test).
+   */
+  public removeAllListeners(): void {
+    // Drop user listeners in place (preserving array identity for any
+    // outstanding dispose closures); keep the host's internal listeners.
+    for (let i = this.messageListeners.length - 1; i >= 0; i--) {
+      if (!this.messageListeners[i].internal) {
+        this.messageListeners.splice(i, 1);
+      }
+    }
   }
 
   /**
    * Answer a request (by its code) on the user's behalf with a fixed value, so
-   * the host does not prompt and writes nothing. Syntactic sugar for an `on`
-   * listener returning `{ respond: value }`; for conditional answers or to also
-   * reword the question, use `on`/`once` directly. Returns a function that
-   * removes the responder again.
+   * the host does not prompt. Syntactic sugar for an `on` listener returning
+   * `{ respond: value, preventDefault: suppressQuestion }`; for conditional
+   * answers or to also reword the question, use `on`/`once` directly. Returns a
+   * function that removes the responder again.
+   *
+   * @param suppressQuestion - whether to also suppress writing the question text.
+   *   Defaults to `true` (answer silently). Pass `false` to still surface the
+   *   question while answering it.
    *
    * @example
    * // Under --force, auto-confirm the destroy prompt without prompting.
    * const dispose = ioHost.respond(IO.CDK_TOOLKIT_I7010, true);
    */
-  public respond<T, U>(code: IoRequestMaker<T, U>, value: U): () => void {
-    return this.addMessageListener(code.code, { once: false, fn: () => ({ respond: value }) });
+  public respond<T, U>(code: IoRequestMaker<T, U>, value: U, suppressQuestion = true): () => void {
+    return this.addMessageListener({ once: false, fn: () => ({ respond: value, preventDefault: suppressQuestion }), matches: messageMatcher(code) });
   }
 
   /**
    * Like `respond`, but the answer is given only once and then removed.
    */
-  public respondOnce<T, U>(code: IoRequestMaker<T, U>, value: U): () => void {
-    return this.addMessageListener(code.code, { once: true, fn: () => ({ respond: value }) });
+  public respondOnce<T, U>(code: IoRequestMaker<T, U>, value: U, suppressQuestion = true): () => void {
+    return this.addMessageListener({ once: true, fn: () => ({ respond: value, preventDefault: suppressQuestion }), matches: messageMatcher(code) });
   }
 
   /**
@@ -539,72 +647,77 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
   /**
    * Add a listener to the registry and return a function that removes it.
    */
-  private addMessageListener(code: IoMessageCode, listener: MessageListener): () => void {
-    const listeners = this.messageListeners.get(code) ?? [];
-    listeners.push(listener);
-    this.messageListeners.set(code, listeners);
+  private addMessageListener(listener: MessageListener): () => void {
+    this.messageListeners.push(listener);
 
     return () => {
-      const index = listeners.indexOf(listener);
+      const index = this.messageListeners.indexOf(listener);
       if (index >= 0) {
-        listeners.splice(index, 1);
+        this.messageListeners.splice(index, 1);
       }
     };
   }
 
   /**
-   * Run all registered listeners for a message's code, in registration order.
+   * Run every registered listener that matches the message, in registration
+   * order. A listener matches by its code (maker) or its custom predicate.
    *
    * A listener may update the message text/level (passed on to subsequent
    * listeners and the rest of the pipeline), prevent the default processing, or
    * (for requests) answer it. `once` listeners are removed after they have run.
+   * Matching is decided against the message as emitted, so a rewrite by an
+   * earlier listener does not change which later listeners apply.
    *
    * Returns the (possibly updated) message, whether the default processing was
    * prevented, and whether a listener answered the request (and with what).
    */
-  private applyMessageListeners(msg: IoMessage<unknown>): {
-    message: IoMessage<unknown>;
+  private async applyMessageListeners<T extends IoMessage<unknown>>(msg: T): Promise<{
+    message: T;
     preventDefault: boolean;
     responded: boolean;
-    response: unknown;
-  } {
+  }> {
     let current = msg;
     let preventDefault = false;
     let responded = false;
-    let response: unknown;
+    // Iterate over a copy so that `once` listeners can remove themselves safely.
+    for (const listener of [...this.messageListeners]) {
+      // Match against the emitted message; a listener receives the cumulatively
+      // transformed `current` message.
+      if (!listener.matches(msg)) {
+        continue;
+      }
 
-    const listeners = msg.code ? this.messageListeners.get(msg.code) : undefined;
-    if (listeners && listeners.length > 0) {
-      // Iterate over a copy so that `once` listeners can remove themselves safely.
-      for (const listener of [...listeners]) {
-        const result = listener.fn(current);
+      // Listeners may be async; await each one before running the next so the
+      // cumulative effect on the message stays order-deterministic.
+      const result = await listener.fn(current);
 
-        if (listener.once) {
-          const index = listeners.indexOf(listener);
-          if (index >= 0) {
-            listeners.splice(index, 1);
-          }
+      if (listener.once) {
+        const index = this.messageListeners.indexOf(listener);
+        if (index >= 0) {
+          this.messageListeners.splice(index, 1);
         }
+      }
 
-        if (result) {
-          if (result.message !== undefined) {
-            current = { ...current, message: result.message };
-          }
-          if (result.level !== undefined) {
-            current = { ...current, level: result.level };
-          }
-          if (result.preventDefault) {
-            preventDefault = true;
-          }
-          if ('respond' in result) {
-            responded = true;
-            response = result.respond;
-          }
+      if (result) {
+        if (result.message !== undefined) {
+          current = { ...current, message: result.message };
+        }
+        if (result.level !== undefined) {
+          current = { ...current, level: result.level };
+        }
+        if (result.preventDefault) {
+          preventDefault = true;
+        }
+        if ('respond' in result && 'defaultResponse' in msg) {
+          // Fold the answer into the request's default response and mark it
+          // answered, so we skip prompting and resolve with this value.
+          current = { ...current, defaultResponse: result.respond };
+          responded = true;
         }
       }
     }
 
-    return { message: current, preventDefault, responded, response };
+    return { message: current, preventDefault, responded };
   }
 
   /**
@@ -617,16 +730,13 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
     // Run any registered listeners. A listener may update the message text
     // and/or prevent the default processing (e.g. stack-activity messages are
     // routed to the activity printer and not written to a stream).
-    const { message, preventDefault } = this.applyMessageListeners(msg);
+    const { message, preventDefault } = await this.applyMessageListeners(msg);
 
     // Tell observers how this message was handled (its effective form and
     // whether it was dropped). Skipped while replaying corked messages so each
     // message is observed exactly once.
-    if (!this.corkReplaying && this.messageObservers.size > 0) {
-      const observation: IoMessageObservation = { emitted: msg, effective: message, dropped: preventDefault };
-      for (const observer of this.messageObservers) {
-        observer(observation);
-      }
+    if (!this.corkReplaying) {
+      this.notifyObservers({ type: 'notify', emitted: msg, effective: message, dropped: preventDefault });
     }
 
     if (preventDefault) {
@@ -634,6 +744,20 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
     }
 
     this.writeMessage(message);
+  }
+
+  /**
+   * Notify every registered message observer of how a message or request was
+   * handled. A no-op when nothing is observing (i.e. outside of tests), so the
+   * surrounding hot paths pay nothing in production.
+   */
+  private notifyObservers(observation: IoMessageObservation): void {
+    if (this.messageObservers.size === 0) {
+      return;
+    }
+    for (const observer of this.messageObservers) {
+      observer(observation);
+    }
   }
 
   /**
@@ -684,9 +808,14 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       return { preventDefault: true }; // handled by the printer; don't also write to a stream
     };
 
-    this.on(IO.CDK_TOOLKIT_I5501, route);
-    this.on(IO.CDK_TOOLKIT_I5502, route);
-    this.on(IO.CDK_TOOLKIT_I5503, route);
+    // A single internal listener (so it survives `removeAllListeners()` and the
+    // host keeps routing stack activity) matching any of the activity codes.
+    this.addMessageListener({
+      once: false,
+      internal: true,
+      fn: route,
+      matches: matchAny(IO.CDK_TOOLKIT_I5501, IO.CDK_TOOLKIT_I5502, IO.CDK_TOOLKIT_I5503),
+    });
   }
 
   /**
@@ -755,16 +884,38 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
   public async requestResponse<DataType, ResponseType>(msg: IoRequest<DataType, ResponseType>): Promise<ResponseType> {
     // Listeners run exactly once here (so we don't go back through `notify`):
     // they may answer the request, or reword/relevel the question shown below.
-    const applied = this.applyMessageListeners(msg);
-    if (applied.responded) {
-      return applied.response as ResponseType;
-    }
-    // The (possibly reworded) text/level to present to the user.
-    const question = applied.message.message;
+    const { message, ...listenerResult } = await this.applyMessageListeners(msg);
 
-    // If the request cannot be prompted for by the CliIoHost, we just accept the default
-    if (!isPromptableRequest(msg)) {
-      this.writeMessage(applied.message);
+    const response = await this.resolveRequest(message, listenerResult);
+
+    // Tell observers how this request was handled: the effective (possibly
+    // reworded) question and the resolved response. A request is reported only
+    // once it has been answered, so it is never `dropped`.
+    this.notifyObservers({ type: 'request', emitted: msg, effective: message, dropped: false });
+
+    return response;
+  }
+
+  /**
+   * Resolve a request to its response: a listener's answer if one was given,
+   * otherwise the answer prompted from the user, otherwise the suggested
+   * default when the host cannot prompt.
+   *
+   * Kept separate from `requestResponse` so the response can be observed in a
+   * single place regardless of which of these paths produced it.
+   */
+  private async resolveRequest<DataType, ResponseType>(
+    msg: IoRequest<DataType, ResponseType>,
+    listenerResult: { preventDefault: boolean; responded: boolean },
+  ): Promise<ResponseType> {
+    // stop processing, a listener has taken care of it
+    if (listenerResult.preventDefault) {
+      return msg.defaultResponse;
+    }
+
+    // if a listener provided a response, we skip interaction
+    if (!isPromptableRequest(msg) || listenerResult.responded) {
+      this.writeMessage(msg);
       return msg.defaultResponse;
     }
 
@@ -795,7 +946,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
         if (isConfirmationPrompt(msg)) {
           await this.writeMessage({
             ...msg,
-            message: `${chalk.cyan(question)} (auto-confirmed)`,
+            message: `${chalk.cyan(msg.message)} (auto-confirmed)`,
           });
           return true;
         }
@@ -804,7 +955,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
         if (msg.defaultResponse) {
           await this.writeMessage({
             ...msg,
-            message: `${chalk.cyan(question)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,
+            message: `${chalk.cyan(msg.message)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,
           });
           return msg.defaultResponse;
         }
@@ -826,13 +977,13 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
       // calling action decide what to do (so abort handling is consistent
       // across actions).
       if (isConfirmationPrompt(msg)) {
-        return promptly.confirm(`${chalk.cyan(question)} (y/n)`);
+        return promptly.confirm(`${chalk.cyan(msg.message)} (y/n)`);
       }
 
       // Asking for a specific value
       const prompt = extractPromptInfo(msg);
       const desc = responseDescription ?? prompt.default;
-      const answer = await promptly.prompt(`${chalk.cyan(question)}${desc ? ` (${desc})` : ''}`, {
+      const answer = await promptly.prompt(`${chalk.cyan(msg.message)}${desc ? ` (${desc})` : ''}`, {
         default: prompt.default,
         trim: true,
       });
@@ -883,6 +1034,32 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
         return new CurrentActivityPrinter(props);
     }
   }
+}
+
+/**
+ * Convert a `MessageSelector` into a predicate that decides whether a listener
+ * applies to a message. A maker matches messages carrying its `code`; a
+ * predicate (e.g. a maker's `.is`, or any `(msg) => boolean`) is used as-is.
+ */
+function messageMatcher(selector: MessageSelector<any>): (msg: IoMessage<unknown>) => boolean {
+  if (typeof selector === 'function') {
+    return selector;
+  }
+  const { code } = selector;
+  return (msg) => msg.code === code;
+}
+
+/**
+ * Combine several selectors into a single predicate that matches a message when
+ * *any* of them matches. Each selector may be a maker (matched by its `code`)
+ * or a predicate.
+ *
+ * Useful for one listener that spans multiple codes, e.g.
+ * `ioHost.on(matchAny(IO.CDK_TOOLKIT_I5501, IO.CDK_TOOLKIT_I5502), listener)`.
+ */
+export function matchAny(...selectors: MessageSelector<any>[]): (msg: IoMessage<unknown>) => boolean {
+  const matchers = selectors.map(messageMatcher);
+  return (msg) => matchers.some((matches) => matches(msg));
 }
 
 /**

--- a/packages/aws-cdk/test/_helpers/io-recorder.test.ts
+++ b/packages/aws-cdk/test/_helpers/io-recorder.test.ts
@@ -1,5 +1,5 @@
 import { IoHostRecorder } from './io-recorder';
-import { asIoHelper } from '../../lib/api-private';
+import { asIoHelper, IO } from '../../lib/api-private';
 import { CliIoHost } from '../../lib/cli/io-host';
 
 describe('IoHostRecorder', () => {
@@ -19,7 +19,7 @@ describe('IoHostRecorder', () => {
     await ioHelper.defaults.result('a result message');
 
     // Every level is present, in order — nothing was dropped by the host's logLevel.
-    const entries = await recorder.entries();
+    const entries = recorder.entries();
     expect(entries.map((e) => e.level)).toEqual([
       'trace',
       'debug',
@@ -40,11 +40,12 @@ describe('IoHostRecorder', () => {
 
   test('records requests (with their resolved response) interleaved with notifications', async () => {
     const ioHost = CliIoHost.instance({ logLevel: 'trace' }, /* forceNew */ true);
-    // Auto-respond so the confirmation request resolves without a TTY.
-    ioHost.isTTY = false;
     const recorder = IoHostRecorder.create(ioHost);
-    const requestSpy = jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true as any);
     const ioHelper = asIoHelper(ioHost, 'destroy');
+
+    // Answer the request through a listener so the real `requestResponse` runs
+    // (and is therefore observed) — the recorder never spies on it.
+    const dispose = ioHost.on({ code: 'CDK_TOOLKIT_I0000' } as any, () => ({ respond: true, preventDefault: true }));
 
     await ioHelper.defaults.info('before');
     await ioHelper.requestResponse({
@@ -57,13 +58,42 @@ describe('IoHostRecorder', () => {
     });
     await ioHelper.defaults.info('after');
 
-    expect(await recorder.entries()).toEqual([
+    expect(recorder.entries()).toEqual([
       expect.objectContaining({ seq: 0, type: 'notify', message: 'before' }),
       expect.objectContaining({ seq: 1, type: 'request', message: 'are you sure?', response: true }),
       expect.objectContaining({ seq: 2, type: 'notify', message: 'after' }),
     ]);
 
-    requestSpy.mockRestore();
+    dispose();
+  });
+
+  test('keeps capturing after jest.resetAllMocks() — it observes rather than spying on the host', async () => {
+    // This is the core robustness property: because the recorder only registers
+    // an `observeMessages` observer (and never `jest.spyOn`s the host methods),
+    // a command test's `jest.resetAllMocks()` in `beforeEach` has nothing of the
+    // recorder's to neuter. The real `notify`/`requestResponse` keep running, so
+    // notifications, requests and listener answers are all still captured.
+    const ioHost = CliIoHost.instance({ logLevel: 'trace' }, /* forceNew */ true);
+    const recorder = IoHostRecorder.create(ioHost);
+    const ioHelper = asIoHelper(ioHost, 'destroy');
+
+    // Mirror what command test files do at the top of every `beforeEach`.
+    jest.resetAllMocks();
+
+    // Answer the prompt the documented way, exactly as a rerouted command test
+    // would (no `jest.spyOn(ioHost, 'requestResponse')` pass-through needed).
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+
+    await ioHelper.defaults.info('before');
+    const answer = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('proceed?', { motivation: 'testing' }));
+    await ioHelper.defaults.info('after');
+
+    expect(answer).toBe(true);
+    expect(recorder.entries()).toEqual([
+      expect.objectContaining({ seq: 0, type: 'notify', message: 'before' }),
+      expect.objectContaining({ seq: 1, type: 'request', code: 'CDK_TOOLKIT_I7010', response: true }),
+      expect.objectContaining({ seq: 2, type: 'notify', message: 'after' }),
+    ]);
   });
 
   test('the `level` option is the single place that decides which levels are snapshotted', async () => {
@@ -80,7 +110,7 @@ describe('IoHostRecorder', () => {
     await ioHelper.defaults.error('an error message');
 
     // trace/debug/info are dropped by the recorder's own threshold (not the host).
-    expect((await recorder.entries()).map((e) => e.level)).toEqual(['warn', 'error']);
+    expect((recorder.entries()).map((e) => e.level)).toEqual(['warn', 'error']);
   });
 
   test('marks a message a listener prevented from being written as `dropped`', async () => {
@@ -95,7 +125,7 @@ describe('IoHostRecorder', () => {
     await ioHelper.notify({ time: new Date(), level: 'info', code: 'CDK_TOOLKIT_I9999', message: 'suppressed', data: undefined });
     await ioHelper.defaults.info('shown');
 
-    const entries = await recorder.entries();
+    const entries = recorder.entries();
     expect(entries).toEqual([
       expect.objectContaining({ code: 'CDK_TOOLKIT_I9999', message: 'suppressed', dropped: true }),
       expect.objectContaining({ code: null, message: 'shown' }),
@@ -115,7 +145,7 @@ describe('IoHostRecorder', () => {
 
     await ioHelper.notify({ time: new Date(), level: 'info', code: 'CDK_TOOLKIT_I9998', message: 'original', data: undefined });
 
-    const entries = await recorder.entries();
+    const entries = recorder.entries();
     expect(entries[0]).toEqual(expect.objectContaining({ code: 'CDK_TOOLKIT_I9998', message: 'rewritten by listener' }));
 
     dispose();

--- a/packages/aws-cdk/test/_helpers/io-recorder.ts
+++ b/packages/aws-cdk/test/_helpers/io-recorder.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
-import type { IoMessage, IoMessageLevel, IoRequest } from '../../lib/api';
+import type { IoMessageLevel } from '../../lib/api';
 import { isMessageRelevantForLevel } from '../../lib/api-private';
 import type { IoMessageObservation, ObservableIoHost } from '../../lib/cli/io-host';
 
@@ -140,26 +140,41 @@ export interface IoHostRecorderOptions {
  *
  * # How it works
  *
- * The recorder installs `jest.spyOn` on the host's `notify` and
- * `requestResponse` methods to capture the ordered stream of messages (merged
- * via jest's global `invocationCallOrder`).
+ * The recorder captures the message stream purely through the host's
+ * `observeMessages` hook (the `ObservableIoHost` contract the `CliIoHost`
+ * implements). The host reports every message it handles — both `notify`
+ * notifications and `requestResponse` requests — in the order it handled them,
+ * along with the *effective* disposition of each one: the text/level after any
+ * registered listeners ran, whether a listener prevented a notification from
+ * being written (`dropped`), and the resolved response for a request.
  *
- * It additionally registers an observer via the host's `observeMessages` hook
- * (when the host implements `ObservableIoHost`, as the `CliIoHost` does) to
- * capture the *effective* disposition of each notified message — i.e. the
- * text/level after any registered listeners have run, and whether a listener
- * prevented it from being written (`dropped`). This makes the snapshot reflect
- * what the user would actually see, so listener-based suppression and level
- * overrides are visible in — and protected by — the snapshot. A plain `IIoHost`
- * that does not implement `ObservableIoHost` still works; the recorder simply
- * falls back to the message as emitted.
+ * Because the recorder only *observes* and never replaces (`spyOn`) the host's
+ * methods, the real `notify`/`requestResponse` always run. This is what makes
+ * it robust: a test's `jest.resetAllMocks()` has nothing of the recorder's to
+ * neuter, so the recorder needs no per-test pass-through boilerplate, and the
+ * real request path runs — so listeners (e.g. a `respondOnce`/`--force`
+ * auto-confirm) are honored exactly as in production. Answer prompts in tests
+ * with `ioHost.respondOnce(IO.<code>, value)` rather than by spying on
+ * `requestResponse`.
+ *
+ * The host must implement `ObservableIoHost`; the `CliIoHost` does. (This is a
+ * CLI-internal test helper, and every recorded host is a `CliIoHost`.)
+ *
+ * # Dropped (suppressed) messages
+ *
+ * A notification a listener suppressed via `preventDefault` (e.g. the CLI drops
+ * toolkit-lib's synth-time line on the `--json list` path) is *recorded* and
+ * tagged `"dropped": true`. This is deliberate: listener-based suppression is
+ * exactly the kind of user-facing behavior the snapshot exists to protect, so a
+ * change to what is suppressed must show up as a snapshot diff. Dropped entries
+ * are therefore part of the committed snapshot, not noise to be filtered out.
  *
  * # Usage
  *
  * The IoHost is a singleton, so there is a single recorder instance per host:
- * `create()` is idempotent and returns the same recorder (installing the spies
- * only once). Jest's `clearMocks` wipes the recorded calls between tests, so
- * the recorder always reflects only the current test's messages.
+ * `create()` is idempotent, returns the same recorder (registering the observer
+ * only once), and clears the per-test observation buffer, so the recorder
+ * always reflects only the current test's messages.
  *
  * ```ts
  * let recorder: IoHostRecorder;
@@ -167,9 +182,12 @@ export interface IoHostRecorderOptions {
  *   recorder = IoHostRecorder.create(ioHost);
  * });
  *
- * test('...', async () => {
+ * test('destroys after confirmation', async () => {
+ *   // Answer the confirmation prompt the real way: a one-shot responder, so
+ *   // the real requestResponse runs and the request is recorded.
+ *   ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
  *   await toolkit.destroy({ ... });
- *   await recorder.matchSnapshot();
+ *   recorder.matchSnapshot();
  * });
  * ```
  *
@@ -179,10 +197,12 @@ export interface IoHostRecorderOptions {
  */
 export class IoHostRecorder {
   /**
-   * Get (or lazily create) the recorder for the given IoHost by spying on its
-   * message methods. Repeated calls for the same host return the same recorder.
+   * Get (or lazily create) the recorder for the given IoHost by registering a
+   * message observer on it. Repeated calls for the same host return the same
+   * recorder (the observer is registered exactly once) and reset its per-test
+   * observation buffer, so each test starts fresh.
    */
-  public static create(host: { notify: any; requestResponse: any }, options: IoHostRecorderOptions = {}): IoHostRecorder {
+  public static create(host: ObservableIoHost, options: IoHostRecorderOptions = {}): IoHostRecorder {
     const existing = IoHostRecorder.cache.get(host);
     if (existing) {
       // Same recorder across the (singleton) host; clear the per-test
@@ -190,18 +210,16 @@ export class IoHostRecorder {
       existing.resetObservations();
       return existing;
     }
-    const notifySpy = jest.spyOn(host as any, 'notify');
-    const requestSpy = jest.spyOn(host as any, 'requestResponse');
-    const recorder = new IoHostRecorder(notifySpy, requestSpy, options);
-    // If the host is observable, capture the effective disposition of each
-    // message (text/level after listeners, and whether it was dropped). This is
-    // opt-in enrichment via a public interface: any plain `IIoHost` still works,
-    // it just won't reflect listener-level changes.
-    if (typeof (host as any).observeMessages === 'function') {
-      (host as unknown as ObservableIoHost).observeMessages((observation) => {
-        recorder.observations.push(observation);
-      });
+    if (typeof host?.observeMessages !== 'function') {
+      throw new Error('IoHostRecorder requires an ObservableIoHost (e.g. CliIoHost); the given host does not implement observeMessages()');
     }
+    const recorder = new IoHostRecorder(options);
+    // Capture the effective disposition of every message the host handles
+    // (notifications and requests). The observer is never removed: the host is
+    // a singleton, so the recorder is shared and the observer is installed once.
+    host.observeMessages((observation) => {
+      recorder.observations.push(observation);
+    });
     IoHostRecorder.cache.set(host, recorder);
     return recorder;
   }
@@ -209,23 +227,18 @@ export class IoHostRecorder {
   /**
    * One recorder per host instance. Because the CLI IoHost is a singleton,
    * this effectively yields a single shared recorder, and ensures we only
-   * install the spies and observer once regardless of how many times `create`
-   * is called.
+   * install the observer once regardless of how many times `create` is called.
    */
   private static readonly cache = new WeakMap<object, IoHostRecorder>();
 
   private readonly scrubbers: Scrubber[];
   private readonly level: IoMessageLevel;
 
-  // Effective disposition of each notified message, collected via the host's
-  // `observeMessages` hook (empty when the host is not observable).
+  // The ordered stream of messages the host handled this test, collected via
+  // its `observeMessages` hook. Cleared between tests by `resetObservations`.
   private readonly observations: IoMessageObservation[] = [];
 
-  private constructor(
-    private readonly notifySpy: jest.SpyInstance,
-    private readonly requestSpy: jest.SpyInstance,
-    options: IoHostRecorderOptions,
-  ) {
+  private constructor(options: IoHostRecorderOptions) {
     this.scrubbers = [...defaultScrubbers(), ...(options.scrubbers ?? [])];
     this.level = options.level ?? 'trace';
   }
@@ -235,95 +248,44 @@ export class IoHostRecorder {
   }
 
   /**
-   * Build the ordered list of recorded entries from the spies.
+   * Build the ordered list of recorded entries from the observed message
+   * stream. Observations are already in the order the host handled them, so no
+   * separate ordering is needed.
    */
-  public async entries(): Promise<RecordedIoEntry[]> {
-    interface Raw {
-      order: number;
-      type: 'notify' | 'request';
-      msg: IoMessage<unknown> | IoRequest<unknown, unknown>;
-      result?: jest.MockResult<any>;
-    }
-
-    const raw: Raw[] = [];
-
-    this.notifySpy.mock.calls.forEach((args, i) => {
-      raw.push({
-        order: this.notifySpy.mock.invocationCallOrder[i],
-        type: 'notify',
-        msg: args[0],
-      });
-    });
-
-    this.requestSpy.mock.calls.forEach((args, i) => {
-      raw.push({
-        order: this.requestSpy.mock.invocationCallOrder[i],
-        type: 'request',
-        msg: args[0],
-        result: this.requestSpy.mock.results[i],
-      });
-    });
-
-    raw.sort((a, b) => a.order - b.order);
-
-    // Map each notified message to the disposition the host computed for it
-    // (post-listener text/level + whether it was prevented from being written).
-    const disposition = this.dispositionByMessage();
-
-    // Build sequentially. The awaited request promises are already settled by
-    // the time we read them, so there is no parallelism to bound here.
+  public entries(): RecordedIoEntry[] {
     const entries: RecordedIoEntry[] = [];
     let seq = 0;
-    for (const r of raw) {
-      // For notifications, prefer the post-listener message; fall back to the
-      // emitted message when the host did not process it (e.g. notify mocked).
-      const effective = (r.type === 'notify' ? disposition.get(r.msg)?.effective : undefined) ?? r.msg;
-      const dropped = r.type === 'notify' ? (disposition.get(r.msg)?.dropped ?? false) : false;
-
+    for (const { type, emitted, effective, dropped } of this.observations) {
       // The single decision point for which levels are included; uses the
       // effective level so listener level-overrides are respected.
       if (!isMessageRelevantForLevel({ level: effective.level }, this.level)) {
         continue;
       }
 
-      const base: RecordedIoEntry = {
+      const entry: RecordedIoEntry = {
         seq: seq++,
-        type: r.type,
-        action: r.msg.action,
+        type,
+        action: emitted.action,
         level: effective.level,
-        code: r.msg.code ?? null,
+        code: emitted.code ?? null,
         message: this.normalize(String(effective.message ?? '')),
+        // A suppressed notification is recorded and flagged so the snapshot
+        // protects listener-based suppression (see the class doc). Requests are
+        // never dropped.
         ...(dropped ? { dropped: true } : {}),
+        // For requests, also record the resolved response (scrubbed).
+        ... ((type === 'request' && 'defaultResponse' in effective) ? { response: this.scrubValue(effective.defaultResponse) } : {}),
       };
-
-      if (r.type === 'request') {
-        entries.push({ ...base, response: this.scrubValue(await resolveResult(r.result)) });
-      } else {
-        entries.push(base);
-      }
+      entries.push(entry);
     }
     return entries;
   }
 
   /**
-   * Index the message dispositions captured from the host's `observeMessages`
-   * hook by the emitted message object, so notifications can be enriched with
-   * their effective form. Empty when the host is not observable, or when it did
-   * not process any messages (e.g. `notify` was mocked to a no-op).
-   */
-  private dispositionByMessage(): Map<object, IoMessageObservation> {
-    const map = new Map<object, IoMessageObservation>();
-    for (const observation of this.observations) {
-      map.set(observation.emitted, observation);
-    }
-    return map;
-  }
-
-  /**
    * Render the recorded entries as NDJSON (one JSON object per line).
    */
-  public async toNdjson(): Promise<string> {
-    const lines = (await this.entries()).map((e) => JSON.stringify(e));
+  public toNdjson(): string {
+    const lines = this.entries().map((e) => JSON.stringify(e));
     return lines.length > 0 ? lines.join('\n') + '\n' : '';
   }
 
@@ -331,8 +293,8 @@ export class IoHostRecorder {
    * Compare the recorded NDJSON against the on-disk snapshot, creating or
    * updating it when running with `-u` (or in `--ci` mode, failing if missing).
    */
-  public async matchSnapshot(name?: string): Promise<void> {
-    const actual = await this.toNdjson();
+  public matchSnapshot(name?: string): void {
+    const actual = this.toNdjson();
     const file = snapshotFilePath(name);
     const update = updateMode();
     const exists = fs.existsSync(file);
@@ -370,33 +332,6 @@ export class IoHostRecorder {
     const json = JSON.stringify(value, (_k, v) => (typeof v === 'string' ? this.normalize(v) : v));
     return json === undefined ? undefined : JSON.parse(json);
   }
-}
-
-/**
- * Resolve the value a `requestResponse` call produced.
- *
- * `requestResponse` is async, so the recorded mock result value is (usually) a
- * promise. By the time we read it (after the action under test has completed)
- * the promise has settled, so awaiting it is safe and yields the real resolved
- * response. A rejection (e.g. `AbortedByUser`) is captured as its error name.
- */
-async function resolveResult(result?: jest.MockResult<any>): Promise<unknown> {
-  if (!result) {
-    return undefined;
-  }
-  // Synchronous throw (rare for an async method, but be safe).
-  if (result.type === 'throw') {
-    return { error: result.value?.name ?? 'Error' };
-  }
-  const value: unknown = result.value;
-  if (value && typeof (value as any).then === 'function') {
-    try {
-      return value;
-    } catch (err: any) {
-      return { error: err?.name ?? 'Error' };
-    }
-  }
-  return value;
 }
 
 type UpdateMode = 'all' | 'new' | 'none';

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import { Context } from '../../../lib/api/context';
 import { IO } from '../../../lib/api-private';
 import type { IoMessage, IoMessageLevel, IoRequest } from '../../../lib/cli/io-host';
-import { CliIoHost } from '../../../lib/cli/io-host';
+import { CliIoHost, matchAny } from '../../../lib/cli/io-host';
 import { CLI_PRIVATE_IO } from '../../../lib/cli/telemetry/messages';
 
 let passThrough: PassThrough;
@@ -206,6 +206,165 @@ describe('CliIoHost', () => {
       await ioHost.notify(listMessage('second'));
 
       expect(observed).toEqual(['first']);
+    });
+
+    test('on() supports async listeners and awaits them before the message is processed', async () => {
+      const order: string[] = [];
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, async (msg) => {
+        await new Promise((resolve) => setImmediate(resolve));
+        order.push(`listener:${msg.message}`);
+        return { message: `async:${msg.message}` };
+      }));
+
+      await ioHost.notify(listMessage('first'));
+      order.push('after-notify');
+
+      // notify() did not resolve until the async listener finished, and the
+      // text it returned was applied before the message was written.
+      expect(order).toEqual(['listener:first', 'after-notify']);
+      expect(mockStdout).toHaveBeenCalledWith('async:first\n');
+    });
+
+    test('requestResponse() awaits an async listener that answers the request', async () => {
+      track(ioHost.on(IO.CDK_TOOLKIT_I7010, async () => {
+        await new Promise((resolve) => setImmediate(resolve));
+        return { respond: true, preventDefault: true };
+      }));
+
+      const answer = await ioHost.requestResponse({
+        time: new Date(),
+        level: 'info',
+        action: 'destroy',
+        code: 'CDK_TOOLKIT_I7010',
+        message: 'proceed?',
+        defaultResponse: true,
+        data: { motivation: 'because' },
+      });
+
+      expect(answer).toBe(true);
+    });
+
+    test('removeAllListeners() removes every user-registered listener', async () => {
+      const observed: string[] = [];
+      // Register via on() and once() and rewrite() — all user listeners.
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901, (msg) => {
+        observed.push(msg.message);
+      }));
+      track(ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${msg.message}`));
+
+      await ioHost.notify(listMessage('before'));
+      ioHost.removeAllListeners();
+      await ioHost.notify(listMessage('after'));
+
+      // The on() listener stopped firing and the rewrite no longer applies.
+      expect(observed).toEqual(['before']);
+      expect(mockStdout).toHaveBeenCalledWith('after\n');
+    });
+
+    test('removeAllListeners() keeps the host internal stack-activity routing', async () => {
+      // Clear all (user) listeners, then verify a stack-activity message is
+      // still routed to the printer and suppressed — i.e. the internal listener
+      // survived.
+      ioHost.removeAllListeners();
+      (ioHost as any).activityPrinter = undefined;
+      const fakePrinter = { notify: jest.fn() };
+      const makeSpy = jest.spyOn(ioHost as any, 'makeActivityPrinter').mockReturnValue(fakePrinter);
+
+      const activity = plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'deploy',
+        code: 'CDK_TOOLKIT_I5502',
+        message: 'raw activity text',
+      });
+      await ioHost.notify(activity);
+
+      expect(fakePrinter.notify).toHaveBeenCalledWith(activity);
+      expect(mockStdout).not.toHaveBeenCalled();
+      expect(mockStderr).not.toHaveBeenCalled();
+
+      makeSpy.mockRestore();
+    });
+
+    test('on() accepts a maker `.is` type guard as the selector', async () => {
+      const observed: string[] = [];
+      track(ioHost.on(IO.CDK_TOOLKIT_I2901.is, (msg) => {
+        observed.push(msg.message);
+      }));
+
+      await ioHost.notify(listMessage('matches'));
+      // A message with a different code is not matched by the type guard.
+      await ioHost.notify(plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: 'CDK_TOOLKIT_I0001',
+        message: 'other',
+      }));
+
+      expect(observed).toEqual(['matches']);
+    });
+
+    test('on() accepts an arbitrary predicate as the selector', async () => {
+      const observed: string[] = [];
+      // Match any message whose code is in the I29xx family.
+      track(ioHost.on((msg) => (msg.code ?? '').startsWith('CDK_TOOLKIT_I29'), (msg) => {
+        observed.push(msg.message);
+      }));
+
+      await ioHost.notify(listMessage('matches'));
+      await ioHost.notify(plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: 'CDK_TOOLKIT_I0001',
+        message: 'nope',
+      }));
+
+      expect(observed).toEqual(['matches']);
+    });
+
+    test('a request maker `.is` predicate can answer a request', async () => {
+      // The motivating example: pass IO.<code>.is as the selector for a request.
+      track(ioHost.on(IO.CDK_TOOLKIT_I7010.is, () => ({ respond: true, preventDefault: true })));
+
+      const answer = await ioHost.requestResponse({
+        time: new Date(),
+        level: 'info',
+        action: 'destroy',
+        code: 'CDK_TOOLKIT_I7010',
+        message: 'proceed?',
+        defaultResponse: false,
+        data: { motivation: 'because' },
+      });
+
+      expect(answer).toBe(true);
+    });
+
+    test('on() with matchAny() fires for any of the given codes', async () => {
+      const observed: string[] = [];
+      track(ioHost.on(matchAny(IO.CDK_TOOLKIT_I2901, IO.CDK_TOOLKIT_I1000), (msg) => {
+        observed.push(`${msg.code}:${msg.message}`);
+      }));
+
+      await ioHost.notify(listMessage('a'));
+      await ioHost.notify(plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: 'CDK_TOOLKIT_I1000',
+        message: 'b',
+      }));
+      // A code not in the set is ignored.
+      await ioHost.notify(plainMessage({
+        time: new Date(),
+        level: 'info',
+        action: 'synth',
+        code: 'CDK_TOOLKIT_I0001',
+        message: 'c',
+      }));
+
+      expect(observed).toEqual(['CDK_TOOLKIT_I2901:a', 'CDK_TOOLKIT_I1000:b']);
     });
 
     test('rewrite() replaces the printed text for every matching message', async () => {
@@ -914,6 +1073,54 @@ describe('CliIoHost', () => {
 
         expect(response).toBe(true);
         expect(mockStdout).toHaveBeenCalledWith(chalk.cyan('Are you sure?') + ' (y/n) ');
+      });
+
+      test('a respond value skips the prompt but still surfaces the question', async () => {
+        // No preventDefault, so the question is written; but the prompt is
+        // skipped and the request resolves with the supplied value.
+        const dispose = ioHost.on(IO.CDK_TOOLKIT_I7010, () => ({ respond: true }));
+
+        const response = await ioHost.requestResponse(confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Are you sure?')); // surfaced, not prompted
+        expect(mockStdout).not.toHaveBeenCalled();
+        dispose();
+      });
+
+      test('respond + preventDefault skips the prompt and suppresses the question', async () => {
+        const dispose = ioHost.on(IO.CDK_TOOLKIT_I7010, () => ({ respond: true, preventDefault: true }));
+
+        const response = await ioHost.requestResponse(confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStdout).not.toHaveBeenCalled();
+        expect(mockStderr).not.toHaveBeenCalled();
+        dispose();
+      });
+
+      test('preventDefault alone skips the prompt silently and resolves with the default', async () => {
+        // confirmRequest()'s defaultResponse is false; preventDefault means the
+        // listener handled it, so we return that default without prompting.
+        const dispose = ioHost.on(IO.CDK_TOOLKIT_I7010, () => ({ preventDefault: true }));
+
+        const response = await ioHost.requestResponse(confirmRequest());
+
+        expect(response).toBe(false);
+        expect(mockStdout).not.toHaveBeenCalled();
+        expect(mockStderr).not.toHaveBeenCalled();
+        dispose();
+      });
+
+      test('respond(..., false) answers the request while still surfacing the question', async () => {
+        const dispose = ioHost.respond(IO.CDK_TOOLKIT_I7010, true, /* suppressQuestion */ false);
+
+        const response = await ioHost.requestResponse(confirmRequest());
+
+        expect(response).toBe(true);
+        expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Are you sure?'));
+        expect(mockStdout).not.toHaveBeenCalled();
+        dispose();
       });
     });
 

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/destroy_failure_emits_a_failure_message_and_rethrows_when_destroyStack_fails.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/destroy_failure_emits_a_failure_message_and_rethrows_when_destroyStack_fails.ndjson
@@ -1,4 +1,4 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"none","level":"error","code":null,"message":"\n ❌  Test-Stack-B: destroy failed Error: Deletion failed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"error","code":null,"message":"\n ❌  Test-Stack-B: destroy failed Error: Deletion failed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_with_an_AbortError_and_destroys_nothing_when_the_user_declines.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_aborts_with_an_AbortError_and_destroys_nothing_when_the_user_declines.ndjson
@@ -1,3 +1,3 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"request","action":"none","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":false}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"request","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":false}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_asks_for_confirmation_and_proceeds_when_the_user_confirms.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_asks_for_confirmation_and_proceeds_when_the_user_confirms.ndjson
@@ -1,5 +1,5 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"request","action":"none","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":true}
-{"seq":3,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":4,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"request","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":true}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_rethrows_an_unexpected_error_from_the_confirmation_prompt.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_rethrows_an_unexpected_error_from_the_confirmation_prompt.ndjson
@@ -1,3 +1,0 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"request","action":"none","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":{"error":"SomethingElse"}}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_a_single_nested_stack_fromDeploy_makes_it_say_deployed.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_a_single_nested_stack_fromDeploy_makes_it_say_deployed.ndjson
@@ -1,4 +1,4 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-A/Test-Stack-C: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-A/Test-Stack-C: deployed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-A/Test-Stack-C: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-A/Test-Stack-C: deployed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_all_top-level_stacks_with_concurrency.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_all_top-level_stacks_with_concurrency.ndjson
@@ -1,6 +1,6 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-A-Display-Name: destroying... [1/2]"}
-{"seq":3,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-B: destroying... [2/2]"}
-{"seq":4,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-A-Display-Name: destroyed"}
-{"seq":5,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: destroying... [1/2]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [2/2]"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-A-Display-Name: destroyed"}
+{"seq":5,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_forwards_the_roleArn_to_destroyStack.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_forwards_the_roleArn_to_destroyStack.ndjson
@@ -1,4 +1,4 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_respects_dependency_order_with_concurrency.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_respects_dependency_order_with_concurrency.ndjson
@@ -1,6 +1,6 @@
-{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
-{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-D: destroying... [1/2]"}
-{"seq":3,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-D: destroyed"}
-{"seq":4,"type":"notify","action":"none","level":"info","code":null,"message":"Test-Stack-C: destroying... [2/2]"}
-{"seq":5,"type":"notify","action":"none","level":"info","code":null,"message":"\n ✅  Test-Stack-C: destroyed"}
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-D: destroying... [1/2]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-D: destroyed"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-C: destroying... [2/2]"}
+{"seq":5,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-C: destroyed"}

--- a/packages/aws-cdk/test/commands/destroy.test.ts
+++ b/packages/aws-cdk/test/commands/destroy.test.ts
@@ -1,6 +1,7 @@
-import { ToolkitError, AbortError } from '@aws-cdk/toolkit-lib';
+import { AbortError } from '@aws-cdk/toolkit-lib';
 import { Deployments } from '../../lib/api';
 import type { DestroyStackOptions } from '../../lib/api/deployments';
+import { IO } from '../../lib/api-private';
 import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
 import { CliIoHost } from '../../lib/cli/io-host';
 import type { TestStackArtifact } from '../_helpers';
@@ -43,11 +44,15 @@ beforeEach(async () => {
 
   ioHost = CliIoHost.instance();
   ioHost.isCI = false;
+  // Run as the `destroy` command so every message — synthesis, the confirmation
+  // request, and the destroy progress — is tagged with the `destroy` action,
+  // exactly as the real CLI would.
+  ioHost.currentAction = 'destroy';
 
   cloudExecutable = await MockCloudExecutable.create({
     stacks: [STACK_A, STACK_B],
     nestedAssemblies: [{ stacks: [STACK_C_NESTED] }],
-  }, undefined, ioHost);
+  }, undefined, ioHost, 'destroy');
 
   cloudFormation = instanceMockFrom(Deployments);
 
@@ -64,10 +69,10 @@ beforeEach(async () => {
   recorder = IoHostRecorder.create(ioHost);
 });
 
-afterEach(async () => {
+afterEach(() => {
   // Snapshot every message the destroy path sent to the CliIoHost. Any change to
   // that stream (e.g. when rerouting through toolkit-lib) shows up as a diff.
-  await recorder.matchSnapshot();
+  recorder.matchSnapshot();
 });
 
 describe('force: true (no confirmation prompt)', () => {
@@ -105,7 +110,7 @@ describe('force: true (no confirmation prompt)', () => {
       env: 'aws://123456789012/bermuda-triangle-1',
       depends: [stackC.stackName],
     };
-    cloudExecutable = await MockCloudExecutable.create({ stacks: [stackC, stackD] }, undefined, ioHost);
+    cloudExecutable = await MockCloudExecutable.create({ stacks: [stackC, stackD] }, undefined, ioHost, 'destroy');
 
     const destroyOrder: string[] = [];
     cloudFormation.destroyStack.mockImplementation(async (options: DestroyStackOptions) => {
@@ -148,7 +153,10 @@ describe('force: true (no confirmation prompt)', () => {
 
 describe('force: false (confirmation prompt)', () => {
   test('asks for confirmation and proceeds when the user confirms', async () => {
-    jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(true as any);
+    // Answer the confirmation prompt with a one-shot responder. The real
+    // requestResponse runs (so the request is recorded in the snapshot); no
+    // spy/pass-through is needed.
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
 
     await toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },
@@ -163,7 +171,7 @@ describe('force: false (confirmation prompt)', () => {
   test('aborts with an AbortError and destroys nothing when the user declines', async () => {
     // The IoHost returns the answer; declining is `false` and the command aborts
     // by throwing an AbortError (non-zero exit, presented softly by the CLI).
-    jest.spyOn(ioHost, 'requestResponse').mockResolvedValue(false as any);
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, false);
 
     const error = await toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },
@@ -175,20 +183,6 @@ describe('force: false (confirmation prompt)', () => {
     expect(error.name).toBe('DestroyAborted');
 
     // Aborted before any destroy happened.
-    expect(cloudFormation.destroyStack).not.toHaveBeenCalled();
-  });
-
-  test('rethrows an unexpected error from the confirmation prompt', async () => {
-    jest.spyOn(ioHost, 'requestResponse').mockImplementation((() => {
-      throw new ToolkitError('SomethingElse', 'tty exploded');
-    }) as any);
-
-    await expect(toolkit.destroy({
-      selector: { patterns: ['Test-Stack-B'] },
-      exclusively: true,
-      force: false,
-    })).rejects.toThrow('tty exploded');
-
     expect(cloudFormation.destroyStack).not.toHaveBeenCalled();
   });
 });

--- a/packages/aws-cdk/test/commands/list.test.ts
+++ b/packages/aws-cdk/test/commands/list.test.ts
@@ -26,13 +26,13 @@ describe('cdk list', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
-    // Exercise the real notify path so the output listeners actually run.
-    jest.spyOn(ioHost, 'notify').mockImplementation(((m: any) => CliIoHost.prototype.notify.call(ioHost, m)) as any);
+    // The recorder observes the host (it does not spy on `notify`), so the real
+    // notify path — and the output listeners — run without any pass-through.
     recorder = IoHostRecorder.create(ioHost);
   });
 
-  afterEach(async () => {
-    await recorder.matchSnapshot();
+  afterEach(() => {
+    recorder.matchSnapshot();
   });
 
   async function list(


### PR DESCRIPTION
Internal only, with no user-facing CLI behavior changes. `CliIoHost` and `IoHostRecorder` are CLI-internal (the recorder is a test helper, and the `.is` addition lives in toolkit-lib's `private` path). This is groundwork for rerouting CLI commands through `toolkit-lib`, plus a more robust IO snapshot harness.

`on`/`once` listeners may now be async (awaited in registration order) and may select messages by a custom predicate, such as a maker's `.is`, in addition to a code. Request makers gain the same `.is` guard. `matchAny` composes selectors, and `removeAllListeners` resets user listeners while keeping the host's internal ones.

`respond` and `preventDefault` are now orthogonal. `preventDefault` means the listener handled it: a notification is not written, and a request skips its prompt silently and resolves with the default. A `respond` value is folded into the request's default response and skips the prompt, but still surfaces the question unless `preventDefault` is also set; `respond`/`respondOnce` expose this via a `suppressQuestion` flag. Separating the two lets a listener suppress output, answer, or both, without one implying the other.

`IoHostRecorder` now captures the stream via `observeMessages` instead of spying on the host. The spy approach was neutralised by the `jest.resetAllMocks()` in command tests, which stopped the real `notify`/`requestResponse` from running and caused order-dependent failures unless each test re-established pass-through by hand. Observing removes that entirely, so tests answer prompts through `respondOnce` with no boilerplate. Destroy snapshots are re-baselined to tag every line with the `destroy` action the real command emits.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
