### PR TITLE
fix(cli): wire 'cdk lsp' through a complete startLspServer entrypoint

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/index.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/index.ts
@@ -4,5 +4,6 @@ export { readAssembly } from './core/assembly-reader';
 export type { AssemblyData, AssemblyReadResult, ConstructNode } from './core/assembly-reader';
 export type { SourceLocation } from './core/source-resolver';
 
+export { startLspServer } from './lsp/main';
 export { startServer, createLspHandlers } from './lsp/server';
 export type { LspHandlers, LspHandlerOptions, LspServerOptions } from './lsp/server';

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
@@ -3,7 +3,12 @@ import { LspIoHost } from './io-host';
 import { startServer } from './server';
 import { runSynth } from '../core/synth-runner';
 
-try {
+/**
+ * Starts the CDK Language Server over the process's stdin/stdout. Wires the
+ * Toolkit-backed bindings the handlers need. This is the single entrypoint
+ * used by the `cdk lsp` CLI command.
+ */
+export function startLspServer(): void {
   startServer({
     readable: process.stdin,
     writable: process.stdout,
@@ -22,8 +27,4 @@ try {
       };
     },
   });
-} catch (err) {
-  const e = err as Error;
-  process.stderr.write(`CDK LSP startup fatal: ${e.stack ?? e.message}\n`);
-  process.exit(1);
 }

--- a/packages/aws-cdk/lib/commands/lsp.ts
+++ b/packages/aws-cdk/lib/commands/lsp.ts
@@ -1,5 +1,5 @@
 import * as process from 'process';
-import { startServer } from '@aws-cdk/cdk-explorer';
+import { startLspServer } from '@aws-cdk/cdk-explorer';
 
 /**
  * Starts the CDK Language Server over stdio.
@@ -10,7 +10,7 @@ import { startServer } from '@aws-cdk/cdk-explorer';
  * closes the stdio channel (stdin end), then exits 0.
  */
 export async function lsp(): Promise<number> {
-  startServer({ readable: process.stdin, writable: process.stdout });
+  startLspServer();
 
   await new Promise<void>((resolve) => {
     const done = () => resolve();

--- a/packages/aws-cdk/test/commands/lsp.test.ts
+++ b/packages/aws-cdk/test/commands/lsp.test.ts
@@ -2,25 +2,21 @@ import * as cdkExplorer from '@aws-cdk/cdk-explorer';
 import { lsp } from '../../lib/commands/lsp';
 
 jest.mock('@aws-cdk/cdk-explorer', () => ({
-  startServer: jest.fn(),
+  startLspServer: jest.fn(),
 }));
 
 describe('lsp command', () => {
-  const startServer = cdkExplorer.startServer as jest.Mock;
+  const startLspServer = cdkExplorer.startLspServer as jest.Mock;
 
   afterEach(() => {
-    startServer.mockClear();
+    startLspServer.mockClear();
   });
 
   test('starts the language server on stdio and exits 0 when stdin closes', async () => {
     const resultPromise = lsp();
 
-    // The server is started over the process stdio streams (the LSP transport).
-    expect(startServer).toHaveBeenCalledTimes(1);
-    expect(startServer).toHaveBeenCalledWith({
-      readable: process.stdin,
-      writable: process.stdout,
-    });
+    // The command delegates to the fully-wired stdio entrypoint.
+    expect(startLspServer).toHaveBeenCalledTimes(1);
 
     // Simulate the LSP client closing the stdio channel.
     process.stdin.emit('end');


### PR DESCRIPTION
startServer now requires toolkitBindingsFactory (added in #1634/#1669), but the cdk lsp command still called it with only { readable, writable }, breaking the build. Expose startLspServer() from cdk-explorer (wires the Toolkit bindings and starts the server) and call it from the CLI. main.ts becomes that exported function, making cdk lsp the single LSP entrypoint.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
