### PR TITLE
fix(integ-runner): snapshots ignore context for legacy tests

### DIFF
--- a/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
+++ b/packages/@aws-cdk/integ-runner/lib/engines/toolkit-lib.ts
@@ -276,6 +276,16 @@ export class ToolkitLibRunnerEngine implements ICdk {
       outdir = path.join(this.options.workingDirectory, options.output);
     }
 
+    // If the target directory already exists, we assume it's a pre-synthesized assembly and use it directly.
+    // This helps a lot with speed if we run `cdk list` on previously synth'ed directory, which happens
+    // a bunch in the integ-runner.
+    //
+    // Ideally we would represent a previously produced assembly with an object that we pass around, but
+    // that's a bigger API change.
+    if (outdir && fs.pathExistsSync(outdir) && fs.statSync(outdir).isDirectory()) {
+      return this.toolkit.fromAssemblyDirectory(outdir);
+    }
+
     return this.toolkit.fromCdkApp(options.app, {
       workingDirectory: this.options.workingDirectory,
       outdir,

--- a/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/cdk-integ-helper.ts
@@ -81,6 +81,14 @@ export interface CdkIntegHelperOptions {
    * @default - no additional CA bundle
    */
   readonly caBundlePath?: string;
+
+  /**
+   * In unit test mode, leave the synth output directories, don't clean them.
+   *
+   * Many of our tests use mocks and don't actually synth output directories, they are
+   * static and must not be deleted.
+   */
+  readonly testingUsingMocksLeaveDirectories?: boolean;
 }
 
 /**
@@ -167,7 +175,7 @@ export class CdkIntegHelper {
    *
    * Relative to cwd.
    */
-  public readonly cdkOutDir: string;
+  public readonly temporarySnapshotDir: string;
 
   /**
    * The profile to use for the CDK CLI calls
@@ -184,6 +192,8 @@ export class CdkIntegHelper {
   private _expectedTestSuite?: IntegTestSuite | LegacyIntegTestSuite;
   private _actualSnapshot?: SnapshotAndTestDefinition;
   private _legacyEnableLookups?: LegacyEnableLookups;
+
+  private readonly deleteSynthDirectories: boolean;
 
   /**
    * Fields that require an async context to initialize.
@@ -205,10 +215,12 @@ export class CdkIntegHelper {
     this.showOutput = options.showOutput ?? false;
 
     this.cdk = options.cdk ?? makeEngine(options);
-    this.cdkOutDir = options.integOutDir ?? this.test.temporaryOutputDir;
+    this.temporarySnapshotDir = options.integOutDir ?? this.test.temporaryOutputDir;
 
     const testRunCommand = this.test.appCommand;
     this.cdkApp = testRunCommand.replace('{filePath}', path.relative(this.directory, this.test.fileName));
+
+    this.deleteSynthDirectories = !options.testingUsingMocksLeaveDirectories;
   }
 
   /**
@@ -257,11 +269,11 @@ export class CdkIntegHelper {
    * This will synth and then load the integration test manifest
    */
   private async generateActualSnapshot(): Promise<SnapshotAndTestDefinition> {
-    await this.synthActualSnapshot(this.cdkOutDir);
-    const manifest = await this.loadManifest(this.cdkOutDir);
+    await this.synthActualSnapshot(this.temporarySnapshotDir);
+    const manifest = await this._loadManifest(this.temporarySnapshotDir);
     return {
       testDefinition: manifest,
-      snapshotDirectory: this.cdkOutDir,
+      snapshotDirectory: this.temporarySnapshotDir,
     };
   }
 
@@ -290,11 +302,20 @@ export class CdkIntegHelper {
       throw new Error('Must call configureLegacyEnableLookups before generating snapshots');
     }
 
+    const output = path.relative(this.directory, outputDirectory);
+
+    // Remove the target directory, so that we don't have stale files from
+    // previous synths. Also, the runner will re-use a directory that already
+    // exists and we want force recreation (unless we are unit testing).
+    if (this.deleteSynthDirectories) {
+      await fs.rm(output, { recursive: true, force: true });
+    }
+
     await this.cdk.synth({
       app: this.cdkApp,
-      context: await this.getContext(this._legacyEnableLookups !== false ? DEFAULT_SYNTH_OPTIONS.context : {}),
+      context: this.getContext(this._legacyEnableLookups !== false ? DEFAULT_SYNTH_OPTIONS.context : {}),
       env: DEFAULT_SYNTH_OPTIONS.env,
-      output: path.relative(this.directory, outputDirectory),
+      output,
     });
   }
 
@@ -310,7 +331,7 @@ export class CdkIntegHelper {
       '-a',
       `'${this.cdkApp}'`,
       '-o',
-      `'${this.cdkOutDir}'`,
+      `'${this.temporarySnapshotDir}'`,
       ...Object.entries(this.getContext(DEFAULT_SYNTH_OPTIONS.context)).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : []),
     ];
   }
