### PR TITLE
feat: run synth with JSII source traces

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/core/synth-runner.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/synth-runner.ts
@@ -58,6 +58,8 @@ export async function runSynth(options: SynthRunnerOptions): Promise<SynthRunRes
     const cx = await options.toolkit.fromCdkApp(app, {
       workingDirectory: options.projectDir,
       lookups: false,
+      // Make jsii forward host-language (Python/Java) source frames; TS resolves via source maps.
+      env: { JSII_HOST_STACK_TRACES: '1' },
     });
     cached = await options.toolkit.synth(cx);
   } catch (err) {

--- a/packages/@aws-cdk/cdk-explorer/test/core/synth-runner.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/synth-runner.test.ts
@@ -65,7 +65,7 @@ describe('runSynth', () => {
     const result = await run(toolkit, projectDir);
 
     expect(result).toEqual({ status: 'success' });
-    expect(toolkit.fromCdkApp).toHaveBeenCalledWith(APP, { workingDirectory: projectDir, lookups: false });
+    expect(toolkit.fromCdkApp).toHaveBeenCalledWith(APP, { workingDirectory: projectDir, lookups: false, env: { JSII_HOST_STACK_TRACES: '1' } });
     expect(cached.dispose).toHaveBeenCalledTimes(1);
   });
 


### PR DESCRIPTION
Setting JSII_HOST_STACK_TRACES=1 on the synth subprocess makes jsii
forward the host-language frames, so resolveFrames finds the .py/.java
source.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
