### PR TITLE
feat: explorer web live refresh

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -16,7 +16,7 @@ export function App(): JSX.Element {
   const [error, setError] = React.useState<string | undefined>();
   const [appDir, setAppDir] = React.useState<string | undefined>();
 
-  React.useEffect(() => {
+  const reload = React.useCallback((): void => {
     Promise.all([api.getTree(), api.getViolations(), api.getAppInfo()])
       .then(([t, v, info]) => {
         setTree(t);
@@ -24,8 +24,15 @@ export function App(): JSX.Element {
         setAppDir(info.appDir);
         setError(undefined);
       })
+      // Keep the last good render on a transient read (e.g. a mid-synth write);
+      // the next assembly-changed event re-fetches once the write has settled.
       .catch((err) => setError(err instanceof Error ? err.message : String(err)));
   }, []);
+
+  React.useEffect(() => {
+    reload();
+    return api.subscribe(reload);
+  }, [reload]);
 
   // Vertical split: violations row's share of the page height (default 33%).
   const vSplit = useSplit({ orientation: 'vertical', defaultFraction: 0.33, min: 0.15, max: 0.85 });

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -1,12 +1,13 @@
-import type {
-  DirEntry,
-  FilesResponse,
-  FileResponse,
-  TreeResponse,
-  ViolationsResponse,
-  WebConstructNode,
-  WebViolation,
-  WebViolationOccurrence,
+import {
+  ASSEMBLY_CHANGED,
+  type DirEntry,
+  type FilesResponse,
+  type FileResponse,
+  type TreeResponse,
+  type ViolationsResponse,
+  type WebConstructNode,
+  type WebViolation,
+  type WebViolationOccurrence,
 } from '../lib/web/protocol';
 
 export type {
@@ -39,4 +40,14 @@ export const api = {
   getTree: (): Promise<TreeResponse> => getJson('/api/tree'),
   getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),
   getAppInfo: (): Promise<AppInfoResponse> => getJson('/api/info'),
+  /**
+   * Subscribe to assembly-changed events from the server, invoking `onChange`
+   * whenever the cloud assembly is rewritten. Returns an unsubscribe that closes
+   * the underlying EventSource.
+   */
+  subscribe: (onChange: () => void): (() => void) => {
+    const source = new EventSource('/api/events');
+    source.addEventListener(ASSEMBLY_CHANGED, () => onChange());
+    return () => source.close();
+  },
 };

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
@@ -52,7 +52,7 @@ export interface AssemblyWatcherOptions {
   /** Invoked (debounced) when the assembly's signal files change. */
   readonly onChange: () => void;
   /** Receives non-fatal watcher errors. */
-  readonly onError?: (error: unknown) => void;
+  readonly onError: (error: unknown) => void;
   /**
    * Factory for the underlying file watcher. Defaults to chokidar; overridden
    * in tests with a fake so behavior is verified without real file IO.
@@ -101,13 +101,13 @@ export function startAssemblyWatcher(options: AssemblyWatcherOptions): AssemblyW
       try {
         options.onChange();
       } catch (error) {
-        options.onError?.(error);
+        options.onError(error);
       }
     }, DEBOUNCE_MS);
   });
 
   watcher.on('error', (error) => {
-    options.onError?.(error);
+    options.onError(error);
   });
 
   return {

--- a/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
@@ -1,14 +1,6 @@
 import type { Request, Response } from 'express';
 
 /**
- * SSE event name signalling that the cloud assembly was rewritten. The event
- * carries no payload: the web server holds no assembly state, so a client
- * re-fetches the construct tree and violations through the regular GET
- * endpoints whenever it sees this.
- */
-export const ASSEMBLY_CHANGED = 'assembly-changed';
-
-/**
  * Tracks connected Server-Sent Events clients and pushes events to all of them.
  * One instance lives per web server. `close()` ends every open stream on
  * shutdown so the HTTP server can stop cleanly.
@@ -25,7 +17,7 @@ export class SseBroadcaster {
     res.set({
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-store',
-      Connection: 'keep-alive',
+      'Connection': 'keep-alive',
     });
     res.flushHeaders();
     this.clients.add(res);

--- a/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
@@ -1,0 +1,58 @@
+import type { Request, Response } from 'express';
+
+/**
+ * SSE event name signalling that the cloud assembly was rewritten. The event
+ * carries no payload: the web server holds no assembly state, so a client
+ * re-fetches the construct tree and violations through the regular GET
+ * endpoints whenever it sees this.
+ */
+export const ASSEMBLY_CHANGED = 'assembly-changed';
+
+/**
+ * Tracks connected Server-Sent Events clients and pushes events to all of them.
+ * One instance lives per web server. `close()` ends every open stream on
+ * shutdown so the HTTP server can stop cleanly.
+ */
+export class SseBroadcaster {
+  private readonly clients = new Set<Response>();
+
+  /**
+   * Express handler for `GET /api/events`. Opens a long-lived SSE stream and
+   * registers the client, removing it when the request closes or the socket
+   * errors so a vanished client is never written to.
+   */
+  public readonly handle = (req: Request, res: Response): void => {
+    res.set({
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-store',
+      Connection: 'keep-alive',
+    });
+    res.flushHeaders();
+    this.clients.add(res);
+
+    const remove = (): void => {
+      this.clients.delete(res);
+    };
+    req.on('close', remove);
+    // A client that vanishes mid-broadcast surfaces here as a socket error.
+    // Drop it and swallow the error rather than crashing the server on an
+    // otherwise-unhandled 'error' event.
+    res.on('error', remove);
+  };
+
+  /** Push a named, payload-free event to every connected client. */
+  public broadcast(eventName: string): void {
+    const frame = `event: ${eventName}\ndata: {}\n\n`;
+    for (const client of this.clients) {
+      client.write(frame);
+    }
+  }
+
+  /** End every open stream and forget the clients. Called on server shutdown. */
+  public close(): void {
+    for (const client of this.clients) {
+      client.end();
+    }
+    this.clients.clear();
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express';
+import type { SseEventName } from './protocol';
 
 /**
  * Tracks connected Server-Sent Events clients and pushes events to all of them.
@@ -26,15 +27,19 @@ export class SseBroadcaster {
       this.clients.delete(res);
     };
     req.on('close', remove);
-    // A client that vanishes mid-broadcast surfaces here as a socket error.
-    // Drop it and swallow the error rather than crashing the server on an
-    // otherwise-unhandled 'error' event.
+    // Evict on socket error too, so a vanished client is never written to.
     res.on('error', remove);
   };
 
-  /** Push a named, payload-free event to every connected client. */
-  public broadcast(eventName: string): void {
-    const frame = `event: ${eventName}\ndata: {}\n\n`;
+  /**
+   * Push an event to every connected client. The `data: {}` line is required:
+   * EventSource does not dispatch a named event whose data buffer is empty, so
+   * the empty payload is what makes the client's listener fire. Writing to a
+   * client that already disconnected is a harmless no-op (returns false, does
+   * not throw); the `close`/`error` handlers in `handle` do the eviction.
+   */
+  public broadcast(event: SseEventName): void {
+    const frame = `event: ${event}\ndata: {}\n\n`;
     for (const client of this.clients) {
       client.write(frame);
     }

--- a/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
@@ -14,7 +14,7 @@ export class SseBroadcaster {
    * registers the client, removing it when the request closes or the socket
    * errors so a vanished client is never written to.
    */
-  public readonly handle = (req: Request, res: Response): void => {
+  public handle(req: Request, res: Response): void {
     res.set({
       'Content-Type': 'text/event-stream',
       'Cache-Control': 'no-store',
@@ -29,7 +29,7 @@ export class SseBroadcaster {
     req.on('close', remove);
     // Evict on socket error too, so a vanished client is never written to.
     res.on('error', remove);
-  };
+  }
 
   /**
    * Push an event to every connected client. The `data: {}` line is required:

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -1,4 +1,11 @@
-/** HTTP contract shared between the web server and the SPA. Types only. */
+/** HTTP and SSE contract shared between the web server and the SPA. */
+
+/**
+ * SSE event name the server sends (and the SPA listens for) when the cloud
+ * assembly is rewritten. The event carries no payload: the server holds no
+ * assembly state, so the SPA re-fetches the tree and violations on receipt.
+ */
+export const ASSEMBLY_CHANGED = 'assembly-changed';
 
 export interface DirEntry {
   readonly name: string;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -2,10 +2,13 @@
 
 /**
  * SSE event name the server sends (and the SPA listens for) when the cloud
- * assembly is rewritten. The event carries no payload: the server holds no
+ * assembly is rewritten. It carries no meaningful payload: the server holds no
  * assembly state, so the SPA re-fetches the tree and violations on receipt.
  */
 export const ASSEMBLY_CHANGED = 'assembly-changed';
+
+/** The SSE event names the server may send. One for now. */
+export type SseEventName = typeof ASSEMBLY_CHANGED;
 
 export interface DirEntry {
   readonly name: string;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -26,7 +26,7 @@ export interface ApiOptions {
    * Reader for the cloud assembly. Injectable for tests; defaults to the real
    * `readAssembly` against {@link assemblyDir}.
    */
-  readonly readAssembly?: (assemblyDir: string) => AssemblyReadResult | Promise<AssemblyReadResult>;
+  readonly readAssembly?: (assemblyDir: string) => Promise<AssemblyReadResult>;
 }
 
 export function createApiRouter(options: ApiOptions): Router {

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -33,6 +33,11 @@ export interface WebServerOptions {
    * overridden in tests with a fake to drive change events deterministically.
    */
   readonly startAssemblyWatcher?: (options: AssemblyWatcherOptions) => AssemblyWatcher;
+  /**
+   * Reports a non-fatal watcher error (live refresh stops updating). Defaults to
+   * writing to stderr; the CLI command passes a sink that routes to its IoHost.
+   */
+  readonly onWatcherError?: (err: unknown) => void;
 }
 
 export interface WebServer {
@@ -96,7 +101,8 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   const watcher = startWatcher({
     assemblyDir,
     onChange: () => events.broadcast(ASSEMBLY_CHANGED),
-    onError: (err) => process.stderr.write(`assembly watcher error: ${(err as Error).message}\n`),
+    onError: options.onWatcherError ?? ((err) =>
+      process.stderr.write(`assembly watcher error: ${err instanceof Error ? err.message : String(err)}\n`)),
   });
 
   let stopped = false;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -17,7 +17,6 @@ const MAX_PORT_ATTEMPTS = 100;
 
 export interface WebServerOptions {
   readonly port?: number;
-  readonly host?: string;
   /**
    * Root of the CDK app. File listing/reading is confined here. Defaults to
    * `process.cwd()`.
@@ -54,7 +53,6 @@ export interface WebServer {
  * @returns A handle to the running server with its URL and a stop function.
  */
 export async function startWebServer(options: WebServerOptions = {}): Promise<WebServer> {
-  const host = options.host ?? '127.0.0.1';
   const appDir = options.appDir ?? process.cwd();
   // Single owner of where the cloud assembly lives: the same resolved path feeds
   // both the read endpoints and the change watcher, so the two never disagree.
@@ -91,8 +89,8 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   const server = http.createServer(app);
 
   const port = options.port !== undefined
-    ? await listenOnPort(server, host, options.port)
-    : await listenWithPortSearch(server, host, DEFAULT_PORT);
+    ? await listenOnPort(server, options.port)
+    : await listenWithPortSearch(server, DEFAULT_PORT);
 
   // Start watching only after the server is listening, so a failed bind does not
   // leave a watcher running. Any synth that rewrites cdk.out (an external
@@ -107,7 +105,7 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 
   let stopped = false;
   return {
-    url: `http://${host}:${port}`,
+    url: `http://127.0.0.1:${port}`,
     stop: async () => {
       if (stopped) return;
       stopped = true;
@@ -123,12 +121,11 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 
 async function listenOnPort(
   server: http.Server,
-  host: string,
   port: number,
 ): Promise<number> {
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
-    server.listen(port, host, () => {
+    server.listen(port, '127.0.0.1', () => {
       server.removeListener('error', reject);
       resolve();
     });
@@ -138,14 +135,13 @@ async function listenOnPort(
 
 async function listenWithPortSearch(
   server: http.Server,
-  host: string,
   startPort: number,
 ): Promise<number> {
   for (let port = startPort; port < startPort + MAX_PORT_ATTEMPTS; port++) {
     try {
       await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
-        server.listen(port, host, () => {
+        server.listen(port, '127.0.0.1', () => {
           server.removeListener('error', reject);
           resolve();
         });

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -1,8 +1,15 @@
 import * as http from 'http';
+import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
+import { ASSEMBLY_CHANGED, SseBroadcaster } from './events';
 import { registerApi } from './routes';
 import { indexHtml, webAsset } from './web-assets';
+import {
+  startAssemblyWatcher as defaultStartAssemblyWatcher,
+  type AssemblyWatcher,
+  type AssemblyWatcherOptions,
+} from '../core/assembly-watcher';
 
 export const DEFAULT_PORT = 4200;
 const MAX_PORT_ATTEMPTS = 100;
@@ -20,6 +27,11 @@ export interface WebServerOptions {
    * Defaults to `<appDir>/cdk.out`.
    */
   readonly assemblyDir?: string;
+  /**
+   * Starts the cdk.out watcher. Defaults to the real chokidar-backed watcher;
+   * overridden in tests with a fake to drive change events deterministically.
+   */
+  readonly startAssemblyWatcher?: (options: AssemblyWatcherOptions) => AssemblyWatcher;
 }
 
 export interface WebServer {
@@ -38,10 +50,18 @@ export interface WebServer {
 export async function startWebServer(options: WebServerOptions = {}): Promise<WebServer> {
   const host = options.host ?? '127.0.0.1';
   const appDir = options.appDir ?? process.cwd();
+  // Single owner of where the cloud assembly lives: the same resolved path feeds
+  // both the read endpoints and the change watcher, so the two never disagree.
+  const assemblyDir = options.assemblyDir ?? path.join(appDir, 'cdk.out');
 
   const app = express();
 
-  registerApi(app, { appDir, assemblyDir: options.assemblyDir });
+  registerApi(app, { appDir, assemblyDir });
+
+  // Live-refresh stream: browsers subscribe here and re-fetch when the assembly
+  // changes. Registered before the /api catch-all so it is not treated as unknown.
+  const events = new SseBroadcaster();
+  app.get('/api/events', events.handle);
 
   // Unknown /api routes must return JSON 404, not fall through to the SPA.
   app.use('/api', (_req, res) => res.status(404).json({ error: 'unknown endpoint' }));
@@ -68,13 +88,25 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
     ? await listenOnPort(server, host, options.port)
     : await listenWithPortSearch(server, host, DEFAULT_PORT);
 
+  // Start watching only after the server is listening, so a failed bind does not
+  // leave a watcher running. Any synth that rewrites cdk.out (an external
+  // `cdk synth`/`cdk watch`, or a future in-process synth) wakes every browser.
+  const startWatcher = options.startAssemblyWatcher ?? defaultStartAssemblyWatcher;
+  const watcher = startWatcher({
+    assemblyDir,
+    onChange: () => events.broadcast(ASSEMBLY_CHANGED),
+    onError: (err) => process.stderr.write(`assembly watcher error: ${(err as Error).message}\n`),
+  });
+
   let stopped = false;
   return {
     url: `http://${host}:${port}`,
-    stop: () => {
-      if (stopped) return Promise.resolve();
+    stop: async () => {
+      if (stopped) return;
       stopped = true;
-      return new Promise<void>((resolve) => {
+      await watcher.close();
+      events.close();
+      await new Promise<void>((resolve) => {
         server.close(() => resolve());
         server.closeAllConnections();
       });

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -2,7 +2,8 @@ import * as http from 'http';
 import * as path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
-import { ASSEMBLY_CHANGED, SseBroadcaster } from './events';
+import { SseBroadcaster } from './events';
+import { ASSEMBLY_CHANGED } from './protocol';
 import { registerApi } from './routes';
 import { indexHtml, webAsset } from './web-assets';
 import {

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -14,6 +14,7 @@ import {
 
 export const DEFAULT_PORT = 4200;
 const MAX_PORT_ATTEMPTS = 100;
+const HOST = 'localhost';
 
 export interface WebServerOptions {
   readonly port?: number;
@@ -89,8 +90,8 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   const server = http.createServer(app);
 
   const port = options.port !== undefined
-    ? await listenOnPort(server, options.port)
-    : await listenWithPortSearch(server, DEFAULT_PORT);
+    ? await listenOnPort(server, options.port, HOST)
+    : await listenWithPortSearch(server, DEFAULT_PORT, HOST);
 
   // Start watching only after the server is listening, so a failed bind does not
   // leave a watcher running. Any synth that rewrites cdk.out (an external
@@ -105,7 +106,7 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 
   let stopped = false;
   return {
-    url: `http://127.0.0.1:${port}`,
+    url: `http://${HOST}:${port}`,
     stop: async () => {
       if (stopped) return;
       stopped = true;
@@ -122,10 +123,11 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 async function listenOnPort(
   server: http.Server,
   port: number,
+  host: string,
 ): Promise<number> {
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);
-    server.listen(port, '127.0.0.1', () => {
+    server.listen(port, host, () => {
       server.removeListener('error', reject);
       resolve();
     });
@@ -136,12 +138,13 @@ async function listenOnPort(
 async function listenWithPortSearch(
   server: http.Server,
   startPort: number,
+  host: string,
 ): Promise<number> {
   for (let port = startPort; port < startPort + MAX_PORT_ATTEMPTS; port++) {
     try {
       await new Promise<void>((resolve, reject) => {
         server.once('error', reject);
-        server.listen(port, '127.0.0.1', () => {
+        server.listen(port, host, () => {
           server.removeListener('error', reject);
           resolve();
         });

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -66,7 +66,7 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   // Live-refresh stream: browsers subscribe here and re-fetch when the assembly
   // changes. Registered before the /api catch-all so it is not treated as unknown.
   const events = new SseBroadcaster();
-  app.get('/api/events', events.handle);
+  app.get('/api/events', events.handle.bind(events));
 
   // Unknown /api routes must return JSON 404, not fall through to the SPA.
   app.use('/api', (_req, res) => res.status(404).json({ error: 'unknown endpoint' }));

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
@@ -36,12 +36,14 @@ class FakeWatcher implements FileWatcher {
 function setup() {
   const fake = new FakeWatcher();
   const onChange = jest.fn();
+  const onError = jest.fn();
   const watcher = startAssemblyWatcher({
     assemblyDir: '/p/cdk.out',
     onChange,
+    onError,
     createWatcher: () => fake,
   });
-  return { fake, onChange, watcher };
+  return { fake, onChange, onError, watcher };
 }
 
 describe('Assembly Watcher', () => {

--- a/packages/@aws-cdk/cdk-explorer/test/web/events.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/events.test.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
-import { ASSEMBLY_CHANGED, SseBroadcaster } from '../../lib/web/events';
+import { SseBroadcaster } from '../../lib/web/events';
+import { ASSEMBLY_CHANGED } from '../../lib/web/protocol';
 
 /**
  * Minimal Request/Response doubles that capture writes and expose the close and

--- a/packages/@aws-cdk/cdk-explorer/test/web/events.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/events.test.ts
@@ -1,0 +1,105 @@
+import type { Request, Response } from 'express';
+import { ASSEMBLY_CHANGED, SseBroadcaster } from '../../lib/web/events';
+
+/**
+ * Minimal Request/Response doubles that capture writes and expose the close and
+ * error handlers the broadcaster registers, so behavior is verified without a
+ * real socket.
+ */
+function fakeClient() {
+  const writes: string[] = [];
+  let ended = false;
+  const reqHandlers: Record<string, () => void> = {};
+  const resHandlers: Record<string, (err?: unknown) => void> = {};
+
+  const req = {
+    on: (event: string, handler: () => void) => {
+      reqHandlers[event] = handler;
+      return req;
+    },
+  } as unknown as Request;
+
+  const res = {
+    set: () => res,
+    flushHeaders: () => undefined,
+    write: (chunk: string) => {
+      writes.push(chunk);
+      return true;
+    },
+    end: () => {
+      ended = true;
+    },
+    on: (event: string, handler: (err?: unknown) => void) => {
+      resHandlers[event] = handler;
+      return res;
+    },
+  } as unknown as Response;
+
+  return {
+    req,
+    res,
+    writes,
+    isEnded: () => ended,
+    disconnect: () => reqHandlers.close?.(),
+    fail: () => resHandlers.error?.(new Error('broken pipe')),
+  };
+}
+
+const FRAME = `event: ${ASSEMBLY_CHANGED}\ndata: {}\n\n`;
+
+describe('SseBroadcaster', () => {
+  test('broadcasts a named, payload-free frame to every connected client', () => {
+    const broadcaster = new SseBroadcaster();
+    const a = fakeClient();
+    const b = fakeClient();
+    broadcaster.handle(a.req, a.res);
+    broadcaster.handle(b.req, b.res);
+
+    broadcaster.broadcast(ASSEMBLY_CHANGED);
+
+    expect(a.writes).toEqual([FRAME]);
+    expect(b.writes).toEqual([FRAME]);
+  });
+
+  test('stops writing to a client after it disconnects', () => {
+    const broadcaster = new SseBroadcaster();
+    const gone = fakeClient();
+    const live = fakeClient();
+    broadcaster.handle(gone.req, gone.res);
+    broadcaster.handle(live.req, live.res);
+
+    gone.disconnect();
+    broadcaster.broadcast(ASSEMBLY_CHANGED);
+
+    expect(gone.writes).toEqual([]);
+    expect(live.writes).toEqual([FRAME]);
+  });
+
+  test('drops a client whose socket errors so a broken pipe is not written again', () => {
+    const broadcaster = new SseBroadcaster();
+    const a = fakeClient();
+    broadcaster.handle(a.req, a.res);
+
+    a.fail();
+    broadcaster.broadcast(ASSEMBLY_CHANGED);
+
+    expect(a.writes).toEqual([]);
+  });
+
+  test('close ends every open stream and reaches no one afterwards', () => {
+    const broadcaster = new SseBroadcaster();
+    const a = fakeClient();
+    const b = fakeClient();
+    broadcaster.handle(a.req, a.res);
+    broadcaster.handle(b.req, b.res);
+
+    broadcaster.close();
+
+    expect(a.isEnded()).toBe(true);
+    expect(b.isEnded()).toBe(true);
+
+    broadcaster.broadcast(ASSEMBLY_CHANGED);
+    expect(a.writes).toEqual([]);
+    expect(b.writes).toEqual([]);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -117,7 +117,7 @@ describe('symlink containment', () => {
 describe('GET /api/tree', () => {
   /** Build an app whose /api router uses an injected assembly reader. */
   function appWith(
-    readAssembly: (dir: string) => AssemblyReadResult,
+    readAssembly: (dir: string) => Promise<AssemblyReadResult>,
     opts: { assemblyDir?: string } = {},
   ): express.Express {
     const a = express();
@@ -127,7 +127,7 @@ describe('GET /api/tree', () => {
 
   test('maps a successful read into an ok TreeResponse with relativized paths', async () => {
     const realAppDir = fs.realpathSync(appDir);
-    const reader = (dir: string): AssemblyReadResult => {
+    const reader = async (dir: string): Promise<AssemblyReadResult> => {
       const node: ConstructNode = {
         path: 'MyStack/Bucket',
         id: 'Bucket',
@@ -155,20 +155,20 @@ describe('GET /api/tree', () => {
   });
 
   test('returns not-synthesized (200) when no assembly is found', async () => {
-    const res = await request(appWith(() => ({ status: 'not-found' }))).get('/api/tree');
+    const res = await request(appWith(async () => ({ status: 'not-found' }))).get('/api/tree');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'not-synthesized' });
   });
 
   test('returns 500 when the read errors', async () => {
-    const res = await request(appWith(() => ({ status: 'error', message: 'bad manifest' }))).get('/api/tree');
+    const res = await request(appWith(async () => ({ status: 'error', message: 'bad manifest' }))).get('/api/tree');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'bad manifest' });
   });
 
   test('defaults the assembly dir to <appDir>/cdk.out', async () => {
     let seen: string | undefined;
-    const reader = (dir: string): AssemblyReadResult => {
+    const reader = async (dir: string): Promise<AssemblyReadResult> => {
       seen = dir;
       return { status: 'not-found' };
     };
@@ -178,7 +178,7 @@ describe('GET /api/tree', () => {
 
   test('honors an explicit assemblyDir override', async () => {
     let seen: string | undefined;
-    const reader = (dir: string): AssemblyReadResult => {
+    const reader = async (dir: string): Promise<AssemblyReadResult> => {
       seen = dir;
       return { status: 'not-found' };
     };
@@ -188,7 +188,7 @@ describe('GET /api/tree', () => {
 });
 
 describe('GET /api/policy-validation', () => {
-  function appWith(readAssembly: (dir: string) => AssemblyReadResult): express.Express {
+  function appWith(readAssembly: (dir: string) => Promise<AssemblyReadResult>): express.Express {
     const a = express();
     a.use('/api', createApiRouter({ appDir, readAssembly }));
     return a;
@@ -196,7 +196,7 @@ describe('GET /api/policy-validation', () => {
 
   test('normalizes violations joined to the construct tree', async () => {
     const realAppDir = fs.realpathSync(appDir);
-    const reader = (dir: string): AssemblyReadResult => {
+    const reader = async (dir: string): Promise<AssemblyReadResult> => {
       const node: ConstructNode = {
         path: 'MyStack/Bucket',
         id: 'Bucket',
@@ -244,13 +244,13 @@ describe('GET /api/policy-validation', () => {
   });
 
   test('returns not-synthesized (200) when no assembly is found', async () => {
-    const res = await request(appWith(() => ({ status: 'not-found' }))).get('/api/policy-validation');
+    const res = await request(appWith(async () => ({ status: 'not-found' }))).get('/api/policy-validation');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ status: 'not-synthesized' });
   });
 
   test('returns 500 when the read errors', async () => {
-    const res = await request(appWith(() => ({ status: 'error', message: 'boom' }))).get('/api/policy-validation');
+    const res = await request(appWith(async () => ({ status: 'error', message: 'boom' }))).get('/api/policy-validation');
     expect(res.status).toBe(500);
     expect(res.body).toEqual({ error: 'boom' });
   });

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -20,17 +20,17 @@ describe('Web Server', () => {
     expect(body).toEqual({ status: 'ok' });
   });
 
-  test('binds to 127.0.0.1 by default', async () => {
+  test('binds to localhost by default', async () => {
     server = await startWebServer();
-    expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(server.url).toMatch(/^http:\/\/localhost:\d+$/);
   });
 
   test('auto-increments port by 1 when default is taken', async () => {
     const first = await startWebServer({ port: DEFAULT_PORT });
     server = await startWebServer();
 
-    expect(first.url).toBe(`http://127.0.0.1:${DEFAULT_PORT}`);
-    expect(server.url).toBe(`http://127.0.0.1:${DEFAULT_PORT + 1}`);
+    expect(first.url).toBe(`http://localhost:${DEFAULT_PORT}`);
+    expect(server.url).toBe(`http://localhost:${DEFAULT_PORT + 1}`);
     await first.stop();
   });
 

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -71,4 +71,47 @@ describe('Web Server', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control')).toBe('no-store');
   });
+
+  test('watches the resolved assembly dir and closes the watcher on stop', async () => {
+    let seenDir: string | undefined;
+    let closed = false;
+    server = await startWebServer({
+      assemblyDir: '/tmp/explorer-test/cdk.out',
+      startAssemblyWatcher: (opts) => {
+        seenDir = opts.assemblyDir;
+        return {
+          close: async () => {
+            closed = true;
+          },
+        };
+      },
+    });
+
+    expect(seenDir).toBe('/tmp/explorer-test/cdk.out');
+
+    await server.stop();
+    expect(closed).toBe(true);
+  });
+
+  test('broadcasts an assembly-changed event to a connected client when the watcher fires', async () => {
+    let fireChange = (): void => undefined;
+    server = await startWebServer({
+      startAssemblyWatcher: (opts) => {
+        fireChange = opts.onChange;
+        return { close: async () => undefined };
+      },
+    });
+
+    const res = await fetch(`${server.url}/api/events`);
+    expect(res.headers.get('content-type')).toMatch(/text\/event-stream/);
+    const body = res.body;
+    if (!body) throw new Error('SSE response had no body');
+    const reader = body.getReader();
+
+    fireChange();
+    const { value } = await reader.read();
+    expect(new TextDecoder().decode(value)).toContain('event: assembly-changed');
+
+    await reader.cancel();
+  });
 });

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -1,3 +1,4 @@
+import { ASSEMBLY_CHANGED } from '../../lib/web/protocol';
 import { startWebServer, DEFAULT_PORT, type WebServer } from '../../lib/web/server';
 
 describe('Web Server', () => {
@@ -110,7 +111,7 @@ describe('Web Server', () => {
 
     fireChange();
     const { value } = await reader.read();
-    expect(new TextDecoder().decode(value)).toContain('event: assembly-changed');
+    expect(new TextDecoder().decode(value)).toContain(`event: ${ASSEMBLY_CHANGED}`);
 
     await reader.cancel();
   });

--- a/packages/aws-cdk/lib/commands/explore.ts
+++ b/packages/aws-cdk/lib/commands/explore.ts
@@ -7,7 +7,12 @@ export interface ExploreOptions {
 }
 
 export async function explore(options: ExploreOptions): Promise<number> {
-  const server = await startWebServer({ port: options.port });
+  const server = await startWebServer({
+    port: options.port,
+    onWatcherError: (err) => void options.ioHelper.defaults.error(
+      `CDK Explorer live refresh stopped: ${err instanceof Error ? err.message : String(err)}`,
+    ),
+  });
   await options.ioHelper.defaults.info(`CDK Explorer running at ${server.url}`);
 
   await new Promise<void>((resolve) => {

--- a/packages/aws-cdk/test/commands/explore.test.ts
+++ b/packages/aws-cdk/test/commands/explore.test.ts
@@ -22,6 +22,6 @@ describe('explore command', () => {
 
     expect(exitCode).toBe(0);
     expect(messages).toHaveLength(1);
-    expect(messages[0]).toMatch(/CDK Explorer running at http:\/\/127\.0\.0\.1:\d+/);
+    expect(messages[0]).toMatch(/CDK Explorer running at http:\/\/localhost:\d+/);
   });
 });


### PR DESCRIPTION
Adds live refresh to the cdk explore web UI. When the cloud assembly on disk changes, the server pushes an event and the SPA re-fetches, so the construct tree and violations stay current without a manual reload.

- SSE stream (GET /api/events): a long-lived server-sent events channel. SseBroadcaster tracks connected clients and pushes to all of them, evicting any that disconnect.
- cdk.out watcher: same watcher as LSP
- SPA: subscribes on load and re-fetches the tree and violations on each event.
- The event carries no payload. The server holds no assembly state, so the client just re-reads /api/tree and /api/policy-validation on receipt. Also narrows the web routes' injectable readAssembly seam to Promise<AssemblyReadResult> to match the real reader.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
