### PR TITLE
feat: synth freshness

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -59,6 +59,23 @@ import type { SynthRunResult } from '../core/synth-runner';
 const REFRESH_LOCK_RETRIES = 10;
 const REFRESH_LOCK_RETRY_MS = 50;
 
+/**
+ * Synth concurrency latch, mirroring `cdk watch` (see toolkit.ts). 'open' = idle,
+ * 'synthing' = a synth is running, 'queued' = a save arrived mid-synth and a
+ * follow-up is owed. No 'pre-ready' (unlike watch there is no ready gate; the LSP
+ * synths on demand).
+ */
+type SynthLatch = 'open' | 'synthing' | 'queued';
+
+/**
+ * When an external writer (a terminal `cdk synth`/`cdk watch`) holds the cdk.out
+ * write lock, the synth retries with exponential backoff + full jitter rather
+ * than giving up, so the LSP always eventually synths the latest save once the
+ * writer releases. Delay is capped; attempts are not.
+ */
+const SYNTH_LOCK_RETRY_BASE_MS = 100;
+const SYNTH_LOCK_RETRY_MAX_MS = 2_000;
+
 export interface LspHandlerOptions {
   /** Override readAssembly for tests. Defaults to reading <applicationDir>/cdk.out. */
   readonly readAssembly?: (assemblyDir: string) => Promise<AssemblyReadResult>;
@@ -177,7 +194,10 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
 
   let applicationDir: string | undefined;
   let shutdownRequested = false;
-  let synthInFlight = false;
+  // Concurrency latch, mirroring `cdk watch` (toolkit.ts): a synth requested
+  // while one runs is batched into a single follow-up, so synths run one at a
+  // time and the assembly catches up to the latest save.
+  let synthLatch: SynthLatch = 'open';
   // URIs (source files, or cdk.json) currently showing synth-failure diagnostics.
   let synthFailureUris = new Set<string>();
   let autoSynthEnabled = false; // off by default; user enables via the CodeLens toggle
@@ -276,20 +296,47 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     }
   }
 
-  // Shared synth invocation used by both the manual CodeLens command and
-  // auto-synth-on-save. The in-flight latch suppresses overlapping synths from
-  // the same LSP instance: a second call while the first is running is dropped
-  // (not queued) and returns lock-conflict immediately. The Toolkit's RWLock
-  // would reject it anyway, but this short-circuits before any setup work.
-  async function guardedSynth(): Promise<SynthRunResult> {
-    if (synthInFlight) return { status: 'lock-conflict' };
-    synthInFlight = true;
-    try {
+  // One synth, retrying the write lock with exponential backoff + full jitter.
+  // The latch guarantees we never contend with our own synth, so a lock-conflict
+  // here is an external writer (a terminal `cdk synth`/`cdk watch`) holding
+  // cdk.out; retry until it releases rather than dropping the synth.
+  async function runSynthWithRetry(): Promise<SynthRunResult> {
+    let delayMs = SYNTH_LOCK_RETRY_BASE_MS;
+    for (;;) {
       const result = await (synthRunner ? synthRunner(currentProjectDir()) : Promise.resolve({ status: 'error', message: 'No synth runner configured' } as const));
-      publishSynthDiagnostics(result);
+      if (result.status !== 'lock-conflict') {
+        publishSynthDiagnostics(result);
+        return result;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * delayMs));
+      delayMs = Math.min(delayMs * 2, SYNTH_LOCK_RETRY_MAX_MS);
+    }
+  }
+
+  // Shared by the manual CodeLens command and auto-synth-on-save. A call while a
+  // synth runs is batched (latch 'queued') and returns lock-conflict now, so the
+  // caller still sees "in progress" while the assembly catches up to the latest
+  // save. Any number of overlapping calls collapse into that one follow-up.
+  async function guardedSynth(): Promise<SynthRunResult> {
+    if (synthLatch !== 'open') {
+      synthLatch = 'queued';
+      return { status: 'lock-conflict' };
+    }
+    synthLatch = 'synthing';
+    try {
+      // Drain the queued slot with a loop (not recursion) so the stack stays
+      // flat. There is no await between reading the latch as not-'queued' and the
+      // finally resetting it to 'open', so under the single-threaded event loop
+      // any request that set 'queued' did so during an await and is observed
+      // here -- no wakeup is lost.
+      let result = await runSynthWithRetry();
+      while ((synthLatch as SynthLatch) === 'queued') {
+        synthLatch = 'synthing';
+        result = await runSynthWithRetry();
+      }
       return result;
     } finally {
-      synthInFlight = false;
+      synthLatch = 'open';
     }
   }
 

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -154,6 +154,10 @@ const NOOP_LOGGER: LogSink = {
   },
 };
 
