### PR TITLE
test(cli-integ): enforce JSON-parseable output for --json commands

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -601,9 +601,19 @@ export class TestFixture extends ShellHelper {
 
     const verboseLevel = options.verboseLevel ?? 1;
 
+    // When '--json' is requested, the returned output must be valid JSON. CDK writes its data
+    // output to stdout and its logs (verbose traces, notices, warnings) to stderr, so we require
+    // 'captureStderr: false' to isolate stdout. Without it, the returned output is 'stdout + stderr'
+    // and the interleaved logs would corrupt the JSON regardless of the command's actual behavior.
+    const assertJson = hasJsonFlag(args) && !options.onlyStderr;
+    if (assertJson && options.captureStderr !== false) {
+      throw new Error(`'cdk ${args.join(' ')}' uses '--json' but does not pass 'captureStderr: false'; ` +
+        'this is required so stdout (the JSON output) is isolated from logs written to stderr');
+    }
+
     await this.cli.makeCliAvailable();
 
-    return this.shell([
+    const output = await this.shell([
       'cdk',
       ...(verbose ? [`-${'v'.repeat(verboseLevel)}`] : []),
       ...args,
@@ -614,6 +624,16 @@ export class TestFixture extends ShellHelper {
         ...options.modEnv,
       },
     });
+
+    if (assertJson) {
+      try {
+        JSON.parse(output);
+      } catch (e: any) {
+        throw new Error(`Expected JSON output from 'cdk ${args.join(' ')}' but could not parse it: ${e.message}\nOutput was:\n${output}`);
+      }
+    }
+
+    return output;
   }
 
   /**
@@ -848,6 +868,17 @@ async function bootstrapWithRetryOnBucketExists(envSpecifier: string, fixture: T
 
 function defined<A>(x: A): x is NonNullable<A> {
   return x !== undefined;
+}
+
+/**
+ * Whether the '--json' flag appears anywhere in the CDK arguments.
+ *
+ * Arguments may be passed either as separate tokens (e.g. `['ls', '--json']`)
+ * or as a single space-joined string (e.g. `['ls --show-dependencies --json']`),
+ * so we match on word boundaries within each argument.
+ */
+function hasJsonFlag(args: string[]): boolean {
+  return args.some((arg) => /(^|\s)--json(\s|=|$)/.test(arg));
 }
 
 /**


### PR DESCRIPTION
Integration tests that invoke the CDK CLI with `--json` (e.g. the `cdk ls --show-dependencies --json` tests) parse the returned output as JSON. Nothing enforced that the output was actually JSON-parseable, so a test could silently assert against log-polluted output.

This adds a generic guard inside `fixture.cdk()`:

- When `--json` is present in the args, the call now **requires** `captureStderr: false`. CDK writes its data output to stdout and its logs (verbose traces, notices, warnings) to stderr; `captureStderr: false` isolates stdout so the returned string is the JSON alone. Without it, the returned output is `stdout + stderr` and the interleaved logs would corrupt the JSON regardless of the command's actual behavior — so we fail fast with a clear message.
- With that isolation guaranteed, the returned output is asserted to be `JSON.parse`-able, throwing an actionable error (including the raw output) otherwise.
- Tests using `onlyStderr` are exempt, since they intentionally return stderr rather than the JSON on stdout.

The two existing `--json` tests already pass `captureStderr: false`, so they satisfy the new requirement without changes.

### Caveat: `--json` is not generically honored by the CLI

`--json` is declared as a *global* option, but there is no generic mechanism that serializes command output as JSON. Only a handful of commands actually read it and opt in by hand (in `cli.ts`): `context`, `list`/`ls`, `bootstrap` (`--show-template`), `synth`/`synthesize`, and `metadata`. For every other command (`deploy`, `diff`, `drift`, `destroy`, `import`, `gc`, etc.) `--json` is accepted but silently ignored.

Consequently this guard implicitly assumes the caller uses `--json` on a command that actually produces JSON. A test such as `cdk deploy --json` would emit ordinary (non-JSON) stdout and now fail the guard even though the CLI behaved as designed. That is acceptable — those are the only commands where asserting on JSON output makes sense — but authors adding a `--json` test against a command that ignores the flag should be aware of it.

> See https://github.com/aws/aws-cdk-cli/issues/1695

Note also that even a command that *does* honor `--json` may only do so conditionally. `cdk ls --json` on its own prints the plain, newline-separated list of stack ids (not JSON); the flag only selects JSON serialization when combined with `--show-dependencies` and/or `--long` (see `formatStackList` in `commands/list-stacks.ts`). So a bare `cdk ls --json` integration test would fail this guard even though the CLI is behaving correctly. This is intentionally left strict: the guard should only be relied on with the flag combinations that actually serialize (which is why the two existing `ls` tests pair `--json` with `--show-dependencies`).

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
