### PR TITLE
feat: explorer UI improvements

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -6,7 +6,7 @@ import SpaceBetween from '@cloudscape-design/components/space-between';
 import Spinner from '@cloudscape-design/components/spinner';
 import * as React from 'react';
 import { buildSourceAnchorIndex, findConstructAtLine } from '../lib/web/source-nav';
-import { api, type DirEntry, type TemplateResponse, type TreeResponse, type ViolationsResponse } from './api';
+import { api, type TemplateResponse, type TreeResponse, type ViolationsResponse } from './api';
 import { CodeViewer, type Diagnostic } from './components/CodeViewer';
 import { ConstructTree } from './components/ConstructTree';
 import type { Language } from './syntax';
@@ -164,8 +164,6 @@ export function App(): JSX.Element {
 
   // File picker state.
   const [showFilePicker, setShowFilePicker] = React.useState<false | 'source' | 'template'>(false);
-  const [pickerDir, setPickerDir] = React.useState('');
-  const [pickerEntries, setPickerEntries] = React.useState<readonly DirEntry[]>([]);
   const pickerRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -173,7 +171,6 @@ export function App(): JSX.Element {
     const handleClick = (e: MouseEvent) => {
       const target = e.target as Node;
       if (pickerRef.current && !pickerRef.current.contains(target)) {
-        // Ignore clicks on the folder buttons themselves (they handle their own toggle)
         if ((target as HTMLElement).closest?.('[aria-label="Open file"], [aria-label="Open template file"]')) return;
         setShowFilePicker(false);
       }
@@ -182,32 +179,34 @@ export function App(): JSX.Element {
     return () => document.removeEventListener('mousedown', handleClick);
   }, [showFilePicker]);
 
-  const openFilePicker = React.useCallback(async (pane: 'source' | 'template') => {
-    setShowFilePicker(pane);
-    try {
-      const res = await api.listFiles('');
-      setPickerDir(res.dir);
-      setPickerEntries(res.entries);
-    } catch { /* ignore */ }
-  }, []);
+  const knownSourceFiles = React.useMemo(
+    () => sourceAnchors ? [...sourceAnchors.keys()].sort() : [],
+    [sourceAnchors],
+  );
 
-  const browseDir = React.useCallback(async (dir: string) => {
-    try {
-      const res = await api.listFiles(dir);
-      setPickerDir(res.dir);
-      setPickerEntries(res.entries);
-    } catch { /* ignore */ }
-  }, []);
+  const knownTemplateFiles = React.useMemo(() => {
+    if (!tree || tree.status !== 'ok') return [];
+    const files = new Set<string>();
+    const walk = (nodes: readonly import('./api').WebConstructNode[]) => {
+      for (const n of nodes) {
+        if (n.templateFile) files.add(n.templateFile);
+        walk(n.children);
+      }
+    };
+    walk(tree.tree);
+    return [...files].sort();
+  }, [tree]);
 
   const pickFile = React.useCallback(async (filePath: string, pane: 'source' | 'template') => {
     try {
-      const res = await api.readFile(filePath);
       if (pane === 'source') {
+        const res = await api.readFile(filePath);
         setSourceFile(res.path);
         setSourceContent(res.content);
       } else {
-        setTemplateFile(res.path);
-        setTemplateData({ content: res.content, resources: {} });
+        const data = await api.getTemplate(filePath);
+        setTemplateFile(filePath);
+        setTemplateData(data);
       }
       setShowFilePicker(false);
     } catch { /* ignore */ }
@@ -243,13 +242,13 @@ export function App(): JSX.Element {
                   <span style={PICKER_ANCHOR_STYLE}>
                     <span style={HEADER_WITH_ACTION_STYLE}>
                       {sourceFile ?? 'Source'}
-                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : void openFilePicker('source')}>
+                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : setShowFilePicker('source')}>
                         <FolderIcon />
                       </button>
                     </span>
                     {showFilePicker === 'source' && (
                       <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
-                        <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'source')} />
+                        <KnownFileList files={knownSourceFiles} onPick={(p) => void pickFile(p, 'source')} />
                       </div>
                     )}
                   </span>
@@ -280,13 +279,13 @@ export function App(): JSX.Element {
                   <span style={PICKER_ANCHOR_STYLE}>
                     <span style={HEADER_WITH_ACTION_STYLE}>
                       {templateFile ?? 'Template'}
-                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : void openFilePicker('template')}>
+                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : setShowFilePicker('template')}>
                         <FolderIcon />
                       </button>
                     </span>
                     {showFilePicker === 'template' && (
                       <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
-                        <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'template')} />
+                        <KnownFileList files={knownTemplateFiles} onPick={(p) => void pickFile(p, 'template')} />
                       </div>
                     )}
                   </span>
@@ -335,24 +334,16 @@ export function App(): JSX.Element {
 }
 
 
