### PR TITLE
feat(cli): typescript init templates use tsc + tsx and swc/jest, on typescript 7

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -44,10 +44,9 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     // still want to test with older versions as well.
     await removeDevDependencies(context);
 
+    // The generated app compiles and runs through `tsc && node` — the TypeScript
+    // compiler itself is the only toolchain needed for `cdk synth`.
     await shell.shell(['npm', 'install', '--save-dev', `typescript@${tsVersion}`]);
-
-    // After we've removed devDependencies we need to re-install ts-node because it's necessary for `cdk synth`
-    await shell.shell(['npm', 'install', '--save-dev', 'ts-node@^10']);
 
     await shell.shell(['npm', 'install']); // Older versions of npm require this to be a separate step from the one above
 
@@ -68,4 +67,11 @@ async function removeDevDependencies(context: TemporaryDirectoryContext) {
   const pj = JSON.parse(await fs.readFile(filename, { encoding: 'utf-8' }));
   delete pj.devDependencies;
   await fs.writeFile(filename, JSON.stringify(pj, undefined, 2), { encoding: 'utf-8' });
+
+  // The generated tsconfig explicitly lists the @types packages we just removed;
+  // with them gone, tsc would fail on the missing type definition files.
+  const tsconfigFilename = path.join(context.integTestDir, 'tsconfig.json');
+  const tsconfig = JSON.parse(await fs.readFile(tsconfigFilename, { encoding: 'utf-8' }));
+  delete tsconfig.compilerOptions.types;
+  await fs.writeFile(tsconfigFilename, JSON.stringify(tsconfig, undefined, 2), { encoding: 'utf-8' });
 }

--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -44,9 +44,9 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
     // still want to test with older versions as well.
     await removeDevDependencies(context);
 
-    // The generated app compiles and runs through `tsc && node` — the TypeScript
-    // compiler itself is the only toolchain needed for `cdk synth`.
-    await shell.shell(['npm', 'install', '--save-dev', `typescript@${tsVersion}`]);
+    // The generated app type-checks with `tsc` and runs through `tsx`, so those
+    // two packages are the only toolchain needed for `cdk synth`.
+    await shell.shell(['npm', 'install', '--save-dev', `typescript@${tsVersion}`, 'tsx@^4']);
 
     await shell.shell(['npm', 'install']); // Older versions of npm require this to be a separate step from the one above
 

--- a/packages/aws-cdk/lib/init-templates/app/typescript/README.md
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/README.md
@@ -6,8 +6,8 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 ## Useful commands
 
-* `%pm-cmd% build`   compile typescript to js
-* `%pm-cmd% watch`   watch for changes and compile
+* `%pm-cmd% build`   type-check the project
+* `%pm-cmd% watch`   watch for changes and type-check
 * `%pm-cmd% test`    perform the jest unit tests
 * `npx cdk deploy`  deploy this stack to your default AWS account/region
 * `npx cdk diff`    compare deployed stack with current state

--- a/packages/aws-cdk/lib/init-templates/app/typescript/cdk.template.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/cdk.template.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx tsc && node bin/%name%.js",
+  "app": "npx tsc && npx tsx bin/%name%.ts",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/packages/aws-cdk/lib/init-templates/app/typescript/cdk.template.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/cdk.template.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/%name%.ts",
+  "app": "npx tsc && node bin/%name%.js",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/packages/aws-cdk/lib/init-templates/app/typescript/jest.config.js
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': ['@swc/jest']
   },
   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
 };

--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -13,7 +13,6 @@
     "jest": "^30",
     "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
-    "ts-node": "^10.9.2",
     "typescript": "~5.9.3"
   },
   "dependencies": {

--- a/packages/aws-cdk/lib/init-templates/app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/package.json
@@ -8,12 +8,14 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.0",
+    "@swc/jest": "^0.2.39",
     "@types/jest": "^30",
     "@types/node": "^24.10.1",
     "jest": "^30",
-    "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
-    "typescript": "~5.9.3"
+    "tsx": "^4.23.0",
+    "typescript": "~7.0.2"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
@@ -24,7 +24,8 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "noEmitOnError": true,
+    "noEmit": true,
+    "isolatedModules": true,
     "types": [
       "jest",
       "node"

--- a/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/tsconfig.json
@@ -23,6 +23,11 @@
     "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
+    ],
+    "noEmitOnError": true,
+    "types": [
+      "jest",
+      "node"
     ]
   },
   "exclude": [

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/jest.config.js
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': ['@swc/jest']
   },
   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
 };

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/package.json
@@ -9,13 +9,14 @@
     "test": "jest"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.0",
+    "@swc/jest": "^0.2.39",
     "@types/jest": "^30",
     "@types/node": "^20.19.24",
     "aws-cdk-lib": "%cdk-version%",
     "constructs": "%constructs-version%",
     "jest": "^30",
-    "ts-jest": "^29",
-    "typescript": "~5.9.3"
+    "typescript": "~7.0.2"
   },
   "peerDependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/lib/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/lib/typescript/tsconfig.json
@@ -23,6 +23,10 @@
     "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
