### PR TITLE
fix(integ-runner): context files not loaded from above working directory

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integration-tests.ts
@@ -150,7 +150,7 @@ export class IntegTest {
    * `cdk.json#context` if not found, upstream from the test.
    */
   public async testSpecificContext(): Promise<Record<string, unknown> | undefined> {
-    return findTestSpecificContext(this.fileName);
+    return findTestSpecificContext(path.dirname(this.fileName));
   }
 }
 

--- a/packages/@aws-cdk/integ-runner/lib/runner/private/test-specific-context.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/private/test-specific-context.ts
@@ -9,6 +9,11 @@ export type CdkContext = Record<string, unknown>;
 const CONTEXT_CACHE = new Map<string, CdkContext | undefined>();
 
 export async function findTestSpecificContext(directory: string): Promise<CdkContext | undefined> {
+  if (!path.isAbsolute(directory)) {
+    // Must be absolute path otherwise path.dirname() below will never go above working directory
+    directory = path.resolve(directory);
+  }
+
   const existing = CONTEXT_CACHE.get(directory);
   if (existing) {
     return existing;

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-helper.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-helper.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { CdkIntegHelper } from '../../lib/runner';
 import { IntegTest } from '../../lib/runner/integration-tests';
+import { findTestSpecificContext } from '../../lib/runner/private/test-specific-context';
 
 let mockCdk: any;
 let tempDir: string;
@@ -70,6 +71,28 @@ test('can read context from parent directory', async () => {
 
   // WHEN / THEN
   expect(helper.getContext()).toMatchObject({ integJsonKey: 'integJsonValue' });
+});
+
+test('can read upwards from current directory', async () => {
+  // GIVEN
+  await writeJson(path.join(tempDir, 'integ.context.json'), {
+    integJsonKey: 'integJsonValue',
+  });
+
+  const oldDir = process.cwd();
+  const subdir = path.join(tempDir, 'subdir');
+  await fs.mkdir(subdir, { recursive: true });
+
+  process.chdir(subdir);
+  try {
+    // WHEN
+    const context = await findTestSpecificContext('.');
+
+    // THEN
+    expect(context).toMatchObject({ integJsonKey: 'integJsonValue' });
+  } finally {
+    process.chdir(oldDir);
+  }
 });
 
 async function makeHelper(relativePath: string) {


### PR DESCRIPTION
Because the `findTestSpecificContext()` function was working on relative path names, it would never go above `.` in `./test/some-test.js`.

But in the CDK repository, there are so many packages with integ tests that we would like to centralize the context file name at a shared parent directory above the packages root.

Therefore, we have to make the path absolute before we start searching.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
