### PR TITLE
fix(cli-integ): update tests for upcoming validation changes

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/output/cdk-ci-true-output-to-stdout.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/output/cdk-ci-true-output-to-stdout.integtest.ts
@@ -1,9 +1,13 @@
 import type { CdkCliOptions } from '../../../lib';
-import { integTest, withDefaultFixture } from '../../../lib';
+import { integTest, withSpecificFixture } from '../../../lib';
 
 integTest(
   'ci=true output to stdout',
-  withDefaultFixture(async (fixture) => {
+
+  // We need to use an app that we are sure is not going to lead to
+  // CloudFormation-Validate warnings, because those will interfere
+  // with the stdout/stderr checks.
+  withSpecificFixture('simple-app', async (fixture) => {
     const execOptions: CdkCliOptions = {
       captureStderr: true,
       onlyStderr: true,
@@ -24,9 +28,11 @@ integTest(
       options: ['--no-notices'],
     };
 
-    const deployOutput = await fixture.cdkDeploy('test-2', execOptions);
-    const diffOutput = await fixture.cdk(['diff', '--no-notices', fixture.fullStackName('test-2')], execOptions);
-    const destroyOutput = await fixture.cdkDestroy('test-2', execOptions);
+    const stackName = 'simple-1';
+
+    const deployOutput = await fixture.cdkDeploy(stackName, execOptions);
+    const diffOutput = await fixture.cdk(['diff', '--no-notices', fixture.fullStackName(stackName)], execOptions);
+    const destroyOutput = await fixture.cdkDestroy(stackName, execOptions);
     expect(deployOutput).toEqual('');
     expect(destroyOutput).toEqual('');
     expect(diffOutput).toEqual('');

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/validate/cdk-validate-reports-violations.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/validate/cdk-validate-reports-violations.integtest.ts
@@ -18,6 +18,6 @@ integTest(
 
     // Construct Annotations plugin picks up the addWarningV2
     expect(output).toContain('This bucket has no lifecycle rules configured');
-    expect(output).toContain('Construct Annotations');
+    expect(output).toContain('Annotation');
   }),
 );


### PR DESCRIPTION
Two changes:

- The `ci=true` test now uses an app that doesn't generate CloudFormation-Validate diagnostics at the app level, so we are testing just the CLI behavior and not anything else.
- We are simplifying the codes in the output report a bit, ("Annotation" instead of "Construct Annotations"), so check for a smaller substring.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
