### PR TITLE
chore: large-pr-checker does not properly match THIRD_PARTY_LICENSES files

### DIFF
--- a/.github/workflows/large-pr-checker.yml
+++ b/.github/workflows/large-pr-checker.yml
@@ -25,7 +25,7 @@ jobs:
         run: git fetch origin main
       - id: get_total_lines_changed
         run: |-
-          size=$(git diff --shortstat origin/main ':(exclude)*.md' ':(exclude)*.test.ts' ':(exclude)*.yml' ':(exclude)*.lock' ':(exclude)THIRD_PARTY_LICENSES' \
+          size=$(git diff --shortstat origin/main ':(exclude)*.md' ':(exclude)*.test.ts' ':(exclude)*.yml' ':(exclude)*.lock' ':(exclude)*THIRD_PARTY_LICENSES' \
                   | awk '{ print $4+$6 }' \
                   | awk -F- '{print $NF}' \
                   | bc)

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1813,7 +1813,7 @@ new IssueRegressionLabeler(repo);
 new PrLabeler(repo);
 
 new LargePrChecker(repo, {
-  excludeFiles: ['*.md', '*.test.ts', '*.yml', '*.lock', 'THIRD_PARTY_LICENSES'],
+  excludeFiles: ['*.md', '*.test.ts', '*.yml', '*.lock', '*THIRD_PARTY_LICENSES'],
 });
 
 // Set allowed scopes based on monorepo packages


### PR DESCRIPTION
## Description
Our `large-pr-checker` currently fails to exclude THIRD_PARTY_LICENSES when it's not at the top level of the repo (which it never is). It therefore counts changes in files like:
- `packages/@aws-cdk/integ-runner/THIRD_PARTY_LICENSES`
- `packages/aws-cdk/THIRD_PARTY_LICENSES`

### Example PR
See the following images:
`large-pr-checker` failure which indicates 7257 lines changed:
<img width="1142" height="253" alt="Screenshot 2026-06-29 at 11 18 02" src="https://github.com/user-attachments/assets/fa1b81b7-ad0e-4b93-8fb7-ae353e713e5e" />

The diff for the PR, where the line count can only possibly be coming from `THIRD_PARTY_LICENSES` files
<img width="1123" height="730" alt="Screenshot 2026-06-29 at 11 17 21" src="https://github.com/user-attachments/assets/c031ad9f-8ae7-4835-a529-96f0a9e39135" />


I also verified manually that the command run within the action does not exclude the `THIRD_PARTY_LICENSES` files:
<img width="786" height="664" alt="Screenshot 2026-06-29 at 11 21 34" src="https://github.com/user-attachments/assets/2ecce0a6-bfba-47d2-86ad-2a5c46fb4d9a" />


## Fix
This changes the matcher such that line changes in ANY file ending in "THIRD_PARTY_LICENSES" is excluded from the line count.


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
