### PR TITLE
fix(cli): don't re-run listeners when replaying corked messages

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -730,7 +730,13 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
     // Run any registered listeners. A listener may update the message text
     // and/or prevent the default processing (e.g. stack-activity messages are
     // routed to the activity printer and not written to a stream).
-    const { message, preventDefault } = await this.applyMessageListeners(msg);
+    //
+    // Skip this while replaying corked messages: the listeners already ran on
+    // the first pass, and running them again would re-transform an
+    // already-transformed message.
+    const { message, preventDefault } = this.corkReplaying
+      ? { message: msg, preventDefault: false }
+      : await this.applyMessageListeners(msg);
 
     // Tell observers how this message was handled (its effective form and
     // whether it was dropped). Skipped while replaying corked messages so each

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -377,6 +377,23 @@ describe('CliIoHost', () => {
       expect(mockStdout).toHaveBeenCalledWith('rewritten:second\n');
     });
 
+    test('a rewrite fires once through a corked replay, not again on the replayed message', async () => {
+      // Messages emitted while corked are buffered and later replayed through
+      // notify() when the cork releases. Listeners must not run on that replay
+      // (they already ran on the first pass), otherwise a rewrite would
+      // re-transform its own output.
+      let calls = 0;
+      track(ioHost.rewrite(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${++calls}:${msg.message}`));
+
+      await ioHost.withCorkedLogging(async () => {
+        await ioHost.notify(listMessage('first'));
+      });
+
+      expect(calls).toBe(1);
+      expect(mockStdout).toHaveBeenCalledWith('rewritten:1:first\n');
+      expect(mockStdout).not.toHaveBeenCalledWith('rewritten:2:rewritten:1:first\n');
+    });
+
     test('rewriteOnce() replaces the text of only the first matching message', async () => {
       track(ioHost.rewriteOnce(IO.CDK_TOOLKIT_I2901, (msg) => `rewritten:${msg.message}`));
 


### PR DESCRIPTION

Messages emitted while logging is corked are buffered and replayed through `notify()` when the cork releases. `notify()` re-ran the message listeners on that replay, so a listener that transforms a message (e.g. a `rewrite`) ran a second time on its own already-transformed output.

This skips `applyMessageListeners` while `corkReplaying`, matching the existing guard that already skips observers on replay. Listeners now run exactly once, on the first pass.

The visible case: under `--yes`, the auto-confirm suffix is added (via `writeMessage`) after listeners run, while corked. On replay, a `rewrite` listener on that request code would clobber the suffix. This is latent on `main` today (nothing registers such a listener yet) but blocks the `cdk deploy` reroute in #1585.

### Test plan

- [x] Unit test in `test/cli/io-host/cli-io-host.test.ts`: a `rewrite` listener fires once through a corked replay, not again on the replayed message. Verified it fails without the fix (listener runs twice) and passes with it.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
