### PR TITLE
fix(cli): exceptions may get masked by PackageManifestNotFound

### DIFF
--- a/packages/aws-cdk/lib/cli/root-dir.ts
+++ b/packages/aws-cdk/lib/cli/root-dir.ts
@@ -20,7 +20,7 @@ export function cliRootDir(fail?: boolean) {
     }
     if (path.dirname(dirname) === dirname) {
       if (fail ?? true) {
-        throw new ToolkitError('PackageManifestNotFound', 'Unable to find package manifest');
+        throw new ToolkitError('PackageManifestNotFound', `Unable to find package manifest up from ${__dirname}`);
       }
       return undefined;
     }

--- a/packages/aws-cdk/lib/cli/version.ts
+++ b/packages/aws-cdk/lib/cli/version.ts
@@ -6,7 +6,13 @@ export function versionWithBuild() {
 }
 
 export function isDeveloperBuildVersion(): boolean {
-  return versionNumber() === '0.0.0';
+  try {
+    return versionNumber() === '0.0.0';
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(`Error determining build version: ${e}`);
+    return false;
+  }
 }
 
 export function versionNumber(): string {


### PR DESCRIPTION
If an exception happens, and then for whatever reason the CLI runs in an environment where it can't find its own `package.json` to decide whether it's running as version `0.0.0` or not, then the actual error gets trampled by a `PackageManifestNotFound` error.

Make sure that the functions involved there never throw, and if we see another `PackageManifestNotFound` add more information so we understand why that's happening in the first place because it shouldn't.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
