### PR TITLE
feat(toolkit-lib): configurable stack event polling interval on deploy and destroy

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -210,6 +210,16 @@ export interface BaseDeployOptions {
    * @default false
    */
   readonly express?: boolean;
+
+  /**
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   *
+   * Increase this value to reduce the number of `DescribeStackEvents` calls,
+   * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.
+   *
+   * @default 2000
+   */
+  readonly stackEventPollingInterval?: number;
 }
 
 export interface DeployOptions extends BaseDeployOptions {

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -26,4 +26,14 @@ export interface DestroyOptions {
    * @default false
    */
   readonly express?: boolean;
+
+  /**
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   *
+   * Increase this value to reduce the number of `DescribeStackEvents` calls,
+   * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.
+   *
+   * @default 2000
+   */
+  readonly stackEventPollingInterval?: number;
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -202,6 +202,13 @@ export interface DeployStackOptions {
    * Whether to use express mode to deploy
    */
   readonly express?: boolean;
+
+  /**
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   *
+   * @default 2000
+   */
+  readonly stackEventPollingInterval?: number;
 }
 
 export async function deployStack(options: DeployStackOptions, ioHelper: IoHelper): Promise<DeployStackResult> {
@@ -691,6 +698,7 @@ class FullCloudFormationDeployment {
       changeSetCreationTime: startTime,
       envResources: this.options.envResources,
       isStackUpdate: this.update,
+      pollingInterval: this.options.stackEventPollingInterval,
     });
     await monitor.start();
 
@@ -771,6 +779,7 @@ export interface DestroyStackOptions {
   roleArn?: string;
   deployName?: string;
   express?: boolean;
+  stackEventPollingInterval?: number;
 }
 
 export interface DestroyStackResult {
@@ -804,6 +813,7 @@ export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHel
     stack: options.stack,
     stackArn: currentStack.stackId,
     ioHelper: ioHelper,
+    pollingInterval: options.stackEventPollingInterval,
   });
   await monitor.start();
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -155,6 +155,13 @@ export interface DeployStackOptions {
    * Whether to deploy with express mode
    */
   readonly express?: boolean;
+
+  /**
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   *
+   * @default 2000
+   */
+  readonly stackEventPollingInterval?: number;
 }
 
 export interface PrepareStackOptions extends Omit<DeployStackOptions, 'deploymentMethod'> {
@@ -264,6 +271,7 @@ export interface DestroyStackOptions {
   deployName?: string;
   roleArn?: string;
   express?: boolean;
+  stackEventPollingInterval?: number;
 }
 
 export interface StackExistsOptions {
@@ -425,6 +433,7 @@ export class Deployments {
         additionalExplorationSdkProvider: async () => (await this.envs.accessStackForLookupBestEffort(options.stack)).sdk,
       }),
       express: options.express,
+      stackEventPollingInterval: options.stackEventPollingInterval,
     }, this.ioHelper);
   }
 
@@ -651,6 +660,7 @@ export class Deployments {
       stack: options.stack,
       deployName: options.deployName,
       express: options.express,
+      stackEventPollingInterval: options.stackEventPollingInterval,
     }, this.ioHelper);
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -892,6 +892,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         extraUserAgent: options.extraUserAgent,
         assetParallelism: options.assetParallelism,
         express: options.express,
+        stackEventPollingInterval: options.stackEventPollingInterval,
       };
 
       // When using change-set method, always create the change set upfront.
@@ -1655,6 +1656,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
             deployName: stack.stackName,
             roleArn: options.roleArn,
             express: options.express,
+            stackEventPollingInterval: options.stackEventPollingInterval,
           });
 
           ret.stacks.push({

--- a/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/deploy.test.ts
@@ -309,6 +309,21 @@ IAM Statement Changes
       successfulDeployment();
     });
 
