### PR TITLE
fix(cli-integ): exclude TypeScript 7.x from the init-typescript-app matrix

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
@@ -4,6 +4,14 @@ import { shell } from './shell';
 
 const MINIMUM_VERSION = '3.9';
 
+/**
+ * The `init-typescript-app` test runs `cdk synth` through `ts-node@^10`, which is
+ * incompatible with TypeScript >= 7 (the Go-based compiler no longer exposes the `ts.sys`
+ * API ts-node reads its configuration through). Exclude 7.x from the matrix until the
+ * template's toolchain supports it — this bound is exclusive.
+ */
+const MAXIMUM_VERSION = '7.0';
+
 export async function npmMostRecentMatching(packageName: string, range: string) {
   const output = JSON.parse(await shell(['node', require.resolve('npm'), '--silent', 'view', `${packageName}@${range}`, 'version', '--json'], {
     show: 'error',
@@ -40,7 +48,8 @@ export async function npmQueryInstalledVersion(packageName: string, dir: string)
  * Use NPM preinstalled on the machine to look up a list of TypeScript versions
  */
 export function typescriptVersionsSync(): string[] {
-  const { stdout } = spawnSync('npm', ['--silent', 'view', `typescript@>=${MINIMUM_VERSION}`, 'version', '--json'], { encoding: 'utf-8' });
+  const range = `>=${MINIMUM_VERSION} <${MAXIMUM_VERSION}`;
+  const { stdout } = spawnSync('npm', ['--silent', 'view', `typescript@${range}`, 'version', '--json'], { encoding: 'utf-8' });
 
   const versions: string[] = JSON.parse(stdout);
   return Array.from(new Set(versions.map(v => v.split('.').slice(0, 2).join('.'))));


### PR DESCRIPTION
## Summary

TypeScript **7.0.2** — the first stable release of the Go-based compiler — was published to npm on 2026-07-08 at 15:55 UTC. The `init-typescript-app` integ test enumerates TypeScript minor versions dynamically from npm at runtime, so `7.0` immediately entered the test matrix on every PR.

The test installs `typescript@7.0` alongside `ts-node@^10` and runs `cdk synth` through ts-node — which is incompatible with TypeScript 7 (the Go compiler no longer exposes the `ts.sys` API ts-node reads its configuration through). Every run since the release crashes:

```
TypeError: Cannot read properties of undefined (reading 'fileExists')
    at readConfig (.../ts-node/dist/configuration.js:91:33)
```

This fails the four `integ_init-templates (init-typescript-app, *)` jobs on **every PR**, regardless of content (first observed on #1676; the last passing run started 26 minutes before the 7.0.2 publish). The crash reproduces standalone with no CDK involvement:

```
npm install typescript@7.0 ts-node@^10 && npx ts-node anything.ts
```

## Fix

Bound the version enumeration in `typescriptVersionsSync` to `<7.0`. The resulting matrix (3.9 through 6.0) is identical to what ran — and passed — before the release. Verified against npm that the fixed range excludes `7.0` and drops nothing else.

## Follow-up

Testing the init template against TypeScript 7 needs a synth toolchain that supports it (a ts-node replacement such as `tsx`, or Node's native type stripping) — that's a template change, not a test-matrix change, so it's left out of this unblocking fix.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license