### PR TITLE
refactor(toolkit-lib): restructure watch as a private combinator over actions

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
@@ -1,6 +1,11 @@
 import type { DeploymentMethod, BaseDeployOptions } from '../deploy';
 
-export interface WatchOptions extends BaseDeployOptions {
+/**
+ * Options that control which files the watch loop observes.
+ *
+ * These are shared between all watch modes (deploy, validate, etc.).
+ */
+export interface WatchFileOptions {
   /**
    * Watch the files in this list
    *
@@ -24,7 +29,12 @@ export interface WatchOptions extends BaseDeployOptions {
    * @default - Current working directory
    */
   readonly watchDir?: string;
+}
 
+/**
+ * Options for watch-deploy mode.
+ */
+export interface WatchOptions extends WatchFileOptions, BaseDeployOptions {
   /**
    * Deployment method
    *

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -59,7 +59,7 @@ import type { RefactorOptions } from '../actions/refactor';
 import { type RollbackOptions } from '../actions/rollback';
 import { type SynthOptions } from '../actions/synth';
 import type { ValidateOptions, ValidateResult } from '../actions/validate';
-import type { IWatcher, WatchOptions } from '../actions/watch';
+import type { IWatcher, WatchFileOptions, WatchOptions } from '../actions/watch';
 import { countAssemblyResults } from './private/count-assembly-results';
 import { WATCH_EXCLUDE_DEFAULTS } from '../actions/watch/private';
 import { EnvironmentAccess } from '../api';
@@ -1145,27 +1145,71 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * Continuously observe project files and deploy the selected stacks
    * automatically when changes are detected. Defaults to hotswap deployments.
    *
-   * This function returns immediately, starting a watcher in the background.
+   * @deprecated Use `watchDeploy()` instead.
    */
   public async watch(cx: ICloudAssemblySource, options: WatchOptions = {}): Promise<IWatcher> {
+    return this.watchDeploy(cx, options);
+  }
+
+  /**
+   * Continuously observe project files and deploy the selected stacks
+   * automatically when changes are detected. Defaults to hotswap deployments.
+   *
+   * This function returns immediately, starting a watcher in the background.
+   */
+  public async watchDeploy(cx: ICloudAssemblySource, options: WatchOptions = {}): Promise<IWatcher> {
     const ioHelper = asIoHelper(this.ioHost, 'watch');
-    await using assembly = await assemblyFromSource(ioHelper, cx, false);
-    const rootDir = options.watchDir ?? process.cwd();
+    const cloudWatchLogMonitor = options.traceLogs ? new CloudWatchLogEventMonitor({ ioHelper }) : undefined;
+
+    return this._watch(cx, options, {
+      command: 'cdk deploy',
+      activity: 'deployment',
+      invoke: async () => {
+        await using assembly = await assemblyFromSource(ioHelper, cx, false);
+        await this.invokeDeployFromWatch(assembly, options, cloudWatchLogMonitor);
+      },
+      onBatchStart: async () => cloudWatchLogMonitor?.deactivate(),
+      onBatchEnd: async () => cloudWatchLogMonitor?.activate(),
+      onDispose: async () => cloudWatchLogMonitor?.deactivate(),
+    });
+  }
+
+  /**
+   * The generic file-watching loop. Observes project files and invokes a callback
+   * on each change, batching concurrent changes into a single follow-up invocation.
+   *
+   * Each invocation re-produces the assembly from the source (via `invoke`), so
+   * file changes between iterations are picked up.
+   */
+  private async _watch(cx: ICloudAssemblySource, fileOptions: WatchFileOptions, props: {
+    command: string;
+    activity: string;
+    invoke: () => Promise<void>;
+    onBatchStart?: () => Promise<void>;
+    onBatchEnd?: () => Promise<void>;
+    onDispose?: () => Promise<void>;
+  }): Promise<IWatcher> {
+    const ioHelper = asIoHelper(this.ioHost, 'watch');
+    const rootDir = fileOptions.watchDir ?? process.cwd();
+
+    // Determine the output directory to exclude from watching. We need to
+    // produce the assembly once here to discover the outdir path.
+    await using initialAssembly = await assemblyFromSource(ioHelper, cx, false);
 
     // For the "include" setting, the behavior is:
     // 1. "watch" setting without an "include" key? We default to observing "**".
     // 2. "watch" setting with an empty "include" key? We default to observing "**".
     // 3. Non-empty "include" key? Just use the "include" key.
-    const watchIncludes = options.include ?? [];
+    const watchIncludes = fileOptions.include ?? [];
     if (watchIncludes.length <= 0) {
       watchIncludes.push('**');
     }
 
     // For the "exclude" setting, the behavior is to add some default excludes in addition to
     // patterns specified by the user sensible default patterns:
-    const watchExcludes = options.exclude ?? [...WATCH_EXCLUDE_DEFAULTS];
+    const watchExcludes = fileOptions.exclude ?? [...WATCH_EXCLUDE_DEFAULTS];
     // 1. The CDK output directory, if it is under the rootDir
-    const relativeOutDir = path.relative(rootDir, assembly.directory);
+    const relativeOutDir = path.relative(rootDir, initialAssembly.directory);
     if (Boolean(relativeOutDir && !relativeOutDir.startsWith('..' + path.sep) && !path.isAbsolute(relativeOutDir))) {
       watchExcludes.push(`${relativeOutDir}/**`);
     }
@@ -1187,38 +1231,36 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       excludes: watchExcludes,
     }));
 