+    test('stackEventPollingInterval option is passed in', async () => {
+      // WHEN
+      const cx = await cdkOutFixture(toolkit, 'stack-with-role');
+      await toolkit.deploy(cx, {
+        stackEventPollingInterval: 10_000,
+      });
+
+      // passed through correctly to Deployments
+      expect(mockDeployStack).toHaveBeenCalledWith(expect.objectContaining({
+        stackEventPollingInterval: 10_000,
+      }));
+
+      successfulDeployment();
+    });
+
     test('warns about resources still stabilizing in Express Mode', async () => {
       // GIVEN
       mockDeployStack.mockResolvedValueOnce({

--- a/packages/@aws-cdk/toolkit-lib/test/actions/destroy.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/destroy.test.ts
@@ -150,6 +150,20 @@ describe('destroy', () => {
     }));
   });
 
+  test('stackEventPollingInterval option is passed in', async () => {
+    // WHEN
+    const cx = await builderFixture(toolkit, 'stack-with-bucket');
+    await toolkit.destroy(cx, {
+      stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+      stackEventPollingInterval: 10_000,
+    });
+
+    // THEN
+    expect(mockDestroyStack).toHaveBeenCalledWith(expect.objectContaining({
+      stackEventPollingInterval: 10_000,
+    }));
+  });
+
   test('action disposes of assembly produced by source', async () => {
     // GIVEN
     const [assemblySource, mockDispose, realDispose] = await disposableCloudAssemblySource(toolkit);

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -10,7 +10,7 @@ import {
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import { CloudFormationStack } from '../../../lib/api/cloudformation';
 import { Deployments } from '../../../lib/api/deployments';
-import { deployStack } from '../../../lib/api/deployments/deploy-stack';
+import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
 import { ToolkitInfo } from '../../../lib/api/toolkit-info';
 import { testStack } from '../../_helpers/assembly';
 import {
@@ -136,6 +136,42 @@ test('prepareStack returns undefined for non-success results', async () => {
 
   // THEN
   expect(result).toBeUndefined();
+});
+
+test('passes through stackEventPollingInterval to deployStack()', async () => {
+  // WHEN
+  await deployments.deployStack({
+    stack: testStack({
+      stackName: 'boop',
+    }),
+    stackEventPollingInterval: 10_000,
+  });
+
+  // THEN
+  expect(deployStack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      stackEventPollingInterval: 10_000,
+    }),
+    expect.anything(),
+  );
+});
+
+test('passes through stackEventPollingInterval to destroyStack()', async () => {
+  // WHEN
+  await deployments.destroyStack({
+    stack: testStack({
+      stackName: 'boop',
+    }),
+    stackEventPollingInterval: 10_000,
+  });
+
+  // THEN
+  expect(destroyStack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      stackEventPollingInterval: 10_000,
+    }),
+    expect.anything(),
+  );
 });
 
 test('placeholders are substituted in CloudFormation execution role', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-polling-interval.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-polling-interval.test.ts
@@ -1,0 +1,156 @@
+import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
+import type { DeployStackOptions as DeployStackApiOptions } from '../../../lib/api/deployments/deploy-stack';
+import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
+import { NoBootstrapStackEnvironmentResources } from '../../../lib/api/environment';
+import { StackArtifactSourceTracer } from '../../../lib/api/source-tracing/private/stack-source-tracing';
+import { StackActivityMonitor } from '../../../lib/api/stack-events';
+import { testStack } from '../../_helpers/assembly';
+import { FakeCloudFormation } from '../../_helpers/fake-aws/fake-cloudformation';
+import { advanceTime } from '../../_helpers/fake-time';
+import {
+  mockCloudFormationClient,
+  mockResolvedEnvironment,
+  MockSdk,
+  MockSdkProvider,
+  restoreSdkMocksToDefault,
+} from '../../_helpers/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+
+jest.mock('../../../lib/api/stack-events', () => {
+  const actual = jest.requireActual('../../../lib/api/stack-events');
+  return {
+    ...actual,
+    StackActivityMonitor: jest.fn().mockImplementation((props) => new actual.StackActivityMonitor(props)),
+  };
+});
+
+jest.mock('../../../lib/api/deployments/checks', () => ({
+  determineAllowCrossAccountAssetPublishing: jest.fn().mockResolvedValue(true),
+}));
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
+
+const FAKE_STACK = testStack({
+  stackName: 'withouterrors',
+  template: {
+    Resources: {
+      MyResource: {
+        Type: 'Test::Resource::Type',
+        Properties: {
+          Bar: 'Bar',
+        },
+      },
+    },
+  },
+});
+
+let sdk: MockSdk;
+let sdkProvider: MockSdkProvider;
+const fakeCfn = new FakeCloudFormation();
+
+beforeEach(() => {
+  fakeCfn.reset();
+
+  sdkProvider = new MockSdkProvider();
+  sdk = new MockSdk();
+  sdk.getUrlSuffix = () => Promise.resolve('amazonaws.com');
+  (StackActivityMonitor as unknown as jest.Mock).mockClear();
+
+  restoreSdkMocksToDefault();
+  fakeCfn.installUsingAwsMock(mockCloudFormationClient);
+
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function standardDeployStackArguments(stack: CloudFormationStackArtifact = FAKE_STACK): DeployStackApiOptions {
+  const resolvedEnvironment = mockResolvedEnvironment();
+  return {
+    stack,
+    sdk,
+    sdkProvider,
+    resolvedEnvironment,
+    envResources: new NoBootstrapStackEnvironmentResources(resolvedEnvironment, sdk, ioHelper),
+    diagnoser: new CloudFormationStackDiagnoser({
+      sdk,
+      sourceTracer: new StackArtifactSourceTracer(stack),
+      ioHelper,
+      topLevelStackHierarchicalId: stack.hierarchicalId,
+    }),
+  };
+}
+
+function monitorConstructorProps() {
+  const calls = (StackActivityMonitor as unknown as jest.Mock).mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[0][0];
+}
+
+describe('deployStack', () => {
+  test('passes stackEventPollingInterval to the StackActivityMonitor', async () => {
+    // WHEN
+    await advanceTime(deployStack({
+      ...standardDeployStackArguments(),
+      deploymentMethod: { method: 'direct' },
+      stackEventPollingInterval: 10_000,
+    }, ioHelper));
+
+    // THEN
+    expect(monitorConstructorProps()).toEqual(expect.objectContaining({
+      pollingInterval: 10_000,
+    }));
+  });
+
+  test('monitor defaults to 2 second polling when stackEventPollingInterval is not set', async () => {
+    // WHEN
+    await advanceTime(deployStack({
+      ...standardDeployStackArguments(),
+      deploymentMethod: { method: 'direct' },
+    }, ioHelper));
+
+    // THEN
+    expect(monitorConstructorProps().pollingInterval).toBeUndefined();
+    const monitor = (StackActivityMonitor as unknown as jest.Mock).mock.results[0].value;
+    expect((monitor as any).pollingInterval).toEqual(2_000);
+  });
+});
+
+describe('destroyStack', () => {
+  test('passes stackEventPollingInterval to the StackActivityMonitor', async () => {
+    // GIVEN
+    fakeCfn.createStackSync({ StackName: 'withouterrors' });
+
+    // WHEN
+    await advanceTime(destroyStack({
+      stack: FAKE_STACK,
+      sdk,
+      stackEventPollingInterval: 10_000,
+    }, ioHelper));
+
+    // THEN
+    expect(monitorConstructorProps()).toEqual(expect.objectContaining({
+      pollingInterval: 10_000,
+    }));
+  });
+
+  test('monitor defaults to 2 second polling when stackEventPollingInterval is not set', async () => {
+    // GIVEN
+    fakeCfn.createStackSync({ StackName: 'withouterrors' });
+
+    // WHEN
+    await advanceTime(destroyStack({
+      stack: FAKE_STACK,
+      sdk,
+    }, ioHelper));
+
+    // THEN
+    expect(monitorConstructorProps().pollingInterval).toBeUndefined();
+    const monitor = (StackActivityMonitor as unknown as jest.Mock).mock.results[0].value;
+    expect((monitor as any).pollingInterval).toEqual(2_000);
+  });
+});


### PR DESCRIPTION
Fixes #1709

### Motivation

`StackActivityMonitor` polls `DescribeStackEvents` every 2 seconds per active stack operation, and the interval is hardcoded. Programmatic consumers running large CI matrices (the Powertools for AWS Lambda (TypeScript) team reports ~50–100 concurrent stack operations) saturate the account-level CloudFormation read API and fail with `CDK_TOOLKIT_E5500`/`CDK_TOOLKIT_E7900` "Throttling: Rate exceeded".

Of the placements proposed in the issue, this implements the per-action option on `DeployOptions`/`DestroyOptions` rather than a global setting on `ToolkitOptions`, keeping the new surface scoped to the actions that construct the monitor.

### Changes

- New optional `stackEventPollingInterval` (milliseconds) on `DeployOptions` and `DestroyOptions`.
- Threaded through `Toolkit.deploy()`/`Toolkit.destroy()` → `Deployments.deployStack()`/`destroyStack()` → the two `new StackActivityMonitor(...)` construction sites in `deploy-stack.ts`. The monitor already supported `pollingInterval`; this only wires it up.
- **Default unchanged (2000 ms)** — fully backward compatible when the option is unset.
- Not included: the rollback monitor (`Deployments.rollbackStack`). This PR covers the deploy and destroy paths from the issue; happy to extend to `RollbackStackOptions` here or in a follow-up if preferred.

### Testing

- Unit tests at all three layers: action option pass-through (`deploy.test.ts`, `destroy.test.ts`), `Deployments` forwarding (`cloudformation-deployments.test.ts`), and monitor construction (`deploy-stack-polling-interval.test.ts`), including asserting the default stays 2 s when the option is unset.
- The monitor-construction tests live in a new file rather than the existing `deploy-stack.test.ts`: they verify the props passed to `new StackActivityMonitor(...)` by wrapping the constructor via a module-level `jest.mock`, which jest hoists file-wide. `deploy-stack.test.ts` doesn't install that mock, so adding it there would have changed the module graph for all ~60 existing tests in that file — a separate file keeps the mock's blast radius to just these four tests.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license