### PR TITLE
fix(cli): route `cdk destroy` through toolkit-lib

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1580,9 +1580,20 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * Destroys the selected Stacks.
    */
   public async destroy(cx: ICloudAssemblySource, options: DestroyOptions = {}): Promise<DestroyResult> {
-    const ioHelper = asIoHelper(this.ioHost, 'destroy');
+    return this._destroyWithAction(cx, 'destroy', options);
+  }
+
+  /**
+   * Synthesize and destroy, labelling the work with an explicit action.
+   *
+   * Kept private: the CLI reaches it (via a `// @ts-ignore`) to keep the
+   * "deployed" wording when a destroy runs as part of a deploy (rollback
+   * cleanup). Not part of the public API.
+   */
+  private async _destroyWithAction(cx: ICloudAssemblySource, action: 'deploy' | 'destroy', options: DestroyOptions = {}): Promise<DestroyResult> {
+    const ioHelper = asIoHelper(this.ioHost, action);
     await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
-    return await this._destroy(assembly, 'destroy', options);
+    return await this._destroy(assembly, action, options);
   }
 
   /**

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -17,7 +17,6 @@ import type { ActionLessRequest, IMessageSpan, IoHelper } from '../../lib/api-pr
 import { asIoHelper, cfnApi, createIgnoreMatcher, IO, tagsForStack, throwIfValidationFailures } from '../../lib/api-private';
 import type { AssetBuildNode, AssetPublishNode, Concurrency, MarkerNode, StackNode, WorkGraph, WorkGraphActions } from '../api';
 import {
-  buildDestroyWorkGraph,
   CloudWatchLogEventMonitor,
   DEFAULT_TOOLKIT_STACK_NAME,
   DiffFormatter,
@@ -912,46 +911,54 @@ export class CdkToolkit {
   }
 
   public async destroy(options: DestroyOptions) {
-    const ioHelper = this.ioHost.asIoHelper();
-
-    const stacks = await this.selectStacksForDestroy(options.selector, options.exclusively);
-
-    if (!options.force) {
-      const motivation = 'Destroying stacks is an irreversible action';
-      const question = `Are you sure you want to delete: ${chalk.blue(stacks.stackArtifacts.map((s) => s.hierarchicalId).join(', '))}`;
-      const confirmed = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req(question, { motivation }));
-      if (!confirmed) {
-        throw new AbortError('DestroyAborted', 'Deletion cancelled');
-      }
-    }
-
-    const concurrency = options.concurrency || 1;
+    // Keep the "deployed" wording when a destroy runs as part of a deploy.
     const action = options.fromDeploy ? 'deploy' : 'destroy';
-    let destroyCount = 0;
 
-    if (concurrency > 1) {
+    if ((options.concurrency || 1) > 1) {
       this.ioHost.stackProgress = StackActivityProgress.EVENTS;
     }
 
-    const destroyStack = async (stackNode: StackNode) => {
-      const stack = stackNode.stack;
-      destroyCount++;
-      await ioHelper.defaults.info(chalk.green('%s: destroying... [%s/%s]'), chalk.blue(stack.displayName), destroyCount, stacks.stackCount);
-      try {
-        await this.props.deployments.destroyStack({
-          stack,
-          deployName: stack.stackName,
-          roleArn: options.roleArn,
-        });
-        await ioHelper.defaults.info(chalk.green(`\n ✅  %s: ${action}ed`), chalk.blue(stack.displayName));
-      } catch (e) {
-        await ioHelper.defaults.error(`\n ❌  %s: ${action} failed`, chalk.blue(stack.displayName), e);
-        throw e;
-      }
-    };
+    // The destroy action runs through toolkit-lib.
+    // Use listeners to keep the messages as they were before.
+    this.ioHost.on(IO.CDK_TOOLKIT_I1001, () => ({ preventDefault: true })); // Starting Synthesis (trace)
+    this.ioHost.on(IO.CDK_TOOLKIT_I1000, () => ({ preventDefault: true })); // ✨ Synthesis time (info)
+    this.ioHost.on(IO.CDK_TOOLKIT_I7101, () => ({ preventDefault: true })); // Starting Destroy (trace)
+    this.ioHost.on(IO.CDK_TOOLKIT_I7001, () => ({ preventDefault: true })); // per-stack Destroy time (trace)
+    this.ioHost.on(IO.CDK_TOOLKIT_I7000, () => ({ preventDefault: true })); // ✨ Destroy time (info)
+    // The success line was `info` in the historical `cdk destroy`, not `result`.
+    this.ioHost.on(IO.CDK_TOOLKIT_I7900, () => ({ level: 'info' })); // ✅ <stack>: destroyed
 
-    const workGraph = buildDestroyWorkGraph(stacks.stackArtifacts, ioHelper);
-    await workGraph.processStacks(concurrency, destroyStack);
+    // toolkit-lib logs a declined confirmation (E7010) and returns gracefully.
+    // The CLI surfaces a decline as a non-zero, soft exit instead: throwing from
+    // the listener both suppresses the log and aborts the command (the top-level
+    // renders `AbortError` as "Deletion cancelled").
+    this.ioHost.on(IO.CDK_TOOLKIT_E7010, () => {
+      throw new AbortError('DestroyAborted', 'Deletion cancelled');
+    });
+
+    if (options.force) {
+      this.ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+    }
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - `_destroyWithAction` is private; the CLI sets the action label.
+      await this.toolkit._destroyWithAction(this.props.cloudExecutable, action, {
+        stacks: {
+          patterns: options.selector.patterns,
+          strategy: options.selector.allTopLevel
+            ? StackSelectionStrategy.MAIN_ASSEMBLY
+            : options.selector.patterns.length > 0
+              ? StackSelectionStrategy.PATTERN_MATCH
+              : StackSelectionStrategy.ONLY_SINGLE,
+          expand: options.exclusively ? ExpandStackSelection.NONE : ExpandStackSelection.DOWNSTREAM,
+        },
+        roleArn: options.roleArn,
+        concurrency: options.concurrency,
+      });
+    } finally {
+      this.ioHost.removeAllListeners();
+    }
   }
 
   public async list(
@@ -1299,18 +1306,6 @@ export class CdkToolkit {
     await this.validateStacks(assembly, selectedForDiff.concat(autoValidateStacks));
 
     return selectedForDiff;
-  }
-
-  private async selectStacksForDestroy(selector: StackSelector, exclusively?: boolean) {
-    const assembly = await this.assembly();
-    const stacks = await assembly.selectStacks(selector, {
-      extend: exclusively ? ExtendedStackSelection.None : ExtendedStackSelection.Downstream,
-      defaultBehavior: DefaultSelection.OnlySingle,
-    });
-
-    // No validation
-
-    return stacks;
   }
 
   /**

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -888,10 +888,10 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
 
     const response = await this.resolveRequest(message, listenerResult);
 
-    // Tell observers how this request was handled: the effective (possibly
-    // reworded) question and the resolved response. A request is reported only
-    // once it has been answered, so it is never `dropped`.
-    this.notifyObservers({ type: 'request', emitted: msg, effective: message, dropped: false });
+    // Tell observers how this request was handled: the effective (possibly reworded) question
+    // and the resolved response. When a listener answered the request with the question suppressed
+    // (`preventDefault`, e.g. `--force` auto-confirm), it is reported as `dropped` since the user never saw it.
+    this.notifyObservers({ type: 'request', emitted: msg, effective: message, dropped: listenerResult.preventDefault });
 
     return response;
   }

--- a/packages/aws-cdk/test/_helpers/io-recorder.test.ts
+++ b/packages/aws-cdk/test/_helpers/io-recorder.test.ts
@@ -44,8 +44,9 @@ describe('IoHostRecorder', () => {
     const ioHelper = asIoHelper(ioHost, 'destroy');
 
     // Answer the request through a listener so the real `requestResponse` runs
-    // (and is therefore observed) — the recorder never spies on it.
-    const dispose = ioHost.on({ code: 'CDK_TOOLKIT_I0000' } as any, () => ({ respond: true, preventDefault: true }));
+    // (and is therefore observed) — the recorder never spies on it. The question
+    // is not suppressed, so it stays in the recorded stream.
+    const dispose = ioHost.on({ code: 'CDK_TOOLKIT_I0000' } as any, () => ({ respond: true }));
 
     await ioHelper.defaults.info('before');
     await ioHelper.requestResponse({
@@ -82,7 +83,8 @@ describe('IoHostRecorder', () => {
 
     // Answer the prompt the documented way, exactly as a rerouted command test
     // would (no `jest.spyOn(ioHost, 'requestResponse')` pass-through needed).
-    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+    // suppressQuestion=false keeps the (shown) prompt in the recorded stream.
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true, false);
 
     await ioHelper.defaults.info('before');
     const answer = await ioHelper.requestResponse(IO.CDK_TOOLKIT_I7010.req('proceed?', { motivation: 'testing' }));
@@ -115,7 +117,7 @@ describe('IoHostRecorder', () => {
 
   test('marks a message a listener prevented from being written as `dropped`', async () => {
     const ioHost = CliIoHost.instance({ logLevel: 'trace' }, /* forceNew */ true);
