### PR TITLE
feat(toolkit-lib): configurable stack stabilization polling interval on deploy, destroy and prepareStack

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -212,10 +212,7 @@ export interface BaseDeployOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
-   *
-   * Also governs the interval used to poll CloudFormation for the stack to stabilize (reach a terminal
-   * state) after the deployment has been issued.
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring stack operations and waiting for stack stabilization.
    *
    * Increase this value to reduce the number of `DescribeStackEvents`/`DescribeStacks` calls,
    * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/deploy/index.ts
@@ -212,9 +212,12 @@ export interface BaseDeployOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
    *
-   * Increase this value to reduce the number of `DescribeStackEvents` calls,
+   * Also governs the interval used to poll CloudFormation for the stack to stabilize (reach a terminal
+   * state) after the deployment has been issued.
+   *
+   * Increase this value to reduce the number of `DescribeStackEvents`/`DescribeStacks` calls,
    * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.
    *
    * @default 2000

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -28,9 +28,12 @@ export interface DestroyOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
    *
-   * Increase this value to reduce the number of `DescribeStackEvents` calls,
+   * Also governs the interval used to poll CloudFormation for the stack to stabilize (reach a terminal
+   * state) after the destroy has been issued.
+   *
+   * Increase this value to reduce the number of `DescribeStackEvents`/`DescribeStacks` calls,
    * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.
    *
    * @default 2000

--- a/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/destroy/index.ts
@@ -28,10 +28,7 @@ export interface DestroyOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
-   *
-   * Also governs the interval used to poll CloudFormation for the stack to stabilize (reach a terminal
-   * state) after the destroy has been issued.
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring stack operations and waiting for stack stabilization.
    *
    * Increase this value to reduce the number of `DescribeStackEvents`/`DescribeStacks` calls,
    * e.g. when many concurrent stack operations are hitting CloudFormation API rate limits.

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -532,9 +532,10 @@ export async function waitForStackDelete(
   cfn: ICloudFormationClient,
   ioHelper: IoHelper,
   stackNameOrArn: string,
+  stabilizationPollingInterval?: number,
 ): Promise<CloudFormationStack | undefined> {
   const stackDisplayName = stackNameFromArn(stackNameOrArn);
-  const stack = await stabilizeStack(cfn, ioHelper, stackNameOrArn);
+  const stack = await stabilizeStack(cfn, ioHelper, stackNameOrArn, stabilizationPollingInterval);
   if (!stack) {
     return undefined;
   }
@@ -566,8 +567,9 @@ export async function waitForStackDeploy(
   cfn: ICloudFormationClient,
   ioHelper: IoHelper,
   stackName: string,
+  stabilizationPollingInterval?: number,
 ): Promise<CloudFormationStack | undefined> {
-  const stack = await stabilizeStack(cfn, ioHelper, stackName);
+  const stack = await stabilizeStack(cfn, ioHelper, stackName, stabilizationPollingInterval);
   if (!stack) {
     return undefined;
   }
@@ -593,6 +595,7 @@ export async function stabilizeStack(
   cfn: ICloudFormationClient,
   ioHelper: IoHelper,
   stackNameOrArn: string,
+  pollingInterval?: number,
 ) {
   const stackDisplayName = stackNameFromArn(stackNameOrArn);
   await ioHelper.defaults.debug(format('Waiting for stack %s to finish creating or updating...', stackDisplayName));
@@ -617,7 +620,7 @@ export async function stabilizeStack(
     }
 
     return stack;
-  });
+  }, pollingInterval);
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -204,7 +204,10 @@ export interface DeployStackOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
+   *
+   * Also governs the interval used to poll for the stack to stabilize (reach a terminal state) after the
+   * operation has been issued.
    *
    * @default 2000
    */
@@ -243,7 +246,7 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       `Found existing stack ${deployName} that had previously failed creation. Deleting it before attempting to re-create it.`,
     );
     await cfn.deleteStack({ StackName: cloudFormationStack.stackId, ClientRequestToken: randomUUID() });
