### PR TITLE
fix: move `github.event.pull_request.base.ref` into env var in `bootstrap-template-protection` workflow

### DIFF
--- a/.github/workflows/bootstrap-template-protection.yml
+++ b/.github/workflows/bootstrap-template-protection.yml
@@ -25,7 +25,9 @@ jobs:
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - name: Checkout base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: git fetch origin "$BASE_REF"
       - name: Check if bootstrap template changed
         id: template-changed
         env:

--- a/projenrc/bootstrap-template-protection.ts
+++ b/projenrc/bootstrap-template-protection.ts
@@ -75,7 +75,10 @@ export class BootstrapTemplateProtection extends Component {
         },
         {
           name: 'Checkout base branch',
-          run: 'git fetch origin ${{ github.event.pull_request.base.ref }}',
+          env: {
+            BASE_REF: '${{ github.event.pull_request.base.ref }}',
+          },
+          run: 'git fetch origin "$BASE_REF"',
         },
         {
           name: 'Check if bootstrap template changed',


### PR DESCRIPTION
Fixes #

The `upgrade` workflow fails when it updates `cdklabs-projen-project-types` to a newer version. A check added in cdklabs/cdklabs-projen-project-types#957 refuses to let any workflow put `${{ github.event.* }}` values straight into a shell command, because that data comes from the pull request and could be used to sneak in unwanted commands.
  
The "Checkout base branch" step in the `bootstrap-template-protection` workflow used the branch name directly in its command:
  
`run: git fetch origin ${{ github.event.pull_request.base.ref }}`

Every other step in the same file already passes this value in through an environment variable.

This PR passes the branch name in as an environment variable and uses it in the command, the same way the neighboring steps do:

  ```ts
  name: 'Checkout base branch',
  env: {
    BASE_REF: '${{ github.event.pull_request.base.ref }}',
  },
  run: 'git fetch origin "$BASE_REF"',
```
### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
