### PR TITLE
test(cli): snapshot the validate command's IoHost message stream

### DIFF
--- a/packages/aws-cdk/test/commands/__io_snapshots__/validate/no_violations_reports_success_when_no_validation_report_exists.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/validate/no_violations_reports_success_when_no_validation_report_exists.ndjson
@@ -1,0 +1,5 @@
+{"seq":0,"type":"notify","action":"validate","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":2,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":3,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I1000","message":"✨  Synthesis time: <DURATION>"}
+{"seq":4,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I9600","message":"Validation did not find any problems."}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/validate/stack_selection_validates_a_single_selected_stack.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/validate/stack_selection_validates_a_single_selected_stack.ndjson
@@ -1,0 +1,5 @@
+{"seq":0,"type":"notify","action":"validate","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":2,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":3,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I1000","message":"✨  Synthesis time: <DURATION>"}
+{"seq":4,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I9600","message":"Validation did not find any problems."}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/validate/with_violations_reports_failure_when_validation_report_has_violations.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/validate/with_violations_reports_failure_when_validation_report_has_violations.ndjson
@@ -1,0 +1,5 @@
+{"seq":0,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"validate","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
+{"seq":3,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I1000","message":"✨  Synthesis time: <DURATION>"}
+{"seq":4,"type":"notify","action":"validate","level":"error","code":"CDK_TOOLKIT_E9600","message":"ERROR S3 Buckets must not be publicly accessible (TestPlugin)\n   Test-Stack-A-Display-Name/MyBucket/Resource (MyBucket)\n   Acknowledge with 'TestPlugin::no-public-buckets'"}

--- a/packages/aws-cdk/test/commands/__io_snapshots__/validate/with_violations_reports_multiple_violations_from_multiple_plugins.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/validate/with_violations_reports_multiple_violations_from_multiple_plugins.ndjson
@@ -1,0 +1,5 @@
+{"seq":0,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"validate","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":2,"type":"notify","action":"validate","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
+{"seq":3,"type":"notify","action":"validate","level":"info","code":"CDK_TOOLKIT_I1000","message":"✨  Synthesis time: <DURATION>"}
+{"seq":4,"type":"notify","action":"validate","level":"error","code":"CDK_TOOLKIT_E9600","message":"ERROR S3 Buckets must not be publicly accessible (SecurityPlugin)\n   Test-Stack-A-Display-Name/MyBucket/Resource (MyBucket)\n   Acknowledge with 'SecurityPlugin::no-public-buckets'\n\nWARNING All resources must have cost allocation tags (CostPlugin)\n   Test-Stack-B/MyTopic/Resource (MyTopic)\n   Acknowledge with 'CostPlugin::require-cost-tags'"}

--- a/packages/aws-cdk/test/commands/validate.test.ts
+++ b/packages/aws-cdk/test/commands/validate.test.ts
@@ -1,0 +1,164 @@
+import * as path from 'path';
+import { StackSelectionStrategy } from '@aws-cdk/toolkit-lib';
+import * as fs from 'fs-extra';
+import { Deployments } from '../../lib/api';
+import { CdkToolkit } from '../../lib/cli/cdk-toolkit';
+import { CliIoHost } from '../../lib/cli/io-host';
+import type { TestStackArtifact } from '../_helpers';
+import { instanceMockFrom, MockCloudExecutable } from '../_helpers';
+import { IoHostRecorder } from '../_helpers/io-recorder';
+
+// These tests snapshot the entire ordered stream of messages that `cdk validate`
+// sends to the CliIoHost. Any future reroute or refactor that changes user-visible
+// output shows up as a snapshot diff. See test/_helpers/io-recorder.ts.
+
+const STACK_A: TestStackArtifact = {
+  stackName: 'Test-Stack-A',
+  template: { Resources: { MyBucket: { Type: 'AWS::S3::Bucket' } } },
+  env: 'aws://123456789012/bermuda-triangle-1',
+  displayName: 'Test-Stack-A-Display-Name',
+};
+
+const STACK_B: TestStackArtifact = {
+  stackName: 'Test-Stack-B',
+  template: { Resources: { MyTopic: { Type: 'AWS::SNS::Topic' } } },
+  env: 'aws://123456789012/bermuda-triangle-1',
+};
+
+let cloudExecutable: MockCloudExecutable;
+let toolkit: CdkToolkit;
+let ioHost: CliIoHost;
+let recorder: IoHostRecorder;
+
+beforeEach(async () => {
+  jest.resetAllMocks();
+
+  ioHost = CliIoHost.instance();
+  ioHost.isCI = false;
+  ioHost.currentAction = 'validate';
+
+  cloudExecutable = await MockCloudExecutable.create({
+    stacks: [STACK_A, STACK_B],
+  }, undefined, ioHost, 'validate');
+
+  toolkit = new CdkToolkit({
+    ioHost,
+    cloudExecutable,
+    configuration: cloudExecutable.configuration,
+    sdkProvider: cloudExecutable.sdkProvider,
+    deployments: instanceMockFrom(Deployments),
+  });
+
+  recorder = IoHostRecorder.create(ioHost);
+});
+
+afterEach(() => {
+  recorder.matchSnapshot();
+});
+
+describe('no violations', () => {
+  test('reports success when no validation report exists', async () => {
+    const exitCode = await toolkit.validate({
+      stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+      online: false,
+    });
+
+    expect(exitCode).toBe(0);
+  });
+});
+
+describe('with violations', () => {
+  test('reports failure when validation report has violations', async () => {
+    // Pre-synthesize to get the assembly directory, then write a validation
+    // report there so the validate action discovers it.
+    // Note: constructPath must use the stack's hierarchicalId (displayName or
+    // artifactId) since the validation report filtering matches on
+    // `constructPath.split('/')[0]` against `stacks.hierarchicalIds`.
+    const assembly = await cloudExecutable.synthesize();
+    await fs.writeJSON(path.join(assembly.directory, 'validation-report.json'), {
+      version: '1.0.0',
+      pluginReports: [{
+        pluginName: 'TestPlugin',
+        conclusion: 'failure',
+        violations: [{
+          ruleName: 'no-public-buckets',
+          description: 'S3 Buckets must not be publicly accessible',
+          severity: 'error',
+          violatingConstructs: [{
+            constructPath: 'Test-Stack-A-Display-Name/MyBucket/Resource',
+            cloudFormationResource: {
+              templatePath: 'Test-Stack-A.template.json',
+              logicalId: 'MyBucket',
+            },
+          }],
+        }],
+      }],
+    });
+
+    const exitCode = await toolkit.validate({
+      stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+      online: false,
+    });
+
+    expect(exitCode).toBe(1);
+  });
+
+  test('reports multiple violations from multiple plugins', async () => {
+    const assembly = await cloudExecutable.synthesize();
+    await fs.writeJSON(path.join(assembly.directory, 'validation-report.json'), {
+      version: '1.0.0',
+      pluginReports: [
+        {
+          pluginName: 'SecurityPlugin',
+          conclusion: 'failure',
+          violations: [{
+            ruleName: 'no-public-buckets',
+            description: 'S3 Buckets must not be publicly accessible',
+            severity: 'error',
+            violatingConstructs: [{
+              constructPath: 'Test-Stack-A-Display-Name/MyBucket/Resource',
+              cloudFormationResource: {
+                templatePath: 'Test-Stack-A.template.json',
+                logicalId: 'MyBucket',
+              },
+            }],
+          }],
+        },
+        {
+          pluginName: 'CostPlugin',
+          conclusion: 'failure',
+          violations: [{
+            ruleName: 'require-cost-tags',
+            description: 'All resources must have cost allocation tags',
+            severity: 'warning',
+            violatingConstructs: [{
+              constructPath: 'Test-Stack-B/MyTopic/Resource',
+              cloudFormationResource: {
+                templatePath: 'Test-Stack-B.template.json',
+                logicalId: 'MyTopic',
+              },
+            }],
+          }],
+        },
+      ],
+    });
+
+    const exitCode = await toolkit.validate({
+      stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+      online: false,
+    });
+
+    expect(exitCode).toBe(1);
+  });
+});
+
+describe('stack selection', () => {
+  test('validates a single selected stack', async () => {
+    const exitCode = await toolkit.validate({
+      stacks: { patterns: ['Test-Stack-A-Display-Name'], strategy: StackSelectionStrategy.PATTERN_MATCH },
+      online: false,
+    });
+
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Captures the full ordered stream of messages the validate command sends to the CliIoHost as committed NDJSON snapshots, so any refactoring that changes user-visible output shows up as a diff in code review.

Covers:
- Success path (no validation report, no violations)
- Failure path (policy plugin violations from a report file)
- Multiple violations from multiple plugins
- Stack selection filtering

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