+async function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
 /** Log auto-synth-on-save outcomes. Errors go to the Output panel; success is silent. */
 function handleSynthOnSave(result: SynthRunResult, log: LogSink): void {
   switch (result.status) {
@@ -237,7 +241,7 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
       } catch (err) {
         if (ToolkitError.isLockError(err)) {
           if (attempt < REFRESH_LOCK_RETRIES) {
-            await new Promise<void>((resolve) => setTimeout(resolve, REFRESH_LOCK_RETRY_MS));
+            await sleep(REFRESH_LOCK_RETRY_MS);
           }
           continue;
         }
@@ -302,15 +306,18 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
   // cdk.out; retry until it releases rather than dropping the synth.
   async function runSynthWithRetry(): Promise<SynthRunResult> {
     let delayMs = SYNTH_LOCK_RETRY_BASE_MS;
-    for (;;) {
+    const deadline = Date.now() + 3_600_000; // 1 hour
+    while (Date.now() < deadline) {
       const result = await (synthRunner ? synthRunner(currentProjectDir()) : Promise.resolve({ status: 'error', message: 'No synth runner configured' } as const));
       if (result.status !== 'lock-conflict') {
         publishSynthDiagnostics(result);
         return result;
       }
-      await new Promise<void>((resolve) => setTimeout(resolve, Math.random() * delayMs));
+      await sleep(Math.random() * delayMs);
       delayMs = Math.min(delayMs * 2, SYNTH_LOCK_RETRY_MAX_MS);
     }
+    const timeoutResult: SynthRunResult = { status: 'error', message: 'Auto-synth timed out waiting for external writer to release cdk.out' };
+    return timeoutResult;
   }
 
   // Shared by the manual CodeLens command and auto-synth-on-save. A call while a

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -587,7 +587,9 @@ describe('LSP Server -- executeCommand', () => {
     await first;
 
     expect(notify.infoMessages.some((m) => m.includes('in progress'))).toBe(true);
-    expect(synthRunner).toHaveBeenCalledTimes(1);
+    // Queue of 1: the coalesced second call is not dropped -- it runs as a
+    // trailing synth once the first completes, so synthRunner runs twice.
+    expect(synthRunner).toHaveBeenCalledTimes(2);
   });
 
   test('didSave and executeCommand share the same in-flight latch', async () => {
@@ -625,7 +627,55 @@ describe('LSP Server -- executeCommand', () => {
 
     // The manual command hit the latch → lock-conflict info message
     expect(notify.infoMessages.some((m) => m.includes('in progress'))).toBe(true);
+    // Queue of 1: the coalesced manual command runs as a trailing synth after
+    // the save-triggered synth completes, so synthRunner runs twice.
+    expect(synthRunner).toHaveBeenCalledTimes(2);
+  });
+
+  test('many overlapping calls coalesce into exactly one trailing synth', async () => {
+    let resolveFirst!: () => void;
+    const firstSynthDone = new Promise<void>((res) => {
+      resolveFirst = res;
+    });
+    const synthRunner = jest.fn<Promise<SynthRunResult>, []>()
+      .mockImplementationOnce(() => firstSynthDone.then(() => ({ status: 'success' } as const)))
+      .mockResolvedValue({ status: 'success' });
+    const { handlers } = createCommandClient({ synthRunner });
+
+    const first = handlers.onExecuteCommand({ command: COMMAND_SYNTH_NOW });
+    // Several requests arrive while the first synth is in flight.
+    await handlers.onExecuteCommand({ command: COMMAND_SYNTH_NOW });
+    await handlers.onExecuteCommand({ command: COMMAND_SYNTH_NOW });
+    await handlers.onExecuteCommand({ command: COMMAND_SYNTH_NOW });
     expect(synthRunner).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await first;
+
+    // The three overlapping calls collapse into a single trailing synth.
+    expect(synthRunner).toHaveBeenCalledTimes(2);
+  });
+
+  test('retries the synth with backoff until an external write lock frees', async () => {
+    jest.useFakeTimers();
+    try {
+      let calls = 0;
+      const synthRunner = jest.fn<Promise<SynthRunResult>, []>(async () => {
+        calls += 1;
+        // Simulate a terminal `cdk synth` holding the lock for the first 3 tries.
+        return calls <= 3 ? { status: 'lock-conflict' } : { status: 'success' };
+      });
+      const { handlers } = createCommandClient({ synthRunner });
+
+      const done = handlers.onExecuteCommand({ command: COMMAND_SYNTH_NOW });
+      await jest.runAllTimersAsync(); // advance through the backoff delays
+      await done;
+
+      // Retried through the 3 lock-conflicts rather than dropping the synth.
+      expect(synthRunner).toHaveBeenCalledTimes(4);
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });
 


### PR DESCRIPTION
Batches LSP auto-synth-on-save into a single trailing re-synth, like `cdk watch`.
A synth requested while one is running sets a queued flag instead of being
dropped; the running synth drains it by running exactly one more synth once it
finishes. Overlapping saves collapse into that one follow-up, so once saves stop
the assembly always catches up to the last save.

One design decision worth thinking about: 
No retry cap on external lock conflicts. The latch guarantees the LSP
  never contends with its own synth, so a `cdk.out` lock conflict is always an
  external writer (a terminal `cdk synth`/`cdk watch`). We retry indefinitely
  with backoff and full jitter rather than drop the synth. Tradeoff: if an
  external writer never releases, auto-synth stays blocked for the session. This
  matches `cdk watch`.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
