### PR TITLE
chore: extract assembly read-lock factory into core

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-lock.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-lock.ts
@@ -1,0 +1,25 @@
+import type { Toolkit } from '@aws-cdk/toolkit-lib';
+
+/**
+ * A held read lock on the cloud assembly directory; `release()` unlocks it.
+ * Wraps the Toolkit's `fromAssemblyDirectory().produce()` readable.
+ */
+export interface AssemblyLock {
+  release(): Promise<void>;
+}
+
+/** Acquire a read lock on the assembly dir; throws a `LockError` on writer contention. */
+export type AcquireAssemblyLock = (assemblyDir: string) => Promise<AssemblyLock>;
+
+/**
+ * Builds an assembly read-lock acquirer from a Toolkit. The read lock is the
+ * Toolkit's own `fromAssemblyDirectory().produce()` lease, so callers never
+ * touch `RWLock` directly; `release()` disposes the lease.
+ */
+export function toolkitAssemblyLock(toolkit: Toolkit): AcquireAssemblyLock {
+  return async (assemblyDir) => {
+    const cx = await toolkit.fromAssemblyDirectory(assemblyDir, { failOnMissingContext: false });
+    const readable = await cx.produce();
+    return { release: () => readable.dispose() };
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
@@ -1,6 +1,7 @@
 import { Toolkit } from '@aws-cdk/toolkit-lib';
 import { LspIoHost } from './io-host';
 import { startServer } from './server';
+import { toolkitAssemblyLock } from '../core/assembly-lock';
 import { runSynth } from '../core/synth-runner';
 
 /**
@@ -19,11 +20,7 @@ export function startLspServer(): void {
       const toolkit = new Toolkit({ ioHost: new LspIoHost(console) });
       return {
         synthRunner: (projectDir) => runSynth({ toolkit, projectDir }),
-        acquireAssemblyLock: async (assemblyDir) => {
-          const cx = await toolkit.fromAssemblyDirectory(assemblyDir, { failOnMissingContext: false });
-          const readable = await cx.produce();
-          return { release: () => readable.dispose() };
-        },
+        acquireAssemblyLock: toolkitAssemblyLock(toolkit),
       };
     },
   });

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -35,6 +35,7 @@ import { synthFailureDiagnostics } from './synth-diagnostics';
 import { sourceTargetAtTemplateOffset } from './template-locator';
 import { WATCH_EXCLUDE_DEFAULTS } from '../../../toolkit-lib/lib/actions/watch/private/helpers';
 import { createIgnoreMatcher } from '../../../toolkit-lib/lib/util/glob-matcher';
+import type { AssemblyLock } from '../core/assembly-lock';
 import {
   readAssembly as defaultReadAssembly,
   type AssemblyReadResult,
@@ -57,13 +58,8 @@ import type { SynthRunResult } from '../core/synth-runner';
 const REFRESH_LOCK_RETRIES = 10;
 const REFRESH_LOCK_RETRY_MS = 50;
 
-/**
- * A held read lock on the cloud assembly directory; `release()` unlocks it.
- * In production this wraps the Toolkit's `fromAssemblyDirectory().produce()` readable.
- */
-export interface AssemblyLock {
-  release(): Promise<void>;
-}
+// Re-exported from core so existing importers keep resolving `AssemblyLock` here.
+export type { AssemblyLock };
 
 export interface LspHandlerOptions {
   /** Override readAssembly for tests. Defaults to reading <applicationDir>/cdk.out. */

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -58,9 +58,6 @@ import type { SynthRunResult } from '../core/synth-runner';
 const REFRESH_LOCK_RETRIES = 10;
 const REFRESH_LOCK_RETRY_MS = 50;
 
-// Re-exported from core so existing importers keep resolving `AssemblyLock` here.
-export type { AssemblyLock };
-
 export interface LspHandlerOptions {
   /** Override readAssembly for tests. Defaults to reading <applicationDir>/cdk.out. */
   readonly readAssembly?: (assemblyDir: string) => Promise<AssemblyReadResult>;

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -6,9 +6,10 @@ import { LockError } from '@aws-cdk/toolkit-lib';
 import type { Diagnostic, InitializeParams } from 'vscode-languageserver/node';
 import { TextDocument } from 'vscode-languageserver-textdocument';
 import type { AssemblyReadResult } from '../../lib';
+import type { AssemblyLock } from '../../lib/core/assembly-lock';
 import type { SynthRunResult } from '../../lib/core/synth-runner';
 import { COMMAND_SYNTH_NOW, type NotifySink } from '../../lib/lsp/commands';
-import { createLspHandlers, type AssemblyLock, type LspHandlerOptions, type LspHandlers } from '../../lib/lsp/server';
+import { createLspHandlers, type LspHandlerOptions, type LspHandlers } from '../../lib/lsp/server';
 
 function makeNotifySink(): NotifySink & { infoMessages: string[]; errorMessages: string[] } {
   const infoMessages: string[] = [];


### PR DESCRIPTION
Matching LSP side of #1706. Moves the assembly read-lock acquirer out of
lib/lsp into lib/core/assembly-lock.ts so the LSP and web server build the
read lock from one shared factory. Pure refactor, LSP behavior is unchanged,
and server.ts re-exports AssemblyLock so existing importers keep resolving it.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
