### PR TITLE
fix: validate template paths and document the LSP server

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1717,14 +1717,12 @@ const cdkExplorer = configureProject(
       'vscode-languageserver@^9',
       'vscode-languageserver-textdocument@^1',
       'vscode-jsonrpc@^8',
-      'express@^4',
       'chokidar@^4',
       '@jridgewell/trace-mapping@^0.3',
       'convert-source-map@^2',
     ],
     devDeps: [
       'vscode-languageserver-protocol@^3',
-      '@types/express@^4',
       '@types/convert-source-map@^2',
     ],
     tsconfig: {

--- a/packages/@aws-cdk/cdk-explorer/.projen/deps.json
+++ b/packages/@aws-cdk/cdk-explorer/.projen/deps.json
@@ -15,11 +15,6 @@
       "type": "build"
     },
     {
-      "name": "@types/express",
-      "version": "^4",
-      "type": "build"
-    },
-    {
       "name": "@types/jest",
       "type": "build"
     },
@@ -133,11 +128,6 @@
     {
       "name": "convert-source-map",
       "version": "^2",
-      "type": "runtime"
-    },
-    {
-      "name": "express",
-      "version": "^4",
       "type": "runtime"
     },
     {

--- a/packages/@aws-cdk/cdk-explorer/README.md
+++ b/packages/@aws-cdk/cdk-explorer/README.md
@@ -1,10 +1,11 @@
 # @aws-cdk/cdk-explorer
 
 A Language Server (LSP) for AWS CDK apps. It runs your CDK app, reads the
-synthesized cloud assembly, and surfaces that back in your editor: code lenses
-on the constructs you author, hover details from the generated CloudFormation,
-go-to-definition from a template to the construct that created it, and
-diagnostics from policy validation.
+synthesized cloud assembly from your project's `cdk.out` directory, and
+surfaces that back in your editor: code lenses on the constructs you author,
+hover details from the generated CloudFormation, go-to-definition from a
+template to the construct that created it, and diagnostics from policy
+validation.
 
 Used by the `cdk lsp` command in the AWS CDK CLI. It is for CDK developers who
 want in-editor feedback without leaving their source files.
@@ -30,7 +31,12 @@ stdin/stdout. You can also start it programmatically:
   generated template.
 - Go to definition: from a position in a synthesized `*.template.json` back to the
   construct source that produced it.
-- Diagnostics: policy validation report findings appear as squiggles in source.
+- Diagnostics: findings from the policy validation report appear as squiggles in
+  your source. The rule description and any suggested fix ride in the diagnostic
+  message, so your editor shows them when you hover the squiggle and in its
+  problems list. The report identifies a violating construct rather than a source
+  line, so a squiggle sits on the line that creates the construct, not on the
+  specific property at fault.
 
 Source-linked features (code lenses, hover, go to definition) currently work for
 TypeScript and Python.

--- a/packages/@aws-cdk/cdk-explorer/README.md
+++ b/packages/@aws-cdk/cdk-explorer/README.md
@@ -1,1 +1,90 @@
-# replace this
+# @aws-cdk/cdk-explorer
+
+A Language Server (LSP) for AWS CDK apps. It runs your CDK app, reads the
+synthesized cloud assembly, and surfaces that back in your editor: code lenses
+on the constructs you author, hover details from the generated CloudFormation,
+go-to-definition from a template to the construct that created it, and
+diagnostics from policy validation.
+
+Used by the `cdk lsp` command in the AWS CDK CLI. It is for CDK developers who
+want in-editor feedback without leaving their source files.
+
+## Status
+
+This release ships the LSP server only. The web interface is not part of this
+package yet.
+
+## Installing and running
+
+The server ships inside the AWS CDK CLI. Start it over stdio:
+
+    cdk lsp
+
+Your editor's LSP client launches that command and talks to it over
+stdin/stdout. You can also start it programmatically:
+
+    import { startLspServer } from '@aws-cdk/cdk-explorer';
+    startLspServer();
+
+## Features
+
+Code lenses appear on source lines that create CloudFormation resources:
+
+- Per resource: a lens titled `Creates <Type>`, or `Creates N resources: <types>`
+  when one construct fans out to several. Clicking it opens that resource in the
+  synthesized template; when a line maps to several resources the client shows a
+  picker.
+- File header (line 0, shown only when the file produces resources):
+  `↻ Synth now` and `▶ Enable auto-synth` when auto-synth is off, or
+  `⏹ Disable auto-synth` when it is on.
+
+Other features:
+
+- Hover: a construct's resolved CloudFormation properties and a link to the
+  generated template.
+- Go to definition: from a position in a synthesized `*.template.json` back to
+  the construct source that produced it.
+- Diagnostics: policy validation report findings appear as squiggles in source.
+
+Source-linked features (code lenses, hover, go to definition) currently work
+for TypeScript and Python.
+
+## Security
+
+`Enable auto-synth` runs your app on every save. When it is on, saving a file
+runs the `app` command from your `cdk.json` (the same command `cdk synth` runs)
+in a subprocess, with your shell environment and AWS credentials. The
+`Synth now` code lens does the same once, on demand.
+
+This mirrors how `cdk synth` and `cdk watch` already work, but the code lens
+makes it a single click. Enable auto-synth only for projects you trust. Do not
+enable it in a workspace whose `cdk.json` or source you have not reviewed, as
+opening it and saving would run that project's command with your credentials.
+
+## Editor integration
+
+`cdk lsp` is a standard stdio language server. No editor plugin is published
+yet; any LSP client can integrate:
+
+- Launch `cdk lsp` and connect over stdin/stdout.
+- On `initialize`, set `initializationOptions.applicationDir` to the CDK project
+  root (the directory containing `cdk.json`). It falls back to the server's
+  working directory if omitted.
+- The server advertises hover, go-to-definition, code lens, and
+  `workspace/executeCommand` for `cdk.explorer.synthNow`,
+  `cdk.explorer.enableAutoSynth`, and `cdk.explorer.disableAutoSynth`.
+- Register a client command named `cdkExplorer.openResource` so the resource
+  lenses navigate. It receives a list of `{ label, description, target }` items;
+  open the target's template location, showing a picker when there is more than
+  one.
+- To refresh lenses after a synth, advertise `workspace.codeLens.refreshSupport`
+  in your client capabilities.
+
+`cdk lsp` is intended to be consumed by an editor extension. Because enabling
+auto-synth runs project code with your credentials (see Security above), the
+integrating extension should gate the first `Enable auto-synth` in a workspace
+behind the editor's workspace-trust prompt.
+
+## Supported clients
+
+LSP clients speaking Language Server Protocol 3.x.

--- a/packages/@aws-cdk/cdk-explorer/README.md
+++ b/packages/@aws-cdk/cdk-explorer/README.md
@@ -9,11 +9,6 @@ diagnostics from policy validation.
 Used by the `cdk lsp` command in the AWS CDK CLI. It is for CDK developers who
 want in-editor feedback without leaving their source files.
 
-## Status
-
-This release ships the LSP server only. The web interface is not part of this
-package yet.
-
 ## Installing and running
 
 The server ships inside the AWS CDK CLI. Start it over stdio:
@@ -28,26 +23,17 @@ stdin/stdout. You can also start it programmatically:
 
 ## Features
 
-Code lenses appear on source lines that create CloudFormation resources:
-
-- Per resource: a lens titled `Creates <Type>`, or `Creates N resources: <types>`
-  when one construct fans out to several. Clicking it opens that resource in the
-  synthesized template; when a line maps to several resources the client shows a
-  picker.
-- File header (line 0, shown only when the file produces resources):
-  `↻ Synth now` and `▶ Enable auto-synth` when auto-synth is off, or
-  `⏹ Disable auto-synth` when it is on.
-
-Other features:
-
+- Code lenses on source lines that create resources: `Creates <Type>` opens that
+  resource in the synthesized template (a picker when a line maps to several),
+  plus `Synth now` / `Enable auto-synth` / `Disable auto-synth` in the file header.
 - Hover: a construct's resolved CloudFormation properties and a link to the
   generated template.
-- Go to definition: from a position in a synthesized `*.template.json` back to
-  the construct source that produced it.
+- Go to definition: from a position in a synthesized `*.template.json` back to the
+  construct source that produced it.
 - Diagnostics: policy validation report findings appear as squiggles in source.
 
-Source-linked features (code lenses, hover, go to definition) currently work
-for TypeScript and Python.
+Source-linked features (code lenses, hover, go to definition) currently work for
+TypeScript and Python.
 
 ## Security
 

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -45,6 +45,7 @@ import {
   type AssemblyWatcher,
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
+import { isWithinRoot } from '../core/source-resolver';
 import type { SynthRunResult } from '../core/synth-runner';
 
 /**
@@ -403,6 +404,10 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
         return undefined;
       }
       const filePath = fileURLToPath(uri);
+      // Bound the client-supplied path to this project's cdk.out before reading.
+      if (!(await isWithinRoot(path.join(currentProjectDir(), 'cdk.out'), filePath))) {
+        return undefined;
+      }
       let templateText: string;
       try {
         templateText = await fs.promises.readFile(filePath, 'utf-8');

--- a/packages/@aws-cdk/cdk-explorer/package.json
+++ b/packages/@aws-cdk/cdk-explorer/package.json
@@ -33,7 +33,6 @@
     "@cdklabs/eslint-plugin": "^2.0.9",
     "@stylistic/eslint-plugin": "^3",
     "@types/convert-source-map": "^2",
-    "@types/express": "^4",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@typescript-eslint/eslint-plugin": "^8",
@@ -62,7 +61,6 @@
     "@jridgewell/trace-mapping": "^0.3",
     "chokidar": "^4",
     "convert-source-map": "^2",
-    "express": "^4",
     "vscode-jsonrpc": "^8",
     "vscode-languageserver": "^9",
     "vscode-languageserver-textdocument": "^1"

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -448,7 +448,9 @@ describe('LSP Server', () => {
 
   test('onDefinition resolves a template position back to construct source', async () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'server-def-'));
-    const templateFile = path.join(dir, 'Stack1.template.json');
+    const outDir = path.join(dir, 'cdk.out');
+    fs.mkdirSync(outDir, { recursive: true });
+    const templateFile = path.join(outDir, 'Stack1.template.json');
     const text = JSON.stringify({ Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } }, undefined, 1);
     fs.writeFileSync(templateFile, text);
     try {
@@ -497,6 +499,23 @@ describe('LSP Server', () => {
       textDocument: { uri: 'untitled:Untitled-1' },
       position: { line: 0, character: 0 },
     })).toBeUndefined();
+  });
+
+  test('onDefinition returns undefined for a template outside the project cdk.out', async () => {
+    const outside = fs.mkdtempSync(path.join(os.tmpdir(), 'server-def-outside-'));
+    const templateFile = path.join(outside, 'Evil.template.json');
+    fs.writeFileSync(templateFile, JSON.stringify({ Resources: {} }));
+    try {
+      const client = createTestClient();
+      await initializeClient(client, { applicationDir: '/p' });
+      const target = await client.handlers.onDefinition({
+        textDocument: { uri: pathToFileURL(templateFile).toString() },
+        position: { line: 0, character: 0 },
+      });
+      expect(target).toBeUndefined();
+    } finally {
+      fs.rmSync(outside, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/@aws-cdk/cdk-explorer/tsconfig.dev.json
+++ b/packages/@aws-cdk/cdk-explorer/tsconfig.dev.json
@@ -26,7 +26,6 @@
     "target": "ES2020",
     "types": [
       "convert-source-map",
-      "express",
       "jest",
       "node"
     ],

--- a/packages/@aws-cdk/cdk-explorer/tsconfig.json
+++ b/packages/@aws-cdk/cdk-explorer/tsconfig.json
@@ -28,7 +28,6 @@
     "target": "ES2020",
     "types": [
       "convert-source-map",
-      "express",
       "jest",
       "node"
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,7 +170,6 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3"
     "@stylistic/eslint-plugin": "npm:^3"
     "@types/convert-source-map": "npm:^2"
-    "@types/express": "npm:^4"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^20"
     "@typescript-eslint/eslint-plugin": "npm:^8"
@@ -185,7 +184,6 @@ __metadata:
     eslint-plugin-jest: "npm:^29.15.2"
     eslint-plugin-jsdoc: "npm:^62.9.0"
     eslint-plugin-prettier: "npm:^4.2.5"
-    express: "npm:^4"
     jest: "npm:^29.7.0"
     jest-junit: "npm:^16"
     nx: "npm:^22.7.5"
@@ -6680,16 +6678,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/body-parser@npm:*":
-  version: 1.19.6
-  resolution: "@types/body-parser@npm:1.19.6"
-  dependencies:
-    "@types/connect": "npm:*"
-    "@types/node": "npm:*"
-  checksum: 10c0/542da05c924dce58ee23f50a8b981fee36921850c82222e384931fda3e106f750f7880c47be665217d72dbe445129049db6eb1f44e7a06b09d62af8f3cca8ea7
-  languageName: node
-  linkType: hard
-
 "@types/chai@npm:^5.2.2":
   version: 5.2.3
   resolution: "@types/chai@npm:5.2.3"
@@ -6697,15 +6685,6 @@ __metadata:
     "@types/deep-eql": "npm:*"
     assertion-error: "npm:^2.0.1"
   checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
-  languageName: node
-  linkType: hard
-
-"@types/connect@npm:*":
-  version: 3.4.38
-  resolution: "@types/connect@npm:3.4.38"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/2e1cdba2c410f25649e77856505cd60223250fa12dff7a503e492208dbfdd25f62859918f28aba95315251fd1f5e1ffbfca1e25e73037189ab85dd3f8d0a148c
   languageName: node
   linkType: hard
 
@@ -6739,30 +6718,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/express-serve-static-core@npm:^4.17.33":
-  version: 4.19.8
-  resolution: "@types/express-serve-static-core@npm:4.19.8"
-  dependencies:
-    "@types/node": "npm:*"
-    "@types/qs": "npm:*"
-    "@types/range-parser": "npm:*"
-    "@types/send": "npm:*"
-  checksum: 10c0/6fb58a85b209e0e421b29c52e0a51dbf7c039b711c604cf45d46470937a5c7c16b30aa5ce9bf7da0bd8a2e9361c95b5055599c0500a96bf4414d26c81f02d7fe
-  languageName: node
-  linkType: hard
-
-"@types/express@npm:^4":
-  version: 4.17.25
-  resolution: "@types/express@npm:4.17.25"
-  dependencies:
-    "@types/body-parser": "npm:*"
-    "@types/express-serve-static-core": "npm:^4.17.33"
-    "@types/qs": "npm:*"
-    "@types/serve-static": "npm:^1"
-  checksum: 10c0/f42b616d2c9dbc50352c820db7de182f64ebbfa8dba6fb6c98e5f8f0e2ef3edde0131719d9dc6874803d25ad9ca2d53471d0fec2fbc60a6003a43d015bab72c4
-  languageName: node
-  linkType: hard
-
 "@types/fs-extra@npm:^11":
   version: 11.0.4
   resolution: "@types/fs-extra@npm:11.0.4"
@@ -6779,13 +6734,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:*"
   checksum: 10c0/235d2fc69741448e853333b7c3d1180a966dd2b8972c8cbcd6b2a0c6cd7f8d582ab2b8e58219dbc62cce8f1b40aa317ff78ea2201cdd8249da5025adebed6f0b
-  languageName: node
-  linkType: hard
-
-"@types/http-errors@npm:*":
-  version: 2.0.5
-  resolution: "@types/http-errors@npm:2.0.5"
-  checksum: 10c0/00f8140fbc504f47356512bd88e1910c2f07e04233d99c88c854b3600ce0523c8cd0ba7d1897667243282eb44c59abb9245959e2428b9de004f93937f52f7c15
   languageName: node
   linkType: hard
 
@@ -6889,13 +6837,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/mime@npm:^1":
-  version: 1.3.5
-  resolution: "@types/mime@npm:1.3.5"
-  checksum: 10c0/c2ee31cd9b993804df33a694d5aa3fa536511a49f2e06eeab0b484fef59b4483777dbb9e42a4198a0809ffbf698081fdbca1e5c2218b82b91603dfab10a10fbc
-  languageName: node
-  linkType: hard
-
 "@types/mime@npm:^2":
   version: 2.0.3
   resolution: "@types/mime@npm:2.0.3"
@@ -6983,54 +6924,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/qs@npm:*":
-  version: 6.15.1
-  resolution: "@types/qs@npm:6.15.1"
-  checksum: 10c0/1dfdbcb4cf2a8f66d57f0b9a9fe6b1c7091cb816687b6698c1351eaf31f62e412cea9b7453a9637b570cd5fad8dced527e5a9e69b4fcc6e318daacd8b749f094
-  languageName: node
-  linkType: hard
-
-"@types/range-parser@npm:*":
-  version: 1.2.7
-  resolution: "@types/range-parser@npm:1.2.7"
-  checksum: 10c0/361bb3e964ec5133fa40644a0b942279ed5df1949f21321d77de79f48b728d39253e5ce0408c9c17e4e0fd95ca7899da36841686393b9f7a1e209916e9381a3c
-  languageName: node
-  linkType: hard
-
 "@types/semver@npm:^7, @types/semver@npm:^7.7.1":
   version: 7.7.1
   resolution: "@types/semver@npm:7.7.1"
   checksum: 10c0/c938aef3bf79a73f0f3f6037c16e2e759ff40c54122ddf0b2583703393d8d3127130823facb880e694caa324eb6845628186aac1997ee8b31dc2d18fafe26268
-  languageName: node
-  linkType: hard
-
-"@types/send@npm:*":
-  version: 1.2.1
-  resolution: "@types/send@npm:1.2.1"
-  dependencies:
-    "@types/node": "npm:*"
-  checksum: 10c0/7673747f8c2d8e67f3b1b3b57e9d4d681801a4f7b526ecf09987bb9a84a61cf94aa411c736183884dc762c1c402a61681eb1ef200d8d45d7e5ec0ab67ea5f6c1
-  languageName: node
-  linkType: hard
-
-"@types/send@npm:<1":
-  version: 0.17.6
-  resolution: "@types/send@npm:0.17.6"
-  dependencies:
-    "@types/mime": "npm:^1"
-    "@types/node": "npm:*"
-  checksum: 10c0/a9d76797f0637738062f1b974e0fcf3d396a28c5dc18c3f95ecec5dabda82e223afbc2d56a0bca46b6326fd7bb229979916cea40de2270a98128fd94441b87c2
-  languageName: node
-  linkType: hard
-
-"@types/serve-static@npm:^1":
-  version: 1.15.10
-  resolution: "@types/serve-static@npm:1.15.10"
-  dependencies:
-    "@types/http-errors": "npm:*"
-    "@types/node": "npm:*"
-    "@types/send": "npm:<1"
-  checksum: 10c0/842fca14c9e80468f89b6cea361773f2dcd685d4616a9f59013b55e1e83f536e4c93d6d8e3ba5072d40c4e7e64085210edd6646b15d538ded94512940a23021f
   languageName: node
   linkType: hard
 
@@ -8519,26 +8416,6 @@ __metadata:
     type-is: "npm:~1.6.18"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/569c1e896297d1fcd8f34026c8d0ab70b90d45343c15c5d8dff5de2bad08125fc1e2f8c2f3f4c1ac6c0caaad115218202594d37dcb8d89d9b5dcae1c2b736aa9
-  languageName: node
-  linkType: hard
-
-"body-parser@npm:~1.20.5":
-  version: 1.20.5
-  resolution: "body-parser@npm:1.20.5"
-  dependencies:
-    bytes: "npm:~3.1.2"
-    content-type: "npm:~1.0.5"
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    destroy: "npm:~1.2.0"
-    http-errors: "npm:~2.0.1"
-    iconv-lite: "npm:~0.4.24"
-    on-finished: "npm:~2.4.1"
-    qs: "npm:~6.15.1"
-    raw-body: "npm:~2.5.3"
-    type-is: "npm:~1.6.18"
-    unpipe: "npm:~1.0.0"
-  checksum: 10c0/ad777ca5e4711eae253c93f50fdc4608c60b76a9710d79e5e5b84581c76691e6ad21ecc9158986d9ea2b365df73e403ca33c27a8bccc1a7cfc2ccc248548118d
   languageName: node
   linkType: hard
 
@@ -10896,45 +10773,6 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
-  languageName: node
-  linkType: hard
-
-"express@npm:^4":
-  version: 4.22.2
-  resolution: "express@npm:4.22.2"
-  dependencies:
-    accepts: "npm:~1.3.8"
-    array-flatten: "npm:1.1.1"
-    body-parser: "npm:~1.20.5"
-    content-disposition: "npm:~0.5.4"
-    content-type: "npm:~1.0.4"
-    cookie: "npm:~0.7.1"
-    cookie-signature: "npm:~1.0.6"
-    debug: "npm:2.6.9"
-    depd: "npm:2.0.0"
-    encodeurl: "npm:~2.0.0"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    finalhandler: "npm:~1.3.1"
-    fresh: "npm:~0.5.2"
-    http-errors: "npm:~2.0.0"
-    merge-descriptors: "npm:1.0.3"
-    methods: "npm:~1.1.2"
-    on-finished: "npm:~2.4.1"
-    parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:~0.1.12"
-    proxy-addr: "npm:~2.0.7"
-    qs: "npm:~6.15.1"
-    range-parser: "npm:~1.2.1"
-    safe-buffer: "npm:5.2.1"
-    send: "npm:~0.19.0"
-    serve-static: "npm:~1.16.2"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:~2.0.1"
-    type-is: "npm:~1.6.18"
-    utils-merge: "npm:1.0.1"
-    vary: "npm:~1.1.2"
-  checksum: 10c0/d06dd4379fd217440b30f8abbe45f0e74931114c1395034f03e7d635196ecdab530d4835a1962a6aa34838d61967dc6f1f77846999bba3032373e9e714222c44
   languageName: node
   linkType: hard
 
@@ -16129,16 +15967,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:~6.15.1":
-  version: 6.15.3
-  resolution: "qs@npm:6.15.3"
-  dependencies:
-    es-define-property: "npm:^1.0.1"
-    side-channel: "npm:^1.1.1"
-  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
-  languageName: node
-  linkType: hard
-
 "queue-microtask@npm:^1.2.2":
   version: 1.2.3
   resolution: "queue-microtask@npm:1.2.3"
@@ -16914,7 +16742,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel-list@npm:^1.0.0, side-channel-list@npm:^1.0.1":
+"side-channel-list@npm:^1.0.0":
   version: 1.0.1
   resolution: "side-channel-list@npm:1.0.1"
   dependencies:
@@ -16959,19 +16787,6 @@ __metadata:
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
   checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
-  languageName: node
-  linkType: hard
-
-"side-channel@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "side-channel@npm:1.1.1"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    object-inspect: "npm:^1.13.4"
-    side-channel-list: "npm:^1.0.1"
-    side-channel-map: "npm:^1.0.1"
-    side-channel-weakmap: "npm:^1.0.2"
-  checksum: 10c0/dc0ab81d67f61bda9247d053ce93f41c3fd8ad2bdcb9cf9d8d2f8540d488f26d87a5e99ebfc07eea49ec025867b2452b705442d974b1478f0395e69f6bfb3270
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- onDefinition now bounds the client-supplied *.template.json path to the project's cdk.out (realpath on both sides) before reading, matching the file-read discipline used elsewhere in the package. Prevents reading arbitrary files via a crafted textDocument/definition request.
- Replace the placeholder README with real content: purpose, how to launch (cdk lsp / startLspServer), features, a security note that auto-synth and 'Synth now' run the cdk.json app command with your credentials on save (enable only on trusted projects), and editor-integration notes.
- Remove the unused express / @types/express dependencies; the web interface is not part of this branch.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
