### PR TITLE
feat: explorer stale source banner

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
+++ b/packages/@aws-cdk/cdk-explorer/frontend/App.tsx
@@ -1,4 +1,5 @@
 import Box from '@cloudscape-design/components/box';
+import Alert from '@cloudscape-design/components/alert';
 import Button from '@cloudscape-design/components/button';
 import Container from '@cloudscape-design/components/container';
 import Header from '@cloudscape-design/components/header';
@@ -35,6 +36,9 @@ export function App(): JSX.Element {
   // Source pane state.
   const [sourceFile, setSourceFile] = React.useState<string | undefined>();
   const [sourceContent, setSourceContent] = React.useState('');
+  // True when the open source file was edited after the current assembly's synth
+  // started, so its squiggles/nav anchors may be stale. Set from /api/file.
+  const [sourceStale, setSourceStale] = React.useState(false);
 
   // Template pane state.
   const [templateFile, setTemplateFile] = React.useState<string | undefined>();
@@ -70,10 +74,33 @@ export function App(): JSX.Element {
       .catch((err) => setError(err instanceof Error ? err.message : String(err)));
   }, []);
 
+  // Re-read the currently open source file, refreshing both its content and its
+  // staleness flag. Used after a synth (assembly changed) to clear a banner, and
+  // on a source edit to raise one, without the user re-opening the file.
+  const refreshOpenSourceFile = React.useCallback(async (): Promise<void> => {
+    const file = sourceFileRef.current;
+    if (!file) return;
+    try {
+      const res = await api.readFile(file);
+      setSourceContent(res.content);
+      setSourceStale(res.stale);
+    } catch {
+      // Keep the last good content; a later event re-tries.
+    }
+  }, []);
+
   React.useEffect(() => {
     reload();
-    return api.subscribe(reload);
-  }, [reload]);
+    return api.subscribe({
+      onAssemblyChanged: () => {
+        reload();
+        void refreshOpenSourceFile();
+      },
+      onSourceChanged: () => {
+        void refreshOpenSourceFile();
+      },
+    });
+  }, [reload, refreshOpenSourceFile]);
 
   /** Navigate to a construct (from tree double-click or violation double-click). */
   const navigate: NavigateHandler = React.useCallback(async (opts) => {
@@ -92,9 +119,11 @@ export function App(): JSX.Element {
           const res = await api.readFile(opts.sourceLocation.file);
           setSourceFile(res.path);
           setSourceContent(res.content);
+          setSourceStale(res.stale);
         } catch {
           setSourceFile(opts.sourceLocation.file);
           setSourceContent(`// Could not load ${opts.sourceLocation.file}`);
+          setSourceStale(false);
         }
       }
     }
