### PR TITLE
fix(cli-integ): failed bootstrapping due to bucket existence

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -854,7 +854,7 @@ async function bootstrapWithRetryOnBucketExists(envSpecifier: string, fixture: T
     if (out.includes(`Environment ${envSpecifier} bootstrapped`)) {
       break;
     }
-    if (out.includes(`${bootstrapBucket} already exists`)) {
+    if (out.includes(`${bootstrapBucket} already exists`) || out.includes('Service: S3, Status Code: 409')) {
       // might be an s3 eventualy consistency issue due to recycled environments.
       if (Date.now() < timeoutDate.getTime()) {
         fixture.log(`Bootstrap of ${envSpecifier} failed due to bucket existence check. Retrying in ${retryAfterSeconds} seconds...`);


### PR DESCRIPTION
We are seeing the following error in our integ tests:

```console

CDKToolkit \|  0/12 \| 2:23:57 PM \| REVIEW_IN_PROGRESS      \| AWS::CloudFormation::Stack \| CDKToolkit User Initiated
--
CDKToolkit \|  0/12 \| 2:24:03 PM \| CREATE_IN_PROGRESS      \| AWS::CloudFormation::Stack \| CDKToolkit User Initiated
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| LookupRole
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| FilePublishingRole
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| CloudFormationExecutionRole
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| ImagePublishingRole
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::ECR::Repository       \| ContainerAssetsRepository
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::S3::Bucket            \| StagingBucket
CDKToolkit \|  0/12 \| 2:24:06 PM \| CREATE_IN_PROGRESS      \| AWS::SSM::Parameter        \| CdkBootstrapVersion
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| FilePublishingRole Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::ECR::Repository       \| ContainerAssetsRepository Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| CloudFormationExecutionRole Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::SSM::Parameter        \| CdkBootstrapVersion Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| ImagePublishingRole Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::S3::Bucket            \| StagingBucket Resource creation Initiated
CDKToolkit \|  0/12 \| 2:24:07 PM \| CREATE_IN_PROGRESS      \| AWS::IAM::Role             \| LookupRole Resource creation Initiated
CDKToolkit \|  1/12 \| 2:24:07 PM \| CREATE_COMPLETE         \| AWS::ECR::Repository       \| ContainerAssetsRepository
CDKToolkit \|  2/12 \| 2:24:07 PM \| CREATE_COMPLETE         \| AWS::SSM::Parameter        \| CdkBootstrapVersion
[14:24:09] Stack CDKToolkit has an ongoing operation in progress and is not stable (CREATE_IN_PROGRESS)
CDKToolkit \|  2/12 \| 2:24:09 PM \| CREATE_FAILED           \| AWS::S3::Bucket            \| StagingBucket Resource handler returned message: "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again. (Service: S3, Status Code: 409, Request ID: 2TBQTSFFHC3XDJAD, Extended Request ID: saR63PJd9lhSglzftVmFS5IMGYRn92lnLPuSgKy+e3NhCzSb+zUByDgk/cugOsbg+MngSBUmZMzMj8Bmfcs4DETTvDCtnNoz) (SDK Attempt Count: 1)" (RequestToken: e614530d-052d-ca7d-464f-87ceeed3f25e, HandlerErrorCode: AlreadyExists)
CDKToolkit \|  2/12 \| 2:24:09 PM \| CREATE_FAILED           \| AWS::IAM::Role             \| CloudFormationExecutionRole Resource creation cancelled
CDKToolkit \|  2/12 \| 2:24:09 PM \| CREATE_FAILED           \| AWS::IAM::Role             \| ImagePublishingRole Resource creation cancelled
CDKToolkit \|  2/12 \| 2:24:09 PM \| CREATE_FAILED           \| AWS::IAM::Role             \| FilePublishingRole Resource creation cancelled
CDKToolkit \|  2/12 \| 2:24:09 PM \| CREATE_FAILED           \| AWS::IAM::Role             \| LookupRole Resource creation cancelled
CDKToolkit \|  2/12 \| 2:24:09 PM \| ROLLBACK_IN_PROGRESS    \| AWS::CloudFormation::Stack \| CDKToolkit The following resource(s) failed to create: [ImagePublishingRole, FilePublishingRole, LookupRole, StagingBucket, CloudFormationExecutionRole]. Rollback requested by user.
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::IAM::Role             \| LookupRole
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::IAM::Role             \| CloudFormationExecutionRole
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::IAM::Role             \| FilePublishingRole
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::ECR::Repository       \| ContainerAssetsRepository
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::IAM::Role             \| ImagePublishingRole
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_IN_PROGRESS      \| AWS::SSM::Parameter        \| CdkBootstrapVersion
CDKToolkit \|  2/12 \| 2:24:12 PM \| DELETE_SKIPPED          \| AWS::S3::Bucket            \| StagingBucket
CDKToolkit \|  1/12 \| 2:24:13 PM \| DELETE_COMPLETE         \| AWS::SSM::Parameter        \| CdkBootstrapVersion
CDKToolkit \|  0/12 \| 2:24:13 PM \| DELETE_COMPLETE         \| AWS::ECR::Repository       \| ContainerAssetsRepository
CDKToolkit \|  1/12 \| 2:24:14 PM \| DELETE_COMPLETE         \| AWS::IAM::Role             \| FilePublishingRole
CDKToolkit \|  2/12 \| 2:24:14 PM \| DELETE_COMPLETE         \| AWS::IAM::Role             \| ImagePublishingRole
CDKToolkit \|  3/12 \| 2:24:14 PM \| DELETE_COMPLETE         \| AWS::IAM::Role             \| LookupRole
CDKToolkit \|  4/12 \| 2:24:14 PM \| DELETE_COMPLETE         \| AWS::IAM::Role             \| CloudFormationExecutionRole
CDKToolkit \|  5/12 \| 2:24:14 PM \| ROLLBACK_COMPLETE       \| AWS::CloudFormation::Stack \| CDKToolkit
 
Failed resources:
CDKToolkit \| 2:24:09 PM \| CREATE_FAILED           \| AWS::S3::Bucket            \| StagingBucket Resource handler returned message: "The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again. (Service: S3, Status Code: 409, Request ID: 2TBQTSFFHC3XDJAD, Extended Request ID: saR63PJd9lhSglzftVmFS5IMGYRn92lnLPuSgKy+e3NhCzSb+zUByDgk/cugOsbg+MngSBUmZMzMj8Bmfcs4DETTvDCtnNoz) (SDK Attempt Count: 1)" (RequestToken: e614530d-052d-ca7d-464f-87ceeed3f25e, HandlerErrorCode: AlreadyExists)
❌  Environment aws://12345678912/sa-east-1 failed bootstrapping: NoStack: CloudFormationStack object does not hold a stack
at get wrapped (/tmp/tmpcdkGm6lWx/node_modules/aws-cdk/lib/index.js:212562:17)
at FullCloudFormationDeployment.monitorDeployment (/tmp/tmpcdkGm6lWx/node_modules/aws-cdk/lib/index.js:228239:107)
at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
at async _BootstrapStack.update (/tmp/tmpcdkGm6lWx/node_modules/aws-cdk/lib/index.js:230120:23)
at async /tmp/tmpcdkGm6lWx/node_modules/aws-cdk/lib/index.js:491018:29 {
type: 'toolkit',
source: 'toolkit',
cause: undefined
}
CloudFormationStack object does not hold a stack
[2026-07-02T14:24:16.032Z] Release \| Allocation '9acd1170-6530-4100-bdd8-07a41209e619' (outcome: 'failure')
[2026-07-02T14:24:16.200Z] Release \| Successfully released allocation '9acd1170-6530-4100-bdd8-07a41209e619' (outcome: 'failure')
Failed bootstrapping aws://12345678912/sa-east-1Error: Failed bootstrapping aws://12345678912/sa-east-1
at bootstrapWithRetryOnBucketExists (/codebuild/output/src1266797660/src/cli_integ/node_modules/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts:845:11)
at processTicksAndRejections (node:internal/process/task_queues:105:5)
at ensureBootstrapped (/codebuild/output/src1266797660/src/cli_integ/node_modules/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts:797:5)
at /codebuild/output/src1266797660/src/cli_integ/node_modules/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts:72:9
at /codebuild/output/src1266797660/src/cli_integ/node_modules/@aws-cdk-testing/cli-integ/lib/with-aws.ts:96:18
at Object.<anonymous> (/codebuild/output/src1266797660/src/cli_integ/node_modules/@aws-cdk-testing/cli-integ/lib/integ-test.ts:59:19)
```

It doesn't fail them because of a jest retry but we still want to get rid of it. This is a known issue due to S3 eventual consistency on bucket existence, caused by the fact we are recycling atmosphere environments fairly quickly.

We already had protection against it but it looks like we were either using the wrong message string, or it somehow changed - I will figure that out later, for now we need to adjust our retry logic.

The relevant part we matching against now is:

> The requested bucket name is not available. The bucket namespace is shared by all users of the system. Please select a different name and try again. (Service: S3, Status Code: 409, Request ID

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