-    // Since 'cdk deploy' is a relatively slow operation for a 'watch' process,
-    // introduce a concurrency latch that tracks the state.
-    // This way, if file change events arrive when a 'cdk deploy' is still executing,
-    // we will batch them, and trigger another 'cdk deploy' after the current one finishes,
-    // making sure 'cdk deploy's  always execute one at a time.
-    // Here's a diagram showing the state transitions:
+    // The invoked command is a relatively slow operation for a 'watch' process,
+    // so we use a concurrency latch that tracks the state.
+    // If file change events arrive while an invocation is still executing,
+    // we batch them and trigger another invocation after the current one finishes,
+    // ensuring invocations always execute one at a time.
+    //
+    // State transitions:
     // --------------                --------    file changed     --------------    file changed     --------------  file changed
     // |            |  ready event   |      | ------------------> |            | ------------------> |            | --------------|
-    // | pre-ready  | -------------> | open |                     | deploying  |                     |   queued   |               |
+    // | pre-ready  | -------------> | open |                     |  running   |                     |   queued   |               |
     // |            |                |      | <------------------ |            | <------------------ |            | <-------------|
-    // --------------                --------  'cdk deploy' done  --------------  'cdk deploy' done  --------------
-    type LatchState = 'pre-ready' | 'open' | 'deploying' | 'queued';
+    // --------------                --------   invocation done   --------------   invocation done   --------------
+    type LatchState = 'pre-ready' | 'open' | 'running' | 'queued';
     let latch: LatchState = 'pre-ready';
 
