### PR TITLE
fix: cannot debug performance issues of internal projects

### DIFF
--- a/packages/aws-cdk/lib/cli/telemetry/schema.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/schema.ts
@@ -5,6 +5,7 @@ interface SessionIdentifiers {
   readonly sessionId: string;
   readonly installationId: string;
   readonly region?: string;
+  readonly amznPackage?: string;
 }
 
 export interface Identifiers extends SessionIdentifiers {

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -337,6 +337,9 @@ export function isValidWrapperUserAgent(value: string | undefined): value is str
  * ```
  * name: "<projectName>"
  * ```
+ *
+ * They will always be in the current working directory, and we will
+ * only do the check if it looks like we're on an Amzn developer machine.
  */
 async function tryDetectAmznPackage(): Promise<string | undefined> {
   try {

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -1,4 +1,7 @@
 import { randomUUID } from 'node:crypto';
+import * as fs from 'node:fs/promises';
+import * as os from 'os';
+import * as pathlib from 'path';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import { getOrCreateInstallationId } from './installation-id';
 import { getLibraryVersion } from './library-version';
@@ -89,6 +92,7 @@ export class TelemetrySession {
         telemetryVersion: '2.0',
         cdkCliVersion: versionNumber(),
         cdkLibraryVersion: await getLibraryVersion(this.ioHost.asIoHelper()),
+        amznPackage: await tryDetectAmznPackage(),
       },
       event: {
         command: {
@@ -319,4 +323,48 @@ export function isValidWrapperUserAgent(value: string | undefined): value is str
   const [name, _version, mode] = parts;
   if (!VALID_USER_AGENTS.includes(name)) return false;
   return mode === 'sandbox' || mode === 'production';
+}
+
+/**
+ * Try to detect a Config file of which the first line looks like
+ *
+ * ```
+ * package.<packageName> = {
+ * ```
+ *
+ * Or a `brazil.ion` file with a line like
+ *
+ * ```
+ * name: "<projectName>"
+ * ```
+ */
+async function tryDetectAmznPackage(): Promise<string | undefined> {
+  try {
+    await fs.stat(pathlib.join(os.homedir(), '.midway'));
+  } catch {
+    // ENOENT
+    return;
+  }
+
+  try {
+    const configFile = await fs.readFile('Config', 'utf-8');
+    const m = configFile.match(/^package\.(\S+)\s*=/);
+    if (m) {
+      return m[1];
+    }
+  } catch {
+    // Any error means no dice.
+  }
+
+  try {
+    const ionFile = await fs.readFile('brazil.ion', 'utf-8');
+    const m = ionFile.match(/(^|\s)name:\s*"([^"]+)"/m);
+    if (m) {
+      return m[2];
+    }
+  } catch {
+    // Any error means no dice.
+  }
+
+  return undefined;
 }

--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -348,7 +348,7 @@ async function tryDetectAmznPackage(): Promise<string | undefined> {
 
   try {
     const configFile = await fs.readFile('Config', 'utf-8');
-    const m = configFile.match(/^package\.(\S+)\s*=/);
+    const m = configFile.match(/^package\.(\S+)\s*=/m);
     if (m) {
       return m[1];
     }

--- a/packages/aws-cdk/test/cli/telemetry/session.test.ts
+++ b/packages/aws-cdk/test/cli/telemetry/session.test.ts
@@ -1,3 +1,6 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import { Context } from '../../../lib/api/context';
 import { CliIoHost } from '../../../lib/cli/io-host';
@@ -552,3 +555,89 @@ describe('isValidWrapperUserAgent', () => {
     expect(isValidWrapperUserAgent(value)).toBe(expected);
   });
 });
+
+describe('with midway present', () => {
+  let origDir: string;
+
+  beforeEach(async () => {
+    const midwayPath = path.join(os.homedir(), '.midway');
+    if (!await pathExists(midwayPath)) {
+      await fs.mkdir(midwayPath, { recursive: true });
+    }
+    origDir = process.cwd();
+    process.chdir(await fs.mkdtemp(path.join(os.tmpdir(), 'mw-')));
+  });
+
+  afterEach(() => {
+    process.chdir(origDir);
+  });
+
+  async function doEmit() {
+    ioHost = CliIoHost.instance({
+      logLevel: 'trace',
+    });
+
+    const client = new IoHostTelemetrySink({ ioHost });
+
+    session = new TelemetrySession({
+      ioHost,
+      client,
+      arguments: { _: ['deploy'], STACKS: ['MyStack'] },
+      context: new Context(),
+    });
+    await session.begin();
+    const spy = jest.spyOn(client, 'emit');
+
+    await session.emit({
+      eventType: 'SYNTH',
+      duration: 1234,
+    });
+
+    return spy.mock.calls[0][0];
+  }
+
+  test('Config file', async () => {
+    await fs.writeFile('Config', [
+      '# -*-perl-*-',
+      '',
+      'package.SomePackage = {',
+      '    flavors = {',
+    ].join('\n'), 'utf-8');
+
+    const telemetryObject = await doEmit();
+    expect(telemetryObject).toEqual(expect.objectContaining({
+      identifiers: expect.objectContaining({
+        amznPackage: 'SomePackage',
+      }),
+    }));
+  });
+
+  test('Ion file', async () => {
+    await fs.writeFile('brazil.ion', [
+      "'brazil_package_spec@1.0'",
+      '',
+      'common::{',
+      '  name: "SomePackage",',
+      '  major_version: "1.0",',
+    ].join('\n'), 'utf-8');
+
+    const telemetryObject = await doEmit();
+    expect(telemetryObject).toEqual(expect.objectContaining({
+      identifiers: expect.objectContaining({
+        amznPackage: 'SomePackage',
+      }),
+    }));
+  });
+});
+
+async function pathExists(x: string) {
+  try {
+    await fs.stat(x);
+    return true;
+  } catch (e: any) {
+    if (e.code === 'ENOENT') {
+      return false;
+    }
+    throw e;
+  }
+}


### PR DESCRIPTION
We can see in telemetry that there are many slow projects, but we have little information other than that. It's hard to see what is making projects slow, and they can be slow for many reasons. Plus, our leadership is concerned about slowness of internal Amazon projects.

This PR is capturing it if CDK is used at Amazon, sending along the project name. We are using multiple markers: first that we are running on an Amazon machine, by detecting an internal authentication technology, then by parsing proprietary build system tools. This makes it vanishingly unlikely that we will accidentally capture external customer data. (Of course, an external customer could always try to poison the signal by putting fake files in the expected places, but if they wanted to do that they could just post garbage to our telemetry endpoint directly).

The existence of the systems exposed here, although not advertised publicly, is also not exactly a secret. There are many references to these systems, what they do and how they do it, across the entire internet and on GitHub.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
