### PR TITLE
fix(cli): entire violation report is printed in red

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
@@ -118,7 +118,7 @@ function formatConstructInfo(fileRoot: string, construct: ViolatingConstructJson
 
   if (construct.constructPath) {
     const cPath = sanitize(construct.constructPath);
-    parts.push(logicalId ? `${chalk.bold(cPath)} (${logicalId})` : chalk.bold(cPath));
+    parts.push(logicalId ? `${cPath} (${logicalId})` : cPath);
   } else {
     // No construct information, show template path and logical ID
     if (construct.cloudFormationResource?.templatePath) {

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -1008,9 +1008,15 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
    */
   private formatMessage(msg: IoMessage<unknown>): string {
     // apply provided style or a default style if we're in TTY mode
-    let message_text = this.isTTY
-      ? styleMap[msg.level](msg.message)
-      : msg.message;
+    let message_text;
+    if (msg.code === 'CDK_TOOLKIT_E9600') {
+      // Message is pre-styled
+      message_text = msg.message;
+    } else {
+      message_text = this.isTTY
+        ? styleMap[msg.level](msg.message)
+        : msg.message;
+    }
 
     // prepend timestamp if IoMessageLevel is DEBUG or TRACE. Postpend a newline.
     return ((msg.level === 'debug' || msg.level === 'trace')


### PR DESCRIPTION
The violation report is printed in red because its message code is `E9600` and all `E*` messages are printed in red.

Make an exception for this one, which has been pre-styled.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
