### PR TITLE
fix(cli): forward --no-validation to the app process via CDK_VALIDATION

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
@@ -103,10 +103,19 @@ export function synthParametersFromSettings(settings: Settings): {
     debugEnvVars.JSII_HOST_STACK_TRACES = '1';
   }
 
+  // When validation is disabled (e.g. via the CLI's `--no-validation`), forward
+  // it to the app process as an environment variable so framework-side validation
+  // layers can honor it. This is read in framework code that has no access to a
+  // construct tree, which is why it is an environment variable rather than context.
+  const validationEnvVars: Record<string, string> = settings.get(['validation']) === false
+    ? { CDK_VALIDATION: 'false' }
+    : {};
+
   return {
     context: contextFromSettings(settings),
     env: {
       ...settings.get(['debugApp']) ? debugEnvVars : {},
+      ...validationEnvVars,
     },
   };
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/environment.ts
@@ -103,19 +103,16 @@ export function synthParametersFromSettings(settings: Settings): {
     debugEnvVars.JSII_HOST_STACK_TRACES = '1';
   }
 
-  // When validation is disabled (e.g. via the CLI's `--no-validation`), forward
-  // it to the app process as an environment variable so framework-side validation
-  // layers can honor it. This is read in framework code that has no access to a
-  // construct tree, which is why it is an environment variable rather than context.
-  const validationEnvVars: Record<string, string> = settings.get(['validation']) === false
-    ? { CDK_VALIDATION: 'false' }
-    : {};
-
   return {
     context: contextFromSettings(settings),
     env: {
       ...settings.get(['debugApp']) ? debugEnvVars : {},
-      ...validationEnvVars,
+      // When validation is disabled (e.g. via the CLI's `--no-validation`), forward
+      // it to the app process as an environment variable so framework-side validation
+      // layers can honor it. This is read in framework code that has no access to a
+      // construct tree, which is why it is an environment variable rather than context.
+      // Only an explicit `false` disables it, so a missing setting fails safe (validation on).
+      ...settings.get(['validation']) === false ? { CDK_VALIDATION: 'false' } : {},
     },
   };
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/prepare-source.ts
@@ -332,6 +332,7 @@ export function settingsFromSynthOptions(synthOpts: AppSynthOptions = {}): Setti
     versionReporting: true,
     assetMetadata: true,
     assetStaging: true,
+    validation: true,
     ...synthOpts,
   }, true);
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/source-builder.ts
@@ -260,6 +260,18 @@ export interface AppSynthOptions {
    * @default ["**"] - all stacks
    */
   readonly bundlingForStacks?: string;
+
+  /**
+   * Validate stacks during synthesis.
+   *
+   * When disabled, sets the `CDK_VALIDATION` environment variable to `false` in
+   * the app process, so framework-side validation layers (including the built-in
+   * CloudFormation template validation) are skipped. This is the value backing
+   * the CLI's `--no-validation` option.
+   *
+   * @default true
+   */
+  readonly validation?: boolean;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/environment.test.ts
@@ -112,3 +112,20 @@ describe('synthParametersFromSettings sets CDK_DEBUG from debugApp', () => {
     delete process.env.JSII_HOST_STACK_TRACES;
   });
 });
+
+describe('synthParametersFromSettings sets CDK_VALIDATION from validation', () => {
+  test('validation: false sets CDK_VALIDATION to false', () => {
+    const { env } = synthParametersFromSettings(new Settings({ validation: false }));
+    expect(env.CDK_VALIDATION).toBe('false');
+  });
+
+  test('validation: true does not set CDK_VALIDATION', () => {
+    const { env } = synthParametersFromSettings(new Settings({ validation: true }));
+    expect(env.CDK_VALIDATION).toBeUndefined();
+  });
+
+  test('no validation setting does not set CDK_VALIDATION', () => {
+    const { env } = synthParametersFromSettings(new Settings({}));
+    expect(env.CDK_VALIDATION).toBeUndefined();
+  });
+});

