### PR TITLE
fix(cdk-explorer): make LSP diagnostics and hover work in strict clients

### DIFF
--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/diagnostics.ts
@@ -14,6 +14,11 @@ import { groupBy } from './codelens';
 import type { ConstructNode } from '../core/assembly-reader';
 import type { SourceLocation } from '../core/source-resolver';
 
+// Range end character: max valid LSP uinteger (2^31-1); clients clamp it to the
+// line length. Not Number.MAX_VALUE, which VS Code tolerates but IntelliJ's
+// lsp4j rejects as out-of-range, silently dropping the diagnostic.
+const END_OF_LINE_CHARACTER = 2_147_483_647;
+
 export interface MapViolationsResult {
   /** One entry per file URI, ready for connection.sendDiagnostics. */
   readonly byUri: Map<string, Diagnostic[]>;
@@ -94,16 +99,15 @@ function anchorViolation(
 }
 
 /**
- * LSP range for a source location. Anchors at the resolved line/column, or at
- * the top of the file when the file is known but the line/column aren't. LSP
- * positions are 0-based; sourceLocation is 1-based. The end spans to
- * Number.MAX_VALUE so the squiggle covers the rest of the line.
+ * LSP range for a source location. Anchors at the resolved line/column, or the
+ * top of the file when line/column aren't known. LSP positions are 0-based;
+ * sourceLocation is 1-based. The end spans the rest of the line.
  */
 function toRange(loc: SourceLocation): Range {
   const hasLineCol = loc.line >= 1 && loc.column >= 1;
   const line = hasLineCol ? loc.line - 1 : 0;
   const character = hasLineCol ? loc.column - 1 : 0;
-  return { start: { line, character }, end: { line, character: Number.MAX_VALUE } };
+  return { start: { line, character }, end: { line, character: END_OF_LINE_CHARACTER } };
 }
 
 function buildDiagnostic(violation: PolicyViolationJson, range: Range, pluginName: string): Diagnostic {

--- a/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/lsp/server.ts
@@ -400,7 +400,9 @@ export function createLspHandlers(options: LspHandlerOptions): LspHandlers {
         serverInfo: { name: 'cdk-lsp', version: manifest.version },
         capabilities: {
           textDocumentSync: {
-            openClose: false,
+            // Accept didOpen/didClose: IntelliJ only attaches diagnostics, hover,
+            // and definition to documents opened against the server.
+            openClose: true,
             // No keystroke-level edits needed yet. Upgrade to Incremental when
             // we need didChange to mark diagnostics as stale on edit.
             change: TextDocumentSyncKind.None,

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/diagnostics.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/diagnostics.test.ts
@@ -71,7 +71,7 @@ describe('mapViolationsToDiagnostics', () => {
     // to LSP's end-of-line sentinel so the squiggle is visible.
     expect(diag.range).toEqual({
       start: { line: 11, character: 4 },
-      end: { line: 11, character: Number.MAX_VALUE },
+      end: { line: 11, character: 2147483647 },
     });
   });
 

--- a/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/lsp/server.test.ts
@@ -147,7 +147,7 @@ describe('LSP Server', () => {
     });
     expect(result).toMatchObject({
       capabilities: {
-        textDocumentSync: { openClose: false, change: 0, save: { includeText: false } },
+        textDocumentSync: { openClose: true, change: 0, save: { includeText: false } },
         codeLensProvider: { resolveProvider: false },
         definitionProvider: true,
       },


### PR DESCRIPTION
The cdk lsp server worked in VS Code but not in strict LSP clients (IntelliJ via the AWS Toolkit). 

- Diagnostic range end now uses the max valid LSP uinteger (2^31-1) instead of Number.MAX_VALUE. The end is a sentinel meaning "to end of line". VS Code clamps an out-of-range value, but IntelliJ's lsp4j rejects the out-of-range double and silently drops the diagnostic, so no squiggles appeared. The LSP spec says clients clamp an over-long end character to the line length, so behavior is unchanged where Number.MAX_VALUE was tolerated.
- Advertise textDocumentSync.openClose. IntelliJ only attaches hover and go-to-definition to documents it has opened against the server; without this it never opens our source files and those features stay dark. 

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
