### PR TITLE
feat(cloud-assembly-schema): add preamble feature, document contract

### DIFF
--- a/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
+++ b/packages/@aws-cdk/cloud-assembly-schema/lib/cloud-assembly/validation-report-schema.ts
@@ -75,6 +75,13 @@ export interface PluginReportJson {
   readonly metadata?: { readonly [key: string]: string };
 
   /**
+   * Any preamble text that the plugin wants to include in the report that is not a violation itself.
+   *
+   * @default - no preamble
+   */
+  readonly preamble?: string;
+
+  /**
    * Violations found by this plugin.
    */
   readonly violations: PolicyViolationJson[];
@@ -261,6 +268,8 @@ export interface SuppressedViolationJson extends PolicyViolationJson {
 export interface CloudFormationResourceJson {
   /**
    * The path to the CloudFormation template containing this resource.
+   *
+   * This path is relative to the Cloud Assembly root directory.
    */
   readonly templatePath: string;
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
@@ -30,6 +30,7 @@ export function formatValidationReports(fileRoot: string, reports: PluginReportJ
 
   return [
     ...pluginFailures.map(formatPluginFailure),
+    ...successfullyExecutedPlugins.flatMap((r) => r.preamble ? [`${chalk.underline(sanitize(r.pluginName))}: ${sanitize(r.preamble)}`] : []),
     ...violations.map((v) => formatViolationBlock(fileRoot, v)),
   ];
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/validate/__snapshots__/validate-formatting.test.ts.snap
+++ b/packages/@aws-cdk/toolkit-lib/test/api/validate/__snapshots__/validate-formatting.test.ts.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formatValidateResult preambles are printed 1`] = `
+"Some Plugin: OMG there are warnings
+
+WARNING Make sure you fix this (Some Plugin)
+   Stack/Resource
+   Acknowledge with 'Some-Plugin::RULE'"
+`;

--- a/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
@@ -220,6 +220,25 @@ describe('formatValidateResult', () => {
     expect(output).toContain('Fake passed message');
     expect(output).toContain('Evil');
   });
+
+  test('preambles are printed', () => {
+    const result = makeResult([{
+      pluginName: 'Some Plugin',
+      conclusion: 'success',
+      preamble: 'OMG there are warnings',
+      violations: [{
+        ruleName: 'RULE',
+        description: 'Make sure you fix this',
+        severity: 'warning',
+        violatingConstructs: [{
+          constructPath: 'Stack/Resource',
+        }],
+      }],
+    }]);
+
+    const output = formatValidateResult(result);
+    expect(output).toMatchSnapshot();
+  });
 });
 
 function formatValidateResult(result: ValidateResult) {


### PR DESCRIPTION
Currently, if there are CloudFormation Validate warnings that the CDK app wants to attach a notification to, it has no option other than to print directly to the console, which interferes with stdout/stderr handling of the CLI.

Add a `preamble?: string` feature to the validation reports which the app can use to ask the CLI to print a user-friendly message.

Also document the missing contract of `templatePath` in the validation of what the path should be relative to; there didn't use to be a contract for it but the only value that makes sense is to have it be relative to the assembly root. The app already encodes this behavior but we document it explicitly here.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