--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -322,6 +322,7 @@ export async function commandLineArgumentsToSettings(ioHelper: IoHelper, argv: A
     language: argv.language,
     pathMetadata: argv.pathMetadata,
     assetMetadata: argv.assetMetadata,
+    validation: argv.validation,
     profile: argv.profile,
     region: argv.region,
     plugin: argv.plugin,


### PR DESCRIPTION
Fixes #1751

`cdk synth --no-validation` does not disable the built-in CloudFormation template validation that runs inside `app.synth()`. The `--validation` value is consumed only on the CLI side and never forwarded to  the app process, so framework-side validation cannot honor it (verified: an app logging `process.env.CDK_VALIDATION` prints `undefined` under `cdk synth --no-validation`).

This forwards the resolved `--validation` value to the app process as `CDK_VALIDATION=false` when disabled, alongside the existing `CDK_DEBUG` handling. Unit tests cover disabled/enabled/unset and the full toolkit-lib suite passes.

This is the CLI half of the opt-out and only takes effect once the framework honors `CDK_VALIDATION` (aws/aws-cdk#38379). Relates to aws/aws-cdk#38378.

#### Testing
  
Verified end-to-end against a local build with the framework gate (aws/aws-cdk#38379) present, since this CLI change only takes effect once the framework honors `CDK_VALIDATION`.

Test app (`app.js`): defines an invalid resource under strict validation, and logs what the process received (the `APP sees ...` line is test instrumentation, not CDK output):

```js
  console.error('APP sees CDK_VALIDATION =', JSON.stringify(process.env.CDK_VALIDATION));
  const cdk = require('aws-cdk-lib');
  const app = new cdk.App({
    context: {
      '@aws-cdk/core:validateAgainstDefaultRules': true,
      '@aws-cdk/core:failSynthOnValidationErrors': true,
    },
  });
  const stack = new cdk.Stack(app, 'ValidationOptOutStack');
  new cdk.CfnResource(stack, 'MyBucket', {
    type: 'AWS::S3::Bucket',
    properties: { BogusProperty: 'invalid-value' },
  });
```
  
`cdk.json`: `{ "app": "node app.js" }`. Whether the validator ran is confirmed by whether `cdk.out/validation-report.json` was written, not just console output.

Before:

```
cdk synth --no-validation
APP sees CDK_VALIDATION = undefined
app.js:11:1
ERROR BogusProperty: Additional properties are not allowed ('BogusProperty' was unexpected) (CloudFormation Validate)
   ValidationOptOutStack/MyBucket (MyBucket) aws-cdk-lib.CfnResource
   Acknowledge with 'CloudFormation-Validate::F3002'
Synthesis finished with errors
AssemblyError: Synthesis finished with errors
    at AssemblyError.withStacks (/xxx/xxx/:xxx:xxx)
    at throwIfValidationFailures (/xxx/xxx/:xxx:xxx)
    at async CdkToolkit.validateStacks (/xxx/xxx/:xxx:xxx)
    at async CdkToolkit.selectStacksForDiff (//xxx/xxx/:xxx:xxx)
    at async CdkToolkit.synth (/xxx/xxx/:xxx:xxx)
    at async exec (/xxx/xxx/:xxx:xxx)
```

After:
```
cdk synth --no-validation
APP sees CDK_VALIDATION = "false"
Resources:
  MyBucket:
    Type: AWS::S3::Bucket
    Properties:
      BogusProperty: invalid-value
    Metadata:
      aws:cdk:path: ValidationOptOutStack/MyBucket
  CDKMetadata:
    Type: AWS::CDK::Metadata
    Properties:
      Analytics: v2:deflate64:H4sIAAAAAAAA/zPQM9AzUEwsL9ZNTsnWzclM0qsOLklMztZxTssLSi3OLy1KTq3VyctPSdXLKtYvMzLRMzTTM1DMKs7M1C0qzSvJzE3VC4LQADOsgchLAAAA
    Metadata:
      aws:cdk:path: ValidationOptOutStack/CDKMetadata/Default
    Condition: CDKMetadataAvailable
Conditions:
  CDKMetadataAvailable:
    Fn::Or:
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - af-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-northeast-3
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-south-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-2
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-3
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - ap-southeast-4
          - Fn::Equals:
              - Ref: AWS::Region
              - ca-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - ca-west-1
          - Fn::Equals:
              - Ref: AWS::Region
              - cn-north-1
          - Fn::Equals:
              - Ref: AWS::Region
              - cn-northwest-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-central-2
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-north-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-south-2
      - Fn::Or:
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-1
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-2
          - Fn::Equals:
              - Ref: AWS::Region
              - eu-west-3
          - Fn::Equals:
              - Ref: AWS::Region
              - il-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - me-central-1
          - Fn::Equals:
              - Ref: AWS::Region
              - me-south-1
          - Fn::Equals:
              - Ref: AWS::Region
              - sa-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - us-east-1
          - Fn::Equals:
              - Ref: AWS::Region
              - us-east-2
          - Fn::Equals:
              - Ref: AWS::Region
              - us-west-1
      - Fn::Equals:
          - Ref: AWS::Region
          - us-west-2
Parameters:
  BootstrapVersion:
    Type: AWS::SSM::Parameter::Value<String>
    Default: /cdk-bootstrap/hnb659fds/version
    Description: Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]

81 feature flags are not configured. Run 'cdk flags --unstable=flags' to learn more.
```
### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
