### PR TITLE
docs(cli): document the cdk lsp command in the CLI README

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/README.md
+++ b/packages/@aws-cdk/cdk-explorer/README.md
@@ -77,6 +77,55 @@ auto-synth runs project code with your credentials (see Security above), the
 integrating extension should gate the first `Enable auto-synth` in a workspace
 behind the editor's workspace-trust prompt.
 
+### Connecting from VS Code with a generic LSP client
+
+Until a dedicated extension is published, you can drive `cdk lsp` from VS Code
+today with a general-purpose "generic LSP client" extension: one that spawns an
+executable you name and speaks LSP to it over stdio. These are third-party
+extensions, not published by AWS, so review one before installing it. One
+example is [Generic LSP Client](https://marketplace.visualstudio.com/items?itemName=zsol.vscode-glspc)
+(`zsol.vscode-glspc`).
+
+Point it at `cdk lsp` in your **User** `settings.json` (not a workspace
+`.vscode/settings.json`; see the note below):
+
+```jsonc
+{
+  "glspc.server.command": "cdk",
+  "glspc.server.commandArguments": ["lsp"],
+  "glspc.server.languageId": ["typescript", "python"],
+  // Set these only if VS Code was not launched from a shell that has your
+  // toolchain on PATH. `$VAR` expands existing environment variables.
+  "glspc.server.environmentVariables": {
+    "PATH": "/absolute/path/to/node/bin:$PATH"
+  }
+}
+```
+
+Requires `aws-cdk >= 2.1132.0`. Hover and diagnostics work over this path; the
+click-through features do not, because a generic client does not implement the
+protocol wiring described above. Trade-offs versus a purpose-built extension:
+
+- **PATH and toolchain.** The server runs your `app` command in a subprocess to
+  synth. VS Code launched from the Dock or Spotlight does not source your shell
+  profile, so an nvm-managed `node` will not be found and synth fails. Launch
+  with `code .` from a configured shell, or set `PATH` (and `JAVA_HOME`
+  for Java apps) in `glspc.server.environmentVariables`.
+- **Template files are not covered.** A generic client attaches by language id,
+  and synthesized `*.template.json` files are plain `json` to VS Code. There is
+  no way to attach only to template files without attaching to every JSON file,
+  so go-to-definition from a template is not available on this path.
+- **Resource and auto-synth lenses do not act.** Navigating from a `Creates ...`
+  lens relies on the client registering the `cdkExplorer.openResource` command
+  described above, and the `Synth now` / auto-synth lenses need a client binding
+  to invoke them. A generic client provides neither, so those lenses appear but
+  are not actionable.
+- **No version or trust handling.** There is no upgrade prompt on an old CLI,
+  and because `glspc.server.command` is a window-scoped setting a workspace can
+  override which executable is spawned. Keep the configuration in User settings,
+  and only trust workspaces whose `cdk.json` and source you have reviewed (see
+  Security above).
+
 ## Supported clients
 
 LSP clients speaking Language Server Protocol 3.x.

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -785,6 +785,37 @@ $ cdk watch --concurrency 5
 It is not recommended to use `watch` for production deployments. See the
 *Hotswap deployments for faster development* section for more information.
 
+### `cdk lsp`
+
+Starts the CDK Language Server, which brings information from your synthesized
+cloud assembly into your editor. It is a standard [Language Server Protocol](https://microsoft.github.io/language-server-protocol/)
+server that communicates over stdio, so any LSP-capable editor (or AI agent)
+can connect to it.
+
+```console
+$ # Normally started by your editor's LSP client, which talks to it over stdin/stdout.
+$ cdk lsp
+```
+
+Once connected, it surfaces:
+
+- **Code lenses** on the source lines that create resources, linking each construct to the resource it produces in the synthesized template.
+- **Hover** details showing a construct's resolved CloudFormation properties.
+- **Go to definition** from a synthesized `*.template.json` back to the construct source that created it.
+- **Diagnostics** from policy validation, shown as squiggles on the constructs that violate a rule.
+
+Source-linked features currently work for TypeScript and Python.
+
+The server can run your app to keep the cloud assembly current (for example, an
+"auto-synth on save" mode offered through your editor). Because that runs your
+project's `app` command with your shell environment and AWS credentials, enable
+it only for projects you trust. This is the same trust model that `cdk synth`
+and `cdk watch` already use.
+
+`cdk lsp` is designed to be driven by an editor extension rather than run by hand.
+For the full feature list, the editor-integration protocol, and the programmatic
+API, see the [`@aws-cdk/cdk-explorer` package README](https://github.com/aws/aws-cdk-cli/blob/main/packages/%40aws-cdk/cdk-explorer/README.md).
+
 ### `cdk import`
 
 Sometimes you want to import AWS resources that were created using other means


### PR DESCRIPTION
The `cdk lsp` command is not mentioned anywhere in the CLI README; its only docs live in the `@aws-cdk/cdk-explorer` sub-package, so the feature is easy to miss.

This adds a Commands entry for `cdk lsp` covering:
- what the language server surfaces (code lenses, hover, go-to-definition, policy-validation diagnostics)
- the currently supported languages (TypeScript and Python)
- the auto-synth trust note (runs your app with your credentials, the same model as `cdk synth` and `cdk watch`)
- a link to the sub-package README for the editor-integration protocol and programmatic API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license