### PR TITLE
feat: synth triggering in the web explorer

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -252,33 +252,31 @@ export function App(): JSX.Element {
           variant="h1"
           description={appDir ?? '—'}
           actions={
-            <div>
-              <SpaceBetween direction="horizontal" size="s" alignItems="center">
-                <Toggle checked={autoSynthEnabled} onChange={({ detail }) => void toggleAutoSynth(detail.checked)}>
-                  Auto-synth on save
-                </Toggle>
-                <Button disabled={autoSynthEnabled} loading={synthing} onClick={() => void handleSynth()}>Synth</Button>
-              </SpaceBetween>
-              {synthFailure && (
-                <Box textAlign="right" margin={{ top: 'xxs' }}>
-                  <Link onFollow={() => setShowFailureModal(true)} variant="secondary">
-                    <StatusIndicator type="error">Synth failed</StatusIndicator>
-                  </Link>
-                </Box>
-              )}
-              {!synthFailure && synthWarning && (
-                <Box textAlign="right" margin={{ top: 'xxs' }}>
-                  <StatusIndicator type="warning">{synthWarning}</StatusIndicator>
-                </Box>
-              )}
-              {lastSynthTime && (
-                <Box color="text-status-inactive" fontSize="body-s" textAlign="right">Last synth at {lastSynthTime}</Box>
-              )}
-            </div>
+            <SpaceBetween direction="horizontal" size="s" alignItems="center">
+              <Toggle checked={autoSynthEnabled} onChange={({ detail }) => void toggleAutoSynth(detail.checked)}>
+                Auto-synth on save
+              </Toggle>
+              <Button disabled={autoSynthEnabled} loading={synthing} onClick={() => void handleSynth()}>Synth</Button>
+            </SpaceBetween>
           }
         >
           CDK Web Explorer
         </Header>
+        {(synthFailure || synthWarning || lastSynthTime) && (
+          <div style={SYNTH_STATUS_ROW_STYLE}>
+            {synthFailure && (
+              <Link onFollow={() => setShowFailureModal(true)} variant="secondary">
+                <StatusIndicator type="error">Synth failed</StatusIndicator>
+              </Link>
+            )}
+            {!synthFailure && synthWarning && (
+              <StatusIndicator type="warning">{synthWarning}</StatusIndicator>
+            )}
+            {lastSynthTime && (
+              <span style={{ color: '#5f6b7a' }}>Last synth at {lastSynthTime}</span>
+            )}
+          </div>
+        )}
       </header>
       {error && <Box color="text-status-error">{error}</Box>}
       <div style={topRowStyle(vSplit)} ref={hSplit.containerRef}>
@@ -569,7 +567,17 @@ const PAGE_STYLE: React.CSSProperties = {
   boxSizing: 'border-box',
   overflow: 'hidden',
 };
-const TITLE_BLOCK_STYLE: React.CSSProperties = { flexShrink: 0, marginBottom: '12px' };
+const TITLE_BLOCK_STYLE: React.CSSProperties = { flexShrink: 0, marginBottom: '12px', position: 'relative' };
+const SYNTH_STATUS_ROW_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  bottom: 0,
+  right: 0,
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontFamily: '"Open Sans", "Helvetica Neue", Roboto, Arial, sans-serif',
+  fontSize: '14px',
+};
 const GROW_STYLE: React.CSSProperties = { flex: '1 1 0', minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', width: '100%' };
 const SYNTH_LOG_STYLE: React.CSSProperties = {
   margin: 0,

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -2,11 +2,15 @@ import Box from '@cloudscape-design/components/box';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
+import Link from '@cloudscape-design/components/link';
+import Modal from '@cloudscape-design/components/modal';
 import SpaceBetween from '@cloudscape-design/components/space-between';
 import Spinner from '@cloudscape-design/components/spinner';
+import StatusIndicator from '@cloudscape-design/components/status-indicator';
+import Toggle from '@cloudscape-design/components/toggle';
 import * as React from 'react';
 import { buildSourceAnchorIndex, findConstructAtLine } from '../lib/web/source-nav';
-import { api, type DirEntry, type TemplateResponse, type TreeResponse, type ViolationsResponse } from './api';
+import { api, type DirEntry, type SynthResult, type SynthStatusEvent, type TemplateResponse, type TreeResponse, type ViolationsResponse } from './api';
 import { CodeViewer, type Diagnostic } from './components/CodeViewer';
 import { ConstructTree } from './components/ConstructTree';
 import type { Language } from './syntax';
@@ -31,6 +35,14 @@ export function App(): JSX.Element {
   const [violations, setViolations] = React.useState<ViolationsResponse | undefined>();
   const [error, setError] = React.useState<string | undefined>();
   const [appDir, setAppDir] = React.useState<string | undefined>();
+
+  // Auto-synth + manual synth state.
+  const [autoSynthEnabled, setAutoSynthEnabled] = React.useState(false);
+  const [synthing, setSynthing] = React.useState(false);
+  const [synthFailure, setSynthFailure] = React.useState<SynthStatusEvent | undefined>();
+  const [showFailureModal, setShowFailureModal] = React.useState(false);
+  const [synthWarning, setSynthWarning] = React.useState<string | undefined>();
+  const [lastSynthTime, setLastSynthTime] = React.useState<string | undefined>();
 
   // Source pane state.
   const [sourceFile, setSourceFile] = React.useState<string | undefined>();
@@ -59,6 +71,9 @@ export function App(): JSX.Element {
         setViolations(v);
         setAppDir(info.appDir);
         setError(undefined);
+        setSynthFailure(undefined);
+        setSynthWarning(undefined);
+        setLastSynthTime(new Date().toLocaleTimeString());
       })
       // Keep the last good render on a transient read (e.g. a mid-synth write);
       // the next assembly-changed event re-fetches once the write has settled.
@@ -67,8 +82,45 @@ export function App(): JSX.Element {
 
   React.useEffect(() => {
     reload();
-    return api.subscribe(reload);
+    void api.getAutoSynth().then((r) => setAutoSynthEnabled(r.enabled)).catch(() => undefined);
+    return api.subscribe({
+      onAssemblyChanged: reload,
+      onSynthFailure: (event) => {
+        setSynthFailure(event);
+        setShowFailureModal(false);
+        setLastSynthTime(new Date().toLocaleTimeString());
+      },
+    });
   }, [reload]);
+
+  /** Toggle auto-synth-on-save; optimistic, reverts if the server rejects. */
+  const toggleAutoSynth = React.useCallback(async (enabled: boolean) => {
+    setAutoSynthEnabled(enabled);
+    try {
+      const res = await api.setAutoSynth(enabled);
+      setAutoSynthEnabled(res.enabled);
+    } catch {
+      setAutoSynthEnabled(!enabled);
+    }
+  }, []);
+
+  /** Run a manual synth. Failures surface via the SYNTH_STATUS subscription. */
+  const handleSynth = React.useCallback(async () => {
+    setSynthing(true);
+    setSynthWarning(undefined);
+    try {
+      const result: SynthResult = await api.synth();
+      if (result.status === 'lock-conflict') {
+        setSynthWarning('Synth skipped — already running');
+      } else if (result.status === 'unavailable') {
+        setSynthWarning('No app configured (missing cdk.json)');
+      }
+    } catch {
+      /* hard failures surfaced via onSynthFailure SSE */
+    } finally {
+      setSynthing(false);
+    }
+  }, []);
 
   /** Navigate to a construct (from tree double-click or violation double-click). */
   const navigate: NavigateHandler = React.useCallback(async (opts) => {
@@ -196,7 +248,37 @@ export function App(): JSX.Element {
   return (
     <div style={PAGE_STYLE} ref={vSplit.containerRef}>
       <header style={TITLE_BLOCK_STYLE}>
-        <Header variant="h1" description={appDir ?? '—'}>CDK Web Explorer</Header>
+        <Header
+          variant="h1"
+          description={appDir ?? '—'}
+          actions={
+            <div>
+              <SpaceBetween direction="horizontal" size="s" alignItems="center">
+                <Toggle checked={autoSynthEnabled} onChange={({ detail }) => void toggleAutoSynth(detail.checked)}>
+                  Auto-synth on save
+                </Toggle>
+                <Button disabled={autoSynthEnabled} loading={synthing} onClick={() => void handleSynth()}>Synth</Button>
+              </SpaceBetween>
+              {synthFailure && (
+                <Box textAlign="right" margin={{ top: 'xxs' }}>
+                  <Link onFollow={() => setShowFailureModal(true)} variant="secondary">
+                    <StatusIndicator type="error">Synth failed</StatusIndicator>
+                  </Link>
+                </Box>
+              )}
+              {!synthFailure && synthWarning && (
+                <Box textAlign="right" margin={{ top: 'xxs' }}>
+                  <StatusIndicator type="warning">{synthWarning}</StatusIndicator>
+                </Box>
+              )}
+              {lastSynthTime && (
+                <Box color="text-status-inactive" fontSize="body-s" textAlign="right">Last synth at {lastSynthTime}</Box>
+              )}
+            </div>
+          }
+        >
+          CDK Web Explorer
+        </Header>
       </header>
       {error && <Box color="text-status-error">{error}</Box>}
       <div style={topRowStyle(vSplit)} ref={hSplit.containerRef}>
@@ -280,6 +362,20 @@ export function App(): JSX.Element {
           </div>
         )}
       </div>
+      {synthFailure && showFailureModal && (
+        <Modal
+          visible
+          onDismiss={() => setShowFailureModal(false)}
+          size="large"
+          header="Synth failed"
+          footer={<Box float="right"><Button variant="primary" onClick={() => setShowFailureModal(false)}>Close</Button></Box>}
+        >
+          <SpaceBetween size="s">
+            <Box color="text-status-error">{synthFailure.message}</Box>
+            {synthFailure.details && <pre style={SYNTH_LOG_STYLE}>{synthFailure.details}</pre>}
+          </SpaceBetween>
+        </Modal>
+      )}
     </div>
   );
 }
@@ -475,6 +571,17 @@ const PAGE_STYLE: React.CSSProperties = {
 };
 const TITLE_BLOCK_STYLE: React.CSSProperties = { flexShrink: 0, marginBottom: '12px' };
 const GROW_STYLE: React.CSSProperties = { flex: '1 1 0', minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', width: '100%' };
+const SYNTH_LOG_STYLE: React.CSSProperties = {
+  margin: 0,
+  maxHeight: '50vh',
+  overflow: 'auto',
+  whiteSpace: 'pre-wrap',
+  fontFamily: 'monospace',
+  fontSize: '12px',
+  background: '#f4f4f4',
+  padding: '8px',
+  borderRadius: '4px',
+};
 
 const HEADER_WITH_ACTION_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '6px' };
 const OPEN_FILE_BUTTON_STYLE: React.CSSProperties = {

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -1,9 +1,11 @@
 import {
   ASSEMBLY_CHANGED,
+  SYNTH_STATUS,
   type DirEntry,
   type FilesResponse,
   type FileResponse,
   type LineRange,
+  type SynthStatusEvent,
   type TemplateResource,
   type TemplateResponse,
   type TreeResponse,
@@ -19,6 +21,7 @@ export type {
   FilesResponse,
   FileResponse,
   LineRange,
+  SynthStatusEvent,
   TemplateResource,
   TemplateResponse,
   TreeResponse,
@@ -38,8 +41,27 @@ async function getJson<T>(url: string): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+async function sendJson<T>(url: string, body?: unknown): Promise<T> {
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: body === undefined ? undefined : { 'Content-Type': 'application/json' },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const errBody = await res.json().catch(() => ({}));
+    throw new Error((errBody as { error?: string }).error ?? `request failed: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
 export interface AppInfoResponse {
   readonly appDir: string;
+}
+
+export interface SynthResult {
+  readonly status: 'success' | 'app-failure' | 'lock-conflict' | 'unavailable' | 'error';
+  readonly message?: string;
+  readonly details?: string;
 }
 
 export const api = {
@@ -48,14 +70,26 @@ export const api = {
   getTree: (): Promise<TreeResponse> => getJson('/api/tree'),
   getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),
   getAppInfo: (): Promise<AppInfoResponse> => getJson('/api/info'),
+  getAutoSynth: (): Promise<{ enabled: boolean }> => getJson('/api/synth/auto'),
+  setAutoSynth: (enabled: boolean): Promise<{ enabled: boolean }> => sendJson('/api/synth/auto', { enabled }),
+  synth: async (): Promise<SynthResult> => {
+    return sendJson<SynthResult>('/api/synth');
+  },
   /**
-   * Subscribe to assembly-changed events from the server, invoking `onChange`
-   * whenever the cloud assembly is rewritten. Returns an unsubscribe that closes
-   * the underlying EventSource.
+   * Subscribe to server-sent events on one EventSource. `onAssemblyChanged`
+   * fires when the cloud assembly is rewritten (re-fetch); the optional
+   * `onSynthFailure` fires with a failed synth's summary + stderr. Returns an
+   * unsubscribe that closes the stream.
    */
-  subscribe: (onChange: () => void): (() => void) => {
+  subscribe: (handlers: {
+    onAssemblyChanged: () => void;
+    onSynthFailure?: (event: SynthStatusEvent) => void;
+  }): (() => void) => {
     const source = new EventSource('/api/events');
-    source.addEventListener(ASSEMBLY_CHANGED, () => onChange());
+    source.addEventListener(ASSEMBLY_CHANGED, () => handlers.onAssemblyChanged());
+    if (handlers.onSynthFailure) {
+      source.addEventListener(SYNTH_STATUS, (ev) => handlers.onSynthFailure!(JSON.parse((ev as MessageEvent).data) as SynthStatusEvent));
+    }
     return () => source.close();
   },
   getTemplate: (file: string): Promise<TemplateResponse> => getJson(`/api/template?file=${encodeURIComponent(file)}`),

--- a/packages/@aws-cdk/cdk-explorer/lib/core/synth-runner.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/synth-runner.ts
@@ -1,6 +1,24 @@
 import { ToolkitError, type Toolkit } from '@aws-cdk/toolkit-lib';
 import { readCdkConfig } from './cdk-config';
 
+/* eslint-disable import/no-relative-packages -- toolkit-lib watch internals are not re-exported from its package index */
+import { WATCH_EXCLUDE_DEFAULTS } from '../../../toolkit-lib/lib/actions/watch/private/helpers';
+
+/**
+ * Files whose changes are not treated as CDK source edits by the source
+ * watchers (the LSP's auto-synth-on-save and the web server), so both apply an
+ * identical policy. Excluding cdk.out is essential: it prevents a
+ * synth -> cdk.out write -> re-synth loop. node_modules and dotfiles cut noise.
+ */
+export const SOURCE_WATCH_EXCLUDES = [
+  ...WATCH_EXCLUDE_DEFAULTS,
+  '**/cdk.out/**',
+  '**/node_modules/**',
+  '.*',
+  '**/.*',
+  '**/.*/**',
+];
+
 /**
  * Hold synth()'s read lock this long before releasing it. While we hold a
  * reader, the next synth cannot take the write lock, so a watcher refresh that

--- a/packages/@aws-cdk/cdk-explorer/lib/index.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/index.ts
@@ -10,5 +10,5 @@ export { startLspServer } from './lsp/main';
 export { startServer, createLspHandlers } from './lsp/server';
 export type { LspHandlers, LspHandlerOptions, LspServerOptions } from './lsp/server';
 
-export { startWebServer } from './web/server';
-export type { WebServer, WebServerOptions } from './web/server';
+export { startCdkExplore } from './web/server';
+export type { WebServer, StartCdkExploreOptions } from './web/server';

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -33,7 +33,6 @@ import { hoverForPosition } from './hover';
 import { offsetAtPosition } from './positions';
 import { synthFailureDiagnostics } from './synth-diagnostics';
 import { sourceTargetAtTemplateOffset } from './template-locator';
-import { WATCH_EXCLUDE_DEFAULTS } from '../../../toolkit-lib/lib/actions/watch/private/helpers';
 import { createIgnoreMatcher } from '../../../toolkit-lib/lib/util/glob-matcher';
 import type { AssemblyLock } from '../core/assembly-lock';
 import {
@@ -46,6 +45,7 @@ import {
   type AssemblyWatcher,
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
+import { SOURCE_WATCH_EXCLUDES } from '../core/synth-runner';
 import { isWithinRoot } from '../core/source-resolver';
 import type { SynthRunResult } from '../core/synth-runner';
 
@@ -347,18 +347,10 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     },
     async onInitialized() {
       const projectDir = currentProjectDir();
-      // Same exclusion logic as toolkit-lib's watch():
-      // WATCH_EXCLUDE_DEFAULTS covers common non-source dirs, then we add cdk.out
-      // (our own output) and dotfiles (editor configs, .git, etc.)
+      // Ignore non-source files (build output, deps, dotfiles). This exclude
+      // policy is shared with the web source watcher; see lib/core/source-watch.
       shouldIgnore = createIgnoreMatcher({
-        exclude: [
-          ...WATCH_EXCLUDE_DEFAULTS,
-          '**/node_modules/**',
-          '**/cdk.out/**',
-          '.*',
-          '**/.*',
-          '**/.*/**',
-        ],
+        exclude: SOURCE_WATCH_EXCLUDES,
         rootDir: projectDir,
       });
       await refreshFromAssembly(projectDir);

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -45,8 +45,8 @@ import {
   type AssemblyWatcher,
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
-import { SOURCE_WATCH_EXCLUDES } from '../core/synth-runner';
 import { isWithinRoot } from '../core/source-resolver';
+import { SOURCE_WATCH_EXCLUDES } from '../core/synth-runner';
 import type { SynthRunResult } from '../core/synth-runner';
 
 /**
@@ -348,7 +348,8 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     async onInitialized() {
       const projectDir = currentProjectDir();
       // Ignore non-source files (build output, deps, dotfiles). This exclude
-      // policy is shared with the web source watcher; see lib/core/source-watch.
+      // policy (SOURCE_WATCH_EXCLUDES, in lib/core/synth-runner) is shared with
+      // the web source watcher.
       shouldIgnore = createIgnoreMatcher({
         exclude: SOURCE_WATCH_EXCLUDES,
         rootDir: projectDir,

--- a/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/events.ts
@@ -1,5 +1,8 @@
 import type { Request, Response } from 'express';
-import type { SseEventName } from './protocol';
+import { SYNTH_STATUS, type SseEventName, type SynthStatusEvent } from './protocol';
+
+/** Max stderr we put on the wire; subprocess output is unbounded, so bound it. */
+const MAX_SYNTH_DETAILS_CHARS = 64 * 1024;
 
 /**
  * Tracks connected Server-Sent Events clients and pushes events to all of them.
@@ -32,14 +35,24 @@ export class SseBroadcaster {
   }
 
   /**
-   * Push an event to every connected client. The `data: {}` line is required:
-   * EventSource does not dispatch a named event whose data buffer is empty, so
-   * the empty payload is what makes the client's listener fire. Writing to a
-   * client that already disconnected is a harmless no-op (returns false, does
-   * not throw); the `close`/`error` handlers in `handle` do the eviction.
+   * Push a payload-less named event to every client. The `data: {}` line is
+   * required: EventSource does not dispatch a named event whose data buffer is
+   * empty, so it is what fires the client's listener. Writing to an already
+   * disconnected client is a harmless no-op; `handle`'s handlers do the eviction.
    */
   public broadcast(event: SseEventName): void {
-    const frame = `event: ${event}\ndata: {}\n\n`;
+    this.send(`event: ${event}\ndata: {}\n\n`);
+  }
+
+  /** Push a SYNTH_STATUS event carrying a failed synth's summary + stderr. */
+  public broadcastSynthStatus(payload: SynthStatusEvent): void {
+    const details = payload.details && payload.details.length > MAX_SYNTH_DETAILS_CHARS
+      ? `${payload.details.slice(0, MAX_SYNTH_DETAILS_CHARS)}\n…truncated`
+      : payload.details;
+    this.send(`event: ${SYNTH_STATUS}\ndata: ${JSON.stringify({ message: payload.message, details })}\n\n`);
+  }
+
+  private send(frame: string): void {
     for (const client of this.clients) {
       client.write(frame);
     }

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -7,8 +7,21 @@
  */
 export const ASSEMBLY_CHANGED = 'assembly-changed';
 
-/** The SSE event names the server may send. One for now. */
-export type SseEventName = typeof ASSEMBLY_CHANGED;
+/**
+ * SSE event carrying a failed synth's outcome (app-failure or an unclassified
+ * error). Fired for both manual and auto synths so the SPA can surface it.
+ * Success is not sent here; it arrives as ASSEMBLY_CHANGED.
+ */
+export const SYNTH_STATUS = 'synth-status';
+
+/** Payload of a {@link SYNTH_STATUS} event: the failure summary and captured stderr. */
+export interface SynthStatusEvent {
+  readonly message: string;
+  readonly details?: string;
+}
+
+/** The SSE event names the server may send. */
+export type SseEventName = typeof ASSEMBLY_CHANGED | typeof SYNTH_STATUS;
 
 export interface DirEntry {
   readonly name: string;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -12,6 +12,7 @@ import { classifyReportSeverity, displaySeverity, severityRank } from './severit
 import type { AcquireAssemblyLock, AssemblyLock } from '../core/assembly-lock';
 import { readAssembly as defaultReadAssembly, type AssemblyData, type AssemblyReadResult, type ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
+import type { SynthRunResult } from '../core/synth-runner';
 
 /** Largest file the viewer returns inline, to avoid buffering huge artifacts into memory and the response. */
 const MAX_FILE_BYTES = 2 * 1024 * 1024;
@@ -39,6 +40,10 @@ export interface ApiOptions {
    * mid-synth assembly. Built from the Toolkit in {@link registerApi}'s caller.
    */
   readonly acquireAssemblyLock: AcquireAssemblyLock;
+  /** Get/set auto-synth state. Omit if synth is not available. */
+  readonly autoSynth?: { get(): boolean; set(enabled: boolean): void };
+  /** Trigger a manual synth. Omit if synth is not available. */
+  readonly synth?: () => Promise<SynthRunResult>;
 }
 
 export function createApiRouter(options: ApiOptions): Router {
@@ -204,6 +209,26 @@ export function createApiRouter(options: ApiOptions): Router {
     const body: TemplateResponse = { content, resources };
     return res.json(body);
   });
+
+  if (options.autoSynth && options.synth) {
+    router.get('/synth/auto', (_req, res) => {
+      res.json({ enabled: options.autoSynth!.get() });
+    });
+
+    router.post('/synth/auto', express.json(), (req, res) => {
+      const { enabled } = req.body ?? {};
+      if (typeof enabled !== 'boolean') {
+        return res.status(400).json({ error: 'enabled must be a boolean' });
+      }
+      options.autoSynth!.set(enabled);
+      return res.json({ enabled: options.autoSynth!.get() });
+    });
+
+    router.post('/synth', async (_req, res) => {
+      const result = await options.synth!();
+      res.json(result);
+    });
+  }
 
   return router;
 }

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -22,7 +22,21 @@ const LOCK_RETRIES = 10;
 const LOCK_RETRY_MS = 50;
 const delay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
-export interface ApiOptions {
+/** Get and set the web server's auto-synth-on-save toggle. */
+export interface AutoSynthControl {
+  get(): boolean;
+  set(enabled: boolean): void;
+}
+
+/**
+ * Synth capability wired into the API: both fields are present together or not
+ * at all, so the synth endpoints are registered only when the server can synth.
+ */
+export type SynthCapability =
+  | { readonly autoSynth: AutoSynthControl; readonly synth: () => Promise<SynthRunResult> }
+  | { readonly autoSynth?: undefined; readonly synth?: undefined };
+
+interface ApiOptionsBase {
   /** Root of the CDK app; all file listing/reading is confined to this directory. */
   readonly appDir: string;
   /**
@@ -40,11 +54,9 @@ export interface ApiOptions {
    * mid-synth assembly. Built from the Toolkit in {@link registerApi}'s caller.
    */
   readonly acquireAssemblyLock: AcquireAssemblyLock;
-  /** Get/set auto-synth state. Omit if synth is not available. */
-  readonly autoSynth?: { get(): boolean; set(enabled: boolean): void };
-  /** Trigger a manual synth. Omit if synth is not available. */
-  readonly synth?: () => Promise<SynthRunResult>;
 }
+
+export type ApiOptions = ApiOptionsBase & SynthCapability;
 
 export function createApiRouter(options: ApiOptions): Router {
   const appDir = canonicalDir(options.appDir);
@@ -210,9 +222,10 @@ export function createApiRouter(options: ApiOptions): Router {
     return res.json(body);
   });
 
-  if (options.autoSynth && options.synth) {
+  if (options.autoSynth) {
+    const { autoSynth, synth } = options;
     router.get('/synth/auto', (_req, res) => {
-      res.json({ enabled: options.autoSynth!.get() });
+      res.json({ enabled: autoSynth.get() });
     });
 
     router.post('/synth/auto', express.json(), (req, res) => {
@@ -220,12 +233,12 @@ export function createApiRouter(options: ApiOptions): Router {
       if (typeof enabled !== 'boolean') {
         return res.status(400).json({ error: 'enabled must be a boolean' });
       }
-      options.autoSynth!.set(enabled);
-      return res.json({ enabled: options.autoSynth!.get() });
+      autoSynth.set(enabled);
+      return res.json({ enabled: autoSynth.get() });
     });
 
     router.post('/synth', async (_req, res) => {
-      const result = await options.synth!();
+      const result = await synth();
       res.json(result);
     });
   }

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -82,6 +82,10 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
 
   const app = express();
 
+  // Live-refresh + synth-status stream. Created before the synth guard so a
+  // failed synth (manual or auto) can broadcast its outcome to browsers.
+  const events = new SseBroadcaster();
+
   let autoSynthEnabled = false;
   let synthInFlight = false;
   // Drop-if-in-flight: mirrors lib/lsp/server.ts. The Toolkit's RWLock on
@@ -91,7 +95,16 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     if (synthInFlight) return { status: 'lock-conflict' };
     synthInFlight = true;
     try {
-      return await options.synthRunner(appDir);
+      const result = await options.synthRunner(appDir);
+      // Surface failures for every synth (manual or auto); success arrives
+      // separately as an assembly-changed refresh.
+      if (result.status === 'app-failure' || result.status === 'error') {
+        events.broadcastSynthStatus({
+          message: result.message,
+          details: result.status === 'app-failure' ? result.details : undefined,
+        });
+      }
+      return result;
     } finally {
       synthInFlight = false;
     }
@@ -117,9 +130,8 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     synth: guardedSynth,
   });
 
-  // Live-refresh stream: browsers subscribe here and re-fetch when the assembly
-  // changes. Registered before the /api catch-all so it is not treated as unknown.
-  const events = new SseBroadcaster();
+  // Browsers subscribe here for assembly-changed + synth-status. Registered
+  // before the /api catch-all so it is not treated as unknown.
   app.get('/api/events', events.handle.bind(events));
 
   // Unknown /api routes must return JSON 404, not fall through to the SPA.

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -6,13 +6,15 @@ import express = require('express');
 import { SseBroadcaster } from './events';
 import { ASSEMBLY_CHANGED } from './protocol';
 import { registerApi } from './routes';
+import { startSourceWatcher, type SourceWatcher, type SourceWatcherOptions } from './source-watcher';
 import { indexHtml, webAsset } from './web-assets';
-import { toolkitAssemblyLock } from '../core/assembly-lock';
+import { toolkitAssemblyLock, type AcquireAssemblyLock } from '../core/assembly-lock';
 import {
   startAssemblyWatcher as defaultStartAssemblyWatcher,
   type AssemblyWatcher,
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
+import { runSynth, type SynthRunResult } from '../core/synth-runner';
 
 export const DEFAULT_PORT = 4200;
 const MAX_PORT_ATTEMPTS = 100;
@@ -40,10 +42,27 @@ export interface WebServerOptions {
    * writing to stderr; the CLI command passes a sink that routes to its IoHost.
    */
   readonly onWatcherError?: (err: unknown) => void;
+  /**
+   * Runs a synth of the project. The CLI command handler injects the real
+   * runner; tests pass a noop or a jest.fn double.
+   */
+  readonly synthRunner: (projectDir: string) => Promise<SynthRunResult>;
+  /**
+   * Factory for the source file watcher. Production injects the chokidar-backed
+   * watcher; tests inject a fake so the base suite doesn't spin up a real
+   * watcher on process.cwd().
+   */
+  readonly startSourceWatcher: (options: SourceWatcherOptions) => SourceWatcher;
+  /**
+   * Acquires the assembly read lock (derived from the shared Toolkit). Required
+   * so read endpoints never observe a torn cdk.out mid-synth; tests inject a noop.
+   */
+  readonly acquireAssemblyLock: AcquireAssemblyLock;
 }
 
 export interface WebServer {
   readonly url: string;
+  autoSynthEnabled: boolean;
   stop(): Promise<void>;
 }
 
@@ -55,7 +74,7 @@ export interface WebServer {
  *
  * @returns A handle to the running server with its URL and a stop function.
  */
-export async function startWebServer(options: WebServerOptions = {}): Promise<WebServer> {
+export async function startWebServer(options: WebServerOptions): Promise<WebServer> {
   const appDir = options.appDir ?? process.cwd();
   // Single owner of where the cloud assembly lives: the same resolved path feeds
   // both the read endpoints and the change watcher, so the two never disagree.
@@ -63,14 +82,39 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
 
   const app = express();
 
-  // The Toolkit provides the assembly read lock (via fromAssemblyDirectory().
-  // produce()); a non-interactive IoHost is fine here since stdout/stderr are
-  // free in the web process, unlike the LSP's stdio channel.
-  const toolkit = new Toolkit({ ioHost: new NonInteractiveIoHost() });
+  let autoSynthEnabled = false;
+  let synthInFlight = false;
+  // Drop-if-in-flight: mirrors lib/lsp/server.ts. The Toolkit's RWLock on
+  // cdk.out is the real cross-process mutex; this in-process boolean is a
+  // deliberate short-circuit before any synth setup work.
+  async function guardedSynth(): Promise<SynthRunResult> {
+    if (synthInFlight) return { status: 'lock-conflict' };
+    synthInFlight = true;
+    try {
+      return await options.synthRunner(appDir);
+    } finally {
+      synthInFlight = false;
+    }
+  }
+  const sourceWatcher = options.startSourceWatcher({
+    appDir,
+    onChange: () => {
+      if (!autoSynthEnabled) return;
+      void guardedSynth();
+    },
+  });
+
   registerApi(app, {
     appDir,
     assemblyDir,
-    acquireAssemblyLock: toolkitAssemblyLock(toolkit),
+    acquireAssemblyLock: options.acquireAssemblyLock,
+    autoSynth: {
+      get: () => autoSynthEnabled,
+      set: (enabled) => {
+        autoSynthEnabled = enabled;
+      },
+    },
+    synth: guardedSynth,
   });
 
   // Live-refresh stream: browsers subscribe here and re-fetch when the assembly
@@ -117,10 +161,17 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   let stopped = false;
   return {
     url: `http://${HOST}:${port}`,
+    get autoSynthEnabled() {
+      return autoSynthEnabled;
+    },
+    set autoSynthEnabled(enabled: boolean) {
+      autoSynthEnabled = enabled;
+    },
     stop: async () => {
       if (stopped) return;
       stopped = true;
       await watcher.close();
+      await sourceWatcher.close();
       events.close();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());
@@ -128,6 +179,41 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
       });
     },
   };
+}
+
+export interface StartCdkExploreOptions {
+  readonly port?: number;
+  /**
+   * Root of the CDK app; also the synth working directory. Defaults to
+   * `process.cwd()`.
+   */
+  readonly appDir?: string;
+  /**
+   * Reports a non-fatal assembly-watcher error. The CLI command routes this to
+   * its IoHost; defaults (in startWebServer) to stderr.
+   */
+  readonly onWatcherError?: (err: unknown) => void;
+}
+
+/**
+ * Production entry point for `cdk explore`. Constructs a Toolkit + IoHost,
+ * wires the synth runner and source watcher, and delegates to `startWebServer`.
+ * Kept separate so `startWebServer` stays a pure testable factory: tests inject
+ * a noop synthRunner and a fake watcher via that lower layer.
+ */
+export async function startCdkExplore(options: StartCdkExploreOptions = {}): Promise<WebServer> {
+  // The one Toolkit for the web process: it owns the cdk.out read lock and runs
+  // synths, so a synth write and an assembly read share a single lock owner. Its
+  // default IoHost is NonInteractiveIoHost (stdout/stderr aren't our transport).
+  const toolkit = new Toolkit({ ioHost: new NonInteractiveIoHost() });
+  return startWebServer({
+    port: options.port,
+    appDir: options.appDir,
+    onWatcherError: options.onWatcherError,
+    synthRunner: (projectDir) => runSynth({ toolkit, projectDir }),
+    acquireAssemblyLock: toolkitAssemblyLock(toolkit),
+    startSourceWatcher,
+  });
 }
 
 async function listenOnPort(

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -42,27 +42,21 @@ export interface WebServerOptions {
    * writing to stderr; the CLI command passes a sink that routes to its IoHost.
    */
   readonly onWatcherError?: (err: unknown) => void;
-  /**
-   * Runs a synth of the project. The CLI command handler injects the real
-   * runner; tests pass a noop or a jest.fn double.
-   */
+  /** Runs a synth of the project, returning its outcome. */
   readonly synthRunner: (projectDir: string) => Promise<SynthRunResult>;
-  /**
-   * Factory for the source file watcher. Production injects the chokidar-backed
-   * watcher; tests inject a fake so the base suite doesn't spin up a real
-   * watcher on process.cwd().
-   */
+  /** Factory for the source file watcher that drives auto-synth. */
   readonly startSourceWatcher: (options: SourceWatcherOptions) => SourceWatcher;
   /**
-   * Acquires the assembly read lock (derived from the shared Toolkit). Required
-   * so read endpoints never observe a torn cdk.out mid-synth; tests inject a noop.
+   * Acquires the assembly read lock (derived from the shared Toolkit) so read
+   * endpoints never observe a torn cdk.out mid-synth.
    */
   readonly acquireAssemblyLock: AcquireAssemblyLock;
 }
 
 export interface WebServer {
   readonly url: string;
-  autoSynthEnabled: boolean;
+  /** Current auto-synth-on-save state; changed via the /api/synth/auto endpoint. */
+  readonly autoSynthEnabled: boolean;
   stop(): Promise<void>;
 }
 
@@ -175,9 +169,6 @@ export async function startWebServer(options: WebServerOptions): Promise<WebServ
     url: `http://${HOST}:${port}`,
     get autoSynthEnabled() {
       return autoSynthEnabled;
-    },
-    set autoSynthEnabled(enabled: boolean) {
-      autoSynthEnabled = enabled;
     },
     stop: async () => {
       if (stopped) return;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/source-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/source-watcher.ts
@@ -1,0 +1,87 @@
+/* eslint-disable import/no-relative-packages -- toolkit-lib's glob-matcher is not re-exported from its package index */
+import * as chokidar from 'chokidar';
+import { createIgnoreMatcher } from '../../../toolkit-lib/lib/util/glob-matcher';
+import type { FileWatcher } from '../core/assembly-watcher';
+import { SOURCE_WATCH_EXCLUDES } from '../core/synth-runner';
+
+const DEBOUNCE_MS = 200;
+
+export interface SourceWatcher {
+  close(): Promise<void>;
+}
+
+export interface SourceWatcherOptions {
+  /** The application directory to watch. */
+  readonly appDir: string;
+  /** Invoked (debounced) when a non-ignored source file changes. */
+  readonly onChange: () => void;
+  /** Receives non-fatal watcher errors. */
+  readonly onError?: (error: unknown) => void;
+  /**
+   * Factory for the underlying file watcher. Defaults to chokidar; overridden
+   * in tests with a fake.
+   */
+  readonly createWatcher?: (appDir: string) => FileWatcher;
+}
+
+// Thin wrapper over real chokidar; exercised via integration, not unit tests.
+/* c8 ignore start */
+function defaultCreateWatcher(appDir: string): FileWatcher {
+  // Perf layer: chokidar applies the same ignore policy while traversing, so it
+  // skips ignored paths at the source instead of streaming them to the handler.
+  // chokidar emits absolute paths on 'all'; the handler re-checks the same
+  // policy as the unit-tested correctness layer.
+  return chokidar.watch(appDir, {
+    ignored: createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: appDir }),
+    ignoreInitial: true,
+  }) as unknown as FileWatcher;
+}
+/* c8 ignore stop */
+
+/**
+ * Watch a CDK app's source tree and fire `onChange` (debounced) when a
+ * non-ignored file changes. The ignore filter runs in the handler so it is
+ * unit-testable through the injected watcher; the real watcher additionally
+ * skips the same paths for performance.
+ */
+export function startSourceWatcher(options: SourceWatcherOptions): SourceWatcher {
+  const createWatcher = options.createWatcher ?? defaultCreateWatcher;
+
+  // drop changes to ignored paths so they never trigger a synth. chokidar emits absolute paths,
+  // which the matcher's rootDir resolves before matching.
+  const shouldIgnore = createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: options.appDir });
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+
+  const watcher = createWatcher(options.appDir);
+
+  watcher.on('all', (_eventName, filePath) => {
+    if (closed) return;
+    if (shouldIgnore(filePath)) return;
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = undefined;
+      try {
+        options.onChange();
+      } catch (error) {
+        options.onError?.(error);
+      }
+    }, DEBOUNCE_MS);
+  });
+
+  watcher.on('error', (error) => {
+    options.onError?.(error);
+  });
+
+  return {
+    async close() {
+      closed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      await watcher.close();
+    },
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/web/source-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/source-watcher.ts
@@ -17,20 +17,15 @@ export interface SourceWatcherOptions {
   readonly onChange: () => void;
   /** Receives non-fatal watcher errors. */
   readonly onError?: (error: unknown) => void;
-  /**
-   * Factory for the underlying file watcher. Defaults to chokidar; overridden
-   * in tests with a fake.
-   */
+  /** Factory for the underlying file watcher. Defaults to chokidar. */
   readonly createWatcher?: (appDir: string) => FileWatcher;
 }
 
-// Thin wrapper over real chokidar; exercised via integration, not unit tests.
 /* c8 ignore start */
 function defaultCreateWatcher(appDir: string): FileWatcher {
-  // Perf layer: chokidar applies the same ignore policy while traversing, so it
-  // skips ignored paths at the source instead of streaming them to the handler.
-  // chokidar emits absolute paths on 'all'; the handler re-checks the same
-  // policy as the unit-tested correctness layer.
+  // chokidar applies the same ignore policy while traversing, so ignored paths
+  // are skipped at the source instead of streamed to the handler. It emits
+  // absolute paths on 'all', which the handler re-checks against the same policy.
   return chokidar.watch(appDir, {
     ignored: createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: appDir }),
     ignoreInitial: true,
@@ -40,9 +35,8 @@ function defaultCreateWatcher(appDir: string): FileWatcher {
 
 /**
  * Watch a CDK app's source tree and fire `onChange` (debounced) when a
- * non-ignored file changes. The ignore filter runs in the handler so it is
- * unit-testable through the injected watcher; the real watcher additionally
- * skips the same paths for performance.
+ * non-ignored file changes. The ignore filter runs in the handler; the real
+ * watcher additionally skips the same paths for performance.
  */
 export function startSourceWatcher(options: SourceWatcherOptions): SourceWatcher {
   const createWatcher = options.createWatcher ?? defaultCreateWatcher;

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -430,3 +430,97 @@ describe('assembly read lock', () => {
     expect(readAssembly).toHaveBeenCalledTimes(2); // mtime changed, so re-read
   });
 });
+
+describe('synth endpoints', () => {
+  let synthApp: express.Express;
+  let mockSynth: jest.Mock;
+  let autoSynthState: boolean;
+
+  beforeEach(() => {
+    autoSynthState = false;
+    mockSynth = jest.fn().mockResolvedValue({ status: 'success' });
+    synthApp = express();
+    synthApp.use('/api', createApiRouter({
+      appDir,
+      autoSynth: {
+        get: () => autoSynthState,
+        set: (enabled) => {
+          autoSynthState = enabled;
+        },
+      },
+      synth: mockSynth,
+    }));
+  });
+
+  describe('GET /api/synth/auto', () => {
+    test('returns current auto-synth state', async () => {
+      const res = await request(synthApp).get('/api/synth/auto');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ enabled: false });
+    });
+
+    test('reflects state after toggle', async () => {
+      autoSynthState = true;
+      const res = await request(synthApp).get('/api/synth/auto');
+      expect(res.body).toEqual({ enabled: true });
+    });
+  });
+
+  describe('POST /api/synth/auto', () => {
+    test('enables auto-synth', async () => {
+      const res = await request(synthApp)
+        .post('/api/synth/auto')
+        .send({ enabled: true });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ enabled: true });
+      expect(autoSynthState).toBe(true);
+    });
+
+    test('disables auto-synth', async () => {
+      autoSynthState = true;
+      const res = await request(synthApp)
+        .post('/api/synth/auto')
+        .send({ enabled: false });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ enabled: false });
+      expect(autoSynthState).toBe(false);
+    });
+
+    test('rejects non-boolean with 400', async () => {
+      const res = await request(synthApp)
+        .post('/api/synth/auto')
+        .send({ enabled: 'yes' });
+      expect(res.status).toBe(400);
+    });
+
+    test('rejects missing body with 400', async () => {
+      const res = await request(synthApp)
+        .post('/api/synth/auto')
+        .send({});
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/synth', () => {
+    test('triggers synth and returns result', async () => {
+      const res = await request(synthApp).post('/api/synth');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'success' });
+      expect(mockSynth).toHaveBeenCalledTimes(1);
+    });
+
+    test('returns app-failure result', async () => {
+      mockSynth.mockResolvedValue({ status: 'app-failure', message: 'compile error' });
+      const res = await request(synthApp).post('/api/synth');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ status: 'app-failure', message: 'compile error' });
+    });
+  });
+
+  describe('without synth configured', () => {
+    test('synth endpoints are not registered', async () => {
+      const res = await request(app).get('/api/synth/auto');
+      expect(res.status).toBe(404);
+    });
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -1,5 +1,27 @@
+import type { AcquireAssemblyLock } from '../../lib/core/assembly-lock';
+import type { SynthRunResult } from '../../lib/core/synth-runner';
 import { ASSEMBLY_CHANGED } from '../../lib/web/protocol';
-import { startWebServer, DEFAULT_PORT, type WebServer } from '../../lib/web/server';
+import { startWebServer, DEFAULT_PORT, type WebServer, type WebServerOptions } from '../../lib/web/server';
+import type { SourceWatcher, SourceWatcherOptions } from '../../lib/web/source-watcher';
+
+const noopSynth: (dir: string) => Promise<SynthRunResult> = async () => ({ status: 'success' });
+const noopStartSourceWatcher = (_opts: SourceWatcherOptions): SourceWatcher => ({
+  async close() {
+  },
+});
+const noopAcquireAssemblyLock: AcquireAssemblyLock = async () => ({
+  release: async () => {
+  },
+});
+
+function startTestServer(overrides: Partial<WebServerOptions> = {}): Promise<WebServer> {
+  return startWebServer({
+    synthRunner: noopSynth,
+    startSourceWatcher: noopStartSourceWatcher,
+    acquireAssemblyLock: noopAcquireAssemblyLock,
+    ...overrides,
+  });
+}
 
 describe('Web Server', () => {
   let server: WebServer;
@@ -11,7 +33,7 @@ describe('Web Server', () => {
   });
 
   test('starts and responds to health check', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
 
     const res = await fetch(`${server.url}/api/health`);
     expect(res.status).toBe(200);
@@ -21,13 +43,13 @@ describe('Web Server', () => {
   });
 
   test('binds to localhost by default', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
     expect(server.url).toMatch(/^http:\/\/localhost:\d+$/);
   });
 
   test('auto-increments port by 1 when default is taken', async () => {
-    const first = await startWebServer({ port: DEFAULT_PORT });
-    server = await startWebServer();
+    const first = await startTestServer({ port: DEFAULT_PORT });
+    server = await startTestServer();
 
     expect(first.url).toBe(`http://localhost:${DEFAULT_PORT}`);
     expect(server.url).toBe(`http://localhost:${DEFAULT_PORT + 1}`);
@@ -35,16 +57,16 @@ describe('Web Server', () => {
   });
 
   test('throws when explicit port is taken', async () => {
-    const first = await startWebServer({ port: 4567 });
+    const first = await startTestServer({ port: 4567 });
     try {
-      await expect(startWebServer({ port: 4567 })).rejects.toThrow();
+      await expect(startTestServer({ port: 4567 })).rejects.toThrow();
     } finally {
       await first.stop();
     }
   });
 
   test('stops cleanly', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
     const url = server.url;
 
     await server.stop();
@@ -53,13 +75,13 @@ describe('Web Server', () => {
   });
 
   test('stop is idempotent', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
     await server.stop();
     await server.stop();
   });
 
   test('unknown /api route returns a JSON 404 rather than the SPA', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
     const res = await fetch(`${server.url}/api/does-not-exist`);
     expect(res.status).toBe(404);
     expect(res.headers.get('content-type')).toMatch(/application\/json/);
@@ -67,7 +89,7 @@ describe('Web Server', () => {
   });
 
   test('serves the SPA index with Cache-Control: no-store so a rebuilt bundle is not served stale', async () => {
-    server = await startWebServer();
+    server = await startTestServer();
     const res = await fetch(`${server.url}/`);
     expect(res.status).toBe(200);
     expect(res.headers.get('cache-control')).toBe('no-store');
@@ -76,7 +98,7 @@ describe('Web Server', () => {
   test('watches the resolved assembly dir and closes the watcher on stop', async () => {
     let seenDir: string | undefined;
     let closed = false;
-    server = await startWebServer({
+    server = await startTestServer({
       assemblyDir: '/tmp/explorer-test/cdk.out',
       startAssemblyWatcher: (opts) => {
         seenDir = opts.assemblyDir;
@@ -96,7 +118,7 @@ describe('Web Server', () => {
 
   test('broadcasts an assembly-changed event to a connected client when the watcher fires', async () => {
     let fireChange = (): void => undefined;
-    server = await startWebServer({
+    server = await startTestServer({
       startAssemblyWatcher: (opts) => {
         fireChange = opts.onChange;
         return { close: async () => undefined };
@@ -116,3 +138,77 @@ describe('Web Server', () => {
     await reader.cancel();
   });
 });
+
+describe('Web Server — auto-synth', () => {
+  let server: WebServer;
+  let mockSynthRunner: jest.Mock<Promise<SynthRunResult>, [string]>;
+  let capturedOnChange: () => void;
+  let fakeWatcherClosed: boolean;
+
+  function fakeStartSourceWatcher(opts: SourceWatcherOptions): SourceWatcher {
+    capturedOnChange = opts.onChange;
+    fakeWatcherClosed = false;
+    return {
+      async close() {
+        fakeWatcherClosed = true;
+      },
+    };
+  }
+
+  beforeEach(async () => {
+    mockSynthRunner = jest.fn<Promise<SynthRunResult>, [string]>().mockResolvedValue({ status: 'success' });
+    server = await startTestServer({
+      synthRunner: mockSynthRunner,
+      startSourceWatcher: fakeStartSourceWatcher,
+    });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  test('auto-synth is off by default', () => {
+    expect(server.autoSynthEnabled).toBe(false);
+  });
+
+  test('source change with auto-synth OFF does not trigger synth', async () => {
+    capturedOnChange();
+    await tick();
+    expect(mockSynthRunner).not.toHaveBeenCalled();
+  });
+
+  test('source change with auto-synth ON triggers synth', async () => {
+    server.autoSynthEnabled = true;
+    capturedOnChange();
+    await tick();
+    expect(mockSynthRunner).toHaveBeenCalledTimes(1);
+  });
+
+  test('toggle via API controls auto-synth behavior', async () => {
+    await fetch(`${server.url}/api/synth/auto`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true }),
+    });
+
+    capturedOnChange();
+    await tick();
+    expect(mockSynthRunner).toHaveBeenCalledTimes(1);
+  });
+
+  test('POST /api/synth triggers a manual synth', async () => {
+    const res = await fetch(`${server.url}/api/synth`, { method: 'POST' });
+    const body = await res.json();
+    expect(body).toEqual({ status: 'success' });
+    expect(mockSynthRunner).toHaveBeenCalledTimes(1);
+  });
+
+  test('stop closes the source watcher', async () => {
+    await server.stop();
+    expect(fakeWatcherClosed).toBe(true);
+  });
+});
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -178,7 +178,11 @@ describe('Web Server — auto-synth', () => {
   });
 
   test('source change with auto-synth ON triggers synth', async () => {
-    server.autoSynthEnabled = true;
+    await fetch(`${server.url}/api/synth/auto`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ enabled: true }),
+    });
     capturedOnChange();
     await tick();
     expect(mockSynthRunner).toHaveBeenCalledTimes(1);

--- a/packages/@aws-cdk/cdk-explorer/test/web/source-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/source-watcher.test.ts
@@ -1,0 +1,140 @@
+import type { FileWatcher } from '../../lib/core/assembly-watcher';
+import { startSourceWatcher } from '../../lib/web/source-watcher';
+
+type AnyListener = (...args: unknown[]) => void;
+
+class FakeWatcher implements FileWatcher {
+  public closed = false;
+  private readonly listeners: Record<string, AnyListener[]> = {};
+
+  public on(event: string, listener: AnyListener): FileWatcher {
+    (this.listeners[event] ??= []).push(listener);
+    return this;
+  }
+
+  public emitFile(eventName: string, filePath: string): void {
+    for (const listener of this.listeners.all ?? []) {
+      listener(eventName, filePath);
+    }
+  }
+
+  public emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners[event] ?? []) {
+      listener(...args);
+    }
+  }
+
+  public async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function setup() {
+  const fake = new FakeWatcher();
+  const onChange = jest.fn();
+  const onError = jest.fn();
+  const watcher = startSourceWatcher({
+    appDir: '/project',
+    onChange,
+    onError,
+    createWatcher: () => fake,
+  });
+  return { fake, onChange, onError, watcher };
+}
+
+describe('Source Watcher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('debounces rapid file changes into a single onChange', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/project/src/app.ts');
+    fake.emitFile('change', '/project/src/stack.ts');
+    fake.emitFile('change', '/project/lib/construct.ts');
+    expect(onChange).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores excluded paths but triggers on real source changes', () => {
+    const { fake, onChange } = setup();
+
+    // node_modules, cdk.out, and dotfiles must never trigger a synth. cdk.out is
+    // the critical one: firing on it would loop, since synth writes cdk.out.
+    fake.emitFile('add', '/project/node_modules/foo/index.js');
+    fake.emitFile('change', '/project/cdk.out/manifest.json');
+    fake.emitFile('add', '/project/.git/HEAD');
+    jest.advanceTimersByTime(200);
+    expect(onChange).not.toHaveBeenCalled();
+
+    fake.emitFile('change', '/project/src/app.ts');
+    jest.advanceTimersByTime(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('resets debounce timer on each new event', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/project/src/app.ts');
+    jest.advanceTimersByTime(150);
+    expect(onChange).not.toHaveBeenCalled();
+
+    fake.emitFile('change', '/project/src/stack.ts');
+    jest.advanceTimersByTime(150);
+    expect(onChange).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(50);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('close cancels pending onChange and closes the underlying watcher', async () => {
+    const { fake, onChange, watcher } = setup();
+
+    fake.emitFile('change', '/project/src/app.ts');
+    await watcher.close();
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(fake.closed).toBe(true);
+  });
+
+  test('ignores events after close', async () => {
+    const { fake, onChange, watcher } = setup();
+
+    await watcher.close();
+    fake.emitFile('change', '/project/src/app.ts');
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('forwards watcher errors to onError', () => {
+    const { fake, onError } = setup();
+
+    fake.emit('error', new Error('watch failed'));
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('forwards onChange throw to onError', () => {
+    const fake = new FakeWatcher();
+    const failure = new Error('handler blew up');
+    const onError = jest.fn();
+    startSourceWatcher({
+      appDir: '/project',
+      onChange: () => {
+        throw failure;
+      },
+      onError,
+      createWatcher: () => fake,
+    });
+
+    fake.emitFile('change', '/project/src/app.ts');
+    expect(() => jest.advanceTimersByTime(200)).not.toThrow();
+
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -10439,6 +10439,34 @@ SOFTWARE.
 
 ----------------
 
+** accepts@1.3.8 - https://www.npmjs.com/package/accepts/v/1.3.8 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** agent-base@7.1.4 - https://www.npmjs.com/package/agent-base/v/7.1.4 | MIT
 (The MIT License)
 
@@ -10546,6 +10574,32 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** array-flatten@1.1.1 - https://www.npmjs.com/package/array-flatten/v/1.1.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** ast-types@0.13.4 - https://www.npmjs.com/package/ast-types/v/0.13.4 | MIT
 Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
 
@@ -10605,6 +10659,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----------------
+
+** body-parser@1.20.4 - https://www.npmjs.com/package/body-parser/v/1.20.4 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -10698,6 +10780,86 @@ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PA
 PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
 FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** bytes@3.1.2 - https://www.npmjs.com/package/bytes/v/3.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015 Jed Watson <jed.watson@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** call-bind-apply-helpers@1.0.2 - https://www.npmjs.com/package/call-bind-apply-helpers/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** call-bound@1.0.4 - https://www.npmjs.com/package/call-bound/v/1.0.4 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -10805,6 +10967,60 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** content-disposition@0.5.4 - https://www.npmjs.com/package/content-disposition/v/0.5.4 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** content-type@1.0.5 - https://www.npmjs.com/package/content-type/v/1.0.5 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** convert-source-map@2.0.0 - https://www.npmjs.com/package/convert-source-map/v/2.0.0 | MIT
 Copyright 2013 Thorsten Lorenz. 
 All rights reserved.
@@ -10833,6 +11049,39 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** cookie-signature@1.0.7 - https://www.npmjs.com/package/cookie-signature/v/1.0.7 | MIT
+
+----------------
+
+** cookie@0.7.2 - https://www.npmjs.com/package/cookie/v/0.7.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** data-uri-to-buffer@6.0.2 - https://www.npmjs.com/package/data-uri-to-buffer/v/6.0.2 | MIT
 (The MIT License)
 
@@ -10856,6 +11105,30 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** debug@2.6.9 - https://www.npmjs.com/package/debug/v/2.6.9 | MIT
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the 'Software'), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 
 ----------------
 
@@ -10928,6 +11201,114 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** depd@2.0.0 - https://www.npmjs.com/package/depd/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2018 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** destroy@1.2.0 - https://www.npmjs.com/package/destroy/v/1.2.0 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2015-2022 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** dunder-proto@1.0.1 - https://www.npmjs.com/package/dunder-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** ee-first@1.1.1 - https://www.npmjs.com/package/ee-first/v/1.1.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** emoji-regex@8.0.0 - https://www.npmjs.com/package/emoji-regex/v/8.0.0 | MIT
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -10949,6 +11330,33 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** encodeurl@2.0.0 - https://www.npmjs.com/package/encodeurl/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -10975,6 +11383,113 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+----------------
+
+** es-define-property@1.0.1 - https://www.npmjs.com/package/es-define-property/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-errors@1.3.0 - https://www.npmjs.com/package/es-errors/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-object-atoms@1.1.1 - https://www.npmjs.com/package/es-object-atoms/v/1.1.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** escape-html@1.0.3 - https://www.npmjs.com/package/escape-html/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Tiancheng "Timothy" Gu
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11079,6 +11594,33 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------
 
+** etag@1.8.1 - https://www.npmjs.com/package/etag/v/1.8.1 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** eventemitter3@4.0.7 - https://www.npmjs.com/package/eventemitter3/v/4.0.7 | MIT
 The MIT License (MIT)
 
@@ -11101,6 +11643,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+----------------
+
+** express@4.22.1 - https://www.npmjs.com/package/express/v/4.22.1 | MIT
+(The MIT License)
+
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11201,6 +11772,33 @@ THE SOFTWARE.
 
 ----------------
 
+** finalhandler@1.3.2 - https://www.npmjs.com/package/finalhandler/v/1.3.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** find-up@4.1.0 - https://www.npmjs.com/package/find-up/v/4.1.0 | MIT
 MIT License
 
@@ -11211,6 +11809,61 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** forwarded@0.2.0 - https://www.npmjs.com/package/forwarded/v/0.2.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** fresh@0.5.2 - https://www.npmjs.com/package/fresh/v/0.5.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11235,7 +11888,84 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ----------------
 
+** function-bind@1.1.2 - https://www.npmjs.com/package/function-bind/v/1.1.2 | MIT
+Copyright (c) 2013 Raynos.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+----------------
+
 ** get-caller-file@2.0.5 - https://www.npmjs.com/package/get-caller-file/v/2.0.5 | ISC
+
+----------------
+
+** get-intrinsic@1.3.0 - https://www.npmjs.com/package/get-intrinsic/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2020 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** get-proto@1.0.1 - https://www.npmjs.com/package/get-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2025 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 
@@ -11285,6 +12015,32 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** gopd@1.2.0 - https://www.npmjs.com/package/gopd/v/1.2.0 | MIT
+MIT License
+
+Copyright (c) 2022 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** graceful-fs@4.2.11 - https://www.npmjs.com/package/graceful-fs/v/4.2.11 | ISC
 The ISC License
 
@@ -11315,6 +12071,86 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** has-symbols@1.1.0 - https://www.npmjs.com/package/has-symbols/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2016 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** hasown@2.0.4 - https://www.npmjs.com/package/hasown/v/2.0.4 | MIT
+MIT License
+
+Copyright (c) Jordan Harband and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** http-errors@2.0.1 - https://www.npmjs.com/package/http-errors/v/2.0.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -11372,8 +12208,79 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** iconv-lite@0.4.24 - https://www.npmjs.com/package/iconv-lite/v/0.4.24 | MIT
+Copyright (c) 2011 Alexander Shtuchkin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
+** inherits@2.0.4 - https://www.npmjs.com/package/inherits/v/2.0.4 | ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+
+----------------
+
 ** ip-address@10.2.0 - https://www.npmjs.com/package/ip-address/v/10.2.0 | MIT
 Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** ipaddr.js@1.9.1 - https://www.npmjs.com/package/ipaddr.js/v/1.9.1 | MIT
+Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11646,6 +12553,87 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** math-intrinsics@1.1.0 - https://www.npmjs.com/package/math-intrinsics/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** media-typer@0.3.0 - https://www.npmjs.com/package/media-typer/v/0.3.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** merge-descriptors@1.0.3 - https://www.npmjs.com/package/merge-descriptors/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** merge2@1.4.1 - https://www.npmjs.com/package/merge2/v/1.4.1 | MIT
 The MIT License (MIT)
 
@@ -11672,10 +12660,121 @@ SOFTWARE.
 
 ----------------
 
+** methods@1.1.2 - https://www.npmjs.com/package/methods/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** micromatch@4.0.8 - https://www.npmjs.com/package/micromatch/v/4.0.8 | MIT
 The MIT License (MIT)
 
 Copyright (c) 2014-present, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** mime-db@1.52.0 - https://www.npmjs.com/package/mime-db/v/1.52.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime-types@2.1.35 - https://www.npmjs.com/package/mime-types/v/2.1.35 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime@1.6.0 - https://www.npmjs.com/package/mime/v/1.6.0 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11724,6 +12823,10 @@ THE SOFTWARE.
 
 ----------------
 
+** ms@2.0.0 - https://www.npmjs.com/package/ms/v/2.0.0 | MIT
+
+----------------
+
 ** ms@2.1.3 - https://www.npmjs.com/package/ms/v/2.1.3 | MIT
 
 ----------------
@@ -11748,7 +12851,90 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** negotiator@0.6.3 - https://www.npmjs.com/package/negotiator/v/0.6.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** netmask@2.1.1 - https://www.npmjs.com/package/netmask/v/2.1.1 | MIT
+
+----------------
+
+** object-inspect@1.13.4 - https://www.npmjs.com/package/object-inspect/v/1.13.4 | MIT
+MIT License
+
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** on-finished@2.4.1 - https://www.npmjs.com/package/on-finished/v/2.4.1 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -11915,6 +13101,35 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** parseurl@1.3.3 - https://www.npmjs.com/package/parseurl/v/1.3.3 | MIT
+
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** path-exists@4.0.0 - https://www.npmjs.com/package/path-exists/v/4.0.0 | MIT
 MIT License
 
@@ -11925,6 +13140,32 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** path-to-regexp@0.1.13 - https://www.npmjs.com/package/path-to-regexp/v/0.1.13 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -12007,6 +13248,33 @@ THE SOFTWARE.
 
 ----------------
 
+** proxy-addr@2.0.7 - https://www.npmjs.com/package/proxy-addr/v/2.0.7 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** proxy-agent@6.5.0 - https://www.npmjs.com/package/proxy-agent/v/6.5.0 | MIT
 (The MIT License)
 
@@ -12058,6 +13326,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** qs@6.14.2 - https://www.npmjs.com/package/qs/v/6.14.2 | BSD-3-Clause
+
+----------------
+
 ** queue-microtask@1.2.3 - https://www.npmjs.com/package/queue-microtask/v/1.2.3 | MIT
 The MIT License (MIT)
 
@@ -12079,6 +13351,61 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** range-parser@1.2.1 - https://www.npmjs.com/package/range-parser/v/1.2.1 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** raw-body@2.5.3 - https://www.npmjs.com/package/raw-body/v/2.5.3 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -12201,6 +13528,58 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** safe-buffer@5.2.1 - https://www.npmjs.com/package/safe-buffer/v/5.2.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) Feross Aboukhadijeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** safer-buffer@2.1.2 - https://www.npmjs.com/package/safer-buffer/v/2.1.2 | MIT
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** semver@7.8.5 - https://www.npmjs.com/package/semver/v/7.8.5 | ISC
 The ISC License
 
@@ -12221,6 +13600,64 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** send@0.19.2 - https://www.npmjs.com/package/send/v/0.19.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2014-2022 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** serve-static@1.16.3 - https://www.npmjs.com/package/serve-static/v/1.16.3 | MIT
+(The MIT License)
+
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** set-blocking@2.0.0 - https://www.npmjs.com/package/set-blocking/v/2.0.0 | ISC
 Copyright (c) 2016, Contributors
 
@@ -12236,6 +13673,128 @@ LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** setprototypeof@1.2.0 - https://www.npmjs.com/package/setprototypeof/v/1.2.0 | ISC
+Copyright (c) 2015, Wes Todd
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** side-channel-list@1.0.1 - https://www.npmjs.com/package/side-channel-list/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-map@1.0.1 - https://www.npmjs.com/package/side-channel-map/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-weakmap@1.0.2 - https://www.npmjs.com/package/side-channel-weakmap/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel@1.1.0 - https://www.npmjs.com/package/side-channel/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -12382,6 +13941,34 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** statuses@2.0.2 - https://www.npmjs.com/package/statuses/v/2.0.2 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** string-width@4.2.3 - https://www.npmjs.com/package/string-width/v/4.2.3 | MIT
 MIT License
 
@@ -12479,6 +14066,32 @@ THE SOFTWARE.
 
 ----------------
 
+** toidentifier@1.0.1 - https://www.npmjs.com/package/toidentifier/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** tslib@2.8.1 - https://www.npmjs.com/package/tslib/v/2.8.1 | 0BSD
 Copyright (c) Microsoft Corporation.
 
@@ -12492,6 +14105,34 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+----------------
+
+** type-is@1.6.18 - https://www.npmjs.com/package/type-is/v/1.6.18 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -12516,6 +14157,85 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** unpipe@1.0.0 - https://www.npmjs.com/package/unpipe/v/1.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** utils-merge@1.0.1 - https://www.npmjs.com/package/utils-merge/v/1.0.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Jared Hanson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vary@1.1.2 - https://www.npmjs.com/package/vary/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------

--- a/packages/aws-cdk/lib/commands/explore.ts
+++ b/packages/aws-cdk/lib/commands/explore.ts
@@ -1,4 +1,4 @@
-import { startWebServer } from '@aws-cdk/cdk-explorer';
+import { startCdkExplore } from '@aws-cdk/cdk-explorer';
 import type { IoHelper } from '../api-private';
 
 export interface ExploreOptions {
@@ -7,7 +7,7 @@ export interface ExploreOptions {
 }
 
 export async function explore(options: ExploreOptions): Promise<number> {
-  const server = await startWebServer({
+  const server = await startCdkExplore({
     port: options.port,
     onWatcherError: (err) => void options.ioHelper.defaults.error(
       `CDK Explorer live refresh stopped: ${err instanceof Error ? err.message : String(err)}`,


### PR DESCRIPTION
- Adds manual and auto-synth capabilities to the web explorer, matching the LSP server's synth-on-save behavior
- Source file watcher (chokidar-backed, debounced, respects `cdk.out`/`node_modules`/dotfile excludes) triggers auto-synth when enabled
- Synth failures broadcast over SSE (`synth-status` event) and surface in the frontend as a clickable "Synth failed" indicator with a detail modal
- `POST /api/synth` for manual synth, `GET/POST /api/synth/auto` for toggle state
- Drop-if-in-flight guard prevents concurrent synths (same pattern as the LSP server)
<img width="290" height="66" alt="Screenshot 2026-07-10 at 1 03 44 PM" src="https://github.com/user-attachments/assets/9ff1474e-c687-45c8-9aab-a8ad7a0cde60" />


<img width="299" height="82" alt="Screenshot 2026-07-10 at 1 03 48 PM" src="https://github.com/user-attachments/assets/84d982af-d186-4e67-803d-bf5c111638a4" />


<img width="305" height="77" alt="Screenshot 2026-07-10 at 1 03 56 PM" src="https://github.com/user-attachments/assets/9c2bcf92-0ab4-4738-863b-365fc1ad15dc" />


If you click on "Synth failed" this opens:
<img width="1509" height="850" alt="Screenshot 2026-07-10 at 1 04 03 PM" src="https://github.com/user-attachments/assets/024832ac-a982-42da-a51c-b49b50ae21cf" />


---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license