### PR TITLE
feat(cdk-explorer): advertise LSP feature and protocol manifest

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/index.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/index.ts
@@ -5,5 +5,6 @@ export type { AssemblyData, AssemblyReadResult, ConstructNode } from './core/ass
 export type { SourceLocation } from './core/source-resolver';
 
 export { startLspServer } from './lsp/main';
+export { cdkLspManifest } from './lsp/features';
 export { startServer, createLspHandlers } from './lsp/server';
 export type { LspHandlers, LspHandlerOptions, LspServerOptions } from './lsp/server';

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/features.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/features.ts
@@ -1,0 +1,36 @@
+import { VERSION } from '../index';
+import { SUPPORTED_COMMANDS } from './commands';
+
+/**
+ * Wire-protocol version for the CDK Language Server.
+ *
+ * Bump this ONLY on a breaking change to an existing feature's request/response
+ * shape or semantics. Do NOT bump it for additive features -- those are
+ * announced by name via `CDK_LSP_FEATURES`. A client rejects (or degrades
+ * against) a server whose protocol exceeds the maximum it was built for.
+ */
+export const CDK_LSP_PROTOCOL = 1;
+
+/**
+ * Named capabilities a client can rely on. Add an entry here whenever you ship
+ * a new LSP feature so clients can gate on it by name, instead of inferring
+ * capability from the CDK CLI version number. Every entry MUST be backed by a
+ * real capability or command (a test in server.test.ts guards against drift).
+ */
+export const CDK_LSP_FEATURES = ['hover', 'codeLens', 'definition', 'synth', 'autoSynth'] as const;
+
+/**
+ * The CDK-specific manifest advertised in the `initialize` response
+ * (`capabilities.experimental.cdk`) and printed by `cdk lsp --features`. This
+ * function is the single source of truth for both surfaces so they cannot drift.
+ */
+export function cdkLspManifest() {
+  return {
+    protocol: CDK_LSP_PROTOCOL,
+    version: VERSION,
+    features: [...CDK_LSP_FEATURES],
+    // Deliberately mirrors executeCommandProvider.commands on the wire so the
+    // `cdk lsp --features` probe (which has no LSP session) can see them too.
+    commands: [...SUPPORTED_COMMANDS],
+  };
+}

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/features.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/features.ts
@@ -1,4 +1,3 @@
-import { VERSION } from '../index';
 import { SUPPORTED_COMMANDS } from './commands';
 
 /**
@@ -23,11 +22,14 @@ export const CDK_LSP_FEATURES = ['hover', 'codeLens', 'definition', 'synth', 'au
  * The CDK-specific manifest advertised in the `initialize` response
  * (`capabilities.experimental.cdk`) and printed by `cdk lsp --features`. This
  * function is the single source of truth for both surfaces so they cannot drift.
+ *
+ * `version` is supplied by the `cdk` CLI entrypoint; the server is a library
+ * and does not know its own shipped version, so the CLI injects it.
  */
