### PR TITLE
fix(cloudformation-diff): handle removed resource metadata

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
@@ -128,8 +128,8 @@ export class TemplateAndChangeSetDiffMerger {
       } else if (type === 'Other') {
         switch (name) {
           case 'Metadata':
-            // we want to ignore metadata changes in the diff, so compare newValue against newValue.
-            change.setOtherChange('Metadata', new types.Difference<string>(value.newValue, value.newValue));
+            // We want to ignore metadata changes in the diff.
+            value.isDifferent = false;
             break;
         }
       }

--- a/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
@@ -317,6 +317,35 @@ describe('fullDiff tests that include changeset', () => {
     expect(differences.differenceCount).toBe(0);
   });
 
+  test('metadata removals are obscured from the diff', () => {
+    // GIVEN
+    const currentTemplate = {
+      Resources: {
+        BucketResource: {
+          Type: 'AWS::S3::Bucket',
+          BucketName: 'magic-bucket',
+          Metadata: {
+            'aws:cdk:path': '/foo/BucketResource',
+          },
+        },
+      },
+    };
+
+    // WHEN
+    const newTemplate = {
+      Resources: {
+        BucketResource: {
+          Type: 'AWS::S3::Bucket',
+          BucketName: 'magic-bucket',
+        },
+      },
+    };
+
+    // THEN
+    const differences = fullDiff(currentTemplate, newTemplate, {});
+    expect(differences.differenceCount).toBe(0);
+  });
+
   test('single element arrays are equivalent to the single element in DependsOn expressions', () => {
     // GIVEN
     const currentTemplate = {


### PR DESCRIPTION
### Issue # (if applicable)

Fixes #390.

Fixes an assertion failure when a CloudFormation resource's `Metadata` is removed.

The template/change-set merger intentionally hides resource Metadata differences. It previously
did this by constructing a replacement difference from the new Metadata value twice. When Metadata
was removed, both values were `undefined`, violating the `Difference` invariant and throwing an
AssertionError.

The fix marks the existing Metadata difference as unchanged instead of constructing another
difference. This preserves the existing behavior of hiding Metadata-only changes and handles
additions, modifications, and removals uniformly.

```text
Metadata removed
      |
      v
existing Difference(old, undefined)
      |
      v
isDifferent = false
      |
      v
no crash; Metadata remains hidden
```

## Testing

- Added a regression test that reproduced the AssertionError before the fix.
- `@aws-cdk/cloudformation-diff`: 147 tests passed.
- Package compile, lint, coverage, license check, and packaging passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

[comment]: <> (by cdk-contribution-skill)