-    const cloudWatchLogMonitor = options.traceLogs ? new CloudWatchLogEventMonitor({ ioHelper }) : undefined;
-    const deployAndWatch = async () => {
-      latch = 'deploying' as LatchState;
-      await cloudWatchLogMonitor?.deactivate();
+    const invokeAndWatch = async () => {
+      latch = 'running' as LatchState;
+      await props.onBatchStart?.();
 
-      await this.invokeDeployFromWatch(assembly, options, cloudWatchLogMonitor);
+      await props.invoke();
 
-      // If latch is still 'deploying' after the 'await', that's fine,
-      // but if it's 'queued', that means we need to deploy again
+      // If latch is still 'running' after the 'await', that's fine,
+      // but if it's 'queued', that means we need to invoke again
       while (latch === 'queued') {
-        // TypeScript doesn't realize latch can change between 'awaits',
-        // and thinks the above 'while' condition is always 'false' without the cast
-        latch = 'deploying';
-        await ioHelper.notify(IO.CDK_TOOLKIT_I5315.msg("Detected file changes during deployment. Invoking 'cdk deploy' again"));
-        await this.invokeDeployFromWatch(assembly, options, cloudWatchLogMonitor);
+        latch = 'running';
+        await ioHelper.notify(IO.CDK_TOOLKIT_I5315.msg(`Detected file changes during ${props.activity}. Invoking '${props.command}' again`));
+        await props.invoke();
       }
       latch = 'open';
-      await cloudWatchLogMonitor?.activate();
+      await props.onBatchEnd?.();
     };
 
     // Create ignore matcher for chokidar v4 compatibility
@@ -1237,13 +1279,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       })
       .on('ready', async () => {
         latch = 'open';
-        await ioHelper.defaults.debug("'watch' received the 'ready' event. From now on, all file changes will trigger a deployment");
-        await ioHelper.notify(IO.CDK_TOOLKIT_I5314.msg("Triggering initial 'cdk deploy'"));
-        await deployAndWatch();
+        await ioHelper.defaults.debug(`'watch' received the 'ready' event. From now on, all file changes will trigger a ${props.activity}`);
+        await ioHelper.notify(IO.CDK_TOOLKIT_I5314.msg(`Triggering initial '${props.command}'`));
+        await invokeAndWatch();
       })
       .on('all', async (event: EventName, filePath: string) => {
         // Filter out non-file events (e.g., 'error', 'raw', 'ready', 'all')
-        // These are handled separately or not relevant for watch deployments
+        // These are handled separately or not relevant for watch
         if (!isFileEvent(event)) {
           return;
         }
@@ -1254,13 +1296,13 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         if (latch === 'pre-ready') {
           await ioHelper.notify(IO.CDK_TOOLKIT_I5311.msg(`'watch' is observing ${event === 'addDir' ? 'directory' : 'the file'} '${filePath}' for changes`, watchEvent));
         } else if (latch === 'open') {
-          await ioHelper.notify(IO.CDK_TOOLKIT_I5312.msg(`Detected change to '${filePath}' (type: ${event}). Triggering 'cdk deploy'`, watchEvent));
-          await deployAndWatch();
+          await ioHelper.notify(IO.CDK_TOOLKIT_I5312.msg(`Detected change to '${filePath}' (type: ${event}). Triggering '${props.command}'`, watchEvent));
+          await invokeAndWatch();
         } else {
-          // this means latch is either 'deploying' or 'queued'
+          // this means latch is either 'running' or 'queued'
           latch = 'queued';
           await ioHelper.notify(IO.CDK_TOOLKIT_I5313.msg(
-            `Detected change to '${filePath}' (type: ${event}) while 'cdk deploy' is still running. Will queue for another deployment after this one finishes'`,
+            `Detected change to '${filePath}' (type: ${event}) while '${props.command}' is still running. Will queue for another ${props.activity} after this one finishes`,
             watchEvent,
           ));
         }
@@ -1270,9 +1312,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     return {
       async dispose() {
-        // stop the logs monitor, if it exists
-        await cloudWatchLogMonitor?.deactivate();
-        // close the watcher itself
+        await props.onDispose?.();
         await watcher.close();
         stoppedPromise.resolve();
         return stoppedPromise.promise;

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1164,7 +1164,15 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     return this._watch(cx, options, {
       command: 'cdk deploy',
       activity: 'deployment',
-      invoke: async () => {
+      invoke: async (initialAssembly) => {
+        // The first invocation reuses the assembly produced at watch startup
+        // (it is fresh by definition: no file has changed yet). Subsequent
+        // invocations are triggered by file changes and re-produce the
+        // assembly so the changes are picked up.
+        if (initialAssembly) {
+          await this.invokeDeployFromWatch(initialAssembly, options, cloudWatchLogMonitor);
+          return;
+        }
         await using assembly = await assemblyFromSource(ioHelper, cx, false);
         await this.invokeDeployFromWatch(assembly, options, cloudWatchLogMonitor);
       },
@@ -1184,7 +1192,16 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   private async _watch(cx: ICloudAssemblySource, fileOptions: WatchFileOptions, props: {
     command: string;
     activity: string;
-    invoke: () => Promise<void>;
+    /**
+     * Run the action once.
+     *
+     * For the initial invocation (before any file has changed) the assembly
+     * produced at watch startup is passed in and may be used directly; it is
+     * fresh by definition. For subsequent invocations it is `undefined` and
+     * the action must re-produce the assembly from the source, so that file
+     * changes are picked up.
+     */
+    invoke: (initialAssembly?: StackAssembly) => Promise<void>;
     onBatchStart?: () => Promise<void>;
     onBatchEnd?: () => Promise<void>;
     onDispose?: () => Promise<void>;
@@ -1192,9 +1209,21 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'watch');
     const rootDir = fileOptions.watchDir ?? process.cwd();
 
-    // Determine the output directory to exclude from watching. We need to
-    // produce the assembly once here to discover the outdir path.
-    await using initialAssembly = await assemblyFromSource(ioHelper, cx, false);
+    // Produce the assembly once at startup: it determines the output directory
+    // to exclude from watching, and is reused for the initial invocation (no
+    // file has changed yet, so it cannot be stale). Its lifetime is managed
+    // manually: disposed after the initial invocation consumes it, or on
+    // watcher dispose if the initial invocation never ran.
+    let initialAssembly: StackAssembly | undefined = await assemblyFromSource(ioHelper, cx, false);
+    const assemblyOutDir = initialAssembly.directory;
+    const consumeInitialAssembly = (): StackAssembly | undefined => {
+      const assembly = initialAssembly;
+      initialAssembly = undefined;
+      return assembly;
+    };
+    const disposeInitialAssembly = async () => {
+      await consumeInitialAssembly()?.dispose();
+    };
 
     // For the "include" setting, the behavior is:
     // 1. "watch" setting without an "include" key? We default to observing "**".
@@ -1209,7 +1238,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     // patterns specified by the user sensible default patterns:
     const watchExcludes = fileOptions.exclude ?? [...WATCH_EXCLUDE_DEFAULTS];
     // 1. The CDK output directory, if it is under the rootDir
-    const relativeOutDir = path.relative(rootDir, initialAssembly.directory);
+    const relativeOutDir = path.relative(rootDir, assemblyOutDir);
     if (Boolean(relativeOutDir && !relativeOutDir.startsWith('..' + path.sep) && !path.isAbsolute(relativeOutDir))) {
       watchExcludes.push(`${relativeOutDir}/**`);
     }
@@ -1246,21 +1275,54 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     type LatchState = 'pre-ready' | 'open' | 'running' | 'queued';
     let latch: LatchState = 'pre-ready';
 
+    // Whether the watcher has been disposed. Once set, no new invocations start.
+    let stopped = false;
+    // The currently executing invocation batch (if any). `dispose()` awaits this
+    // so that in-flight work (e.g. a synthesis subprocess) completes before the
+    // watcher reports itself as stopped and resources are cleaned up.
+    let inFlight: Promise<void> = Promise.resolve();
+
+    // Run one invocation, reporting (never propagating) failures: this runs
+    // inside chokidar event callbacks, where a rejection would be unhandled
+    // and crash the process. Synthesis failures are expected while the user
+    // is mid-edit; watching must survive them and try again on the next change.
+    //
+    // The first invocation receives the assembly produced at watch startup
+    // (fresh by definition); every later invocation re-produces from source.
+    const invokeSafe = async () => {
+      const assembly = consumeInitialAssembly();
+      try {
+        await props.invoke(assembly);
+      } catch (e: any) {
+        await ioHelper.defaults.error(formatErrorMessage(e));
+      } finally {
+        await assembly?.dispose();
+      }
+    };
+
     const invokeAndWatch = async () => {
       latch = 'running' as LatchState;
       await props.onBatchStart?.();
 
-      await props.invoke();
+      await invokeSafe();
 
       // If latch is still 'running' after the 'await', that's fine,
       // but if it's 'queued', that means we need to invoke again
-      while (latch === 'queued') {
+      while (latch === 'queued' && !stopped) {
         latch = 'running';
         await ioHelper.notify(IO.CDK_TOOLKIT_I5315.msg(`Detected file changes during ${props.activity}. Invoking '${props.command}' again`));
-        await props.invoke();
+        await invokeSafe();
       }
       latch = 'open';
       await props.onBatchEnd?.();
+    };
+
+    const startInvocation = async () => {
+      if (stopped) {
+        return;
+      }
+      inFlight = invokeAndWatch();
+      await inFlight;
     };
 
     // Create ignore matcher for chokidar v4 compatibility
@@ -1281,7 +1343,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         latch = 'open';
         await ioHelper.defaults.debug(`'watch' received the 'ready' event. From now on, all file changes will trigger a ${props.activity}`);
         await ioHelper.notify(IO.CDK_TOOLKIT_I5314.msg(`Triggering initial '${props.command}'`));
-        await invokeAndWatch();
+        await startInvocation();
       })
       .on('all', async (event: EventName, filePath: string) => {
         // Filter out non-file events (e.g., 'error', 'raw', 'ready', 'all')
@@ -1297,7 +1359,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
           await ioHelper.notify(IO.CDK_TOOLKIT_I5311.msg(`'watch' is observing ${event === 'addDir' ? 'directory' : 'the file'} '${filePath}' for changes`, watchEvent));
         } else if (latch === 'open') {
           await ioHelper.notify(IO.CDK_TOOLKIT_I5312.msg(`Detected change to '${filePath}' (type: ${event}). Triggering '${props.command}'`, watchEvent));
-          await invokeAndWatch();
+          await startInvocation();
         } else {
           // this means latch is either 'running' or 'queued'
           latch = 'queued';
@@ -1312,6 +1374,12 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     return {
       async dispose() {
+        // Prevent new invocations, then wait for any in-flight invocation to
+        // complete so we don't tear down resources under running work.
+        stopped = true;
+        await inFlight.catch(() => {});
+        // Dispose the startup assembly if no invocation ever consumed it.
+        await disposeInitialAssembly();
         await props.onDispose?.();
         await watcher.close();
         stoppedPromise.resolve();

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -1377,7 +1377,8 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         // Prevent new invocations, then wait for any in-flight invocation to
         // complete so we don't tear down resources under running work.
         stopped = true;
-        await inFlight.catch(() => {});
+        await inFlight.catch(() => {
+        });
         // Dispose the startup assembly if no invocation ever consumed it.
         await disposeInitialAssembly();
         await props.onDispose?.();

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
@@ -294,12 +294,12 @@ describe('watch re-synthesis', () => {
 
     const producesTotal = produceSpy.mock.calls.length;
 
-    // 3 deployments (1 ready + 2 changes) must each produce a fresh assembly.
-    // The initial assembly produced for outdir discovery is an extra produce(),
-    // so we expect at least 4 total.
+    // 3 deployments: the initial one (ready event) reuses the assembly
+    // produced at watch startup (fresh by definition), while every
+    // file-change iteration must re-produce so the changes are picked up.
     expect(deploySpy).toHaveBeenCalledTimes(3);
-    expect(producesAfterReady).toBeGreaterThanOrEqual(2); // 1 for outdir + 1 for first deploy
-    expect(producesTotal).toBeGreaterThanOrEqual(4); // 1 for outdir + 3 for each deployment
+    expect(producesAfterReady).toBe(1); // startup produce, reused by the initial deployment
+    expect(producesTotal).toBe(3); // startup + one per file-change iteration
   });
 });
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch.test.ts
@@ -277,7 +277,31 @@ describe('watch', () => {
   });
 });
 
-// @todo unit test watch with file events
+describe('watch re-synthesis', () => {
+  test('re-produces the assembly on each file-change iteration', async () => {
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const produceSpy = jest.spyOn(cx, 'produce');
+
+    await toolkit.watch(cx, { include: [] });
+
+    // Initial deployment (ready event)
+    await fakeChokidarWatcherOn.readyCallback();
+    const producesAfterReady = produceSpy.mock.calls.length;
+
+    // Two file-change iterations
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'app.ts');
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'lib.ts');
+
+    const producesTotal = produceSpy.mock.calls.length;
+
+    // 3 deployments (1 ready + 2 changes) must each produce a fresh assembly.
+    // The initial assembly produced for outdir discovery is an extra produce(),
+    // so we expect at least 4 total.
+    expect(deploySpy).toHaveBeenCalledTimes(3);
+    expect(producesAfterReady).toBeGreaterThanOrEqual(2); // 1 for outdir + 1 for first deploy
+    expect(producesTotal).toBeGreaterThanOrEqual(4); // 1 for outdir + 3 for each deployment
+  });
+});
 
 describe('watch chokidar configuration', () => {
   test('watches root directory (.) instead of glob patterns', async () => {


### PR DESCRIPTION
No functional changes.

Refactor `Toolkit.watch()` into a layered architecture:

- **`_watch(cx, fileOptions, { invoke, hooks })`** — private combinator that owns the chokidar file-watching loop, the concurrency latch, and the error-swallowing policy. It is parameterized by the action (e.g. `deploy`, `validate`) to run on each iteration via the `invoke` callback.

- **`watchDeploy(cx, options)`** — new public method that carries the deploy-specific glue: hotswap defaults, CloudWatch log monitor pause/resume hooks, and the existing user-agent tagging.

- **`watch(cx, options)`** — deprecated alias for `watchDeploy()`.

- In the future, we will author **`watchValidate(cx, options)`** as a public method that will carry validate-specific defaults.

**Bug fix:** The previous `watch()` implementation called `produce()` once at startup and reused the same `StackAssembly` for every file-change iteration, meaning subsequent deployments never picked up source changes. The refactored `watchDeploy` now calls `produce()` (via `assemblyFromSource`) inside each invocation, so file changes are re-synthesized per iteration.

**Type split:** `WatchFileOptions` is extracted from `WatchOptions` as a standalone interface containing only include/exclude/watchDir. This allows future watch modes (e.g. `validate`) to compose file-watching settings with their own action-specific options without inheriting deploy fields.

All 20 existing watch tests pass unchanged + 1 new regression test proving per-iteration re-synthesis.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
