### PR TITLE
chore(cli): add tests for express mode output on deploy and destroy

### DIFF
--- a/packages/aws-cdk/test/commands/__io_snapshots__/deploy/--express_does_not_warn_when_no_resources_are_still_stabilizing.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/deploy/--express_does_not_warn_when_no_resources_are_still_stabilizing.ndjson
@@ -1,0 +1,13 @@
+{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":3,"type":"notify","action":"deploy","level":"debug","code":null,"message":"Checking for previously published assets"}
+{"seq":4,"type":"notify","action":"deploy","level":"debug","code":null,"message":"0 total assets, 0 still need to be published"}
+{"seq":5,"type":"notify","action":"deploy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: deploying... [1/1]"}
+{"seq":6,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3000","message":"Starting Deploy ..."}
+{"seq":7,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✅  Test-Stack-A-Display-Name"}
+{"seq":8,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Deployment time: <DURATION>\n"}
+{"seq":9,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack ARN:"}
+{"seq":10,"type":"notify","action":"deploy","level":"result","code":null,"message":"arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/Test-Stack-A/abcd"}
+{"seq":11,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3001","message":"\n✨  Deploy time: <DURATION>\n"}
+{"seq":12,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Total time: <DURATION>\n"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/deploy/--express_warns_about_resources_still_stabilizing_when_deployStack_reports_them.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/deploy/--express_warns_about_resources_still_stabilizing_when_deployStack_reports_them.ndjson
@@ -1,0 +1,14 @@
+{"seq":0,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":3,"type":"notify","action":"deploy","level":"debug","code":null,"message":"Checking for previously published assets"}
+{"seq":4,"type":"notify","action":"deploy","level":"debug","code":null,"message":"0 total assets, 0 still need to be published"}
+{"seq":5,"type":"notify","action":"deploy","level":"info","code":null,"message":"Test-Stack-A-Display-Name: deploying... [1/1]"}
+{"seq":6,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3000","message":"Starting Deploy ..."}
+{"seq":7,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✅  Test-Stack-A-Display-Name"}
+{"seq":8,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Deployment time: <DURATION>\n"}
+{"seq":9,"type":"notify","action":"deploy","level":"warn","code":"CDK_TOOLKIT_W5902","message":"⚠️  Stack deployed using Express Mode. Resources still stabilizing: MyResource\n"}
+{"seq":10,"type":"notify","action":"deploy","level":"info","code":null,"message":"Stack ARN:"}
+{"seq":11,"type":"notify","action":"deploy","level":"result","code":null,"message":"arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/Test-Stack-A/abcd"}
+{"seq":12,"type":"notify","action":"deploy","level":"trace","code":"CDK_CLI_I3001","message":"\n✨  Deploy time: <DURATION>\n"}
+{"seq":13,"type":"notify","action":"deploy","level":"info","code":null,"message":"\n✨  Total time: <DURATION>\n"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/--express_does_not_warn_when_no_resources_are_still_tearing_down.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/--express_does_not_warn_when_no_resources_are_still_tearing_down.ndjson
@@ -1,0 +1,4 @@
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n✅  Test-Stack-B: destroyed"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/destroy/--express_warns_about_resources_still_tearing_down_when_destroyStack_reports_them.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/destroy/--express_warns_about_resources_still_tearing_down_when_destroyStack_reports_them.ndjson
@@ -1,0 +1,5 @@
+{"seq":0,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"destroy","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7100","message":"Test-Stack-B: destroying... [1/1]"}
+{"seq":3,"type":"notify","action":"destroy","level":"info","code":"CDK_TOOLKIT_I7900","message":"\n✅  Test-Stack-B: destroyed"}
+{"seq":4,"type":"notify","action":"destroy","level":"warn","code":"CDK_TOOLKIT_W7902","message":"⚠️  Stack deleted using Express Mode. Resources still tearing down: MyResource\n"}

--- a/packages/aws-cdk/test/commands/deploy.test.ts
+++ b/packages/aws-cdk/test/commands/deploy.test.ts
@@ -478,3 +478,50 @@ describe('deploy failures', () => {
     expect(error.name).toBe('DeployStackFailed');
   });
 });
+
+describe('--express', () => {
+  test('warns about resources still stabilizing when deployStack reports them', async () => {
+    // Express Mode returns success while some resources are still settling; the
+    // deploy path surfaces this as an extra warning listing those resources.
+    cloudFormation.deployStack.mockResolvedValue({
+      type: 'did-deploy-stack',
+      stackArn: 'arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/Test-Stack-A/abcd',
+      noOp: false,
+      outputs: {},
+      deleteFailures: [],
+      stabilizingResources: [{
+        logicalResourceId: 'MyResource',
+        resourceType: 'AWS::S3::Bucket',
+        reason: 'Resource operation completed using Express Mode. It may continue becoming available in the background.',
+      }],
+    });
+
+    await toolkit.deploy({
+      selector: { patterns: ['Test-Stack-A-Display-Name'] },
+      exclusively: true,
+      deploymentMethod: { method: 'change-set' },
+      requireApproval: RequireApproval.NEVER,
+      express: true,
+    });
+
+    expect(cloudFormation.deployStack).toHaveBeenCalledWith(
+      expect.objectContaining({ express: true }),
+    );
+  });
+
+  test('does not warn when no resources are still stabilizing', async () => {
+    // Express Mode is on, but the default mock reports an empty
+    // `stabilizingResources`, so the deploy path emits no stabilization warning.
+    await toolkit.deploy({
+      selector: { patterns: ['Test-Stack-A-Display-Name'] },
+      exclusively: true,
+      deploymentMethod: { method: 'change-set' },
+      requireApproval: RequireApproval.NEVER,
+      express: true,
+    });
+
+    expect(cloudFormation.deployStack).toHaveBeenCalledWith(
+      expect.objectContaining({ express: true }),
+    );
+  });
+});

--- a/packages/aws-cdk/test/commands/destroy.test.ts
+++ b/packages/aws-cdk/test/commands/destroy.test.ts
@@ -203,3 +203,49 @@ describe('destroy failure', () => {
     })).rejects.toThrow('Deletion failed');
   });
 });
+
+describe('--express', () => {
+  test('warns about resources still tearing down when destroyStack reports them', async () => {
+    // Express Mode returns success while some resources are still tearing down;
+    // the destroy path surfaces this as an extra warning listing those resources.
+    destroyStackMock.mockResolvedValue({
+      stackArn: 'arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/test',
+      stabilizingResources: [{
+        logicalResourceId: 'MyResource',
+        resourceType: 'AWS::S3::Bucket',
+        reason: 'Resource deletion Initiated',
+      }],
+    } as any);
+
+    await toolkit.destroy({
+      selector: { patterns: ['Test-Stack-B'] },
+      exclusively: true,
+      force: true,
+      express: true,
+    });
+
+    expect(destroyStackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ express: true }),
+    );
+  });
+
+  test('does not warn when no resources are still tearing down', async () => {
+    // Express Mode is on, but destroyStack reports an empty
+    // `stabilizingResources`, so the destroy path emits no stabilization warning.
+    destroyStackMock.mockResolvedValue({
+      stackArn: 'arn:aws:cloudformation:bermuda-triangle-1:123456789012:stack/test',
+      stabilizingResources: [],
+    } as any);
+
+    await toolkit.destroy({
+      selector: { patterns: ['Test-Stack-B'] },
+      exclusively: true,
+      force: true,
+      express: true,
+    });
+
+    expect(destroyStackMock).toHaveBeenCalledWith(
+      expect.objectContaining({ express: true }),
+    );
+  });
+});


### PR DESCRIPTION
Add tests to record changes in output for `cdk deploy` and `cdk destroy` when using express mode

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