-export function cdkLspManifest() {
+export function cdkLspManifest(version?: string) {
   return {
     protocol: CDK_LSP_PROTOCOL,
-    version: VERSION,
+    version,
     features: [...CDK_LSP_FEATURES],
     // Deliberately mirrors executeCommandProvider.commands on the wire so the
     // `cdk lsp --features` probe (which has no LSP session) can see them too.

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/main.ts
@@ -9,10 +9,11 @@ import { runSynth } from '../core/synth-runner';
  * Toolkit-backed bindings the handlers need. This is the single entrypoint
  * used by the `cdk lsp` CLI command.
  */
-export function startLspServer(): void {
+export function startLspServer(version?: string): void {
   startServer({
     readable: process.stdin,
     writable: process.stdout,
+    version,
     // Build the Toolkit once connection.console exists (so output reaches the
     // editor Output panel), then bind the two ops the handlers need. The read
     // lock comes from fromAssemblyDirectory().produce(), so we never touch RWLock.

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -80,6 +80,8 @@ export interface LspHandlerOptions {
   readonly readAssembly?: (assemblyDir: string) => Promise<AssemblyReadResult>;
   /** Acquire a read lock on the assembly dir; throws a `LockError` on writer contention. */
   readonly acquireAssemblyLock: (assemblyDir: string) => Promise<AssemblyLock>;
+  /** Shipped CDK CLI version to advertise (serverInfo + manifest). Injected by the entrypoint; omitted in tests. */
+  readonly version?: string;
   /**
    * Sink for non-fatal messages. In production, the connection's console writes
    * to the editor's Output panel; in tests, capture into an array.
@@ -127,6 +129,8 @@ export interface LspServerOptions {
   readonly writable: NodeJS.WritableStream;
   /** Builds the Toolkit-backed bindings once `connection.console` exists. Required; main.ts always wires it. */
   readonly toolkitBindingsFactory: ToolkitBindingsFactory;
+  /** Shipped CDK CLI version to advertise. Injected by main.ts from the CLI. */
+  readonly version?: string;
 }
 
 /** Pure handler functions for LSP messages, extracted for direct unit testing. */
@@ -379,7 +383,7 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     onInitialize(params) {
       applicationDir = params.initializationOptions?.applicationDir;
       codeLensRefreshSupported = params.capabilities.workspace?.codeLens?.refreshSupport ?? false;
-      const manifest = cdkLspManifest();
+      const manifest = cdkLspManifest(options.version);
       return {
         serverInfo: { name: 'cdk-lsp', version: manifest.version },
         capabilities: {
@@ -519,6 +523,7 @@ export function startServer(options: LspServerOptions): void {
         void connection.sendRequest(CodeLensRefreshRequest.type);
       }
     },
+    version: options.version,
     synthRunner,
     acquireAssemblyLock,
     notify: {

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -29,6 +29,7 @@ import { WATCH_EXCLUDE_DEFAULTS, createIgnoreMatcher } from '../api-private';
 import { codeLensesForFile } from './codelens';
 import { executeCommand, SUPPORTED_COMMANDS, type NotifySink } from './commands';
 import { mapViolationsToDiagnostics } from './diagnostics';
+import { cdkLspManifest } from './features';
 import { hoverForPosition } from './hover';
 import { offsetAtPosition } from './positions';
 import { synthFailureDiagnostics } from './synth-diagnostics';
@@ -378,7 +379,9 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
     onInitialize(params) {
       applicationDir = params.initializationOptions?.applicationDir;
       codeLensRefreshSupported = params.capabilities.workspace?.codeLens?.refreshSupport ?? false;
+      const manifest = cdkLspManifest();
       return {
+        serverInfo: { name: 'cdk-lsp', version: manifest.version },
         capabilities: {
           textDocumentSync: {
             openClose: false,
@@ -394,6 +397,9 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
           executeCommandProvider: { commands: [...SUPPORTED_COMMANDS] },
           // Hover a construct's creation line to see its resolved CFN properties.
           hoverProvider: true,
+          // Non-standard: lets a client discover CDK-specific features and the
+          // wire protocol version ahead of use; also backs `cdk lsp --features`.
+          experimental: { cdk: manifest },
         },
       };
     },

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -53,6 +53,7 @@ function createTestClient(opts?: Partial<LspHandlerOptions>): CapturedClient {
     acquireAssemblyLock: opts?.acquireAssemblyLock ?? mockAssemblyLock,
     synthRunner: opts?.synthRunner,
     notify: opts?.notify,
+    version: opts?.version,
     logger: log,
     onPublishDiagnostics: (uri, diagnostics) => published.push({ uri, diagnostics }),
     onRefreshCodeLenses: refreshCodeLens,
@@ -154,19 +155,18 @@ describe('LSP Server', () => {
   });
 
   test('initialize advertises serverInfo and the experimental.cdk feature manifest', () => {
-    const client = createTestClient();
+    const client = createTestClient({ version: '9.9.9' });
     const result = client.handlers.onInitialize({
       processId: null,
       capabilities: {},
       rootUri: null,
       initializationOptions: {},
     });
-    expect(result.serverInfo).toMatchObject({ name: 'cdk-lsp' });
-    expect(typeof result.serverInfo?.version).toBe('string');
+    expect(result.serverInfo).toEqual({ name: 'cdk-lsp', version: '9.9.9' });
     expect(result.capabilities.experimental).toMatchObject({
       cdk: {
         protocol: 1,
-        version: result.serverInfo?.version,
+        version: '9.9.9',
         features: expect.arrayContaining(['hover', 'codeLens', 'definition', 'synth', 'autoSynth']),
         commands: expect.arrayContaining([COMMAND_SYNTH_NOW]),
       },

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -153,6 +153,52 @@ describe('LSP Server', () => {
     });
   });
 
+  test('initialize advertises serverInfo and the experimental.cdk feature manifest', () => {
+    const client = createTestClient();
+    const result = client.handlers.onInitialize({
+      processId: null,
+      capabilities: {},
+      rootUri: null,
+      initializationOptions: {},
+    });
+    expect(result.serverInfo).toMatchObject({ name: 'cdk-lsp' });
+    expect(typeof result.serverInfo?.version).toBe('string');
+    expect(result.capabilities.experimental).toMatchObject({
+      cdk: {
+        protocol: 1,
+        version: result.serverInfo?.version,
+        features: expect.arrayContaining(['hover', 'codeLens', 'definition', 'synth', 'autoSynth']),
+        commands: expect.arrayContaining([COMMAND_SYNTH_NOW]),
+      },
+    });
+  });
+
+  test('every advertised cdk feature is backed by a real capability (guards manifest drift)', () => {
+    const client = createTestClient();
+    const result = client.handlers.onInitialize({
+      processId: null,
+      capabilities: {},
+      rootUri: null,
+      initializationOptions: {},
+    });
+    const caps = result.capabilities;
+    const commands = caps.executeCommandProvider?.commands ?? [];
+    const backing: Record<string, boolean> = {
+      hover: !!caps.hoverProvider,
+      codeLens: !!caps.codeLensProvider,
+      definition: !!caps.definitionProvider,
+      synth: commands.includes('cdk.explorer.synthNow'),
+      autoSynth: commands.includes('cdk.explorer.enableAutoSynth') && commands.includes('cdk.explorer.disableAutoSynth'),
+    };
+    const manifest = (caps.experimental as { cdk: { features: string[]; commands: string[] } }).cdk;
+    // An advertised feature with no backing capability means the list is lying.
+    for (const feature of manifest.features) {
+      expect(backing[feature]).toBe(true);
+    }
+    // The manifest's command list must mirror the wire executeCommandProvider list.
+    expect(manifest.commands).toEqual(commands);
+  });
+
   test('didSave triggers auto-synth for non-ignored source files when auto-synth is enabled', async () => {
     const synthRunner = jest.fn<Promise<SynthRunResult>, []>().mockResolvedValue({ status: 'success' });
     const client = createTestClient({ synthRunner });

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -529,6 +529,13 @@ export async function makeConfig(): Promise<CliConfig> {
       },
       'lsp': {
         description: 'Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration',
+        options: {
+          features: {
+            type: 'boolean',
+            default: false,
+            desc: 'Print the LSP feature manifest as JSON and exit instead of starting the server. Lets a client probe LSP presence and capabilities without opening a session.',
+          },
+        },
       },
       'orphan': {
         arg: {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -1165,7 +1165,14 @@
       "description": "Check your set-up for potential problems"
     },
     "lsp": {
-      "description": "Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration"
+      "description": "Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration",
+      "options": {
+        "features": {
+          "type": "boolean",
+          "default": false,
+          "desc": "Print the LSP feature manifest as JSON and exit instead of starting the server. Lets a client probe LSP presence and capabilities without opening a session."
+        }
+      }
     },
     "orphan": {
       "arg": {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -327,7 +327,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
       case 'lsp':
         ioHost.currentAction = 'lsp';
-        return lsp();
+        return lsp({ features: argv.features });
 
       case 'ls':
       case 'list':

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -329,7 +329,9 @@ export function convertYargsToUserInput(args: any): UserInput {
       break;
 
     case 'lsp':
-      commandOptions = {};
+      commandOptions = {
+        features: args.features,
+      };
       break;
 
     case 'orphan':
@@ -593,7 +595,9 @@ export function convertConfigToUserInput(config: any): UserInput {
     browser: config.docs?.browser,
   };
   const doctorOptions = {};
-  const lspOptions = {};
+  const lspOptions = {
+    features: config.lsp?.features,
+  };
   const orphanOptions = {};
   const refactorOptions = {
     additionalStackName: config.refactor?.additionalStackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -1118,7 +1118,13 @@ export function parseCommandLineArguments(args: Array<string>): any {
       }),
     )
     .command('doctor', 'Check your set-up for potential problems')
-    .command('lsp', 'Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration')
+    .command('lsp', 'Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration', (yargs: Argv) =>
+      yargs.option('features', {
+        default: false,
+        type: 'boolean',
+        desc: 'Print the LSP feature manifest as JSON and exit instead of starting the server. Lets a client probe LSP presence and capabilities without opening a session.',
+      }),
+    )
     .command('orphan [PATHS..]', 'Detach resources from a CloudFormation stack without deleting them', (yargs: Argv) => yargs)
     .command('refactor [STACKS..]', 'Moves resources between stacks or within the same stack', (yargs: Argv) =>
       yargs

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -147,7 +147,7 @@ export interface UserInput {
   /**
    * Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration
    */
-  readonly lsp?: {};
+  readonly lsp?: LspOptions;
 
   /**
    * Detach resources from a CloudFormation stack without deleting them
@@ -1772,6 +1772,20 @@ export interface DocsOptions {
    * @default - undefined
    */
   readonly browser?: string;
+}
+
+/**
+ * Start the CDK Language Server (LSP) over stdio for editor and AI-agent integration
+ *
+ * @struct
+ */
+export interface LspOptions {
+  /**
+   * Print the LSP feature manifest as JSON and exit instead of starting the server. Lets a client probe LSP presence and capabilities without opening a session.
+   *
+   * @default - false
+   */
+  readonly features?: boolean;
 }
 
 /**

--- a/packages/aws-cdk/lib/commands/lsp.ts
+++ b/packages/aws-cdk/lib/commands/lsp.ts
@@ -1,5 +1,6 @@
 import * as process from 'process';
 import { cdkLspManifest, startLspServer } from '@aws-cdk/cdk-explorer';
+import { versionNumber } from '../cli/version';
 
 /**
  * Runs the CDK Language Server command.
@@ -15,11 +16,11 @@ export async function lsp(options: { readonly features?: boolean } = {}): Promis
   // without starting the server, so a client can detect LSP presence and
   // features without opening a session.
   if (options.features) {
-    process.stdout.write(JSON.stringify(cdkLspManifest()) + '\n');
+    process.stdout.write(JSON.stringify(cdkLspManifest(versionNumber())) + '\n');
     return 0;
   }
 
-  startLspServer();
+  startLspServer(versionNumber());
 
   await new Promise<void>((resolve) => {
     const done = () => resolve();

--- a/packages/aws-cdk/lib/commands/lsp.ts
+++ b/packages/aws-cdk/lib/commands/lsp.ts
@@ -1,15 +1,24 @@
 import * as process from 'process';
-import { startLspServer } from '@aws-cdk/cdk-explorer';
+import { cdkLspManifest, startLspServer } from '@aws-cdk/cdk-explorer';
 
 /**
- * Starts the CDK Language Server over stdio.
+ * Runs the CDK Language Server command.
  *
- * The server speaks LSP/JSON-RPC on stdin/stdout, so this command must not
- * write anything else to stdout. CDK CLI logs go to stderr by default, which
- * keeps the protocol channel clean. The process runs until the LSP client
- * closes the stdio channel (stdin end), then exits 0.
+ * With `--features`, prints the LSP capability manifest as JSON and exits.
+ * Otherwise starts the server, which speaks LSP/JSON-RPC on stdin/stdout -- in
+ * that mode the command must not write anything else to stdout (CDK CLI logs go
+ * to stderr, keeping the protocol channel clean). The server runs until the LSP
+ * client closes the stdio channel (stdin end), then exits 0.
  */
-export async function lsp(): Promise<number> {
+export async function lsp(options: { readonly features?: boolean } = {}): Promise<number> {
+  // `--features` is a probe: print the capability manifest as JSON and exit
+  // without starting the server, so a client can detect LSP presence and
+  // features without opening a session.
+  if (options.features) {
+    process.stdout.write(JSON.stringify(cdkLspManifest()) + '\n');
+    return 0;
+  }
+
   startLspServer();
 
   await new Promise<void>((resolve) => {

--- a/packages/aws-cdk/test/commands/lsp.test.ts
+++ b/packages/aws-cdk/test/commands/lsp.test.ts
@@ -3,6 +3,7 @@ import { lsp } from '../../lib/commands/lsp';
 
 jest.mock('@aws-cdk/cdk-explorer', () => ({
   startLspServer: jest.fn(),
+  cdkLspManifest: jest.fn(() => ({ protocol: 1, features: ['hover'], commands: ['cdk.explorer.synthNow'] })),
 }));
 
 describe('lsp command', () => {
@@ -22,5 +23,18 @@ describe('lsp command', () => {
     process.stdin.emit('end');
 
     await expect(resultPromise).resolves.toBe(0);
+  });
+
+  test('--features prints the manifest as JSON and exits without starting the server', async () => {
+    const write = jest.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    try {
+      await expect(lsp({ features: true })).resolves.toBe(0);
+      expect(startLspServer).not.toHaveBeenCalled();
+      expect(write).toHaveBeenCalledTimes(1);
+      const printed = (write.mock.calls[0][0] as string).trim();
+      expect(JSON.parse(printed)).toEqual({ protocol: 1, features: ['hover'], commands: ['cdk.explorer.synthNow'] });
+    } finally {
+      write.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
The CDK Language Server now advertises a capability manifest on initialize: a protocol version, a named feature list, and the supported commands, exposed via serverInfo and capabilities.experimental.cdk. A new 'cdk lsp --features' flag prints the same manifest as JSON and exits, so a client can probe LSP presence and capabilities without opening a session.

This lets clients gate features by name rather than inferring them from the CDK CLI version. A test guards the advertised feature list against drift from the real server capabilities.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