-function FilePicker({ dir, entries, onBrowse, onPick }: {
-  readonly dir: string;
-  readonly entries: readonly DirEntry[];
-  readonly onBrowse: (dir: string) => void;
+function KnownFileList({ files, onPick }: {
+  readonly files: readonly string[];
   readonly onPick: (path: string) => void;
 }): JSX.Element {
+  if (files.length === 0) return <Box color="text-status-inactive">No files found.</Box>;
   return (
     <SpaceBetween size="xxs">
-      <Box variant="code">/{dir}</Box>
-      {dir !== '' && <Button variant="inline-link" iconName="folder" onClick={() => onBrowse(dir.includes('/') ? dir.slice(0, dir.lastIndexOf('/')) : '')}>../</Button>}
-      {entries.map((entry) => (
-        <Button
-          key={entry.path}
-          variant="inline-link"
-          iconName={entry.type === 'dir' ? 'folder' : 'file'}
-          onClick={() => entry.type === 'dir' ? onBrowse(entry.path) : onPick(entry.path)}
-        >
-          {entry.type === 'dir' ? `${entry.name}/` : entry.name}
+      {files.map((file) => (
+        <Button key={file} variant="inline-link" iconName="file" onClick={() => onPick(file)}>
+          {file}
         </Button>
       ))}
     </SpaceBetween>

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -10,7 +10,7 @@ import { api, type DirEntry, type TemplateResponse, type TreeResponse, type Viol
 import { CodeViewer, type Diagnostic } from './components/CodeViewer';
 import { ConstructTree } from './components/ConstructTree';
 import type { Language } from './syntax';
-import { TemplateViewer } from './components/TemplateViewer';
+import { TemplateViewer, type Format } from './components/TemplateViewer';
 import { ViolationsPanel } from './components/ViolationsPanel';
 import type { NavigateHandler } from './nav-types';
 export type { NavigateHandler } from './nav-types';
@@ -39,6 +39,7 @@ export function App(): JSX.Element {
   // Template pane state.
   const [templateFile, setTemplateFile] = React.useState<string | undefined>();
   const [templateData, setTemplateData] = React.useState<TemplateResponse | undefined>();
+  const [templateFormat, setTemplateFormat] = React.useState<Format>('yaml');
 
   // Refs for current values in async callbacks (avoids stale closures).
   const sourceFileRef = React.useRef(sourceFile);
@@ -239,20 +240,22 @@ export function App(): JSX.Element {
             <div style={CODE_PANE_STYLE}>
               <Container fitHeight header={
                 <Header variant="h2">
-                  <span style={HEADER_WITH_ACTION_STYLE}>
-                    {sourceFile ?? 'Source'}
-                    <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : void openFilePicker('source')}>
-                      <FolderIcon />
-                    </button>
+                  <span style={PICKER_ANCHOR_STYLE}>
+                    <span style={HEADER_WITH_ACTION_STYLE}>
+                      {sourceFile ?? 'Source'}
+                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : void openFilePicker('source')}>
+                        <FolderIcon />
+                      </button>
+                    </span>
+                    {showFilePicker === 'source' && (
+                      <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
+                        <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'source')} />
+                      </div>
+                    )}
                   </span>
                 </Header>
               }>
                 <div style={CODE_PANE_INNER_STYLE}>
-                  {showFilePicker === 'source' && (
-                    <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
-                      <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'source')} />
-                    </div>
-                  )}
                   {sourceContent ? (
                     <CodeViewer
                       content={sourceContent}
@@ -273,21 +276,23 @@ export function App(): JSX.Element {
             </div>
             <div style={CODE_PANE_STYLE}>
               <Container fitHeight header={
-                <Header variant="h2">
-                  <span style={HEADER_WITH_ACTION_STYLE}>
-                    {templateFile ?? 'Template'}
-                    <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : void openFilePicker('template')}>
-                      <FolderIcon />
-                    </button>
+                <Header variant="h2" actions={templateData && <FormatToggle format={templateFormat} onChange={setTemplateFormat} />}>
+                  <span style={PICKER_ANCHOR_STYLE}>
+                    <span style={HEADER_WITH_ACTION_STYLE}>
+                      {templateFile ?? 'Template'}
+                      <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : void openFilePicker('template')}>
+                        <FolderIcon />
+                      </button>
+                    </span>
+                    {showFilePicker === 'template' && (
+                      <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
+                        <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'template')} />
+                      </div>
+                    )}
                   </span>
                 </Header>
               }>
                 <div style={CODE_PANE_INNER_STYLE}>
-                  {showFilePicker === 'template' && (
-                    <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
-                      <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'template')} />
-                    </div>
-                  )}
                   {templateData ? (
                     <TemplateViewer
                       jsonContent={templateData.content}
@@ -298,6 +303,7 @@ export function App(): JSX.Element {
                       onResourceDoubleClick={jumpToSource}
                       templateFile={templateFile}
                       violations={violations?.status === 'ok' ? violations.violations : undefined}
+                      format={templateFormat}
                     />
                   ) : templateFile ? (
                     <Box color="text-status-error">Could not load {templateFile}</Box>
@@ -565,20 +571,22 @@ const FOLDER_BUTTON_STYLE: React.CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
 };
-const CODE_PANE_INNER_STYLE: React.CSSProperties = { position: 'relative', height: '100%' };
+const CODE_PANE_INNER_STYLE: React.CSSProperties = { height: '100%' };
+const PICKER_ANCHOR_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-flex', alignItems: 'center' };
 const PICKER_DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',
-  top: 0,
+  top: '100%',
   left: 0,
-  right: 0,
-  maxHeight: '60vh',
+  marginTop: '4px',
+  maxHeight: '50vh',
+  minWidth: '320px',
   overflowY: 'auto',
   background: '#ffffff',
   border: '1px solid #d1d5db',
   borderRadius: '4px',
   boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
   padding: '8px',
-  zIndex: 10,
+  zIndex: 100,
 };
 
 const CODE_PANES_STYLE: React.CSSProperties = {
@@ -621,6 +629,15 @@ const RESIZER_BUTTON_VERTICAL: React.CSSProperties = {
   borderRadius: '7px',
 };
 
+function FormatToggle({ format, onChange }: { readonly format: Format; readonly onChange: (f: Format) => void }): JSX.Element {
+  return (
+    <span style={FORMAT_TOGGLE_GROUP_STYLE}>
+      <button type="button" style={format === 'yaml' ? FORMAT_TOGGLE_ACTIVE_STYLE : FORMAT_TOGGLE_STYLE} onClick={() => onChange('yaml')}>YAML</button>
+      <button type="button" style={format === 'json' ? FORMAT_TOGGLE_ACTIVE_STYLE : FORMAT_TOGGLE_STYLE} onClick={() => onChange('json')}>JSON</button>
+    </span>
+  );
+}
+
 function FolderIcon(): JSX.Element {
   return (
     <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
@@ -629,6 +646,14 @@ function FolderIcon(): JSX.Element {
   );
 }
 
+const FORMAT_TOGGLE_GROUP_STYLE: React.CSSProperties = { display: 'inline-flex', gap: '2px' };
+const FORMAT_TOGGLE_STYLE: React.CSSProperties = {
+  border: '1px solid #d1d5db', borderRadius: '4px', background: '#fafafa',
+  cursor: 'pointer', fontSize: '11px', padding: '2px 8px', color: '#5f6b7a', lineHeight: '16px',
+};
+const FORMAT_TOGGLE_ACTIVE_STYLE: React.CSSProperties = {
+  ...FORMAT_TOGGLE_STYLE, background: '#0972d3', color: '#ffffff', borderColor: '#0972d3',
+};
 const VIOLATIONS_TITLE_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '6px' };
 const FILTER_PILL_STYLE: React.CSSProperties = {
   display: 'inline-flex', alignItems: 'center', gap: '4px',

--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -52,6 +52,10 @@ export function App(): JSX.Element {
   const [nav, setNav] = React.useState<NavTarget | undefined>();
   const navCounterRef = React.useRef(0);
 
+  // Violations filter: when set, only violations affecting this construct path are shown.
+  const [violationFilter, setViolationFilter] = React.useState<string | undefined>();
+  const [violationSearch, setViolationSearch] = React.useState('');
+
   const reload = React.useCallback((): void => {
     Promise.all([api.getTree(), api.getViolations(), api.getAppInfo()])
       .then(([t, v, info]) => {
@@ -74,6 +78,10 @@ export function App(): JSX.Element {
   const navigate: NavigateHandler = React.useCallback(async (opts) => {
     const counter = ++navCounterRef.current;
     const color = opts.color ?? NEUTRAL_COLOR;
+
+    if (opts.constructPath) {
+      setViolationFilter(opts.constructPath);
+    }
 
     let sourceTarget: NavTarget['source'];
     if (opts.sourceLocation) {
@@ -149,6 +157,7 @@ export function App(): JSX.Element {
       sourceLocation: node.sourceLocation,
       templateFile: node.templateFile,
       logicalId: node.logicalId,
+      constructPath: node.path,
     });
   }, [sourceAnchors, navigate]);
 
@@ -156,6 +165,21 @@ export function App(): JSX.Element {
   const [showFilePicker, setShowFilePicker] = React.useState<false | 'source' | 'template'>(false);
   const [pickerDir, setPickerDir] = React.useState('');
   const [pickerEntries, setPickerEntries] = React.useState<readonly DirEntry[]>([]);
+  const pickerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!showFilePicker) return;
+    const handleClick = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (pickerRef.current && !pickerRef.current.contains(target)) {
+        // Ignore clicks on the folder buttons themselves (they handle their own toggle)
+        if ((target as HTMLElement).closest?.('[aria-label="Open file"], [aria-label="Open template file"]')) return;
+        setShowFilePicker(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [showFilePicker]);
 
   const openFilePicker = React.useCallback(async (pane: 'source' | 'template') => {
     setShowFilePicker(pane);
@@ -217,27 +241,34 @@ export function App(): JSX.Element {
                 <Header variant="h2">
                   <span style={HEADER_WITH_ACTION_STYLE}>
                     {sourceFile ?? 'Source'}
-                    <button type="button" style={OPEN_FILE_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : void openFilePicker('source')}>Open</button>
+                    <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'source' ? 'Close picker' : 'Open file'} aria-label="Open file" onClick={() => showFilePicker === 'source' ? setShowFilePicker(false) : void openFilePicker('source')}>
+                      <FolderIcon />
+                    </button>
                   </span>
                 </Header>
               }>
-                {showFilePicker === 'source' ? (
-                  <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'source')} />
-                ) : sourceContent ? (
-                  <CodeViewer
-                    content={sourceContent}
-                    language={detectLanguage(sourceFile)}
-                    highlightStart={nav?.source?.startLine}
-                    highlightEnd={nav?.source?.endLine}
-                    highlightColor={nav?.color}
-                    navCounter={nav?.navCounter}
-                    scrollToLine={nav?.source?.startLine}
-                    onLineDoubleClick={handleSourceDoubleClick}
-                    diagnostics={buildDiagnostics(sourceFile, violations)}
-                  />
-                ) : (
-                  <Box color="text-status-inactive">Double-click a construct to view its source.</Box>
-                )}
+                <div style={CODE_PANE_INNER_STYLE}>
+                  {showFilePicker === 'source' && (
+                    <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
+                      <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'source')} />
+                    </div>
+                  )}
+                  {sourceContent ? (
+                    <CodeViewer
+                      content={sourceContent}
+                      language={detectLanguage(sourceFile)}
+                      highlightStart={nav?.source?.startLine}
+                      highlightEnd={nav?.source?.endLine}
+                      highlightColor={nav?.color}
+                      navCounter={nav?.navCounter}
+                      scrollToLine={nav?.source?.startLine}
+                      onLineDoubleClick={handleSourceDoubleClick}
+                      diagnostics={buildDiagnostics(sourceFile, violations)}
+                    />
+                  ) : (
+                    <Box color="text-status-inactive">Double-click a construct to view its source.</Box>
+                  )}
+                </div>
               </Container>
             </div>
             <div style={CODE_PANE_STYLE}>
@@ -245,26 +276,35 @@ export function App(): JSX.Element {
                 <Header variant="h2">
                   <span style={HEADER_WITH_ACTION_STYLE}>
                     {templateFile ?? 'Template'}
-                    <button type="button" style={OPEN_FILE_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : void openFilePicker('template')}>Open</button>
+                    <button type="button" style={FOLDER_BUTTON_STYLE} title={showFilePicker === 'template' ? 'Close picker' : 'Open file'} aria-label="Open template file" onClick={() => showFilePicker === 'template' ? setShowFilePicker(false) : void openFilePicker('template')}>
+                      <FolderIcon />
+                    </button>
                   </span>
                 </Header>
               }>
-                {showFilePicker === 'template' ? (
-                  <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'template')} />
-                ) : templateData ? (
-                  <TemplateViewer
-                    jsonContent={templateData.content}
-                    resources={templateData.resources}
-                    highlightLogicalId={nav?.template?.logicalId}
-                    highlightColor={nav?.color}
-                    navCounter={nav?.navCounter}
-                    onResourceDoubleClick={jumpToSource}
-                  />
-                ) : templateFile ? (
-                  <Box color="text-status-error">Could not load {templateFile}</Box>
-                ) : (
-                  <Box color="text-status-inactive">Double-click a construct to view its template.</Box>
-                )}
+                <div style={CODE_PANE_INNER_STYLE}>
+                  {showFilePicker === 'template' && (
+                    <div ref={pickerRef} style={PICKER_DROPDOWN_STYLE}>
+                      <FilePicker dir={pickerDir} entries={pickerEntries} onBrowse={browseDir} onPick={(p) => void pickFile(p, 'template')} />
+                    </div>
+                  )}
+                  {templateData ? (
+                    <TemplateViewer
+                      jsonContent={templateData.content}
+                      resources={templateData.resources}
+                      highlightLogicalId={nav?.template?.logicalId}
+                      highlightColor={nav?.color}
+                      navCounter={nav?.navCounter}
+                      onResourceDoubleClick={jumpToSource}
+                      templateFile={templateFile}
+                      violations={violations?.status === 'ok' ? violations.violations : undefined}
+                    />
+                  ) : templateFile ? (
+                    <Box color="text-status-error">Could not load {templateFile}</Box>
+                  ) : (
+                    <Box color="text-status-inactive">Double-click a construct to view its template.</Box>
+                  )}
+                </div>
               </Container>
             </div>
           </div>
@@ -274,8 +314,12 @@ export function App(): JSX.Element {
         <Resizer split={vSplit} />
         {!vSplit.collapsed && (
           <div style={GROW_STYLE}>
-            <Container fitHeight header={<Header variant="h2">Violations</Header>}>
-              <ViolationsContent violations={violations} onNavigate={navigate} />
+            <Container fitHeight header={
+              <Header variant="h2" actions={<ViolationsActions search={violationSearch} onSearchChange={setViolationSearch} />}>
+                <ViolationsTitle filter={violationFilter} onClearFilter={() => setViolationFilter(undefined)} />
+              </Header>
+            }>
+              <ViolationsContent violations={violations} onNavigate={navigate} filter={violationFilter} onClearFilter={() => setViolationFilter(undefined)} search={violationSearch} />
             </Container>
           </div>
         )}
@@ -317,12 +361,47 @@ function ConstructTreeContent({ tree, onNavigate }: { readonly tree?: TreeRespon
   return <ConstructTree nodes={tree.tree} onNavigate={onNavigate} />;
 }
 
-function ViolationsContent({ violations, onNavigate }: { readonly violations?: ViolationsResponse; readonly onNavigate: NavigateHandler }): JSX.Element {
+function ViolationsContent({ violations, onNavigate, filter, onClearFilter, search }: {
+  readonly violations?: ViolationsResponse;
+  readonly onNavigate: NavigateHandler;
+  readonly filter?: string;
+  readonly onClearFilter: () => void;
+  readonly search: string;
+}): JSX.Element {
   if (!violations) return <Spinner />;
   if (violations.status === 'not-synthesized') {
     return <Box color="text-status-inactive">No cloud assembly found.</Box>;
   }
-  return <ViolationsPanel violations={violations.violations} onNavigate={onNavigate} />;
+  return <ViolationsPanel violations={violations.violations} onNavigate={onNavigate} filter={filter} onClearFilter={onClearFilter} search={search} />;
+}
+
+function ViolationsTitle({ filter, onClearFilter }: { readonly filter?: string; readonly onClearFilter: () => void }): JSX.Element {
+  if (!filter) return <>Violations</>;
+  const name = filter.split('/').pop() || filter;
+  return (
+    <span style={VIOLATIONS_TITLE_STYLE}>
+      Violations for
+      <span style={FILTER_PILL_STYLE}>
+        {name}
+        <button type="button" style={FILTER_CLEAR_STYLE} onClick={onClearFilter} title="Show all violations">&times;</button>
+      </span>
+    </span>
+  );
+}
+
+function ViolationsActions({ search, onSearchChange }: {
+  readonly search: string;
+  readonly onSearchChange: (value: string) => void;
+}): JSX.Element {
+  return (
+    <input
+      type="text"
+      placeholder="Search"
+      value={search}
+      onChange={(e) => onSearchChange(e.target.value)}
+      style={VIOLATIONS_SEARCH_STYLE}
+    />
+  );
 }
 
 interface SplitOptions {
@@ -477,15 +556,29 @@ const TITLE_BLOCK_STYLE: React.CSSProperties = { flexShrink: 0, marginBottom: '1
 const GROW_STYLE: React.CSSProperties = { flex: '1 1 0', minWidth: 0, minHeight: 0, display: 'flex', flexDirection: 'column', width: '100%' };
 
 const HEADER_WITH_ACTION_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '6px' };
-const OPEN_FILE_BUTTON_STYLE: React.CSSProperties = {
+const FOLDER_BUTTON_STYLE: React.CSSProperties = {
+  border: 'none',
+  background: 'none',
+  cursor: 'pointer',
+  padding: '2px',
+  color: '#5f6b7a',
+  display: 'inline-flex',
+  alignItems: 'center',
+};
+const CODE_PANE_INNER_STYLE: React.CSSProperties = { position: 'relative', height: '100%' };
+const PICKER_DROPDOWN_STYLE: React.CSSProperties = {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  maxHeight: '60vh',
+  overflowY: 'auto',
+  background: '#ffffff',
   border: '1px solid #d1d5db',
   borderRadius: '4px',
-  background: '#fafafa',
-  cursor: 'pointer',
-  fontSize: '11px',
-  padding: '1px 6px',
-  color: '#5f6b7a',
-  lineHeight: '16px',
+  boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+  padding: '8px',
+  zIndex: 10,
 };
 
 const CODE_PANES_STYLE: React.CSSProperties = {
@@ -526,6 +619,29 @@ const RESIZER_BUTTON_VERTICAL: React.CSSProperties = {
   width: '14px',
   height: '40px',
   borderRadius: '7px',
+};
+
+function FolderIcon(): JSX.Element {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M1 3.5A1.5 1.5 0 012.5 2h3.172a1.5 1.5 0 011.06.44l.658.658A.5.5 0 007.744 3.25H13.5A1.5 1.5 0 0115 4.75v7.75a1.5 1.5 0 01-1.5 1.5h-11A1.5 1.5 0 011 12.5v-9z" />
+    </svg>
+  );
+}
+
+const VIOLATIONS_TITLE_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '6px' };
+const FILTER_PILL_STYLE: React.CSSProperties = {
+  display: 'inline-flex', alignItems: 'center', gap: '4px',
+  background: '#f2f8fd', border: '1px solid #89bdee', borderRadius: '12px',
+  padding: '1px 8px 1px 10px', fontSize: '14px', color: '#0972d3', fontWeight: 600,
+};
+const FILTER_CLEAR_STYLE: React.CSSProperties = {
+  background: 'none', border: 'none', cursor: 'pointer',
+  fontSize: '14px', lineHeight: 1, color: '#0972d3', padding: '0 2px',
+};
+const VIOLATIONS_SEARCH_STYLE: React.CSSProperties = {
+  width: '160px', padding: '3px 8px', border: '1px solid #d1d5db',
+  borderRadius: '4px', fontSize: '13px', outline: 'none',
 };
 
 function detectLanguage(file: string | undefined): Language {

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -1,7 +1,5 @@
 import {
   ASSEMBLY_CHANGED,
-  type DirEntry,
-  type FilesResponse,
   type FileResponse,
   type LineRange,
   type TemplateResource,
@@ -15,8 +13,6 @@ import {
 } from '../lib/web/protocol';
 
 export type {
-  DirEntry,
-  FilesResponse,
   FileResponse,
   LineRange,
   TemplateResource,
@@ -43,7 +39,6 @@ export interface AppInfoResponse {
 }
 
 export const api = {
-  listFiles: (dir = ''): Promise<FilesResponse> => getJson(`/api/files?dir=${encodeURIComponent(dir)}`),
   readFile: (filePath: string): Promise<FileResponse> => getJson(`/api/file?path=${encodeURIComponent(filePath)}`),
   getTree: (): Promise<TreeResponse> => getJson('/api/tree'),
   getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/CodeViewer.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/CodeViewer.tsx
@@ -84,9 +84,13 @@ export function CodeViewer({
     return map;
   }, [diagnostics]);
 
+  const lastNavRef = React.useRef<number | undefined>();
+  const animateNav = navCounter !== lastNavRef.current;
+  React.useEffect(() => { lastNavRef.current = navCounter; }, [navCounter]);
+
   React.useEffect(() => {
     if (scrollToLine && scrollTargetRef.current) {
-      scrollTargetRef.current.scrollIntoView({ block: 'start', behavior: 'smooth' });
+      scrollTargetRef.current.scrollIntoView({ block: 'start', behavior: animateNav ? 'smooth' : 'instant' });
     }
   }, [scrollToLine, navCounter]);
 
@@ -103,9 +107,9 @@ export function CodeViewer({
 
         return (
           <div
-            key={`${lineNum}-${navCounter}`}
+            key={`${lineNum}-${animateNav ? navCounter : 'stable'}`}
             ref={isScrollTarget ? scrollTargetRef : undefined}
-            className={isHighlighted ? 'nav-highlight' : undefined}
+            className={isHighlighted && animateNav ? 'nav-highlight' : undefined}
             style={{
               ...LINE_STYLE,
               ...(isHighlighted ? { ['--nav-highlight-color' as string]: highlightColor ?? '#0972d3' } : undefined),

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
@@ -62,6 +62,7 @@ function TreeNode({ node, depth, onNavigate }: { readonly node: WebConstructNode
       sourceLocation: node.sourceLocation,
       templateFile: node.templateFile,
       logicalId: node.logicalId,
+      constructPath: node.path,
       color,
     });
   }, [node, severityColor, onNavigate]);

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ConstructTree.tsx
@@ -113,7 +113,7 @@ function friendlyType(type: string): string {
 
 function labelStyle(severityColor: string | undefined, inheritedColor: string | undefined): React.CSSProperties {
   if (severityColor) return { ...LABEL_STYLE, color: severityColor };
-  if (inheritedColor) return { ...LABEL_STYLE, color: inheritedColor, opacity: 0.7 };
+  if (inheritedColor) return { ...LABEL_STYLE, color: inheritedColor };
   return LABEL_STYLE;
 }
 
@@ -126,7 +126,7 @@ const SEVERITY_DOT_STYLE: React.CSSProperties = {
 };
 const LIST_STYLE: React.CSSProperties = { listStyle: 'none', margin: 0, paddingLeft: '12px', borderLeft: '1px solid #e9ebed' };
 const ITEM_STYLE: React.CSSProperties = { padding: '2px 0' };
-const ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0, overflow: 'hidden' };
+const ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: '4px', minWidth: 0, overflow: 'hidden', cursor: 'default' };
 const ROW_CLICKABLE_STYLE: React.CSSProperties = { ...ROW_STYLE, cursor: 'pointer' };
 const LABEL_STYLE: React.CSSProperties = {
   flex: '1 1 auto',

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/TemplateViewer.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/TemplateViewer.tsx
@@ -12,9 +12,10 @@ export interface TemplateViewerProps {
   readonly onResourceDoubleClick?: (logicalId: string) => void;
   readonly templateFile?: string;
   readonly violations?: readonly WebViolation[];
+  readonly format: Format;
 }
 
-type Format = 'yaml' | 'json';
+export type Format = 'yaml' | 'json';
 
 interface ResourceSection {
   readonly logicalId: string;
@@ -31,8 +32,8 @@ export function TemplateViewer({
   onResourceDoubleClick,
   templateFile,
   violations,
+  format,
 }: TemplateViewerProps): JSX.Element {
-  const [format, setFormat] = React.useState<Format>('yaml');
 
   const { displayContent, displayResources, sections } = React.useMemo(() => {
     if (format === 'json') {
@@ -84,31 +85,17 @@ export function TemplateViewer({
   }, [sections, onResourceDoubleClick]);
 
   return (
-    <div style={WRAPPER_STYLE}>
-      <div style={TOOLBAR_STYLE}>
-        <button
-          type="button"
-          style={format === 'yaml' ? TOGGLE_ACTIVE_STYLE : TOGGLE_STYLE}
-          onClick={() => setFormat('yaml')}
-        >YAML</button>
-        <button
-          type="button"
-          style={format === 'json' ? TOGGLE_ACTIVE_STYLE : TOGGLE_STYLE}
-          onClick={() => setFormat('json')}
-        >JSON</button>
-      </div>
-      <CodeViewer
-        content={displayContent}
-        language={format}
-        highlightStart={highlight?.start}
-        highlightEnd={highlight?.end}
-        highlightColor={highlightColor}
-        navCounter={navCounter}
-        scrollToLine={highlight?.start}
-        onLineDoubleClick={handleDoubleClick}
-        diagnostics={diagnostics}
-      />
-    </div>
+    <CodeViewer
+      content={displayContent}
+      language={format}
+      highlightStart={highlight?.start}
+      highlightEnd={highlight?.end}
+      highlightColor={highlightColor}
+      navCounter={navCounter}
+      scrollToLine={highlight?.start}
+      onLineDoubleClick={handleDoubleClick}
+      diagnostics={diagnostics}
+    />
   );
 }
 
@@ -160,38 +147,6 @@ function jsonToYaml(jsonContent: string): YamlResult {
   return { displayContent, displayResources, sections: buildSections(displayResources) };
 }
 
-const WRAPPER_STYLE: React.CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  minHeight: 0,
-};
-
-const TOOLBAR_STYLE: React.CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  gap: '4px',
-  padding: '4px 0',
-  flexShrink: 0,
-};
-
-const TOGGLE_STYLE: React.CSSProperties = {
-  border: '1px solid #d1d5db',
-  borderRadius: '4px',
-  background: '#fafafa',
-  cursor: 'pointer',
-  fontSize: '11px',
-  padding: '2px 8px',
-  color: '#5f6b7a',
-  lineHeight: '16px',
-};
-
-const TOGGLE_ACTIVE_STYLE: React.CSSProperties = {
-  ...TOGGLE_STYLE,
-  background: '#0972d3',
-  color: '#ffffff',
-  borderColor: '#0972d3',
-};
 
 function violationSeverity(severity: string | undefined): 'error' | 'warning' | 'info' {
   switch (severity) {

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/TemplateViewer.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/TemplateViewer.tsx
@@ -1,7 +1,7 @@
 import { isNode, isScalar, isMap, LineCounter, parseDocument, stringify } from 'yaml';
 import * as React from 'react';
-import type { TemplateResource } from '../api';
-import { CodeViewer } from './CodeViewer';
+import type { TemplateResource, WebViolation } from '../api';
+import { CodeViewer, type Diagnostic } from './CodeViewer';
 
 export interface TemplateViewerProps {
   readonly jsonContent: string;
@@ -10,6 +10,8 @@ export interface TemplateViewerProps {
   readonly highlightColor?: string;
   readonly navCounter?: number;
   readonly onResourceDoubleClick?: (logicalId: string) => void;
+  readonly templateFile?: string;
+  readonly violations?: readonly WebViolation[];
 }
 
 type Format = 'yaml' | 'json';
@@ -27,6 +29,8 @@ export function TemplateViewer({
   highlightColor,
   navCounter,
   onResourceDoubleClick,
+  templateFile,
+  violations,
 }: TemplateViewerProps): JSX.Element {
   const [format, setFormat] = React.useState<Format>('yaml');
 
@@ -48,6 +52,26 @@ export function TemplateViewer({
     const block = highlightLogicalId ? displayResources[highlightLogicalId]?.block : undefined;
     return block ? { start: block.startLine, end: block.endLine } : undefined;
   }, [highlightLogicalId, displayResources]);
+
+  const diagnostics = React.useMemo(() => {
+    if (!templateFile || !violations?.length) return undefined;
+    const lines = displayContent.split('\n');
+    const diags: Diagnostic[] = [];
+    for (const violation of violations) {
+      const severity = violationSeverity(violation.severity);
+      for (const occ of violation.occurrences) {
+        if (occ.templateFile === templateFile && occ.logicalId) {
+          const resource = displayResources[occ.logicalId];
+          if (resource) {
+            const line = lines[resource.block.startLine - 1];
+            const startCol = line ? line.search(/\S/) + 1 : 1;
+            diags.push({ startLine: resource.block.startLine, startCol: Math.max(1, startCol), severity, message: violation.description });
+          }
+        }
+      }
+    }
+    return diags.length > 0 ? diags : undefined;
+  }, [templateFile, violations, displayResources, displayContent]);
 
   const handleDoubleClick = React.useCallback((line: number) => {
     if (!onResourceDoubleClick) return;
@@ -82,6 +106,7 @@ export function TemplateViewer({
         navCounter={navCounter}
         scrollToLine={highlight?.start}
         onLineDoubleClick={handleDoubleClick}
+        diagnostics={diagnostics}
       />
     </div>
   );
@@ -167,3 +192,15 @@ const TOGGLE_ACTIVE_STYLE: React.CSSProperties = {
   color: '#ffffff',
   borderColor: '#0972d3',
 };
+
+function violationSeverity(severity: string | undefined): 'error' | 'warning' | 'info' {
+  switch (severity) {
+    case 'fatal':
+    case 'error':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    default:
+      return 'info';
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/components/ViolationsPanel.tsx
@@ -10,13 +10,23 @@ import type { NavigateHandler } from '../nav-types';
 interface ViolationsPanelProps {
   readonly violations: readonly WebViolation[];
   readonly onNavigate: NavigateHandler;
+  readonly filter?: string;
+  readonly onClearFilter: () => void;
+  readonly search: string;
 }
 
-export function ViolationsPanel({ violations, onNavigate }: ViolationsPanelProps): JSX.Element {
+export function ViolationsPanel({ violations, onNavigate, filter, search }: ViolationsPanelProps): JSX.Element {
   if (violations.length === 0) {
     return <StatusIndicator type="success">No policy violations.</StatusIndicator>;
   }
-  const sorted = [...violations].sort((a, b) => severityRank(displaySeverity(a)) - severityRank(displaySeverity(b)));
+
+  const filtered = filterViolations(violations, filter, search);
+  const sorted = [...filtered].sort((a, b) => severityRank(displaySeverity(a)) - severityRank(displaySeverity(b)));
+
+  if (sorted.length === 0) {
+    return <Box color="text-status-inactive">{filter ? 'No violations for this resource.' : 'No matching violations.'}</Box>;
+  }
+
   return (
     <div style={SCROLL_STYLE}>
       <SpaceBetween size="xs">
@@ -28,29 +38,65 @@ export function ViolationsPanel({ violations, onNavigate }: ViolationsPanelProps
   );
 }
 
+function filterViolations(violations: readonly WebViolation[], filter: string | undefined, search: string): readonly WebViolation[] {
+  let result = violations;
+
+  if (filter) {
+    const filtered: WebViolation[] = [];
+    for (const v of result) {
+      const matchingOccs = v.occurrences.filter(
+        (occ) => occ.constructPath === filter || occ.constructPath.startsWith(filter + '/'),
+      );
+      if (matchingOccs.length > 0) {
+        filtered.push({ ...v, occurrences: matchingOccs });
+      }
+    }
+    result = filtered;
+  }
+
+  if (search.trim()) {
+    const q = search.trim().toLowerCase();
+    result = result.filter((v) =>
+      v.ruleName.toLowerCase().includes(q) ||
+      (v.description ?? '').toLowerCase().includes(q) ||
+      (v.suggestedFix ?? '').toLowerCase().includes(q) ||
+      v.occurrences.some((occ) => occ.constructPath.toLowerCase().includes(q)),
+    );
+  }
+
+  return result;
+}
+
+
 function ViolationItem({ violation, onNavigate }: { readonly violation: WebViolation; readonly onNavigate: NavigateHandler }): JSX.Element {
   const severity = displaySeverity(violation);
   const count = violation.occurrences.length;
+  const title = violation.description?.trim() || violation.ruleName;
+  const showRuleName = title !== violation.ruleName;
   return (
     <ExpandableSection
       variant="footer"
       headerText={
-        <span style={HEADER_STYLE}>
-          <span style={severityStyle(severity)}>[{severity.toUpperCase()}]</span>
-          <span style={RULE_STYLE}>{violation.ruleName}</span>
-          <span style={META_STYLE}>
+        <div style={HEADER_WRAPPER_STYLE}>
+          <div style={HEADER_ROW_STYLE}>
+            <span style={TITLE_GROUP_STYLE}>
+              <span style={severityStyle(severity)}>[{severity.toUpperCase()}]</span>
+              <span style={RULE_STYLE} title={violation.ruleName}>{title}</span>
+            </span>
+            {showRuleName && <code style={RULE_NAME_STYLE} title={violation.ruleName}>{violation.ruleName}</code>}
+          </div>
+          <div style={SUBTITLE_STYLE}>
             {count} {count === 1 ? 'construct' : 'constructs'} {'·'} {violation.source}
-          </span>
-        </span>
+          </div>
+        </div>
       }
     >
-      <SpaceBetween size="xxs">
-        <Box>{violation.description}</Box>
+      <div style={BODY_STYLE}>
         {violation.suggestedFix && <Box variant="small">Suggested fix: {violation.suggestedFix}</Box>}
         {violation.occurrences.map((occ, i) => (
           <OccurrenceRow key={`${occ.constructPath}:${i}`} occurrence={occ} severity={severity} onNavigate={onNavigate} />
         ))}
-      </SpaceBetween>
+      </div>
     </ExpandableSection>
   );
 }
@@ -60,7 +106,7 @@ function OccurrenceRow({ occurrence, severity, onNavigate }: {
   readonly severity: string;
   readonly onNavigate: NavigateHandler;
 }): JSX.Element {
-  const handleDoubleClick = React.useCallback(() => {
+  const handleClick = React.useCallback(() => {
     if (!occurrence.sourceLocation && !occurrence.templateFile) return;
     onNavigate({
       sourceLocation: occurrence.sourceLocation,
@@ -73,7 +119,7 @@ function OccurrenceRow({ occurrence, severity, onNavigate }: {
 
   return (
     <Box variant="small" color="text-status-inactive">
-      <span style={OCCURRENCE_STYLE} onDoubleClick={handleDoubleClick} title="Double-click to navigate">
+      <span style={LINK_STYLE} onClick={handleClick} title="Navigate to source">
         {occurrence.constructPath}
         {occurrence.logicalId ? ` → ${occurrence.logicalId}` : ''}
         {occurrence.templateFile ? ` (${occurrence.templateFile})` : ''}
@@ -83,11 +129,15 @@ function OccurrenceRow({ occurrence, severity, onNavigate }: {
 }
 
 function severityStyle(severity: string): React.CSSProperties {
-  return { color: severityHexColor(severity), fontWeight: 700 };
+  return { color: severityHexColor(severity), fontWeight: 700, whiteSpace: 'nowrap', flexShrink: 0 };
 }
 
-const SCROLL_STYLE: React.CSSProperties = { maxHeight: '100%', overflowY: 'auto' };
-const HEADER_STYLE: React.CSSProperties = { display: 'inline-flex', alignItems: 'center', gap: '8px' };
-const RULE_STYLE: React.CSSProperties = { fontWeight: 700 };
-const META_STYLE: React.CSSProperties = { color: '#5f6b7a', fontWeight: 400, fontSize: '12px' };
-const OCCURRENCE_STYLE: React.CSSProperties = { cursor: 'default' };
+const SCROLL_STYLE: React.CSSProperties = { flex: '1 1 0', overflowY: 'auto', overflowX: 'hidden', minHeight: 0 };
+const HEADER_WRAPPER_STYLE: React.CSSProperties = { display: 'flex', flexDirection: 'column', gap: '2px', width: '100%', overflow: 'hidden' };
+const HEADER_ROW_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'baseline', gap: '8px', width: '100%', justifyContent: 'space-between', overflow: 'hidden' };
+const TITLE_GROUP_STYLE: React.CSSProperties = { display: 'flex', alignItems: 'baseline', gap: '8px', minWidth: 0, flex: '1 1 0', overflow: 'hidden' };
+const RULE_STYLE: React.CSSProperties = { fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' };
+const RULE_NAME_STYLE: React.CSSProperties = { fontFamily: 'monospace', fontSize: '12px', color: '#5f6b7a', fontWeight: 400, whiteSpace: 'nowrap', flexShrink: 0 };
+const SUBTITLE_STYLE: React.CSSProperties = { color: '#5f6b7a', fontWeight: 400, fontSize: '12px' };
+const BODY_STYLE: React.CSSProperties = { paddingLeft: '4px', display: 'flex', flexDirection: 'column', gap: '4px' };
+const LINK_STYLE: React.CSSProperties = { color: '#0972d3', textDecoration: 'underline', cursor: 'pointer' };

--- a/packages/@aws-cdk/cdk-explorer/frontend/highlight.css
+++ b/packages/@aws-cdk/cdk-explorer/frontend/highlight.css
@@ -15,3 +15,20 @@
   animation: nav-highlight-fade 3s ease-out forwards;
   pointer-events: none;
 }
+
+/* Make expandable section headers stretch to full width */
+[class*="header-wrapper_"] {
+  width: 100%;
+}
+[class*="expand-button_"][class*="header-button_"] {
+  flex: 1 1 auto;
+}
+[class*="header-text_"][class*="header-label_"] {
+  flex: 1 1 auto;
+}
+
+/* Tighten expanded content: reduce top gap and indent under header text */
+[class*="content_"][class*="content-footer_"] {
+  padding-top: 2px !important;
+  padding-left: 20px !important;
+}

--- a/packages/@aws-cdk/cdk-explorer/frontend/nav-types.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/nav-types.ts
@@ -6,4 +6,5 @@ export type NavigateHandler = (opts: {
   logicalId?: string;
   propertyPaths?: readonly string[];
   color?: string;
+  constructPath?: string;
 }) => void;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -10,18 +10,6 @@ export const ASSEMBLY_CHANGED = 'assembly-changed';
 /** The SSE event names the server may send. One for now. */
 export type SseEventName = typeof ASSEMBLY_CHANGED;
 
-export interface DirEntry {
-  readonly name: string;
-  /** Path relative to the app directory, usable as the next `dir`/`path` value. POSIX separators. */
-  readonly path: string;
-  readonly type: 'dir' | 'file';
-}
-
-export interface FilesResponse {
-  readonly dir: string;
-  readonly entries: readonly DirEntry[];
-}
-
 export interface FileResponse {
   readonly path: string;
   readonly content: string;

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -6,7 +6,7 @@ import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import { type Router, type Express, type Response } from 'express';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
-import type { DirEntry, LineRange, TemplateResource, TemplateResponse, TreeResponse, ViolationsResponse, WebConstructNode, WebSourceLocation, WebViolation, WebViolationOccurrence } from './protocol';
+import type { LineRange, TemplateResource, TemplateResponse, TreeResponse, ViolationsResponse, WebConstructNode, WebSourceLocation, WebViolation, WebViolationOccurrence } from './protocol';
 import { resolveWithinRoot } from './safe-path';
 import { classifyReportSeverity, displaySeverity, severityRank } from './severity';
 import type { AcquireAssemblyLock, AssemblyLock } from '../core/assembly-lock';
@@ -103,24 +103,6 @@ export function createApiRouter(options: ApiOptions): Router {
 
   router.get('/info', (_req, res) => {
     res.json({ appDir });
-  });
-
-  router.get('/files', (req, res) => {
-    const dir = typeof req.query.dir === 'string' ? req.query.dir : '';
-    const resolved = resolveWithinRoot(appDir, dir);
-    if (!resolved) {
-      return res.status(403).json({ error: 'path escapes application directory' });
-    }
-    let stat: fs.Stats;
-    try {
-      stat = fs.statSync(resolved);
-    } catch {
-      return res.status(404).json({ error: 'directory not found' });
-    }
-    if (!stat.isDirectory()) {
-      return res.status(400).json({ error: 'not a directory' });
-    }
-    return res.json({ dir: toPosix(path.relative(appDir, resolved)), entries: listDir(appDir, resolved) });
   });
 
   router.get('/file', (req, res) => {
@@ -470,21 +452,6 @@ function offsetRangeToLineRange(range: { start: number; end: number }, lineOffse
     startLine: offsetToLine(range.start, lineOffsets),
     endLine: offsetToLine(Math.max(range.start, range.end - 1), lineOffsets),
   };
-}
-
-function listDir(appDir: string, dir: string): DirEntry[] {
-  return fs.readdirSync(dir, { withFileTypes: true })
-    .map((entry): DirEntry => ({
-      name: entry.name,
-      path: toPosix(path.relative(appDir, path.join(dir, entry.name))),
-      type: entry.isDirectory() ? 'dir' : 'file',
-    }))
-    .sort(byTypeThenName);
-}
-
-function byTypeThenName(a: DirEntry, b: DirEntry): number {
-  if (a.type !== b.type) return a.type === 'dir' ? -1 : 1;
-  return a.name.localeCompare(b.name);
 }
 
 /** Normalize OS separators to '/' so the API contract is stable across platforms. */

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -44,34 +44,6 @@ describe('GET /api/health', () => {
   });
 });
 
-describe('GET /api/files', () => {
-  test('lists the root directory with directories first', async () => {
-    const res = await request(app).get('/api/files');
-    expect(res.status).toBe(200);
-    expect(res.body.dir).toBe('');
-    expect(res.body.entries).toEqual([
-      { name: 'lib', path: 'lib', type: 'dir' },
-      { name: 'app.ts', path: 'app.ts', type: 'file' },
-    ]);
-  });
-
-  test('lists a subdirectory', async () => {
-    const res = await request(app).get('/api/files').query({ dir: 'lib' });
-    expect(res.status).toBe(200);
-    expect(res.body.entries).toEqual([{ name: 'stack.ts', path: path.join('lib', 'stack.ts'), type: 'file' }]);
-  });
-
-  test('rejects traversal outside the app directory with 403', async () => {
-    const res = await request(app).get('/api/files').query({ dir: '../..' });
-    expect(res.status).toBe(403);
-  });
-
-  test('returns 404 for a missing directory', async () => {
-    const res = await request(app).get('/api/files').query({ dir: 'nope' });
-    expect(res.status).toBe(404);
-  });
-});
-
 describe('GET /api/file', () => {
   test('returns file content', async () => {
     const res = await request(app).get('/api/file').query({ path: 'app.ts' });

--- a/packages/aws-cdk/THIRD_PARTY_LICENSES
+++ b/packages/aws-cdk/THIRD_PARTY_LICENSES
@@ -10439,6 +10439,34 @@ SOFTWARE.
 
 ----------------
 
+** accepts@1.3.8 - https://www.npmjs.com/package/accepts/v/1.3.8 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** agent-base@7.1.4 - https://www.npmjs.com/package/agent-base/v/7.1.4 | MIT
 (The MIT License)
 
@@ -10546,6 +10574,32 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** array-flatten@1.1.1 - https://www.npmjs.com/package/array-flatten/v/1.1.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** ast-types@0.13.4 - https://www.npmjs.com/package/ast-types/v/0.13.4 | MIT
 Copyright (c) 2013 Ben Newman <bn@cs.stanford.edu>
 
@@ -10605,6 +10659,34 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+----------------
+
+** body-parser@1.20.4 - https://www.npmjs.com/package/body-parser/v/1.20.4 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -10698,6 +10780,86 @@ INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PA
 PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE
 FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
 ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** bytes@3.1.2 - https://www.npmjs.com/package/bytes/v/3.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015 Jed Watson <jed.watson@me.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** call-bind-apply-helpers@1.0.2 - https://www.npmjs.com/package/call-bind-apply-helpers/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** call-bound@1.0.4 - https://www.npmjs.com/package/call-bound/v/1.0.4 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -10805,6 +10967,60 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** content-disposition@0.5.4 - https://www.npmjs.com/package/content-disposition/v/0.5.4 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** content-type@1.0.5 - https://www.npmjs.com/package/content-type/v/1.0.5 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** convert-source-map@2.0.0 - https://www.npmjs.com/package/convert-source-map/v/2.0.0 | MIT
 Copyright 2013 Thorsten Lorenz. 
 All rights reserved.
@@ -10833,6 +11049,39 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** cookie-signature@1.0.7 - https://www.npmjs.com/package/cookie-signature/v/1.0.7 | MIT
+
+----------------
+
+** cookie@0.7.2 - https://www.npmjs.com/package/cookie/v/0.7.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Roman Shtylman <shtylman@gmail.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** data-uri-to-buffer@6.0.2 - https://www.npmjs.com/package/data-uri-to-buffer/v/6.0.2 | MIT
 (The MIT License)
 
@@ -10856,6 +11105,30 @@ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
 CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
 TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----------------
+
+** debug@2.6.9 - https://www.npmjs.com/package/debug/v/2.6.9 | MIT
+(The MIT License)
+
+Copyright (c) 2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software 
+and associated documentation files (the 'Software'), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
 
 ----------------
 
@@ -10928,6 +11201,114 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 ----------------
 
+** depd@2.0.0 - https://www.npmjs.com/package/depd/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2018 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** destroy@1.2.0 - https://www.npmjs.com/package/destroy/v/1.2.0 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2015-2022 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** dunder-proto@1.0.1 - https://www.npmjs.com/package/dunder-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** ee-first@1.1.1 - https://www.npmjs.com/package/ee-first/v/1.1.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** emoji-regex@8.0.0 - https://www.npmjs.com/package/emoji-regex/v/8.0.0 | MIT
 Copyright Mathias Bynens <https://mathiasbynens.be/>
 
@@ -10949,6 +11330,33 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** encodeurl@2.0.0 - https://www.npmjs.com/package/encodeurl/v/2.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -10975,6 +11383,113 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+
+----------------
+
+** es-define-property@1.0.1 - https://www.npmjs.com/package/es-define-property/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-errors@1.3.0 - https://www.npmjs.com/package/es-errors/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** es-object-atoms@1.1.1 - https://www.npmjs.com/package/es-object-atoms/v/1.1.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** escape-html@1.0.3 - https://www.npmjs.com/package/escape-html/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2013 TJ Holowaychuk
+Copyright (c) 2015 Andreas Lubbe
+Copyright (c) 2015 Tiancheng "Timothy" Gu
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11079,6 +11594,33 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------
 
+** etag@1.8.1 - https://www.npmjs.com/package/etag/v/1.8.1 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** eventemitter3@4.0.7 - https://www.npmjs.com/package/eventemitter3/v/4.0.7 | MIT
 The MIT License (MIT)
 
@@ -11101,6 +11643,35 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+
+----------------
+
+** express@4.22.1 - https://www.npmjs.com/package/express/v/4.22.1 | MIT
+(The MIT License)
+
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11201,6 +11772,33 @@ THE SOFTWARE.
 
 ----------------
 
+** finalhandler@1.3.2 - https://www.npmjs.com/package/finalhandler/v/1.3.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** find-up@4.1.0 - https://www.npmjs.com/package/find-up/v/4.1.0 | MIT
 MIT License
 
@@ -11211,6 +11809,61 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** forwarded@0.2.0 - https://www.npmjs.com/package/forwarded/v/0.2.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** fresh@0.5.2 - https://www.npmjs.com/package/fresh/v/0.5.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2016-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------
@@ -11235,7 +11888,84 @@ OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
 
 ----------------
 
+** function-bind@1.1.2 - https://www.npmjs.com/package/function-bind/v/1.1.2 | MIT
+Copyright (c) 2013 Raynos.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+
+----------------
+
 ** get-caller-file@2.0.5 - https://www.npmjs.com/package/get-caller-file/v/2.0.5 | ISC
+
+----------------
+
+** get-intrinsic@1.3.0 - https://www.npmjs.com/package/get-intrinsic/v/1.3.0 | MIT
+MIT License
+
+Copyright (c) 2020 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** get-proto@1.0.1 - https://www.npmjs.com/package/get-proto/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2025 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ----------------
 
@@ -11285,6 +12015,32 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** gopd@1.2.0 - https://www.npmjs.com/package/gopd/v/1.2.0 | MIT
+MIT License
+
+Copyright (c) 2022 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** graceful-fs@4.2.11 - https://www.npmjs.com/package/graceful-fs/v/4.2.11 | ISC
 The ISC License
 
@@ -11315,6 +12071,86 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** has-symbols@1.1.0 - https://www.npmjs.com/package/has-symbols/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2016 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** hasown@2.0.4 - https://www.npmjs.com/package/hasown/v/2.0.4 | MIT
+MIT License
+
+Copyright (c) Jordan Harband and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** http-errors@2.0.1 - https://www.npmjs.com/package/http-errors/v/2.0.1 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2016 Douglas Christopher Wilson doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -11372,8 +12208,79 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** iconv-lite@0.4.24 - https://www.npmjs.com/package/iconv-lite/v/0.4.24 | MIT
+Copyright (c) 2011 Alexander Shtuchkin
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
+** inherits@2.0.4 - https://www.npmjs.com/package/inherits/v/2.0.4 | ISC
+The ISC License
+
+Copyright (c) Isaac Z. Schlueter
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+
+
+----------------
+
 ** ip-address@10.2.0 - https://www.npmjs.com/package/ip-address/v/10.2.0 | MIT
 Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** ipaddr.js@1.9.1 - https://www.npmjs.com/package/ipaddr.js/v/1.9.1 | MIT
+Copyright (C) 2011-2017 whitequark <whitequark@whitequark.org>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11646,6 +12553,87 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** math-intrinsics@1.1.0 - https://www.npmjs.com/package/math-intrinsics/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2024 ECMAScript Shims
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** media-typer@0.3.0 - https://www.npmjs.com/package/media-typer/v/0.3.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** merge-descriptors@1.0.3 - https://www.npmjs.com/package/merge-descriptors/v/1.0.3 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** merge2@1.4.1 - https://www.npmjs.com/package/merge2/v/1.4.1 | MIT
 The MIT License (MIT)
 
@@ -11672,10 +12660,121 @@ SOFTWARE.
 
 ----------------
 
+** methods@1.1.2 - https://www.npmjs.com/package/methods/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2013-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+----------------
+
 ** micromatch@4.0.8 - https://www.npmjs.com/package/micromatch/v/4.0.8 | MIT
 The MIT License (MIT)
 
 Copyright (c) 2014-present, Jon Schlinkert.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** mime-db@1.52.0 - https://www.npmjs.com/package/mime-db/v/1.52.0 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime-types@2.1.35 - https://www.npmjs.com/package/mime-types/v/2.1.35 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** mime@1.6.0 - https://www.npmjs.com/package/mime/v/1.6.0 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2010 Benjamin Thomas, Robert Kieffer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -11724,6 +12823,10 @@ THE SOFTWARE.
 
 ----------------
 
+** ms@2.0.0 - https://www.npmjs.com/package/ms/v/2.0.0 | MIT
+
+----------------
+
 ** ms@2.1.3 - https://www.npmjs.com/package/ms/v/2.1.3 | MIT
 
 ----------------
@@ -11748,7 +12851,90 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** negotiator@0.6.3 - https://www.npmjs.com/package/negotiator/v/0.6.3 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 Federico Romero
+Copyright (c) 2012-2014 Isaac Z. Schlueter
+Copyright (c) 2014-2015 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** netmask@2.1.1 - https://www.npmjs.com/package/netmask/v/2.1.1 | MIT
+
+----------------
+
+** object-inspect@1.13.4 - https://www.npmjs.com/package/object-inspect/v/1.13.4 | MIT
+MIT License
+
+Copyright (c) 2013 James Halliday
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** on-finished@2.4.1 - https://www.npmjs.com/package/on-finished/v/2.4.1 | MIT
+(The MIT License)
+
+Copyright (c) 2013 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -11915,6 +13101,35 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** parseurl@1.3.3 - https://www.npmjs.com/package/parseurl/v/1.3.3 | MIT
+
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2017 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** path-exists@4.0.0 - https://www.npmjs.com/package/path-exists/v/4.0.0 | MIT
 MIT License
 
@@ -11925,6 +13140,32 @@ Permission is hereby granted, free of charge, to any person obtaining a copy of 
 The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** path-to-regexp@0.1.13 - https://www.npmjs.com/package/path-to-regexp/v/0.1.13 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2014 Blake Embrey (hello@blakeembrey.com)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -12007,6 +13248,33 @@ THE SOFTWARE.
 
 ----------------
 
+** proxy-addr@2.0.7 - https://www.npmjs.com/package/proxy-addr/v/2.0.7 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** proxy-agent@6.5.0 - https://www.npmjs.com/package/proxy-agent/v/6.5.0 | MIT
 (The MIT License)
 
@@ -12058,6 +13326,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** qs@6.14.2 - https://www.npmjs.com/package/qs/v/6.14.2 | BSD-3-Clause
+
+----------------
+
 ** queue-microtask@1.2.3 - https://www.npmjs.com/package/queue-microtask/v/1.2.3 | MIT
 The MIT License (MIT)
 
@@ -12079,6 +13351,61 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** range-parser@1.2.1 - https://www.npmjs.com/package/range-parser/v/1.2.1 | MIT
+(The MIT License)
+
+Copyright (c) 2012-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2015-2016 Douglas Christopher Wilson <doug@somethingdoug.com
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** raw-body@2.5.3 - https://www.npmjs.com/package/raw-body/v/2.5.3 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2022 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 
 ----------------
@@ -12201,6 +13528,58 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----------------
 
+** safe-buffer@5.2.1 - https://www.npmjs.com/package/safe-buffer/v/5.2.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) Feross Aboukhadijeh
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
+** safer-buffer@2.1.2 - https://www.npmjs.com/package/safer-buffer/v/2.1.2 | MIT
+MIT License
+
+Copyright (c) 2018 Nikita Skovoroda <chalkerx@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** semver@7.8.5 - https://www.npmjs.com/package/semver/v/7.8.5 | ISC
 The ISC License
 
@@ -12221,6 +13600,64 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** send@0.19.2 - https://www.npmjs.com/package/send/v/0.19.2 | MIT
+(The MIT License)
+
+Copyright (c) 2012 TJ Holowaychuk
+Copyright (c) 2014-2022 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** serve-static@1.16.3 - https://www.npmjs.com/package/serve-static/v/1.16.3 | MIT
+(The MIT License)
+
+Copyright (c) 2010 Sencha Inc.
+Copyright (c) 2011 LearnBoost
+Copyright (c) 2011 TJ Holowaychuk
+Copyright (c) 2014-2016 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
 ** set-blocking@2.0.0 - https://www.npmjs.com/package/set-blocking/v/2.0.0 | ISC
 Copyright (c) 2016, Contributors
 
@@ -12236,6 +13673,128 @@ LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
 OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
 WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** setprototypeof@1.2.0 - https://www.npmjs.com/package/setprototypeof/v/1.2.0 | ISC
+Copyright (c) 2015, Wes Todd
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+----------------
+
+** side-channel-list@1.0.1 - https://www.npmjs.com/package/side-channel-list/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-map@1.0.1 - https://www.npmjs.com/package/side-channel-map/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2024 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel-weakmap@1.0.2 - https://www.npmjs.com/package/side-channel-weakmap/v/1.0.2 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
+** side-channel@1.1.0 - https://www.npmjs.com/package/side-channel/v/1.1.0 | MIT
+MIT License
+
+Copyright (c) 2019 Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ----------------
@@ -12382,6 +13941,34 @@ IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 ----------------
 
+** statuses@2.0.2 - https://www.npmjs.com/package/statuses/v/2.0.2 | MIT
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+----------------
+
 ** string-width@4.2.3 - https://www.npmjs.com/package/string-width/v/4.2.3 | MIT
 MIT License
 
@@ -12479,6 +14066,32 @@ THE SOFTWARE.
 
 ----------------
 
+** toidentifier@1.0.1 - https://www.npmjs.com/package/toidentifier/v/1.0.1 | MIT
+MIT License
+
+Copyright (c) 2016 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+----------------
+
 ** tslib@2.8.1 - https://www.npmjs.com/package/tslib/v/2.8.1 | 0BSD
 Copyright (c) Microsoft Corporation.
 
@@ -12492,6 +14105,34 @@ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
 LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
 OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
 PERFORMANCE OF THIS SOFTWARE.
+
+----------------
+
+** type-is@1.6.18 - https://www.npmjs.com/package/type-is/v/1.6.18 | MIT
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 
 ----------------
 
@@ -12516,6 +14157,85 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** unpipe@1.0.0 - https://www.npmjs.com/package/unpipe/v/1.0.0 | MIT
+(The MIT License)
+
+Copyright (c) 2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** utils-merge@1.0.1 - https://www.npmjs.com/package/utils-merge/v/1.0.1 | MIT
+The MIT License (MIT)
+
+Copyright (c) 2013-2017 Jared Hanson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+----------------
+
+** vary@1.1.2 - https://www.npmjs.com/package/vary/v/1.1.2 | MIT
+(The MIT License)
+
+Copyright (c) 2014-2017 Douglas Christopher Wilson
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ----------------


### PR DESCRIPTION
UI improvements to the CDK Web Explorer's violations panel, construct tree, file picker, and template pane diagnostics.

**Violations Panel**
- Human-readable violation titles: Violation headers show the description (e.g. "Require point-in-time recovery for a DynamoDB table") as the primary title instead of the raw rule name, with the rule name shown right-aligned in monospace as a secondary identifier
- Search bar: Added a search input (top-right in header) that filters violations across all text fields (description, rule name, construct path, suggested fix)
- Resource filter on double-click: Double-clicking a construct in the tree or a squiggle in the source pane filters the violations panel to show only violations for that resource (and its children)
- Dismissable filter pill: When filtered, the header shows "Violations for [ResourceName ×]" with a clear button pill/chip
- Right-aligned rule names: Monospace rule name pushed to far-right of each violation row (matching construct tree type alignment) 
- Two-row header layout: Severity + description on row 1, count/source subtitle on row 2
- Tighter expanded content: Reduced gap between violation header and expanded body, indented expanded content under the header
- Clickable construct paths: Occurrence paths styled as blue underlined links with single-click navigation (was double-click)

<img width="1489" height="264" alt="Screenshot 2026-07-16 at 12 23 46 PM" src="https://github.com/user-attachments/assets/f71293e0-f718-439e-af67-9810f0354d8e" />

**Template Pane**
- Squiggle diagnostics: Resources with violations now show wavy underline squiggles in the template pane, which skip leading whitespace: Underlines start at the first non-space character
- YAML/JSON format toggle moved to header: Toggle is now in the upper-right of the template pane header (always visible regardless of scroll), only appears when a template is loaded. On switch, takes you to the same PLACE in the other format, not the same line number 

<img width="912" height="826" alt="Screenshot 2026-07-16 at 1 01 35 PM" src="https://github.com/user-attachments/assets/54d51e5b-92bc-4a97-a695-f67655fa1eae" />

**Construct Tree**
- Removed opacity on inherited colors: Tree labels with inherited severity colors now display at full opacity
- Default cursor on non-clickable rows: Non-expandable rows show default cursor instead of pointer
<img width="372" height="510" alt="Screenshot 2026-07-16 at 12 24 38 PM" src="https://github.com/user-attachments/assets/0ec61972-b889-4daf-8872-1cfd8327170f" />

**File Picker**
- Folder icon button: Replaced the grey "Open" button with a folder icon
- Dropdown overlay: File picker overlays the code pane instead of replacing it (code stays mounted underneath)
- No animation replay: Opening/closing the file picker no longer re-triggers the navigation highlight animation
- Click-outside to close: Clicking anywhere outside the picker dismisses it

<img width="538" height="528" alt="Screenshot 2026-07-16 at 1 03 54 PM" src="https://github.com/user-attachments/assets/9f7ae741-72e1-4732-98b8-92fc9becb582" />


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