+    ],
+    "types": [
+      "jest",
+      "node"
     ]
   },
   "exclude": [

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/README.template.md
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/README.template.md
@@ -7,8 +7,8 @@ The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
 ## Useful commands
 
-* `%pm-cmd% build`   compile typescript to js
-* `%pm-cmd% watch`   watch for changes and compile
+* `%pm-cmd% build`   type-check the project
+* `%pm-cmd% watch`   watch for changes and type-check
 * `%pm-cmd% test`    perform the jest unit tests
 * `cdk deploy`      deploy this stack to your default AWS account/region
 * `cdk diff`        compare deployed stack with current state

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/cdk.template.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/cdk.template.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx tsc && node bin/%name%.js",
+  "app": "npx tsc && npx tsx bin/%name%.ts",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/cdk.template.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/cdk.template.json
@@ -1,5 +1,5 @@
 {
-  "app": "npx ts-node --prefer-ts-exts bin/%name%.ts",
+  "app": "npx tsc && node bin/%name%.js",
   "watch": {
     "include": ["**"],
     "exclude": [

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/jest.config.js
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   roots: ['<rootDir>/test'],
   testMatch: ['**/*.test.ts'],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    '^.+\\.tsx?$': ['@swc/jest']
   },
   setupFilesAfterEnv: ['aws-cdk-lib/testhelpers/jest-autoclean'],
 };

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -13,7 +13,6 @@
     "jest": "^30",
     "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
-    "ts-node": "^10.9.2",
     "typescript": "~5.9.3"
   },
   "dependencies": {

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/package.json
@@ -8,12 +8,14 @@
     "cdk": "cdk"
   },
   "devDependencies": {
+    "@swc/core": "^1.15.0",
+    "@swc/jest": "^0.2.39",
     "@types/jest": "^30",
     "@types/node": "^24.10.1",
     "jest": "^30",
-    "ts-jest": "^29",
     "aws-cdk": "%cdk-cli-version%",
-    "typescript": "~5.9.3"
+    "tsx": "^4.23.0",
+    "typescript": "~7.0.2"
   },
   "dependencies": {
     "aws-cdk-lib": "%cdk-version%",

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
@@ -24,7 +24,8 @@
     "typeRoots": [
       "./node_modules/@types"
     ],
-    "noEmitOnError": true,
+    "noEmit": true,
+    "isolatedModules": true,
     "types": [
       "jest",
       "node"

--- a/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
+++ b/packages/aws-cdk/lib/init-templates/sample-app/typescript/tsconfig.json
@@ -23,6 +23,11 @@
     "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types"
+    ],
+    "noEmitOnError": true,
+    "types": [
+      "jest",
+      "node"
     ]
   },
   "exclude": [


### PR DESCRIPTION
## Summary

TypeScript **7.0.2** was published on 2026-07-08. `ts-node@10` reads the compiler's `ts.sys` API, which TypeScript 7 no longer exposes, and ts-node has no compatible release. `ts-jest@29` likewise caps its peer dependency at `typescript <7`. Two consequences:

1. Any generated CDK project whose owner manually upgrades `typescript` past `~5.9` crashes on `cdk synth`:
   ```
   TypeError: Cannot read properties of undefined (reading 'fileExists')
       at readConfig (.../ts-node/dist/configuration.js:91:33)
   ```
2. The `init-typescript-app` integ test enumerates TypeScript versions live from npm, so `7.0` entered the matrix immediately and the `integ_init-templates` jobs fail on every PR.

This PR moves the TypeScript init templates to TypeScript 7 and replaces the compiler-API-dependent tooling:

- **App execution**: `npx tsc && npx tsx bin/<name>.ts` — `tsc` type-checks (`noEmit`), then [tsx](https://tsx.is/) (esbuild-based) runs the app. Follows @mrgrain's review suggestion, with plain `npx` chaining instead of `npx -c` for portability across npm versions and Windows.
- **Tests**: jest with [`@swc/jest`](https://swc.rs/docs/usage/jest) (transpile-only, no type checking). Faster than `ts-jest`, which we also can't use with TypeScript 7 due to `ts-jest` depending on `ts-node`. Type errors in `test/` are still caught by `npm run build`, since the tsconfig includes the test directory.

Neither tsx nor swc drives the TypeScript compiler API, so the templates no longer break when the compiler's internals change.

## Template changes

Made changes to typescript templates as follows:

For `app` + `sample-app` typescript variants
- Upgrade typescript to v7
- `cdk.template.json`: use app command `npx tsc && npx tsx bin/<name>.ts`
- `package.json`: drop `ts-node` and `ts-jest`; add `tsx`, `@swc/core`, `@swc/jest`
- `tsconfig.json`: add `noEmit`, `isolatedModules` (esbuild transpiles file-by-file), and an explicit `types: ["jest", "node"]` list — TS 6+ no longer auto-includes all of `node_modules/@types`
- `jest.config.js`: transform `@swc/jest`
- `README`: `build`/`watch` descriptions now say "type-check" since `tsc` no longer emits

For `lib` typescript variant

- Similar to above changes, but omit `noEmit`, since there is no `app` command.

## Test changes

- The cli-integ version-matrix test installs `tsx` alongside the matrix's `typescript` version

## Verified locally with a built CLI

- Rendered all three templates into scratch projects with `typescript@7.0.2`: `npm install` resolves, `npm run build` passes under the Go-based compiler, `npm test` passes through `@swc/jest`, and the app command runs end to end
- A deliberate type error fails `npx tsc` with exit 1, blocking synth
- The template tsconfigs type-check under TS 5.5, 5.9, 6.0, and 7.0 (the integ test matrix spans versions younger than 2 years)

## User-facing notes

- Existing projects are not affected — this only changes what `cdk init` generates for new projects.
- New projects start on TypeScript 7. `tsc` still type-checks every synth, but tsx (esbuild) executes the app, so synth and watch iterations are faster than ts-node's compiler-API path.
- Jest no longer type-checks test files at test-time (swc is transpile-only); `npm run build` covers that.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
