### PR TITLE
fix: namespaced rule names are doubled up

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
@@ -112,6 +112,11 @@ export type PolicyValidationReportConclusion = 'success' | 'failure';
 export interface PolicyViolationJson {
   /**
    * The name of the rule that was violated.
+   *
+   * This may include a namespace: `'<namespace>::<rule-name>'`. If it does not,
+   * the plugin name will be used as the namespace.
+   *
+   * The namespace must be included when acknowledging the violation.
    */
   readonly ruleName: string;
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
@@ -71,10 +71,13 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
     lines.push(chalk.underline(sanitize(location)));
   }
 
+  const ruleName = v.ruleName.includes('::') ? v.ruleName : `${v.pluginName}::${v.ruleName}`;
+  const namespace = ruleName.split('::')[0];
+
   lines.push([
     chalk.bold(getSeverityColor(v.severity)(sanitize(v.severity))),
     chalk.bold(stripAckTag(sanitize(v.description))),
-    chalk.grey(`(${sanitize(v.pluginName)})`),
+    chalk.grey(`(${sanitize(namespace)})`),
   ].join(' '));
 
   const constructInfo = formatConstructInfo(fileRoot, v.construct);
@@ -85,11 +88,11 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
   }
 
   if (isSuppressibleViolation(v)) {
-    const ackId = `${sanitize(v.pluginName)}::${sanitize(v.ruleName)}`.replace(/ /g, '-');
+    const ackId = `${sanitize(ruleName)}`.replace(/ /g, '-');
     lines.push(`   ${chalk.grey(`Acknowledge with '${ackId}'`)}`);
   } else {
     // If not acknowledgeable, we should still show the rule name for reference.
-    lines.push(`   ${chalk.grey(`Rule ${sanitize(v.ruleName)}`)}`);
+    lines.push(`   ${chalk.grey(`Rule ${sanitize(ruleName)}`)}`);
   }
 
   return lines.join('\n');

--- a/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
@@ -145,6 +145,22 @@ describe('formatValidateResult', () => {
     expect(output).toContain("Acknowledge with 'SecurityPlugin::no-public-buckets'");
   });
 
+  test('support custom namespaces for rule names', () => {
+    const result = makeResult([{
+      pluginName: 'SecurityPlugin',
+      conclusion: 'failure',
+      violations: [{
+        ruleName: 'SillyGoose::no-public-buckets',
+        description: 'bad bucket',
+        severity: 'error',
+        violatingConstructs: [{ constructPath: 'Stack/Bucket' }],
+      }],
+    }]);
+
+    const output = formatValidateResult(result);
+    expect(output).toContain("Acknowledge with 'SillyGoose::no-public-buckets'");
+  });
+
   test('includes constructFqn when present', () => {
     const result = makeResult([{
       pluginName: 'TestPlugin',


### PR DESCRIPTION
In https://github.com/aws/aws-cdk/pull/38256 we made it so rules can have their own namespaces, that may be different from the plugin name.

Add support for that in the CLI as well.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
