### PR TITLE
docs: update TypeScript examples from ts-node to tsx

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -40,8 +40,8 @@ TYPESCRIPT_VERSIONS.forEach(tsVersion => {
 
     await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'app', '--generate-only']);
 
-    // Necessary because recent versions of ts-jest require TypeScript>=4.3 but we
-    // still want to test with older versions as well.
+    // Remove devDependencies that may have peer dependency constraints incompatible
+    // with older TypeScript versions we test against.
     await removeDevDependencies(context);
 
     // The generated app type-checks with `tsc` and runs through `tsx`, so those

--- a/packages/aws-cdk/CONTRIBUTING.md
+++ b/packages/aws-cdk/CONTRIBUTING.md
@@ -199,7 +199,7 @@ That "basically" it, hope it makes sense...
 
 ### Init template integration tests
 
-Init template tests will initialize and compile the init templates that the
+Init template tests will initialize and type-check the init templates that the
 CLI ships with.
 
 REQUIREMENTS

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -349,7 +349,7 @@ The following shows a sample `cdk.json` where the `outputsFile` key is set to *o
 
 ```json
 {
-  "app": "npx ts-node bin/myproject.ts",
+  "app": "npx tsx bin/myproject.ts",
   "context": {
     "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",
@@ -413,7 +413,7 @@ When `cdk deploy` is executed, deployment events will include the complete histo
 
 ```json
 {
-  "app": "npx ts-node bin/myproject.ts",
+  "app": "npx tsx bin/myproject.ts",
   "context": {
     "@aws-cdk/core:enableStackNameDuplicates": "true",
     "aws-cdk:enableDiffNoFail": "true",


### PR DESCRIPTION
Updates Typescript docs examples, following support for TS 7.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