-    const recorder = IoHostRecorder.create(ioHost);
+    const recorder = IoHostRecorder.create(ioHost, { excludeDropped: false });
     const ioHelper = asIoHelper(ioHost, 'destroy');
 
     // Suppress a specific coded message, the way the CLI drops the synth/destroy

--- a/packages/aws-cdk/test/_helpers/io-recorder.ts
+++ b/packages/aws-cdk/test/_helpers/io-recorder.ts
@@ -123,6 +123,17 @@ export interface IoHostRecorderOptions {
    * @default - only the default scrubbers
    */
   readonly scrubbers?: Scrubber[];
+
+  /**
+   * Omit messages a listener prevented from being written (`dropped`) entirely,
+   * so the snapshot contains only what the user actually sees.
+   *
+   * Set to `false` to keep dropped messages (tagged `"dropped": true`) when you
+   * want listener-based suppression to stay visible.
+   *
+   * @default true
+   */
+  readonly excludeDropped?: boolean;
 }
 
 /**
@@ -233,6 +244,7 @@ export class IoHostRecorder {
 
   private readonly scrubbers: Scrubber[];
   private readonly level: IoMessageLevel;
+  private readonly excludeDropped: boolean;
 
   // The ordered stream of messages the host handled this test, collected via
   // its `observeMessages` hook. Cleared between tests by `resetObservations`.
@@ -241,6 +253,7 @@ export class IoHostRecorder {
   private constructor(options: IoHostRecorderOptions) {
     this.scrubbers = [...defaultScrubbers(), ...(options.scrubbers ?? [])];
     this.level = options.level ?? 'trace';
+    this.excludeDropped = options.excludeDropped ?? true;
   }
 
   private resetObservations(): void {
@@ -256,6 +269,11 @@ export class IoHostRecorder {
     const entries: RecordedIoEntry[] = [];
     let seq = 0;
     for (const { type, emitted, effective, dropped } of this.observations) {
+      // Optionally omit suppressed messages so the snapshot reflects only what
+      // the user sees.
+      if (dropped && this.excludeDropped) {
+        continue;
+      }
       // The single decision point for which levels are included; uses the
       // effective level so listener level-overrides are respected.
       if (!isMessageRelevantForLevel({ level: effective.level }, this.level)) {

--- a/packages/aws-cdk/test/commands/__io_snapshots__/deploy/require-approval_--require-approval_any-change_aborts_and_deploys_nothing_when_declined.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/deploy/require-approval_--require-approval_any-change_aborts_and_deploys_nothing_when_declined.ndjson
@@ -4,4 +4,3 @@
 {"seq":3,"type":"notify","action":"deploy","level":"debug","code":null,"message":"Checking for previously published assets"}
 {"seq":4,"type":"notify","action":"deploy","level":"debug","code":null,"message":"0 total assets, 0 still need to be published"}
 {"seq":5,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack Test-Stack-A-Display-Name\nResources\n[+] AWS::CDK::Test TemplateName\n\n"}
-{"seq":6,"type":"request","action":"deploy","level":"info","code":"CDK_TOOLKIT_I5060","message":"\"--require-approval\" is set to 'any-change': Do you wish to deploy these changes?","response":false}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/deploy/require-approval_--require-approval_any-change_prompts_and_proceeds_when_confirmed.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/deploy/require-approval_--require-approval_any-change_prompts_and_proceeds_when_confirmed.ndjson
@@ -4,12 +4,11 @@
 {"seq":3,"type":"notify","action":"deploy","level":"debug","code":null,"message":"Checking for previously published assets"}
 {"seq":4,"type":"notify","action":"deploy","level":"debug","code":null,"message":"0 total assets, 0 still need to be published"}
 {"seq":5,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack Test-Stack-A-Display-Name\nResources\n[+] AWS::CDK::Test TemplateName\n\n"}
-{"seq":6,"type":"request","action":"deploy","level":"info","code":"CDK_TOOLKIT_I5060","message":"\"--require-approval\" is set to 'any-change': Do you wish to deploy these changes?","response":true}
-{"seq":7,"type":"notify","action":"deploy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: deploying... [1/1]"}
-{"seq":8,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3000","message":"Starting Deploy ..."}
-{"seq":9,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n ✅  Test-Stack-A-Display-Name"}
-{"seq":10,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Deployment time: <DURATION>\n"}
-{"seq":11,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack ARN:"}
-{"seq":12,"type":"notify","action":"deploy","level":"result","code":null,"message":"arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/Test-Stack-A/abcd"}
-{"seq":13,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3001","message":"\n✨  Deploy time: <DURATION>\n"}
-{"seq":14,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Total time: <DURATION>\n"}
+{"seq":6,"type":"notify","action":"deploy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: deploying... [1/1]"}
+{"seq":7,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3000","message":"Starting Deploy ..."}
+{"seq":8,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n ✅  Test-Stack-A-Display-Name"}
+{"seq":9,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Deployment time: <DURATION>\n"}
+{"seq":10,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack ARN:"}
+{"seq":11,"type":"notify","action":"deploy","level":"result","code":null,"message":"arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/Test-Stack-A/abcd"}
+{"seq":12,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3001","message":"\n✨  Deploy time: <DURATION>\n"}
+{"seq":13,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Total time: <DURATION>\n"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/destroy_failure_emits_a_failure_message_and_rethrows_when_destroyStack_fails.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/destroy_failure_emits_a_failure_message_and_rethrows_when_destroyStack_fails.ndjson
@@ -1,4 +1,4 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"destroy","level":"error","code":null,"message":"\n ❌  Test-Stack-B: destroy failed Error: Deletion failed"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"error","code":"CDK_TOOLKIT_E7900","message":"❌  Test-Stack-B: destroy failed Error: Deletion failed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_asks_for_confirmation_and_proceeds_when_the_user_confirms.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_false_confirmation_prompt_asks_for_confirmation_and_proceeds_when_the_user_confirms.ndjson
@@ -1,5 +1,5 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
 {"seq":2,"type":"request","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7010","message":"Are you sure you want to delete: Test-Stack-B","response":true}
-{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_a_single_nested_stack_fromDeploy_makes_it_say_deployed.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_a_single_nested_stack_fromDeploy_makes_it_say_deployed.ndjson
@@ -1,4 +1,4 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-A/Test-Stack-C: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-A/Test-Stack-C: deployed"}
+{"seq":2,"type":"notify","action":"deploy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-A/Test-Stack-C: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"deploy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-A/Test-Stack-C: deployed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_all_top-level_stacks_with_concurrency.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_destroys_all_top-level_stacks_with_concurrency.ndjson
@@ -1,6 +1,6 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: destroying... [1/2]"}
-{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [2/2]"}
-{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-A-Display-Name: destroyed"}
-{"seq":5,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-A-Display-Name: destroying... [1/2]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [2/2]"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-A-Display-Name: destroyed"}
+{"seq":5,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_forwards_the_roleArn_to_destroyStack.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_forwards_the_roleArn_to_destroyStack.ndjson
@@ -1,4 +1,4 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-B: destroying... [1/1]"}
-{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-B: destroyed"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_respects_dependency_order_with_concurrency.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/force_true_no_confirmation_prompt_respects_dependency_order_with_concurrency.ndjson
@@ -1,6 +1,6 @@
 {"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":2,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-D: destroying... [1/2]"}
-{"seq":3,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-D: destroyed"}
-{"seq":4,"type":"notify","action":"destroy","level":"info","code":null,"message":"Test-Stack-C: destroying... [2/2]"}
-{"seq":5,"type":"notify","action":"destroy","level":"info","code":null,"message":"\n ✅  Test-Stack-C: destroyed"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-D: destroying... [1/2]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-D: destroyed"}
+{"seq":4,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-C: destroying... [2/2]"}
+{"seq":5,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n ✅  Test-Stack-C: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/list/cdk_list_prints_machine-readable_JSON_without_the_synthesis-time_line.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/list/cdk_list_prints_machine-readable_JSON_without_the_synthesis-time_line.ndjson
@@ -1,5 +1,4 @@
 {"seq":0,"type":"notify","action":"list","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
 {"seq":1,"type":"notify","action":"list","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
 {"seq":2,"type":"notify","action":"list","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
-{"seq":3,"type":"notify","action":"list","level":"info","code":"CDK_TOOLKIT_I1000","message":"✨  Synthesis time: <DURATION>","dropped":true}
-{"seq":4,"type":"notify","action":"list","level":"result","code":"CDK_TOOLKIT_I2901","message":"Test-Stack-A\nTest-Stack-B"}
+{"seq":3,"type":"notify","action":"list","level":"result","code":"CDK_TOOLKIT_I2901","message":"Test-Stack-A\nTest-Stack-B"}

--- a/packages/aws-cdk/test/commands/destroy.test.ts
+++ b/packages/aws-cdk/test/commands/destroy.test.ts
@@ -33,7 +33,7 @@ const STACK_C_NESTED: TestStackArtifact = {
 };
 
 let cloudExecutable: MockCloudExecutable;
-let cloudFormation: jest.Mocked<Deployments>;
+let destroyStackMock: jest.SpyInstance;
 let toolkit: CdkToolkit;
 let ioHost = CliIoHost.instance();
 let recorder: IoHostRecorder;
@@ -54,14 +54,17 @@ beforeEach(async () => {
     nestedAssemblies: [{ stacks: [STACK_C_NESTED] }],
   }, undefined, ioHost, 'destroy');
 
-  cloudFormation = instanceMockFrom(Deployments);
+  // The rerouted destroy runs through toolkit-lib, which builds its own
+  // Deployments. Intercept at the prototype so the real CFN calls never run.
+  destroyStackMock = jest.spyOn(Deployments.prototype, 'destroyStack')
+    .mockResolvedValue({ stackArn: 'arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/test' } as any);
 
   toolkit = new CdkToolkit({
     ioHost,
     cloudExecutable,
     configuration: cloudExecutable.configuration,
     sdkProvider: cloudExecutable.sdkProvider,
-    deployments: cloudFormation,
+    deployments: instanceMockFrom(Deployments),
   });
 
   // Single recorder bound to the (singleton) ioHost; `clearMocks` scopes the
@@ -84,7 +87,7 @@ describe('force: true (no confirmation prompt)', () => {
       fromDeploy: true,
     });
 
-    expect(cloudFormation.destroyStack).toHaveBeenCalledTimes(1);
+    expect(destroyStackMock).toHaveBeenCalledTimes(1);
   });
 
   test('destroys all top-level stacks with concurrency', async () => {
@@ -95,7 +98,7 @@ describe('force: true (no confirmation prompt)', () => {
       concurrency: 5,
     });
 
-    expect(cloudFormation.destroyStack).toHaveBeenCalledTimes(2);
+    expect(destroyStackMock).toHaveBeenCalledTimes(2);
   });
 
   test('respects dependency order with concurrency', async () => {
@@ -113,7 +116,7 @@ describe('force: true (no confirmation prompt)', () => {
     cloudExecutable = await MockCloudExecutable.create({ stacks: [stackC, stackD] }, undefined, ioHost, 'destroy');
 
     const destroyOrder: string[] = [];
-    cloudFormation.destroyStack.mockImplementation(async (options: DestroyStackOptions) => {
+    destroyStackMock.mockImplementation(async (options: DestroyStackOptions) => {
       destroyOrder.push(options.stack.stackName);
       return { stackArn: 'arn' };
     });
@@ -123,7 +126,7 @@ describe('force: true (no confirmation prompt)', () => {
       cloudExecutable,
       configuration: cloudExecutable.configuration,
       sdkProvider: cloudExecutable.sdkProvider,
-      deployments: cloudFormation,
+      deployments: instanceMockFrom(Deployments),
     });
 
     await toolkit.destroy({
@@ -145,7 +148,7 @@ describe('force: true (no confirmation prompt)', () => {
       roleArn: 'arn:aws:iam::123456789012:role/DestroyRole',
     });
 
-    expect(cloudFormation.destroyStack).toHaveBeenCalledWith(
+    expect(destroyStackMock).toHaveBeenCalledWith(
       expect.objectContaining({ roleArn: 'arn:aws:iam::123456789012:role/DestroyRole' }),
     );
   });
@@ -155,8 +158,9 @@ describe('force: false (confirmation prompt)', () => {
   test('asks for confirmation and proceeds when the user confirms', async () => {
     // Answer the confirmation prompt with a one-shot responder. The real
     // requestResponse runs (so the request is recorded in the snapshot); no
-    // spy/pass-through is needed.
-    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+    // spy/pass-through is needed. suppressQuestion=false: a non-forced destroy
+    // shows the prompt to the user, so it stays in the snapshot.
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true, false);
 
     await toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },
@@ -165,13 +169,14 @@ describe('force: false (confirmation prompt)', () => {
     });
 
     // Confirmed -> the stack is actually destroyed.
-    expect(cloudFormation.destroyStack).toHaveBeenCalledTimes(1);
+    expect(destroyStackMock).toHaveBeenCalledTimes(1);
   });
 
   test('aborts with an AbortError and destroys nothing when the user declines', async () => {
     // The IoHost returns the answer; declining is `false` and the command aborts
     // by throwing an AbortError (non-zero exit, presented softly by the CLI).
-    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, false);
+    // suppressQuestion=false: the prompt is shown to the user (non-forced).
+    ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, false, false);
 
     const error = await toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },
@@ -183,13 +188,13 @@ describe('force: false (confirmation prompt)', () => {
     expect(error.name).toBe('DestroyAborted');
 
     // Aborted before any destroy happened.
-    expect(cloudFormation.destroyStack).not.toHaveBeenCalled();
+    expect(destroyStackMock).not.toHaveBeenCalled();
   });
 });
 
 describe('destroy failure', () => {
   test('emits a failure message and rethrows when destroyStack fails', async () => {
-    cloudFormation.destroyStack.mockRejectedValue(new Error('Deletion failed'));
+    destroyStackMock.mockRejectedValue(new Error('Deletion failed'));
 
     await expect(toolkit.destroy({
       selector: { patterns: ['Test-Stack-B'] },


### PR DESCRIPTION
Routes `cdk destroy` through the toolkit-lib destroy action, the same way `cdk list` was rerouted, and removes the legacy `CdkToolkit.destroy` implementation.

User-facing output and behavior are unchanged. The CLI keeps the destroy output identical with `CliIoHost` listeners:

- suppresses the toolkit-lib synthesis/destroy lifecycle lines the CLI never showed (it keeps emitting its own synth lines)
- keeps the success line at `info` (toolkit-lib emits it as `result`)
- `--force` auto-confirms the deletion prompt without showing it
- a declined confirmation still exits non-zero with a soft "Deletion cancelled"

`toolkit-lib` behavior is unchanged: its destroy action still logs the declined confirmation and returns, and the CLI turns that into the non-zero exit (by throwing from the `E7010` listener). The action label is preserved so a destroy triggered by a deploy still says "deployed", via a private `_destroyWithAction`.

The destroy IO-snapshot tests assert the recorded user-facing stream is unchanged.

## Technical details

- IO-snapshot recorder now omits listener-suppressed (`dropped`) messages by default, and `requestResponse` marks a suppressed prompt as `dropped`, so snapshots contain exactly what the user sees.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