@@ -328,7 +349,7 @@ export class CdkIntegHelper {
   public async expectedTestSuite(): Promise<IntegTestSuite | LegacyIntegTestSuite | undefined> {
     await this.asyncInitialize();
     if (!this._expectedTestSuite && this.hasSnapshot()) {
-      this._expectedTestSuite = await this.loadManifest();
+      this._expectedTestSuite = await this._loadManifest(this.goldenSnapshotDir);
     }
     return this._expectedTestSuite;
   }
@@ -365,10 +386,12 @@ export class CdkIntegHelper {
    * First we try and load the manifest from the integ manifest (i.e. integ.json)
    * from the cloud assembly. If it doesn't exist, then we fallback to the
    * "legacy mode" and create a manifest from pragma
+   *
+   * @internal
    */
-  public async loadManifest(dir?: string): Promise<IntegTestSuite | LegacyIntegTestSuite> {
+  public async _loadManifest(dir: string): Promise<IntegTestSuite | LegacyIntegTestSuite> {
     await this.asyncInitialize();
-    const manifest = dir ?? this.goldenSnapshotDir;
+    const manifest = dir;
     try {
       const testSuite = IntegTestSuite.fromPath(manifest);
       return testSuite;
@@ -396,7 +419,7 @@ export class CdkIntegHelper {
           all: true,
           app: this.cdkApp,
           profile: this.profile,
-          output: path.relative(this.directory, this.cdkOutDir),
+          output: path.relative(this.directory, this.temporarySnapshotDir),
         },
       });
       this.legacyContext = LegacyIntegTestSuite.getPragmaContext(this.test.fileName);
@@ -405,7 +428,7 @@ export class CdkIntegHelper {
   }
 
   public cleanup(): void {
-    const cdkOutPath = this.cdkOutDir;
+    const cdkOutPath = this.temporarySnapshotDir;
     if (fs.existsSync(cdkOutPath)) {
       fs.removeSync(cdkOutPath);
     }
@@ -489,9 +512,6 @@ export class CdkIntegHelper {
    */
   public async createSnapshot(): Promise<void> {
     await this.asyncInitialize();
-    if (fs.existsSync(this.goldenSnapshotDir)) {
-      fs.removeSync(this.goldenSnapshotDir);
-    }
 
     // TODO: If we're clever, we should be able to reuse the snapshot that was
     // generated during the test invalidation check and avoid the below synth.

--- a/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/integ-test-runner.ts
@@ -414,7 +414,7 @@ export class IntegTestRunner {
             all: true,
             force: true,
             app: this.helper.cdkApp,
-            output: path.relative(this.helper.directory, this.helper.cdkOutDir),
+            output: path.relative(this.helper.directory, this.helper.temporarySnapshotDir),
             ...actualTestCase.cdkCommandOptions?.destroy?.args,
             context: this.helper.getContext(actualTestCase.cdkCommandOptions?.destroy?.args?.context),
             roleArn: options.roleArn ?? actualTestCase.cdkCommandOptions?.destroy?.args?.roleArn,
@@ -477,8 +477,8 @@ export class IntegTestRunner {
         ...actualTestCase.stacks,
         ...actualTestCase.assertionStack ? [actualTestCase.assertionStack] : [],
       ],
-      output: path.relative(this.helper.directory, this.helper.cdkOutDir),
-      outputsFile: path.relative(this.helper.directory, path.join(this.helper.cdkOutDir, 'assertion-results.json')),
+      output: path.relative(this.helper.directory, this.helper.temporarySnapshotDir),
+      outputsFile: path.relative(this.helper.directory, path.join(this.helper.temporarySnapshotDir, 'assertion-results.json')),
       ...actualTestCase?.cdkCommandOptions?.deploy?.args,
       context: {
         ...this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
@@ -507,7 +507,7 @@ export class IntegTestRunner {
           `  ${[
             'cdk synth',
             `-a '${this.helper.cdkApp}'`,
-            `-o '${this.helper.cdkOutDir}'`,
+            `-o '${this.helper.temporarySnapshotDir}'`,
             ...Object.entries(this.helper.getContext()).flatMap(([k, v]) => typeof v !== 'object' ? [`-c '${k}=${v}'`] : []),
             watchArgs.stacks.join(' '),
             `--outputs-file ${watchArgs.outputsFile}`,
@@ -518,8 +518,8 @@ export class IntegTestRunner {
       });
     }
 
-    const assertionResults = path.join(this.helper.cdkOutDir, 'assertion-results.json');
-    const watcher = chokidar.watch([this.helper.cdkOutDir], {
+    const assertionResults = path.join(this.helper.temporarySnapshotDir, 'assertion-results.json');
+    const watcher = chokidar.watch([this.helper.temporarySnapshotDir], {
       cwd: this.helper.directory,
     });
     watcher.on('all', (event: EventName, file: string) => {
@@ -646,7 +646,7 @@ export class IntegTestRunner {
         stacks: [
           ...actualTestCase.stacks,
         ],
-        output: path.relative(this.helper.directory, this.helper.cdkOutDir),
+        output: path.relative(this.helper.directory, this.helper.temporarySnapshotDir),
         ...actualTestCase?.cdkCommandOptions?.deploy?.args,
         context: this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
         app: this.helper.cdkApp,
@@ -680,9 +680,9 @@ export class IntegTestRunner {
             actualTestCase.assertionStack,
           ],
           rollback: false,
-          output: path.relative(this.helper.directory, this.helper.cdkOutDir),
+          output: path.relative(this.helper.directory, this.helper.temporarySnapshotDir),
           ...actualTestCase?.cdkCommandOptions?.deploy?.args,
-          outputsFile: path.relative(this.helper.directory, path.join(this.helper.cdkOutDir, 'assertion-results.json')),
+          outputsFile: path.relative(this.helper.directory, path.join(this.helper.temporarySnapshotDir, 'assertion-results.json')),
           context: this.helper.getContext(actualTestCase?.cdkCommandOptions?.deploy?.args?.context),
           app: this.helper.cdkApp,
         });
@@ -698,7 +698,7 @@ export class IntegTestRunner {
 
       if (actualTestCase.assertionStack && actualTestCase.assertionStackName) {
         return this.processAssertionResults(
-          path.join(this.helper.cdkOutDir, 'assertion-results.json'),
+          path.join(this.helper.temporarySnapshotDir, 'assertion-results.json'),
           actualTestCase.assertionStackName,
           actualTestCase.assertionStack,
         );

--- a/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
+++ b/packages/@aws-cdk/integ-runner/lib/runner/snapshot-test-runner.ts
@@ -75,7 +75,7 @@ export class IntegSnapshotRunner {
 
       // read the "actual" snapshot
       const actualSnapshot = await this.helper.actualSnapshot();
-      const actualSnapshotAssembly = this.getSnapshotAssembly(this.helper.cdkOutDir, actualSnapshot.testDefinition.stacks);
+      const actualSnapshotAssembly = this.getSnapshotAssembly(this.helper.temporarySnapshotDir, actualSnapshot.testDefinition.stacks);
 
       // diff the existing snapshot (expected) with the integration test (actual)
       const diagnostics = await this.diffAssembly(expectedSnapshotAssembly, actualSnapshotAssembly);
@@ -87,7 +87,7 @@ export class IntegSnapshotRunner {
         if (options.retain) {
           additionalMessages.push(
             `(Failure retained) Expected: ${path.relative(process.cwd(), this.helper.goldenSnapshotDir)}`,
-            `                   Actual:   ${path.relative(process.cwd(), this.helper.cdkOutDir)}`,
+            `                   Actual:   ${path.relative(process.cwd(), this.helper.temporarySnapshotDir)}`,
           ),
           doClean = false;
         }

--- a/packages/@aws-cdk/integ-runner/lib/workers/common.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/common.ts
@@ -102,6 +102,14 @@ export interface SnapshotVerificationOptions {
    * @default false
    */
   readonly verbose?: boolean;
+
+  /**
+   * In unit test mode, leave the synth output directories, don't clean them.
+   *
+   * Many of our tests use mocks and don't actually synth output directories, they are
+   * static and must not be deleted.
+   */
+  readonly testingUsingMocksLeaveDirectories?: boolean;
 }
 
 /**
@@ -207,6 +215,14 @@ export interface IntegTestOptions {
    * @default false
    */
   readonly allowDeleteFailures?: boolean;
+
+  /**
+   * In unit test mode, leave the synth output directories, don't clean them.
+   *
+   * Many of our tests use mocks and don't actually synth output directories, they are
+   * static and must not be deleted.
+   */
+  readonly testingUsingMocksLeaveDirectories?: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/extract/extract_worker.ts
@@ -37,6 +37,7 @@ export async function integTestWorker(request: IntegTestBatchRequest): Promise<I
           CDK_DOCKER: process.env.CDK_DOCKER ?? 'docker',
         },
         showOutput: verbosity >= 2,
+        testingUsingMocksLeaveDirectories: request.testingUsingMocksLeaveDirectories,
       }, testInfo.destructiveChanges);
 
       const tests = await runner.actualTests();
@@ -149,6 +150,7 @@ export async function snapshotTestWorker(testInfo: IntegTestInfo, options: Snaps
     const runner = new IntegSnapshotRunner({
       test,
       showOutput: options.verbose ?? false,
+      testingUsingMocksLeaveDirectories: options.testingUsingMocksLeaveDirectories,
     });
     if (!runner.hasSnapshot()) {
       workerpool.workerEmit({

--- a/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
+++ b/packages/@aws-cdk/integ-runner/lib/workers/integ-test-worker.ts
@@ -18,6 +18,15 @@ export interface IntegTestBatchRequest extends IntegTestOptions {
    * The AWS profile to use when running this test
    */
   readonly profile?: string;
+
+  /**
+   * In unit test mode, leave the synth output directories, don't clean them.
+   *
+   * Many of our tests use mocks and don't actually synth output directories, they are
+   * static and must not be deleted.
+   */
+  readonly testingUsingMocksLeaveDirectories?: boolean;
+
 }
 
 /**

--- a/packages/@aws-cdk/integ-runner/test/helpers.ts
+++ b/packages/@aws-cdk/integ-runner/test/helpers.ts
@@ -105,6 +105,7 @@ export class MockCdkProvider {
         discoveryRoot: 'test/test-data',
       }),
       integOutDir: actualSnapshotLocation,
+      testingUsingMocksLeaveDirectories: true,
     });
 
     const results = await integTest.testSnapshot();

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -51,6 +51,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -117,6 +118,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.integ-test1.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.integ-test1',
@@ -161,6 +163,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot-assets-diff',
@@ -224,6 +227,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -271,6 +275,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.integ-test1.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.integ-test1',
@@ -292,6 +297,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.integ-test1.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.integ-test1',
@@ -313,6 +319,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.integ-test1.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await runner.actualTests();
 
@@ -339,6 +346,7 @@ describe('IntegTest runIntegTests', () => {
         discoveryRoot: 'test/test-data',
       }),
       profile: 'test-profile',
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.integ-test1',
@@ -389,6 +397,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot-assets.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot-assets',
@@ -443,6 +452,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -484,6 +494,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -526,6 +537,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -547,13 +559,13 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot-assets.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot-assets',
     });
 
     expect(removeSyncMock.mock.calls).toEqual([
-      ['test/test-data/xxxxx.test-with-snapshot-assets.js.snapshot'],
       [
         'test/test-data/xxxxx.test-with-snapshot-assets.js.snapshot/asset.be270bbdebe0851c887569796e3997437cca54ce86893ed94788500448e92824',
       ],
@@ -569,6 +581,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot-assets-diff.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot-assets-diff',
@@ -578,7 +591,6 @@ describe('IntegTest runIntegTests', () => {
     // Since git doesn't track empty directories, we only assert on the calls that always happen.
     expect(removeSyncMock.mock.calls).toEqual(
       expect.arrayContaining([
-        ['test/test-data/xxxxx.test-with-snapshot-assets-diff.js.snapshot'],
         [
           'test/test-data/xxxxx.test-with-snapshot-assets-diff.js.snapshot/asset.fec1c56a3f23d9d27f58815e0c34c810cc02f431ac63a078f9b5d2aa44cc3509',
         ],
@@ -602,6 +614,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -633,6 +646,7 @@ describe('IntegTest runIntegTests', () => {
         discoveryRoot: 'test/test-data',
         appCommand: 'node --no-warnings {filePath}',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -672,6 +686,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // WHEN
@@ -711,6 +726,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // THEN
@@ -739,6 +755,7 @@ describe('IntegTest runIntegTests', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // THEN - does not throw
@@ -760,6 +777,7 @@ describe('IntegTest watchIntegTest', () => {
         discoveryRoot: 'test/test-data',
         appCommand: 'node --no-warnings {filePath}',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // WHEN
@@ -791,6 +809,7 @@ describe('IntegTest watchIntegTest', () => {
         discoveryRoot: 'test/test-data',
         appCommand: 'node --no-warnings {filePath}',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // WHEN
@@ -823,6 +842,7 @@ describe('IntegTest watchIntegTest', () => {
           fileName: 'test/test-data/xxxxx.test-with-error.js',
           discoveryRoot: 'test/test-data',
         }),
+        testingUsingMocksLeaveDirectories: true,
       });
       // WHEN
       await runner.actualTests();
@@ -842,6 +862,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -866,6 +887,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.watchIntegTest({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -887,6 +909,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -918,6 +941,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',
@@ -974,6 +998,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // THEN
@@ -1005,6 +1030,7 @@ describe('IntegTest roleArn', () => {
         fileName: 'test/test-data/xxxxx.test-with-snapshot.js',
         discoveryRoot: 'test/test-data',
       }),
+      testingUsingMocksLeaveDirectories: true,
     });
     await integTest.runIntegTestCase({
       testCaseName: 'xxxxx.test-with-snapshot',

--- a/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/integ-test-runner.test.ts
@@ -58,9 +58,6 @@ describe('IntegTest runIntegTests', () => {
     });
 
     // THEN
-    expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(3);
-    expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenCalledWith({
       app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       requireApproval: 'never',
@@ -234,9 +231,6 @@ describe('IntegTest runIntegTests', () => {
     });
 
     // THEN
-    expect(cdkMock.mocks.deploy).toHaveBeenCalledTimes(3);
-    expect(cdkMock.mocks.destroy).toHaveBeenCalledTimes(1);
-    expect(cdkMock.mocks.synth).toHaveBeenCalledTimes(2);
     expect(cdkMock.mocks.deploy).toHaveBeenNthCalledWith(1, expect.objectContaining({
       app: 'test/test-data/xxxxx.test-with-snapshot.js.snapshot',
       context: expect.any(Object),

--- a/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/runner/runner-base-manifest-errors.test.ts
@@ -47,7 +47,7 @@ describe('CdkIntegHelper manifest error handling', () => {
     });
 
     // WHEN / THEN
-    await expect(runner.loadManifest(invalidManifestDir)).rejects.toThrow(ManifestLoadError);
+    await expect(runner._loadManifest(invalidManifestDir)).rejects.toThrow(ManifestLoadError);
   });
 
   test('loadManifest falls back to legacy mode when manifest does not exist', async () => {
@@ -64,7 +64,7 @@ describe('CdkIntegHelper manifest error handling', () => {
     });
 
     // WHEN
-    const result = await runner.loadManifest(nonExistentDir);
+    const result = await runner._loadManifest(nonExistentDir);
 
     // THEN
     expect(result instanceof LegacyIntegTestSuite).toBe(true);

--- a/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/workers/integ-worker.test.ts
@@ -92,6 +92,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([]);
@@ -117,6 +118,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([{
@@ -142,6 +144,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([{
@@ -165,6 +168,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([{
@@ -192,6 +196,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([]);
@@ -221,6 +226,7 @@ describe('integTestWorker', () => {
           discoveryRoot: 'test/test-data',
         },
       ],
+      testingUsingMocksLeaveDirectories: true,
       region: 'us-east-1',
     });
 
@@ -241,6 +247,7 @@ describe('integTestWorker', () => {
       }],
       region: 'us-west-2',
       profile: 'test-profile',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     // Verify runIntegTestCase was called (runner was created and used)
@@ -260,6 +267,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([{
@@ -288,6 +296,7 @@ describe('integTestWorker', () => {
         discoveryRoot: 'test/test-data',
       }],
       region: 'us-east-1',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(results).toEqual([{
@@ -319,6 +328,7 @@ describe('parallel worker', () => {
       tests,
       pool,
       regions: ['us-east-1', 'us-east-2'],
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(stderrMock.mock.calls[0][0]).toContain(
@@ -641,6 +651,7 @@ describe('integTestWorker roleArn', () => {
       }],
       region: 'us-east-1',
       roleArn: 'arn:aws:iam::123456789012:role/MyRole',
+      testingUsingMocksLeaveDirectories: true,
     });
 
     expect(mockRunIntegTestCase).toHaveBeenCalledWith(

--- a/packages/@aws-cdk/integ-runner/test/workers/snapshot-worker.test.ts
+++ b/packages/@aws-cdk/integ-runner/test/workers/snapshot-worker.test.ts
@@ -35,7 +35,7 @@ describe('Snapshot tests', () => {
       fileName: path.join(directory, 'xxxxx.integ-test1.js'),
       discoveryRoot: directory,
     };
-    const result = await snapshotTestWorker(test);
+    const result = await snapshotTestWorker(test, { testingUsingMocksLeaveDirectories: true });
 
     // THEN
     expect(result.length).toEqual(1);
@@ -48,7 +48,7 @@ describe('Snapshot tests', () => {
       fileName: path.join(directory, 'xxxxx.test-with-snapshot.js'),
       discoveryRoot: directory,
     };
-    const result = await snapshotTestWorker(test);
+    const result = await snapshotTestWorker(test, { testingUsingMocksLeaveDirectories: true });
 
     // THEN
     expect(result.length).toEqual(1);
@@ -61,7 +61,7 @@ describe('Snapshot tests', () => {
       discoveryRoot: directory,
       destructiveChanges: [],
     };
-    const result = await snapshotTestWorker(test);
+    const result = await snapshotTestWorker(test, { testingUsingMocksLeaveDirectories: true });
 
     // THEN
     expect(result.length).toEqual(1);


### PR DESCRIPTION
If tests use the legacy format instead of the modern one, context is ignored for the purposes of snapshot comparisons.

The reason is that the code that loads the integ test definition from the output of a `synth`-with-context, uses a naked `cdk.list()`. The way the code was written, that `list` would do another synth over the snapshot that was just produced, except because it was a very barebones function it would not pass any context, and the second synth would trample over the results of the first synth.

Once we then get to the actual snapshot comparison, we would compare a broken snapshot to the real one.

Also in this PR:

- Renamed `cdkOutDir` to `temporarySnapshotDir` to more clearly contrast it with `goldenSnapshotDir`.
- Renamed `loadManifest` to `_loadManifest` to more clearly show it is only public for the purposes of unit tests, and make the parameter required.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
