### PR TITLE
fix: keep source-tracing helpers out of toolkit-lib public API

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/api-private.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/api-private.ts
@@ -1,0 +1,4 @@
+/* eslint-disable import/no-relative-packages */
+export { findCreationStackTrace } from '../../toolkit-lib/lib/api/source-tracing/private/stack-source-tracing';
+export { WATCH_EXCLUDE_DEFAULTS } from '../../toolkit-lib/lib/actions/watch/private/helpers';
+export { createIgnoreMatcher } from '../../toolkit-lib/lib/util/glob-matcher';

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -2,9 +2,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { buildConstructTreeAsync, CloudAssembly, MANIFEST_FILE, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
-/* eslint-disable import/no-relative-packages */
+import { findCreationStackTrace } from '../api-private';
 import { SourceMapResolver, isWithinRoot, type SourceLocation } from './source-resolver';
-import { findCreationStackTrace } from '../../../toolkit-lib/lib/api/source-tracing/private/stack-source-tracing';
 
 /**
  * A construct from the cloud assembly, decorated with the user source location

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-reader.ts
@@ -2,8 +2,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { buildConstructTreeAsync, CloudAssembly, MANIFEST_FILE, type ConstructTreeNode } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE, type PolicyValidationReportJson } from '@aws-cdk/cloud-assembly-schema';
-import { findCreationStackTrace } from '@aws-cdk/toolkit-lib';
+/* eslint-disable import/no-relative-packages */
 import { SourceMapResolver, isWithinRoot, type SourceLocation } from './source-resolver';
+import { findCreationStackTrace } from '../../../toolkit-lib/lib/api/source-tracing/private/stack-source-tracing';
 
 /**
  * A construct from the cloud assembly, decorated with the user source location

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -25,7 +25,7 @@ import {
   type Location,
   type RemoteConsole,
 } from 'vscode-languageserver/node';
-/* eslint-disable import/no-relative-packages */
+import { WATCH_EXCLUDE_DEFAULTS, createIgnoreMatcher } from '../api-private';
 import { codeLensesForFile } from './codelens';
 import { executeCommand, SUPPORTED_COMMANDS, type NotifySink } from './commands';
 import { mapViolationsToDiagnostics } from './diagnostics';
@@ -33,8 +33,6 @@ import { hoverForPosition } from './hover';
 import { offsetAtPosition } from './positions';
 import { synthFailureDiagnostics } from './synth-diagnostics';
 import { sourceTargetAtTemplateOffset } from './template-locator';
-import { WATCH_EXCLUDE_DEFAULTS } from '../../../toolkit-lib/lib/actions/watch/private/helpers';
-import { createIgnoreMatcher } from '../../../toolkit-lib/lib/util/glob-matcher';
 import type { AssemblyLock } from '../core/assembly-lock';
 import {
   readAssembly as defaultReadAssembly,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/source-tracing/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/source-tracing/index.ts
@@ -1,2 +1,1 @@
 export * from './types';
-export { findCreationStackTrace, findMutationStackTraces } from './private/stack-source-tracing';


### PR DESCRIPTION
Follow-up to review feedback on #1681. `findCreationStackTrace` / `findMutationStackTraces` were re-exported from toolkit-lib's public `api/source-tracing` index, adding new public API surface.

Instead, cdk-explorer imports `findCreationStackTrace` directly from toolkit-lib's private module via a relative path, the same mechanism already used in `lsp/server.ts`. Keeps the helpers out of toolkit-lib's public API.

Verification: cdk-explorer + toolkit-lib compile clean, cdk-explorer core jest suites pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license