@@ -131,6 +160,7 @@ export function App(): JSX.Element {
         const res = await api.readFile(resource.source.file);
         setSourceFile(res.path);
         setSourceContent(res.content);
+        setSourceStale(res.stale);
       } catch { return; }
     }
     setNav({
@@ -203,6 +233,7 @@ export function App(): JSX.Element {
         const res = await api.readFile(filePath);
         setSourceFile(res.path);
         setSourceContent(res.content);
+        setSourceStale(res.stale);
       } else {
         const data = await api.getTemplate(filePath);
         setTemplateFile(filePath);
@@ -256,17 +287,26 @@ export function App(): JSX.Element {
               }>
                 <div style={CODE_PANE_INNER_STYLE}>
                   {sourceContent ? (
-                    <CodeViewer
-                      content={sourceContent}
-                      language={detectLanguage(sourceFile)}
-                      highlightStart={nav?.source?.startLine}
-                      highlightEnd={nav?.source?.endLine}
-                      highlightColor={nav?.color}
-                      navCounter={nav?.navCounter}
-                      scrollToLine={nav?.source?.startLine}
-                      onLineDoubleClick={handleSourceDoubleClick}
-                      diagnostics={buildDiagnostics(sourceFile, violations)}
-                    />
+                    <div style={SOURCE_PANE_COLUMN_STYLE}>
+                      {sourceStale && (
+                        <Alert type="warning">
+                          This file has been modified since the last synth, so its violations and diagnostics may be stale. Re-run <code>cdk synth</code> to refresh.
+                        </Alert>
+                      )}
+                      <div style={GROW_STYLE}>
+                        <CodeViewer
+                          content={sourceContent}
+                          language={detectLanguage(sourceFile)}
+                          highlightStart={nav?.source?.startLine}
+                          highlightEnd={nav?.source?.endLine}
+                          highlightColor={nav?.color}
+                          navCounter={nav?.navCounter}
+                          scrollToLine={nav?.source?.startLine}
+                          onLineDoubleClick={handleSourceDoubleClick}
+                          diagnostics={buildDiagnostics(sourceFile, violations)}
+                        />
+                      </div>
+                    </div>
                   ) : (
                     <Box color="text-status-inactive">Double-click a construct to view its source.</Box>
                   )}
@@ -563,6 +603,14 @@ const FOLDER_BUTTON_STYLE: React.CSSProperties = {
   alignItems: 'center',
 };
 const CODE_PANE_INNER_STYLE: React.CSSProperties = { height: '100%' };
+// Source pane stacks an optional staleness banner above the scrolling viewer.
+const SOURCE_PANE_COLUMN_STYLE: React.CSSProperties = {
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  minHeight: 0,
+  gap: '8px',
+};
 const PICKER_ANCHOR_STYLE: React.CSSProperties = { position: 'relative', display: 'inline-flex', alignItems: 'center' };
 const PICKER_DROPDOWN_STYLE: React.CSSProperties = {
   position: 'absolute',

--- a/packages/@aws-cdk/cdk-explorer/frontend/api.ts
+++ b/packages/@aws-cdk/cdk-explorer/frontend/api.ts
@@ -1,5 +1,6 @@
 import {
   ASSEMBLY_CHANGED,
+  SOURCE_CHANGED,
   type FileResponse,
   type LineRange,
   type TemplateResource,
@@ -44,13 +45,19 @@ export const api = {
   getViolations: (): Promise<ViolationsResponse> => getJson('/api/policy-validation'),
   getAppInfo: (): Promise<AppInfoResponse> => getJson('/api/info'),
   /**
-   * Subscribe to assembly-changed events from the server, invoking `onChange`
-   * whenever the cloud assembly is rewritten. Returns an unsubscribe that closes
-   * the underlying EventSource.
+   * Subscribe to the server's live-refresh stream. `onAssemblyChanged` fires
+   * when the cloud assembly is rewritten (re-fetch tree/violations);
+   * `onSourceChanged` fires when a source file is edited (re-check the open
+   * file's staleness). Returns an unsubscribe that closes the EventSource.
    */
-  subscribe: (onChange: () => void): (() => void) => {
+  subscribe: (handlers: { onAssemblyChanged?: () => void; onSourceChanged?: () => void }): (() => void) => {
     const source = new EventSource('/api/events');
-    source.addEventListener(ASSEMBLY_CHANGED, () => onChange());
+    if (handlers.onAssemblyChanged) {
+      source.addEventListener(ASSEMBLY_CHANGED, () => handlers.onAssemblyChanged!());
+    }
+    if (handlers.onSourceChanged) {
+      source.addEventListener(SOURCE_CHANGED, () => handlers.onSourceChanged!());
+    }
     return () => source.close();
   },
   getTemplate: (file: string): Promise<TemplateResponse> => getJson(`/api/template?file=${encodeURIComponent(file)}`),

--- a/packages/@aws-cdk/cdk-explorer/lib/api-private.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/api-private.ts
@@ -2,3 +2,4 @@
 export { findCreationStackTrace } from '../../toolkit-lib/lib/api/source-tracing/private/stack-source-tracing';
 export { WATCH_EXCLUDE_DEFAULTS } from '../../toolkit-lib/lib/actions/watch/private/helpers';
 export { createIgnoreMatcher } from '../../toolkit-lib/lib/util/glob-matcher';
+export { SYNTH_LOCK_FILE } from '../../toolkit-lib/lib/api/rwlock';

--- a/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/assembly-watcher.ts
@@ -2,6 +2,7 @@ import * as path from 'path';
 import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
 import { VALIDATION_REPORT_FILE } from '@aws-cdk/cloud-assembly-schema';
 import * as chokidar from 'chokidar';
+import { SYNTH_LOCK_FILE } from '../api-private';
 
 /**
  * The name of the construct tree metadata file emitted alongside the manifest.
@@ -51,6 +52,12 @@ export interface AssemblyWatcherOptions {
   readonly assemblyDir: string;
   /** Invoked (debounced) when the assembly's signal files change. */
   readonly onChange: () => void;
+  /**
+   * Invoked when synth write-lock activity (`synth.lock`) first appears, i.e. a
+   * synth started. `atMs` is the observation time. Lets a consumer date-stamp
+   * source-file staleness against synth start rather than synth finish.
+   */
+  readonly onSynthActivity?: (atMs: number) => void;
   /** Receives non-fatal watcher errors. */
   readonly onError?: (error: unknown) => void;
   /**
@@ -90,9 +97,19 @@ export function startAssemblyWatcher(options: AssemblyWatcherOptions): AssemblyW
 
   const watcher = createWatcher(options.assemblyDir);
 
-  watcher.on('all', (_eventName, filePath) => {
+  watcher.on('all', (eventName, filePath) => {
     if (closed) return;
-    if (!ASSEMBLY_SIGNAL_FILES.has(path.basename(filePath))) return;
+    const base = path.basename(filePath);
+    if (base === SYNTH_LOCK_FILE) {
+      // toolkit-lib's `RWLock` creates this marker for the duration of a synth,
+      // so its appearance is our only signal that a synth has started (the
+      // explorer never starts synths itself). Record it, but never treat it as
+      // an assembly refresh: the lock's create/delete would otherwise cause
+      // spurious reloads.
+      if (eventName === 'add') options.onSynthActivity?.(Date.now());
+      return;
+    }
+    if (!ASSEMBLY_SIGNAL_FILES.has(base)) return;
     if (timer) {
       clearTimeout(timer);
     }

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-watcher.ts
@@ -1,0 +1,102 @@
+import * as chokidar from 'chokidar';
+import { WATCH_EXCLUDE_DEFAULTS, createIgnoreMatcher } from '../api-private';
+import type { FileWatcher } from './assembly-watcher';
+
+// Coalesce an editor's burst of writes (e.g. save-all) into a single signal.
+const DEBOUNCE_MS = 200;
+
+/**
+ * Paths under the app dir that never count as a source change: toolkit-lib's
+ * own watch exclusions, dependencies, our synth output (`cdk.out`), and
+ * dotfiles (editor configs, `.git`). Applied both at the chokidar level (so the
+ * tree is never traversed) and re-checked in the handler.
+ */
+const SOURCE_WATCH_EXCLUDES = [
+  ...WATCH_EXCLUDE_DEFAULTS,
+  '**/node_modules/**',
+  '**/cdk.out/**',
+  '.*',
+  '**/.*',
+  '**/.*/**',
+];
+
+/** A running source-tree watcher. */
+export interface SourceWatcher {
+  /** Stop watching and release the underlying file handles. */
+  close(): Promise<void>;
+}
+
+export interface SourceWatcherOptions {
+  /** The application directory whose source tree is watched. */
+  readonly appDir: string;
+  /** Invoked (debounced) when a non-ignored source file changes. */
+  readonly onChange: () => void;
+  /** Receives non-fatal watcher errors. */
+  readonly onError: (error: unknown) => void;
+  /**
+   * Factory for the underlying file watcher. Defaults to chokidar; overridden
+   * in tests with a fake so behavior is verified without real file IO.
+   */
+  readonly createWatcher?: (appDir: string) => FileWatcher;
+}
+
+// Thin wrapper over real chokidar; exercised via integration, not unit tests.
+/* c8 ignore start */
+function defaultCreateWatcher(appDir: string): FileWatcher {
+  // chokidar applies the same ignore policy while traversing, so excluded paths
+  // (node_modules, cdk.out, dotfiles) are skipped at the source instead of
+  // streamed to the handler. It emits absolute paths, which the handler
+  // re-checks against the same policy.
+  return chokidar.watch(appDir, {
+    ignored: createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: appDir }),
+    ignoreInitial: true,
+  }) as unknown as FileWatcher;
+}
+/* c8 ignore stop */
+
+/**
+ * Watch a CDK app's source tree and fire `onChange` (debounced) when a
+ * non-ignored file changes.
+ */
+export function startSourceWatcher(options: SourceWatcherOptions): SourceWatcher {
+  const createWatcher = options.createWatcher ?? defaultCreateWatcher;
+  // Drop changes to ignored paths so they never raise a spurious signal. chokidar
+  // emits absolute paths, which the matcher's rootDir resolves before matching.
+  const shouldIgnore = createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: options.appDir });
+
+  let timer: NodeJS.Timeout | undefined;
+  let closed = false;
+
+  const watcher = createWatcher(options.appDir);
+
+  watcher.on('all', (_eventName, filePath) => {
+    if (closed) return;
+    if (shouldIgnore(filePath)) return;
+    if (timer) {
+      clearTimeout(timer);
+    }
+    timer = setTimeout(() => {
+      timer = undefined;
+      try {
+        options.onChange();
+      } catch (error) {
+        options.onError(error);
+      }
+    }, DEBOUNCE_MS);
+  });
+
+  watcher.on('error', (error) => {
+    options.onError(error);
+  });
+
+  return {
+    async close() {
+      closed = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+      await watcher.close();
+    },
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/core/source-watcher.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/source-watcher.ts
@@ -11,7 +11,7 @@ const DEBOUNCE_MS = 200;
  * dotfiles (editor configs, `.git`). Applied both at the chokidar level (so the
  * tree is never traversed) and re-checked in the handler.
  */
-const SOURCE_WATCH_EXCLUDES = [
+export const SOURCE_WATCH_EXCLUDES = [
   ...WATCH_EXCLUDE_DEFAULTS,
   '**/node_modules/**',
   '**/cdk.out/**',
@@ -54,6 +54,41 @@ function defaultCreateWatcher(appDir: string): FileWatcher {
 }
 /* c8 ignore stop */
 
+/** A debounced action: coalesces a burst of triggers into one delayed run. */
+interface Debounced {
+  /** Schedule `action`, resetting the delay if a run is already pending. */
+  trigger(): void;
+  /** Drop a pending run, if any. */
+  cancel(): void;
+}
+
+/**
+ * Run `action` once, `delayMs` after the most recent `trigger()`. Each new
+ * trigger restarts the delay, so a burst collapses into a single trailing run.
+ * `cancel()` discards a pending run (used on close). This is a debounce, not a
+ * sleep: the pending run is cancelable and reset on every trigger.
+ */
+function debounce(action: () => void, delayMs: number): Debounced {
+  let timer: NodeJS.Timeout | undefined;
+  return {
+    trigger() {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      timer = setTimeout(() => {
+        timer = undefined;
+        action();
+      }, delayMs);
+    },
+    cancel() {
+      if (timer) {
+        clearTimeout(timer);
+        timer = undefined;
+      }
+    },
+  };
+}
+
 /**
  * Watch a CDK app's source tree and fire `onChange` (debounced) when a
  * non-ignored file changes.
@@ -64,25 +99,21 @@ export function startSourceWatcher(options: SourceWatcherOptions): SourceWatcher
   // emits absolute paths, which the matcher's rootDir resolves before matching.
   const shouldIgnore = createIgnoreMatcher({ exclude: SOURCE_WATCH_EXCLUDES, rootDir: options.appDir });
 
-  let timer: NodeJS.Timeout | undefined;
   let closed = false;
+  const debounced = debounce(() => {
+    try {
+      options.onChange();
+    } catch (error) {
+      options.onError(error);
+    }
+  }, DEBOUNCE_MS);
 
   const watcher = createWatcher(options.appDir);
 
   watcher.on('all', (_eventName, filePath) => {
     if (closed) return;
     if (shouldIgnore(filePath)) return;
-    if (timer) {
-      clearTimeout(timer);
-    }
-    timer = setTimeout(() => {
-      timer = undefined;
-      try {
-        options.onChange();
-      } catch (error) {
-        options.onError(error);
-      }
-    }, DEBOUNCE_MS);
+    debounced.trigger();
   });
 
   watcher.on('error', (error) => {
@@ -92,10 +123,7 @@ export function startSourceWatcher(options: SourceWatcherOptions): SourceWatcher
   return {
     async close() {
       closed = true;
-      if (timer) {
-        clearTimeout(timer);
-        timer = undefined;
-      }
+      debounced.cancel();
       await watcher.close();
     },
   };

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -25,7 +25,7 @@ import {
   type Location,
   type RemoteConsole,
 } from 'vscode-languageserver/node';
-import { WATCH_EXCLUDE_DEFAULTS, createIgnoreMatcher } from '../api-private';
+import { createIgnoreMatcher } from '../api-private';
 import { codeLensesForFile } from './codelens';
 import { executeCommand, SUPPORTED_COMMANDS, type NotifySink } from './commands';
 import { mapViolationsToDiagnostics } from './diagnostics';
@@ -45,6 +45,7 @@ import {
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
 import { isWithinRoot } from '../core/source-resolver';
+import { SOURCE_WATCH_EXCLUDES } from '../core/source-watcher';
 import type { SynthRunResult } from '../core/synth-runner';
 
 /**
@@ -399,18 +400,10 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     },
     async onInitialized() {
       const projectDir = currentProjectDir();
-      // Same exclusion logic as toolkit-lib's watch():
-      // WATCH_EXCLUDE_DEFAULTS covers common non-source dirs, then we add cdk.out
-      // (our own output) and dotfiles (editor configs, .git, etc.)
+      // Ignore non-source paths (deps, cdk.out, dotfiles) using the same policy
+      // the web explorer's source watcher applies.
       shouldIgnore = createIgnoreMatcher({
-        exclude: [
-          ...WATCH_EXCLUDE_DEFAULTS,
-          '**/node_modules/**',
-          '**/cdk.out/**',
-          '.*',
-          '**/.*',
-          '**/.*/**',
-        ],
+        exclude: SOURCE_WATCH_EXCLUDES,
         rootDir: projectDir,
       });
       await refreshFromAssembly(projectDir);

--- a/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/protocol.ts
@@ -7,12 +7,25 @@
  */
 export const ASSEMBLY_CHANGED = 'assembly-changed';
 
-/** The SSE event names the server may send. One for now. */
-export type SseEventName = typeof ASSEMBLY_CHANGED;
+/**
+ * SSE event name sent when a source file under the app directory changes. Lets
+ * the SPA re-check the open file's staleness (and refresh its content) the
+ * instant it is edited, without waiting for the next assembly refresh.
+ */
+export const SOURCE_CHANGED = 'source-changed';
+
+/** The SSE event names the server may send. */
+export type SseEventName = typeof ASSEMBLY_CHANGED | typeof SOURCE_CHANGED;
 
 export interface FileResponse {
   readonly path: string;
   readonly content: string;
+  /**
+   * True when the file on disk was modified after the synth that produced the
+   * currently loaded assembly started, so its highlighted lines and violations
+   * may be out of date. Best-effort (see `StalenessTracker`).
+   */
+  readonly stale: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/routes.ts
@@ -9,6 +9,7 @@ import express = require('express');
 import type { LineRange, TemplateResource, TemplateResponse, TreeResponse, ViolationsResponse, WebConstructNode, WebSourceLocation, WebViolation, WebViolationOccurrence } from './protocol';
 import { resolveWithinRoot } from './safe-path';
 import { classifyReportSeverity, displaySeverity, severityRank } from './severity';
+import { StalenessTracker } from './staleness';
 import type { AcquireAssemblyLock, AssemblyLock } from '../core/assembly-lock';
 import { readAssembly as defaultReadAssembly, type AssemblyData, type AssemblyReadResult, type ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
@@ -39,6 +40,14 @@ export interface ApiOptions {
    * mid-synth assembly. Built from the Toolkit in {@link registerApi}'s caller.
    */
   readonly acquireAssemblyLock: AcquireAssemblyLock;
+  /**
+   * Tracks source-file staleness against synth timing; `/api/file` reads it to
+   * stamp each response. Injected by the server, which owns the reference: the
+   * assembly watcher advances it once per generation and feeds it synth-start
+   * activity. Defaults to a private tracker (never stale) for a standalone
+   * router with no watcher driving it.
+   */
+  readonly staleness?: StalenessTracker;
 }
 
 export function createApiRouter(options: ApiOptions): Router {
@@ -46,6 +55,7 @@ export function createApiRouter(options: ApiOptions): Router {
   const assemblyDir = options.assemblyDir ?? path.join(options.appDir, 'cdk.out');
   const readAssembly = options.readAssembly ?? defaultReadAssembly;
   const acquireAssemblyLock = options.acquireAssemblyLock;
+  const staleness = options.staleness ?? new StalenessTracker();
   let cachedAssembly: { result: AssemblyReadResult; mtimeMs: number } | undefined;
 
   /** mtime of the assembly's manifest, or undefined when no assembly exists yet. */
@@ -130,7 +140,11 @@ export function createApiRouter(options: ApiOptions): Router {
     if (isBinary(buffer)) {
       return res.status(415).json({ error: 'binary file cannot be displayed' });
     }
-    return res.json({ path: toPosix(path.relative(appDir, resolved)), content: buffer.toString('utf-8') });
+    return res.json({
+      path: toPosix(path.relative(appDir, resolved)),
+      content: buffer.toString('utf-8'),
+      stale: staleness.isStale(stat.mtimeMs),
+    });
   });
 
   router.get('/tree', async (_req, res) => {

--- a/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/server.ts
@@ -1,11 +1,14 @@
+import * as fs from 'fs';
 import * as http from 'http';
 import * as path from 'path';
+import { MANIFEST_FILE } from '@aws-cdk/cloud-assembly-api';
 import { Toolkit, NonInteractiveIoHost } from '@aws-cdk/toolkit-lib';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import express = require('express');
 import { SseBroadcaster } from './events';
-import { ASSEMBLY_CHANGED } from './protocol';
+import { ASSEMBLY_CHANGED, SOURCE_CHANGED } from './protocol';
 import { registerApi } from './routes';
+import { StalenessTracker } from './staleness';
 import { indexHtml, webAsset } from './web-assets';
 import { toolkitAssemblyLock } from '../core/assembly-lock';
 import {
@@ -13,6 +16,11 @@ import {
   type AssemblyWatcher,
   type AssemblyWatcherOptions,
 } from '../core/assembly-watcher';
+import {
+  startSourceWatcher as defaultStartSourceWatcher,
+  type SourceWatcher,
+  type SourceWatcherOptions,
+} from '../core/source-watcher';
 
 export const DEFAULT_PORT = 4200;
 const MAX_PORT_ATTEMPTS = 100;
@@ -35,6 +43,11 @@ export interface WebServerOptions {
    * overridden in tests with a fake to drive change events deterministically.
    */
   readonly startAssemblyWatcher?: (options: AssemblyWatcherOptions) => AssemblyWatcher;
+  /**
+   * Starts the source-tree watcher that drives live staleness. Defaults to the
+   * real chokidar-backed watcher; overridden in tests with a fake.
+   */
+  readonly startSourceWatcher?: (options: SourceWatcherOptions) => SourceWatcher;
   /**
    * Reports a non-fatal watcher error (live refresh stops updating). Defaults to
    * writing to stderr; the CLI command passes a sink that routes to its IoHost.
@@ -61,16 +74,38 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   // both the read endpoints and the change watcher, so the two never disagree.
   const assemblyDir = options.assemblyDir ?? path.join(appDir, 'cdk.out');
 
+  // mtime of the assembly manifest (undefined when none exists yet). Used as the
+  // staleness fallback reference (synth-finish time) when no synth-start lock was
+  // observed for a generation.
+  const manifestMtimeMs = (): number | undefined => {
+    try {
+      return fs.statSync(path.join(assemblyDir, MANIFEST_FILE)).mtimeMs;
+    } catch {
+      return undefined;
+    }
+  };
+
   const app = express();
 
   // The Toolkit provides the assembly read lock (via fromAssemblyDirectory().
   // produce()); a non-interactive IoHost is fine here since stdout/stderr are
   // free in the web process, unlike the LSP's stdio channel.
   const toolkit = new Toolkit({ ioHost: new NonInteractiveIoHost() });
+  // Owns source-file staleness: the assembly watcher advances its per-generation
+  // reference (see onChange below) and feeds it synth-start activity, and
+  // /api/file reads it.
+  const staleness = new StalenessTracker();
+  // Anchor to the assembly present at startup. The watcher uses ignoreInitial so
+  // it never fires for an already-synthesized assembly; without this, a file
+  // edited before the server started would not read as stale until the next
+  // synth. No synth-start was observed, so this uses the manifest-mtime fallback.
+  const initialManifestMtime = manifestMtimeMs();
+  if (initialManifestMtime !== undefined) staleness.onAssemblyRefreshed(initialManifestMtime);
   registerApi(app, {
     appDir,
     assemblyDir,
     acquireAssemblyLock: toolkitAssemblyLock(toolkit),
+    staleness,
   });
 
   // Live-refresh stream: browsers subscribe here and re-fetch when the assembly
@@ -109,9 +144,28 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
   const startWatcher = options.startAssemblyWatcher ?? defaultStartAssemblyWatcher;
   const watcher = startWatcher({
     assemblyDir,
-    onChange: () => events.broadcast(ASSEMBLY_CHANGED),
+    onChange: () => {
+      // Advance the staleness reference to this new generation before waking
+      // browsers, so the /api/file they re-fetch reads the current reference.
+      // The watcher is the single owner of the reference: it observes both the
+      // synth-start lock (onSynthActivity) and the generation change here.
+      const mtime = manifestMtimeMs();
+      if (mtime !== undefined) staleness.onAssemblyRefreshed(mtime);
+      events.broadcast(ASSEMBLY_CHANGED);
+    },
+    onSynthActivity: (atMs) => staleness.noteSynthActivity(atMs),
     onError: options.onWatcherError ?? ((err) =>
       process.stderr.write(`assembly watcher error: ${err instanceof Error ? err.message : String(err)}\n`)),
+  });
+
+  // Watch the app's source tree so an edit re-checks the open file's staleness
+  // (and refreshes its content) immediately, without waiting for the next synth.
+  const startSource = options.startSourceWatcher ?? defaultStartSourceWatcher;
+  const sourceWatcher = startSource({
+    appDir,
+    onChange: () => events.broadcast(SOURCE_CHANGED),
+    onError: options.onWatcherError ?? ((err) =>
+      process.stderr.write(`source watcher error: ${err instanceof Error ? err.message : String(err)}\n`)),
   });
 
   let stopped = false;
@@ -121,6 +175,7 @@ export async function startWebServer(options: WebServerOptions = {}): Promise<We
       if (stopped) return;
       stopped = true;
       await watcher.close();
+      await sourceWatcher.close();
       events.close();
       await new Promise<void>((resolve) => {
         server.close(() => resolve());

--- a/packages/@aws-cdk/cdk-explorer/lib/web/staleness.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/web/staleness.ts
@@ -1,0 +1,45 @@
+/**
+ * Tracks whether an open source file is out of date relative to the cloud
+ * assembly the explorer is currently showing.
+ *
+ * A file is stale when it was modified after the synth that produced the current
+ * assembly *started*, not merely after it finished. An edit made while a synth
+ * was in flight may not have been picked up by that synth, so its squiggles and
+ * navigation anchors can already be wrong; treating "modified after synth start"
+ * as stale catches that race.
+ *
+ * The reference timestamp for a generation is the moment synth write-lock
+ * activity (`synth.lock`) was first observed since the last refresh. If none was
+ * observed (the synth predated the server, or the lock was too brief to catch),
+ * it falls back to the assembly manifest's mtime, i.e. synth-finish time. This
+ * is a best-effort heuristic: at worst a squiggle sits on the wrong line until
+ * the next synth, which is acceptable.
+ */
+export class StalenessTracker {
+  /** Reference for the loaded generation; undefined until the first assembly read. */
+  private reference: number | undefined;
+
+  /** Earliest synth-activity timestamp seen since the last assembly refresh. */
+  private synthActivitySince: number | undefined;
+
+  /** Record synth write-lock activity (a synth started). Earliest since last refresh wins. */
+  public noteSynthActivity(atMs: number): void {
+    if (this.synthActivitySince === undefined) {
+      this.synthActivitySince = atMs;
+    }
+  }
+
+  /**
+   * Freeze the staleness reference for a newly loaded assembly generation.
+   * Prefers the observed synth start; falls back to the manifest mtime.
+   */
+  public onAssemblyRefreshed(manifestMtimeMs: number): void {
+    this.reference = this.synthActivitySince ?? manifestMtimeMs;
+    this.synthActivitySince = undefined;
+  }
+
+  /** True when a file last modified at `fileMtimeMs` is newer than the current reference. */
+  public isStale(fileMtimeMs: number): boolean {
+    return this.reference !== undefined && fileMtimeMs > this.reference;
+  }
+}

--- a/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/assembly-watcher.test.ts
@@ -36,12 +36,16 @@ class FakeWatcher implements FileWatcher {
 function setup() {
   const fake = new FakeWatcher();
   const onChange = jest.fn();
+  const onError = jest.fn();
+  const onSynthActivity = jest.fn();
   const watcher = startAssemblyWatcher({
     assemblyDir: '/p/cdk.out',
     onChange,
+    onError,
+    onSynthActivity,
     createWatcher: () => fake,
   });
-  return { fake, onChange, watcher };
+  return { fake, onChange, onError, onSynthActivity, watcher };
 }
 
 describe('Assembly Watcher', () => {
@@ -69,6 +73,27 @@ describe('Assembly Watcher', () => {
 
     jest.advanceTimersByTime(500);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('reports the write lock (synth.lock) appearing as synth activity', () => {
+    const { fake, onChange, onSynthActivity } = setup();
+
+    fake.emitFile('add', '/p/cdk.out/synth.lock');
+
+    expect(onSynthActivity).toHaveBeenCalledTimes(1);
+    expect(onSynthActivity).toHaveBeenCalledWith(expect.any(Number));
+    // The write lock is never an assembly refresh.
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('does not report synth activity for a read lock or a lock removal', () => {
+    const { fake, onSynthActivity } = setup();
+
+    fake.emitFile('add', '/p/cdk.out/read.12345.1.lock');
+    fake.emitFile('unlink', '/p/cdk.out/synth.lock');
+
+    expect(onSynthActivity).not.toHaveBeenCalled();
   });
 
   test('ignores non-signal files such as templates', () => {

--- a/packages/@aws-cdk/cdk-explorer/test/core/source-watcher.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/source-watcher.test.ts
@@ -1,0 +1,109 @@
+import type { FileWatcher } from '../../lib/core/assembly-watcher';
+import { startSourceWatcher } from '../../lib/core/source-watcher';
+
+type AnyListener = (...args: unknown[]) => void;
+
+/** A controllable in-memory stand-in for chokidar's FSWatcher. */
+class FakeWatcher implements FileWatcher {
+  public closed = false;
+  private readonly listeners: Record<string, AnyListener[]> = {};
+
+  public on(event: string, listener: AnyListener): FileWatcher {
+    (this.listeners[event] ??= []).push(listener);
+    return this;
+  }
+
+  public emitFile(eventName: string, filePath: string): void {
+    for (const listener of this.listeners.all ?? []) {
+      listener(eventName, filePath);
+    }
+  }
+
+  public emit(event: string, ...args: unknown[]): void {
+    for (const listener of this.listeners[event] ?? []) {
+      listener(...args);
+    }
+  }
+
+  public async close(): Promise<void> {
+    this.closed = true;
+  }
+}
+
+function setup() {
+  const fake = new FakeWatcher();
+  const onChange = jest.fn();
+  const onError = jest.fn();
+  const watcher = startSourceWatcher({
+    appDir: '/proj',
+    onChange,
+    onError,
+    createWatcher: () => fake,
+  });
+  return { fake, onChange, onError, watcher };
+}
+
+describe('Source Watcher', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  test('fires a single debounced onChange for a burst of source edits', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/proj/lib/stack.ts');
+    fake.emitFile('change', '/proj/app.ts');
+    expect(onChange).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(200);
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores dependencies, synth output, and dotfiles', () => {
+    const { fake, onChange } = setup();
+
+    fake.emitFile('change', '/proj/node_modules/pkg/index.js');
+    fake.emitFile('change', '/proj/cdk.out/tree.json');
+    fake.emitFile('change', '/proj/.git/HEAD');
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('close stops a pending onChange and closes the underlying watcher', async () => {
+    const { fake, onChange, watcher } = setup();
+
+    fake.emitFile('change', '/proj/lib/stack.ts');
+    await watcher.close();
+
+    jest.advanceTimersByTime(500);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(fake.closed).toBe(true);
+  });
+
+  test('forwards watcher errors to onError', () => {
+    const { fake, onError } = setup();
+
+    fake.emit('error', new Error('boom'));
+
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  test('forwards an onChange throw to onError instead of leaking from the timer', () => {
+    const fake = new FakeWatcher();
+    const failure = new Error('handler blew up');
+    const onError = jest.fn();
+    startSourceWatcher({
+      appDir: '/proj',
+      onChange: () => {
+        throw failure;
+      },
+      onError,
+      createWatcher: () => fake,
+    });
+
+    fake.emitFile('change', '/proj/lib/stack.ts');
+    expect(() => jest.advanceTimersByTime(200)).not.toThrow();
+
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+});

--- a/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/routes.test.ts
@@ -9,6 +9,7 @@ import express = require('express');
 import request = require('supertest');
 import type { AssemblyReadResult, ConstructNode } from '../../lib/core/assembly-reader';
 import { createApiRouter } from '../../lib/web/routes';
+import { StalenessTracker } from '../../lib/web/staleness';
 
 let appDir: string;
 let app: express.Express;
@@ -48,7 +49,31 @@ describe('GET /api/file', () => {
   test('returns file content', async () => {
     const res = await request(app).get('/api/file').query({ path: 'app.ts' });
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ path: 'app.ts', content: 'export const x = 1;\n' });
+    expect(res.body).toEqual({ path: 'app.ts', content: 'export const x = 1;\n', stale: false });
+  });
+
+  test('flags a file modified after the staleness reference as stale', async () => {
+    const staleness = new StalenessTracker();
+    // Reference well before the fixture file was written, so it reads as stale.
+    staleness.onAssemblyRefreshed(0);
+    const a = express();
+    a.use('/api', createApiRouter({ appDir, acquireAssemblyLock: noopAssemblyLock, staleness }));
+
+    const res = await request(a).get('/api/file').query({ path: 'app.ts' });
+    expect(res.status).toBe(200);
+    expect(res.body.stale).toBe(true);
+  });
+
+  test('does not flag a file older than the staleness reference', async () => {
+    const staleness = new StalenessTracker();
+    // Reference far in the future, so no file can be newer than it.
+    staleness.onAssemblyRefreshed(Date.now() + 60_000);
+    const a = express();
+    a.use('/api', createApiRouter({ appDir, acquireAssemblyLock: noopAssemblyLock, staleness }));
+
+    const res = await request(a).get('/api/file').query({ path: 'app.ts' });
+    expect(res.status).toBe(200);
+    expect(res.body.stale).toBe(false);
   });
 
   test('requires a path parameter', async () => {

--- a/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/server.test.ts
@@ -1,4 +1,4 @@
-import { ASSEMBLY_CHANGED } from '../../lib/web/protocol';
+import { ASSEMBLY_CHANGED, SOURCE_CHANGED } from '../../lib/web/protocol';
 import { startWebServer, DEFAULT_PORT, type WebServer } from '../../lib/web/server';
 
 describe('Web Server', () => {
@@ -112,6 +112,46 @@ describe('Web Server', () => {
     fireChange();
     const { value } = await reader.read();
     expect(new TextDecoder().decode(value)).toContain(`event: ${ASSEMBLY_CHANGED}`);
+
+    await reader.cancel();
+  });
+
+  test('starts a source watcher and closes it on stop', async () => {
+    let closed = false;
+    server = await startWebServer({
+      startAssemblyWatcher: () => ({ close: async () => undefined }),
+      startSourceWatcher: (opts) => {
+        expect(opts.appDir).toBeDefined();
+        return {
+          close: async () => {
+            closed = true;
+          },
+        };
+      },
+    });
+
+    await server.stop();
+    expect(closed).toBe(true);
+  });
+
+  test('broadcasts a source-changed event when the source watcher fires', async () => {
+    let fireSourceChange = (): void => undefined;
+    server = await startWebServer({
+      startAssemblyWatcher: () => ({ close: async () => undefined }),
+      startSourceWatcher: (opts) => {
+        fireSourceChange = opts.onChange;
+        return { close: async () => undefined };
+      },
+    });
+
+    const res = await fetch(`${server.url}/api/events`);
+    const body = res.body;
+    if (!body) throw new Error('SSE response had no body');
+    const reader = body.getReader();
+
+    fireSourceChange();
+    const { value } = await reader.read();
+    expect(new TextDecoder().decode(value)).toContain(`event: ${SOURCE_CHANGED}`);
 
     await reader.cancel();
   });

--- a/packages/@aws-cdk/cdk-explorer/test/web/staleness.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/web/staleness.test.ts
@@ -1,0 +1,50 @@
+import { StalenessTracker } from '../../lib/web/staleness';
+
+describe('StalenessTracker', () => {
+  test('reports nothing stale before any assembly is loaded', () => {
+    const t = new StalenessTracker();
+    expect(t.isStale(Number.MAX_SAFE_INTEGER)).toBe(false);
+  });
+
+  test('a file modified after the reference is stale; at or before is not', () => {
+    const t = new StalenessTracker();
+    t.onAssemblyRefreshed(1_000);
+    expect(t.isStale(1_001)).toBe(true);
+    expect(t.isStale(1_000)).toBe(false); // equal is not newer
+    expect(t.isStale(999)).toBe(false);
+  });
+
+  test('prefers observed synth-start over the manifest mtime (option 2)', () => {
+    const t = new StalenessTracker();
+    t.noteSynthActivity(500); // synth started at 500
+    t.onAssemblyRefreshed(2_000); // ...and finished (manifest) at 2000
+    // A file edited at 800 (during the synth) is newer than synth-start -> stale,
+    // even though it predates synth-finish.
+    expect(t.isStale(800)).toBe(true);
+  });
+
+  test('keeps the earliest synth-activity timestamp within a generation', () => {
+    const t = new StalenessTracker();
+    t.noteSynthActivity(500);
+    t.noteSynthActivity(1_500); // later activity does not move the reference
+    t.onAssemblyRefreshed(3_000);
+    expect(t.isStale(600)).toBe(true); // newer than 500
+  });
+
+  test('falls back to the manifest mtime when no synth activity was observed', () => {
+    const t = new StalenessTracker();
+    t.onAssemblyRefreshed(2_000);
+    expect(t.isStale(1_500)).toBe(false);
+    expect(t.isStale(2_500)).toBe(true);
+  });
+
+  test('clears synth activity after a refresh so the next generation re-measures', () => {
+    const t = new StalenessTracker();
+    t.noteSynthActivity(500);
+    t.onAssemblyRefreshed(2_000); // reference = 500
+    // Next generation: no new activity observed -> falls back to its manifest mtime.
+    t.onAssemblyRefreshed(4_000); // reference = 4000
+    expect(t.isStale(3_000)).toBe(false);
+    expect(t.isStale(4_500)).toBe(true);
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/lib/api/rwlock.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/rwlock.ts
@@ -3,6 +3,12 @@ import * as path from 'path';
 import { LockError } from '../toolkit/toolkit-error';
 
 /**
+ * The marker file a writer (i.e. a synth) creates in the locked directory for
+ * the duration of the write.
+ */
+export const SYNTH_LOCK_FILE = 'synth.lock';
+
+/**
  * A single-writer/multi-reader lock on a directory
  *
  * It uses marker files with PIDs in them as a locking marker; the PIDs will be
@@ -21,7 +27,7 @@ export class RWLock {
   constructor(public readonly directory: string) {
     this.pidString = `${process.pid}`;
 
-    this.writerFile = path.join(this.directory, 'synth.lock');
+    this.writerFile = path.join(this.directory, SYNTH_LOCK_FILE);
   }
 
   /**


### PR DESCRIPTION
Adds a banner to the web explorer's source pane that warns when the open file has been edited since the last synth, so its violations and diagnostics may be stale.

The explorer reads source files live from disk, but violation source locations come from the cloud assembly and are frozen at the last synth. If you edit a file without re-synthing, the code shown updates while the violation markers stay where synth left them, so a marker can sit on the wrong line. The explorer never runs synths itself and has no direct signal that one happened, so it cannot keep the two in lockstep. This surfaces that gap honestly instead of showing misplaced markers silently.

**Behavior**
The source pane always shows the current file on disk.
When the open file's last-modified time is newer than the current assembly's synth, a warning shows: "This file has been modified since the last synth, so its violations and diagnostics may be stale. Re-run cdk synth to refresh."
The banner appears the moment you save. A source-tree watcher pushes an event over the existing SSE stream, so you do not have to re-open the file.
After a synth completes and the explorer reloads the assembly, the open file is re-fetched and the banner clears.
Options considered


I looked at four ways to handle staleness:

1. Require synth-on-save in the web explorer. Keep the assembly always fresh by triggering a synth on every source change. Rejected: web synth-triggering was descoped, the explorer is a read-only viewer over cdk.out, and forcing a synth on every edit duplicates the LSP's job, adds a synth runner and lock coordination to the web process, and takes control of an expensive operation away from the user.
2. Snapshot and serve (caching). On synth start, cache the source files and serve that snapshot so the markers always line up with the displayed code, showing a banner when disk differs from the snapshot. Rejected for this change: it needs a per-generation content store, an atomic swap of assembly and snapshot together, and a full source-tree read per synth, and it shows the user older code rather than their current edits. It removes wrong-line markers entirely, but that failure is rare and low-impact, so the cost is not justified here.
3. Reference the synth finish. Read the source at synth finish and flag a file whose last-modified time is later than that. Simple, but it misses the in-flight case: an edit made while a synth is running lands before that synth finishes, so it would not be flagged even though the synth may not have picked it up.
4. Reference the synth start (chosen). Record when synth write-lock activity first appears (the synth.lock marker the toolkit's RWLock creates), and treat a file modified after that point as stale. This catches the in-flight edit that option 3 misses, at the cost of over-flagging by at most one synth's duration, which self-heals on the next assembly. It needs no synth machinery and keeps the explorer read-only.

Design decisions
Reference is synth start, not synth finish, for the reason in option 4. When no write-lock activity is observed for a generation (the synth predated the server, or the lock was too brief to catch), it falls back to the manifest mtime, which degrades gracefully to option 3.
Staleness is decided server-side and returned as a stale flag on /api/file. The client only renders it; it cannot compute it, since it does not know synth timing.
The assembly watcher is the single owner of the reference. It already observes both signals it needs, the synth.lock start and the assembly generation change, so it advances the reference once per generation before waking browsers, and the read endpoints only read it. Keeping this in one place avoids a reference that lags a synth or gets overwritten by concurrent reads.
mtime, not a content hash. A save that does not change content gives a false stale flag. That is acceptable under the same best-effort bar: the worst case is a banner you did not need until the next synth.
The banner covers any open source file, not only files carrying violations, since a stale navigation anchor matters too. It is scoped to the source pane; templates are regenerated by synth, so they are never "source".
<img width="961" height="842" alt="Screenshot 2026-07-17 at 12 31 29 PM" src="https://github.com/user-attachments/assets/79ef4227-6bb2-45c8-992a-f84e6bcde6ca" />


Open questions:
I know in my demo meeting we decided that the web shouldn't have synthing capabilities, but having a banner that says "run synth" without a button to directly run synth seems unintuitive.  Happy to hear opinions on if we think this means we should add manual and / or auto synth back into the web (and how we should handle the queue of 1 then, just have it be in-process still?).


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
