### PR TITLE
fix: improve error surfacing, express mode attempts to update stack instead of using rollback API

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -541,14 +541,19 @@ class FullCloudFormationDeployment {
     const replacement = hasReplacement(changeSetDescription);
     const isPausedFailState = this.cloudFormationStack.stackStatus.isRollbackable;
     const rollback = this.options.rollback ?? true;
-    const expressNoRollback = this.options.express && this.options.rollback !== true;
+
+    // Route express mode deployments directly to executeChangeset, express mode stacks cannot use rollback API
+    if (this.options.express) {
+      return this.executeChangeSet(changeSetDescription);
+    }
+
     if (isPausedFailState && replacement) {
       return { type: 'failpaused-need-rollback-first', reason: 'replacement', status: this.cloudFormationStack.stackStatus.name };
     }
     if (isPausedFailState && rollback) {
       return { type: 'failpaused-need-rollback-first', reason: 'not-norollback', status: this.cloudFormationStack.stackStatus.name };
     }
-    if ((!rollback || expressNoRollback) && replacement) {
+    if (!rollback && replacement) {
       return { type: 'replacement-requires-rollback' };
     }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
@@ -25,7 +25,7 @@ export function formatErrorMessage(error: any): string {
     return error.message;
   }
 
-  // Some service errors carry no `message` at all. 
+  // Some service errors carry no `message` at all.
   // Surface whatever the AWS SDK gives us
   const fromSdk = formatSdkError(error);
   if (fromSdk) {

--- a/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/util/format-error.ts
@@ -20,6 +20,46 @@ export function formatErrorMessage(error: any): string {
     return `${error.message}\n${formatErrorMessage(error.cause)}`;
   }
 
-  // Fallback for regular Error or other types
-  return error?.message || error?.toString() || 'Unknown error';
+  // Regular Error or other types with a usable message
+  if (error?.message) {
+    return error.message;
+  }
+
+  // Some service errors carry no `message` at all. 
+  // Surface whatever the AWS SDK gives us
+  const fromSdk = formatSdkError(error);
+  if (fromSdk) {
+    return fromSdk;
+  }
+
+  // fallback if AWS SDK has no information for us
+  return error?.toString() || 'Unknown error';
+}
+
+/**
+ * Build a message from an AWS SDK error's name/code and response metadata.
+ *
+ * Returns `undefined` if there is nothing useful to say.
+ */
+function formatSdkError(error: any): string | undefined {
+  const name: string | undefined = error?.name ?? error?.code;
+  const metadata = error?.$metadata ?? {};
+  const details: string[] = [];
+  if (typeof metadata.httpStatusCode === 'number') {
+    details.push(`HTTP ${metadata.httpStatusCode}`);
+  }
+  if (metadata.requestId) {
+    details.push(`request id: ${metadata.requestId}`);
+  }
+
+  if (name && details.length > 0) {
+    return `${name} (${details.join(', ')})`;
+  }
+  if (name) {
+    return name;
+  }
+  if (details.length > 0) {
+    return details.join(', ');
+  }
+  return undefined;
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -1507,11 +1507,15 @@ test.each([
   },
 );
 
-// Express mode disables rollback by default, so a replacement still requires a
-// rollback-enabled deployment unless the user explicitly opted into rollback.
+// CloudFormation's RollbackStack API is not supported for stacks last deployed
+// with express mode, so `cdk deploy --express` (without an explicit `--rollback`)
+// must never route through the rollback path. It always fix-forwards via the
+// change set / UpdateStack and lets CloudFormation surface any error (including a
+// rejected replacement on a disable-rollback stack). `--express --rollback`
+// explicitly opts back into the rollback-enabled path.
 test.each([
-  // --express alone (rollback defaults off): replacement needs a rollback-enabled deployment
-  ['express, no explicit rollback', { express: true } as Partial<DeployStackApiOptions>, 'replacement-requires-rollback'],
+  // --express alone (rollback defaults off): always fix-forward, never divert to rollback
+  ['express, no explicit rollback', { express: true } as Partial<DeployStackApiOptions>, 'did-deploy-stack'],
   // --express --rollback: rollback is explicitly enabled, so the replacement deploys directly
   ['express with rollback=true', { express: true, rollback: true } as Partial<DeployStackApiOptions>, 'did-deploy-stack'],
 ] satisfies Array<[string, Partial<DeployStackApiOptions>, string]>)(
@@ -1523,6 +1527,37 @@ test.each([
     });
     givenTemplateIs(FAKE_STACK.template);
     givenChangeSetContainsReplacement(true);
+
+    // WHEN
+    const result = await advanceTime(testDeployStack({
+      ...standardDeployStackArguments(FAKE_STACK),
+      forceDeployment: true, // Bypass 'canSkipDeploy'
+      ...options,
+    }));
+
+    // THEN
+    expect(result.type).toEqual(expectedType);
+  },
+);
+
+// A stack last deployed with express mode that is in a paused fail state
+// (UPDATE_FAILED) cannot be recovered via the RollbackStack API. `cdk deploy
+// --express` must therefore always fix-forward via createChangeSet/UpdateStack
+// instead of routing to the rollback path.
+test.each([
+  ['express, no explicit rollback, no-replacement', { express: true } as Partial<DeployStackApiOptions>, 'no-replacement', 'did-deploy-stack'],
+  ['express, no explicit rollback, replacement', { express: true } as Partial<DeployStackApiOptions>, 'replacement', 'did-deploy-stack'],
+  ['express with rollback=true, no-replacement', { express: true, rollback: true } as Partial<DeployStackApiOptions>, 'no-replacement', 'did-deploy-stack'],
+  ['express with rollback=true, replacement', { express: true, rollback: true } as Partial<DeployStackApiOptions>, 'replacement', 'did-deploy-stack'],
+] satisfies Array<[string, Partial<DeployStackApiOptions>, 'replacement' | 'no-replacement', string]>)(
+  'failed express stack does not route to rollback: %s -> %s',
+  async (_name, options, replacement, expectedType) => {
+    // GIVEN
+    givenStackExists({
+      StackStatus: StackStatus.UPDATE_FAILED,
+    });
+    givenTemplateIs(FAKE_STACK.template);
+    givenChangeSetContainsReplacement(replacement === 'replacement');
 
     // WHEN
     const result = await advanceTime(testDeployStack({

--- a/packages/@aws-cdk/toolkit-lib/test/util/format-error.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/util/format-error.test.ts
@@ -23,4 +23,42 @@ describe('formatErrorMessage', () => {
     expect(formatErrorMessage(null)).toBe('Unknown error');
     expect(formatErrorMessage(undefined)).toBe('Unknown error');
   });
+
+  test('should surface SDK error name and metadata when there is no message', () => {
+    const error = {
+      name: 'InternalFailure',
+      message: '',
+      $metadata: {
+        httpStatusCode: 500,
+        requestId: '296a5792-c977-4dd4-8f9b-269ae8c0b221',
+      },
+    };
+    const result = formatErrorMessage(error);
+    expect(result).toBe('InternalFailure (HTTP 500, request id: 296a5792-c977-4dd4-8f9b-269ae8c0b221)');
+  });
+
+  test('should fall back to the SDK error `code` when `name` is absent', () => {
+    const error = {
+      code: 'ValidationError',
+      $metadata: { httpStatusCode: 400 },
+    };
+    const result = formatErrorMessage(error);
+    expect(result).toBe('ValidationError (HTTP 400)');
+  });
+
+  test('should return just the error name when no metadata is present', () => {
+    const error = { name: 'InternalFailure' };
+    const result = formatErrorMessage(error);
+    expect(result).toBe('InternalFailure');
+  });
+
+  test('should prefer a real message over SDK metadata', () => {
+    const error = {
+      name: 'ValidationError',
+      message: 'Stack is in UPDATE_FAILED state',
+      $metadata: { httpStatusCode: 400 },
+    };
+    const result = formatErrorMessage(error);
+    expect(result).toBe('Stack is in UPDATE_FAILED state');
+  });
 });


### PR DESCRIPTION
Fixes #1739 

Service error message is sometimes not properly surfaced and we have to go through the SDK to get to it. 
Current behavior is that in some cases instead of a useful error message, we instead get `Unknown`. New behavior should minimize how often we find an error that forces us to show unknown since we attempt to get error message from SDK before falling back to showing `Unknown`.

Express mode was released recently and it does not support RollbackStack API. 
We now attempt to directly update stacks that have failed express mode deployments when deploying with express mode instead of attempting to roll them back first.

Old behavior:
```
cdk deploy --express (--rollback) --> use Rollback API to rollback if failed --> deploy new changes 
```
New behavior:
```
cdk deploy --express (--rollback) --> deploy new changes
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
