### PR TITLE
fix: fatal validations are not properly hyphenated

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
@@ -87,12 +87,12 @@ function formatViolationBlock(fileRoot: string, v: FlattenedViolation): string {
     lines.push(`   Suggested fix: ${sanitize(v.suggestedFix).replace(/\n/g, '\n   ')}`);
   }
 
+  const ackId = `${sanitize(ruleName)}`.replace(/ /g, '-');
   if (isSuppressibleViolation(v)) {
-    const ackId = `${sanitize(ruleName)}`.replace(/ /g, '-');
     lines.push(`   ${chalk.grey(`Acknowledge with '${ackId}'`)}`);
   } else {
     // If not acknowledgeable, we should still show the rule name for reference.
-    lines.push(`   ${chalk.grey(`Rule ${sanitize(ruleName)}`)}`);
+    lines.push(`   ${chalk.grey(`Rule ${sanitize(ackId)}`)}`);
   }
 
   return lines.join('\n');

--- a/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
@@ -161,6 +161,22 @@ describe('formatValidateResult', () => {
     expect(output).toContain("Acknowledge with 'SillyGoose::no-public-buckets'");
   });
 
+  test('correctly render ID of unacknowledgeable rules', () => {
+    const result = makeResult([{
+      pluginName: 'Security Plugin',
+      conclusion: 'failure',
+      violations: [{
+        ruleName: 'no-public-buckets',
+        description: 'bad bucket',
+        severity: 'fatal',
+        violatingConstructs: [{ constructPath: 'Stack/Bucket' }],
+      }],
+    }]);
+
+    const output = formatValidateResult(result);
+    expect(output).toContain('Rule Security-Plugin::no-public-buckets');
+  });
+
   test('includes constructFqn when present', () => {
     const result = makeResult([{
       pluginName: 'TestPlugin',


### PR DESCRIPTION
We replace spaces in plugin names with hyphens, but forgot to do it for for fatal validations.

Fix that.


---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