-    const deletedStack = await waitForStackDelete(cfn, ioHelper, cloudFormationStack.stackId);
+    const deletedStack = await waitForStackDelete(cfn, ioHelper, cloudFormationStack.stackId, options.stackEventPollingInterval);
     if (deletedStack && deletedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new DeploymentError(
         `Failed deleting stack ${deployName} that had previously failed creation (current state: ${deletedStack.stackStatus})`,
@@ -704,7 +707,7 @@ class FullCloudFormationDeployment {
 
     let finalState = this.cloudFormationStack;
     try {
-      const successStack = await waitForStackDeploy(this.cfn, this.ioHelper, this.stackName);
+      const successStack = await waitForStackDeploy(this.cfn, this.ioHelper, this.stackName, this.options.stackEventPollingInterval);
 
       // This shouldn't really happen, but catch it anyway. You never know.
       if (!successStack) {
@@ -819,7 +822,7 @@ export async function destroyStack(options: DestroyStackOptions, ioHelper: IoHel
 
   try {
     await cfn.deleteStack({ StackName: currentStack.stackId, RoleARN: options.roleArn, ClientRequestToken: randomUUID(), DeploymentConfig: { Mode: options.express ? 'EXPRESS' : 'STANDARD' } });
-    const destroyedStack = await waitForStackDelete(cfn, ioHelper, currentStack.stackId);
+    const destroyedStack = await waitForStackDelete(cfn, ioHelper, currentStack.stackId, options.stackEventPollingInterval);
     if (destroyedStack && destroyedStack.stackStatus.name !== 'DELETE_COMPLETE') {
       throw new DeploymentError(`Failed to destroy ${deployName}: ${destroyedStack.stackStatus}`, 'StackDestroyFailed');
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -204,10 +204,7 @@ export interface DeployStackOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
-   *
-   * Also governs the interval used to poll for the stack to stabilize (reach a terminal state) after the
-   * operation has been issued.
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring stack operations and waiting for stack stabilization.
    *
    * @default 2000
    */

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -157,7 +157,10 @@ export interface DeployStackOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
+   *
+   * Also governs the interval used to poll for the stack to stabilize (reach a terminal state) after the
+   * operation has been issued.
    *
    * @default 2000
    */
@@ -462,7 +465,7 @@ export class Deployments {
     // execute: false internally, not when the user explicitly asked for --no-execute).
     if (result.noOp && options.cleanupOnNoOp) {
       const changeSetName = options.deploymentMethod.changeSetName ?? DEFAULT_DEPLOY_CHANGE_SET_NAME;
-      await this.cleanupChangeSet(options.stack, changeSetName);
+      await this.cleanupChangeSet(options.stack, changeSetName, options.stackEventPollingInterval);
     }
 
     return result;
@@ -472,7 +475,11 @@ export class Deployments {
    * Clean up a change set that was created by prepareStack but never executed.
    * If the stack was created in REVIEW_IN_PROGRESS state (new stack), delete the stack too.
    */
-  public async cleanupChangeSet(stack: cxapi.CloudFormationStackArtifact, changeSetName: string): Promise<void> {
+  public async cleanupChangeSet(
+    stack: cxapi.CloudFormationStackArtifact,
+    changeSetName: string,
+    stackEventPollingInterval?: number,
+  ): Promise<void> {
     const env = await this.envs.accessStackForMutableStackOperations(stack);
     const cfn = env.sdk.cloudFormation();
     const deployName = stack.stackName;
@@ -488,7 +495,7 @@ export class Deployments {
     // Delete it and wait for the deletion to complete so we don't leave an empty stack behind.
     if (cloudFormationStack.stackStatus.name === 'REVIEW_IN_PROGRESS') {
       await cfn.deleteStack({ StackName: deployName, ClientRequestToken: randomUUID() });
-      await waitForStackDelete(cfn, this.ioHelper, deployName);
+      await waitForStackDelete(cfn, this.ioHelper, deployName, stackEventPollingInterval);
     }
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -157,10 +157,7 @@ export interface DeployStackOptions {
   readonly express?: boolean;
 
   /**
-   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring a stack operation.
-   *
-   * Also governs the interval used to poll for the stack to stabilize (reach a terminal state) after the
-   * operation has been issued.
+   * Time in milliseconds to wait between polling CloudFormation for stack events while monitoring stack operations and waiting for stack stabilization.
    *
    * @default 2000
    */

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -943,7 +943,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         }));
         if (!deployConfirmed) {
           if (prepareResult?.changeSet?.ChangeSetName) {
-            await deployments.cleanupChangeSet(stack, prepareResult.changeSet.ChangeSetName);
+            await deployments.cleanupChangeSet(stack, prepareResult.changeSet.ChangeSetName, options.stackEventPollingInterval);
           }
           throw new AbortError('DeployAborted', 'Deployment cancelled');
         }

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cfn-api-stabilization-polling-interval.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cfn-api-stabilization-polling-interval.test.ts
@@ -1,0 +1,118 @@
+import { DescribeStacksCommand, StackStatus } from '@aws-sdk/client-cloudformation';
+import type { ICloudFormationClient } from '../../../lib/api/aws-auth/private';
+import { stabilizeStack, waitForStackDelete, waitForStackDeploy } from '../../../lib/api/deployments/cfn-api';
+import { advanceTime } from '../../_helpers/fake-time';
+import { MockSdk, mockCloudFormationClient, restoreSdkMocksToDefault } from '../../_helpers/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
+
+let cfn: ICloudFormationClient;
+
+beforeEach(() => {
+  restoreSdkMocksToDefault();
+  cfn = new MockSdk().cloudFormation();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+function stackResponse(status: StackStatus) {
+  return {
+    Stacks: [
+      {
+        StackName: 'my-stack',
+        StackId: 'my-stack-id',
+        CreationTime: new Date(),
+        StackStatus: status,
+      },
+    ],
+  };
+}
+
+describe('stabilizeStack', () => {
+  test('polls DescribeStacks at the default 5s interval when no interval is given', async () => {
+    // GIVEN
+    mockCloudFormationClient
+      .on(DescribeStacksCommand)
+      .resolvesOnce(stackResponse(StackStatus.UPDATE_IN_PROGRESS))
+      .resolvesOnce(stackResponse(StackStatus.UPDATE_IN_PROGRESS))
+      .resolves(stackResponse(StackStatus.UPDATE_COMPLETE));
+
+    // WHEN
+    const promise = stabilizeStack(cfn, ioHelper, 'my-stack');
+
+    // THEN: two 5s ticks are needed before the stack stabilizes
+    await jest.advanceTimersByTimeAsync(4999);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 1);
+
+    await jest.advanceTimersByTimeAsync(1);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 2);
+
+    const result = await advanceTime(promise);
+    expect(result?.stackStatus.name).toEqual(StackStatus.UPDATE_COMPLETE);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 3);
+  });
+
+  test('polls DescribeStacks at the given interval', async () => {
+    // GIVEN
+    mockCloudFormationClient
+      .on(DescribeStacksCommand)
+      .resolvesOnce(stackResponse(StackStatus.UPDATE_IN_PROGRESS))
+      .resolves(stackResponse(StackStatus.UPDATE_COMPLETE));
+
+    // WHEN
+    const promise = stabilizeStack(cfn, ioHelper, 'my-stack', 10_000);
+
+    // THEN
+    await jest.advanceTimersByTimeAsync(9_999);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 1);
+
+    const result = await advanceTime(promise);
+    expect(result?.stackStatus.name).toEqual(StackStatus.UPDATE_COMPLETE);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 2);
+  });
+});
+
+describe('waitForStackDeploy', () => {
+  test('forwards the polling interval to stabilizeStack', async () => {
+    // GIVEN
+    mockCloudFormationClient
+      .on(DescribeStacksCommand)
+      .resolvesOnce(stackResponse(StackStatus.CREATE_IN_PROGRESS))
+      .resolves(stackResponse(StackStatus.CREATE_COMPLETE));
+
+    // WHEN
+    const promise = waitForStackDeploy(cfn, ioHelper, 'my-stack', 10_000);
+
+    // THEN
+    await jest.advanceTimersByTimeAsync(9_999);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 1);
+
+    await advanceTime(promise);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 2);
+  });
+});
+
+describe('waitForStackDelete', () => {
+  test('forwards the polling interval to stabilizeStack', async () => {
+    // GIVEN
+    mockCloudFormationClient
+      .on(DescribeStacksCommand)
+      .resolvesOnce(stackResponse(StackStatus.DELETE_IN_PROGRESS))
+      .resolves(stackResponse(StackStatus.DELETE_COMPLETE));
+
+    // WHEN
+    const promise = waitForStackDelete(cfn, ioHelper, 'my-stack', 10_000);
+
+    // THEN
+    await jest.advanceTimersByTimeAsync(9_999);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 1);
+
+    await advanceTime(promise);
+    expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStacksCommand, 2);
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -10,6 +10,7 @@ import {
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import { CloudFormationStack } from '../../../lib/api/cloudformation';
 import { Deployments } from '../../../lib/api/deployments';
+import * as cfnApi from '../../../lib/api/deployments/cfn-api';
 import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
 import { ToolkitInfo } from '../../../lib/api/toolkit-info';
 import { testStack } from '../../_helpers/assembly';
@@ -136,6 +137,39 @@ test('prepareStack returns undefined for non-success results', async () => {
 
   // THEN
   expect(result).toBeUndefined();
+});
+
+test('prepareStack forwards stackEventPollingInterval to cleanupChangeSet as the stabilization interval', async () => {
+  // GIVEN
+  (deployStack as jest.Mock).mockResolvedValue({
+    type: 'did-deploy-stack',
+    noOp: true,
+    deleteFailures: [],
+    stabilizingResources: [],
+    outputs: {},
+    stackArn: 'arn:stack',
+    changeSet: { ChangeSetName: 'my-cs', Status: 'CREATE_COMPLETE' },
+  });
+  givenStacks({
+    boop: { template: {}, stackStatus: 'REVIEW_IN_PROGRESS' },
+  });
+  const waitForStackDeleteSpy = jest.spyOn(cfnApi, 'waitForStackDelete');
+
+  // WHEN
+  await deployments.prepareStack({
+    stack: testStack({ stackName: 'boop' }),
+    deploymentMethod: { method: 'change-set' },
+    cleanupOnNoOp: true,
+    stackEventPollingInterval: 10_000,
+  });
+
+  // THEN
+  expect(waitForStackDeleteSpy).toHaveBeenCalledWith(
+    expect.anything(),
+    expect.anything(),
+    'boop',
+    10_000,
+  );
 });
 
 test('passes through stackEventPollingInterval to deployStack()', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-polling-interval.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-polling-interval.test.ts
@@ -1,4 +1,5 @@
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import * as cfnApi from '../../../lib/api/deployments/cfn-api';
 import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
 import type { DeployStackOptions as DeployStackApiOptions } from '../../../lib/api/deployments/deploy-stack';
 import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
@@ -29,6 +30,15 @@ jest.mock('../../../lib/api/deployments/checks', () => ({
   determineAllowCrossAccountAssetPublishing: jest.fn().mockResolvedValue(true),
 }));
 
+jest.mock('../../../lib/api/deployments/cfn-api', () => {
+  const actual = jest.requireActual('../../../lib/api/deployments/cfn-api');
+  return {
+    ...actual,
+    waitForStackDeploy: jest.fn(actual.waitForStackDeploy),
+    waitForStackDelete: jest.fn(actual.waitForStackDelete),
+  };
+});
+
 const ioHost = new TestIoHost();
 const ioHelper = ioHost.asHelper('deploy');
 
@@ -57,6 +67,8 @@ beforeEach(() => {
   sdk = new MockSdk();
   sdk.getUrlSuffix = () => Promise.resolve('amazonaws.com');
   (StackActivityMonitor as unknown as jest.Mock).mockClear();
+  (cfnApi.waitForStackDeploy as jest.Mock).mockClear();
+  (cfnApi.waitForStackDelete as jest.Mock).mockClear();
 
   restoreSdkMocksToDefault();
   fakeCfn.installUsingAwsMock(mockCloudFormationClient);
@@ -118,6 +130,23 @@ describe('deployStack', () => {
     const monitor = (StackActivityMonitor as unknown as jest.Mock).mock.results[0].value;
     expect((monitor as any).pollingInterval).toEqual(2_000);
   });
+
+  test('passes stackEventPollingInterval to waitForStackDeploy as the stabilization interval', async () => {
+    // WHEN
+    await advanceTime(deployStack({
+      ...standardDeployStackArguments(),
+      deploymentMethod: { method: 'direct' },
+      stackEventPollingInterval: 10_000,
+    }, ioHelper));
+
+    // THEN
+    expect(cfnApi.waitForStackDeploy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      10_000,
+    );
+  });
 });
 
 describe('destroyStack', () => {
@@ -152,5 +181,25 @@ describe('destroyStack', () => {
     expect(monitorConstructorProps().pollingInterval).toBeUndefined();
     const monitor = (StackActivityMonitor as unknown as jest.Mock).mock.results[0].value;
     expect((monitor as any).pollingInterval).toEqual(2_000);
+  });
+
+  test('passes stackEventPollingInterval to waitForStackDelete as the stabilization interval', async () => {
+    // GIVEN
+    fakeCfn.createStackSync({ StackName: 'withouterrors' });
+
+    // WHEN
+    await advanceTime(destroyStack({
+      stack: FAKE_STACK,
+      sdk,
+      stackEventPollingInterval: 10_000,
+    }, ioHelper));
+
+    // THEN
+    expect(cfnApi.waitForStackDelete).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      10_000,
+    );
   });
 });


### PR DESCRIPTION
Fixes #1723

### Motivation

Follow-on to #1709/#1710, which made the `StackActivityMonitor` event-polling interval (`DescribeStackEvents`) configurable via `stackEventPollingInterval`. There's a second hardcoded polling loop that wasn't touched: the stabilization waiter. `stabilizeStack()` in `lib/api/deployments/cfn-api.ts` — via the exported `waitForStackDeploy()`/`waitForStackDelete()` — calls the module-private `waitFor(valueProvider, timeout = 5000)`, polling `DescribeStacks` every 5s per in-flight stack to detect a terminal state, with no option threading to it.

Programmatic consumers running large CI matrices who already slowed the event monitor via `stackEventPollingInterval` saw `DescribeStacks` from this stabilization loop become the dominant CloudFormation read-API caller instead, still triggering throttling.

### Design decision: one parameter, not two

`stackEventPollingInterval` now governs both the event-polling and stabilization-polling intervals, rather than adding a new sibling parameter (e.g. `stackStabilizationPollingInterval`). Going with reuse over a second parameter to avoid growing the public options surface on `DeployOptions`/`DestroyOptions` for a distinction most consumers won't need to control separately — both loops exist to reduce `DescribeStack*` call volume against the same CloudFormation rate limit. Happy to split it into a separate parameter in a follow-up if maintainers would rather keep the two tunable independently.

### Changes

- Added an optional `stabilizationPollingInterval`/`pollingInterval` parameter to `waitForStackDelete()`, `waitForStackDeploy()`, and `stabilizeStack()` in `cfn-api.ts`. Default unchanged (5000ms).
- Threaded the existing `stackEventPollingInterval` option through to that new parameter — it already sits right beside the `waitForStackDeploy`/`waitForStackDelete` calls in `deploy-stack.ts` (deploy, destroy, and the delete-before-recreate path).
- Threaded through:
  - `deployStack()`/`destroyStack()` in `deploy-stack.ts` (all three call sites: delete-before-recreate, post-deploy stabilization, post-destroy stabilization)
  - `Deployments.cleanupChangeSet()` (the change-set cleanup path, called from `prepareStack()` and from `Toolkit.deploy()` when a user declines the deploy confirmation prompt)
- Updated doc comments on `stackEventPollingInterval` at each layer (`DeployOptions`, `DestroyOptions`, `DeployStackOptions` in both `deploy-stack.ts` and `deployments.ts`) to note it also governs stabilization polling.
- No public API surface changes — `stackEventPollingInterval` already existed; only its scope of effect changed, and doc comments were updated to reflect that.

### Not included

Per the issue, two call sites needed confirming during implementation:
- `waitForStackDelete` from `Deployments.cleanupChangeSet` — **included** (see above).
- The rollback path (`Deployments.rollbackStack`), which calls `stabilizeStack` directly — **deferred**. This is the same rollback monitor that #1710 explicitly deferred for event polling, so leaving it out here keeps this PR consistent with that scope. Happy to add `stackEventPollingInterval` support to `RollbackStackOptions` in a follow-up if maintainers want it included.

### Testing

- New `cfn-api-stabilization-polling-interval.test.ts`: directly exercises `stabilizeStack`, `waitForStackDeploy`, and `waitForStackDelete` with fake timers, asserting `DescribeStacks` polling cadence at both the 5s default and a custom interval.
- Extended `deploy-stack-polling-interval.test.ts`: asserts `deployStack()`/`destroyStack()` forward `stackEventPollingInterval` to `waitForStackDeploy`/`waitForStackDelete` as the stabilization interval, alongside the existing `StackActivityMonitor` assertions.
- Extended `cloudformation-deployments.test.ts`: asserts `prepareStack()` forwards `stackEventPollingInterval` through `cleanupChangeSet()` to `waitForStackDelete`.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license