### PR TITLE
fix(toolkit-lib): hooks without annotations fail deployments without showing failure details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,7 +219,10 @@ Integration tests live in `packages/@aws-cdk-testing/cli-integ/` and deploy real
 cd packages/@aws-cdk-testing/cli-integ
 bin/run-suite cli-integ-tests
 
-# Run a specific test
+# Run a specific test by file name (preferred; one test per file)
+bin/run-suite -a cli-integ-tests -F cdk-deploy-new-stack.integtest
+
+# Run a specific test by name
 bin/run-suite -a cli-integ-tests -t 'test name substring'
 ```
 

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/lambda-hook-app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/lambda-hook-app/app.js
@@ -1,0 +1,74 @@
+const cdk = require('aws-cdk-lib/core');
+const iam = require('aws-cdk-lib/aws-iam');
+const lambda = require('aws-cdk-lib/aws-lambda');
+const s3 = require('aws-cdk-lib/aws-s3');
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+if (!stackPrefix) {
+  throw new Error('the STACK_NAME_PREFIX environment variable is required');
+}
+
+const testStackName = `${stackPrefix}-lambda-hook-test`;
+
+// The detailed failure reason, only available through the hook result APIs
+const hookFailureMessage = 'Ingress must not allow 0.0.0.0/0 to non-HTTP(s) ports';
+
+// Setup a Lambda Hook that will fail change sets of the test stack
+class LambdaHookSetupStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    // Hook handler that always fails with a detailed message
+    const hookFunction = new lambda.Function(this, 'HookFunction', {
+      runtime: lambda.Runtime.NODEJS_LATEST,
+      handler: 'index.handler',
+      code: lambda.Code.fromInline(`
+        exports.handler = async (event) => {
+          return {
+            hookStatus: 'FAILED',
+            errorCode: 'NonCompliant',
+            message: ${JSON.stringify(hookFailureMessage)},
+            clientRequestToken: event.clientRequestToken,
+          };
+        };
+      `),
+    });
+
+    // IAM role for Lambda Hook execution
+    const hookRole = new iam.Role(this, 'LambdaHookExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('hooks.cloudformation.amazonaws.com'),
+    });
+    hookFunction.grantInvoke(hookRole);
+
+    // Lambda Hook - fails CHANGE_SET operations, but only for the test stack
+    new cdk.CfnLambdaHook(this, 'LambdaHook', {
+      alias: 'Private::Lambda::TestHook',
+      executionRole: hookRole.roleArn,
+      failureMode: 'FAIL',
+      hookStatus: 'ENABLED',
+      lambdaFunction: hookFunction.functionArn,
+      targetOperations: ['CHANGE_SET'],
+      stackFilters: {
+        filteringCriteria: 'ALL',
+        stackNames: {
+          // Only evaluate the test stack, to not interfere with anything else in the account
+          include: [testStackName],
+        },
+      },
+    });
+  }
+}
+
+class LambdaHookTestStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    new s3.CfnBucket(this, 'SomeBucket');
+  }
+}
+
+const app = new cdk.App();
+new LambdaHookSetupStack(app, `${stackPrefix}-lambda-hook-setup`);
+new LambdaHookTestStack(app, testStackName);
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/lambda-hook-app/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/lambda-hook-app/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "node app.js",
+  "versionReporting": false
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-lambda-hook-change-set-failure-displays-hook-status-reason.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/deploy/cdk-deploy-lambda-hook-change-set-failure-displays-hook-status-reason.integtest.ts
@@ -1,0 +1,20 @@
+import { integTest, withSpecificFixture } from '../../../lib';
+
+jest.setTimeout(2 * 60 * 60_000);
+
+integTest(
+  'deploy with lambda hook change set failure displays hook status reason',
+  withSpecificFixture('lambda-hook-app', async (fixture) => {
+    // Deploy the setup stack which creates the Lambda Hook via CloudFormation
+    await fixture.cdkDeploy('lambda-hook-setup');
+
+    // Attempt to deploy the test stack; the Lambda Hook fails its change set.
+    // Lambda Hooks don't emit annotations, so the detailed failure reason is only
+    // available via the hook result APIs and must be surfaced from there.
+    const deployOutput = await fixture.cdkDeploy('lambda-hook-test', {
+      allowErrExit: true,
+    });
+    expect(deployOutput).toContain("Hook 'Private::Lambda::TestHook' failed");
+    expect(deployOutput).toContain('Ingress must not allow 0.0.0.0/0 to non-HTTP(s) ports');
+  }),
+);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/aws-auth/sdk.ts
@@ -125,6 +125,8 @@ import type {
   GetHookResultCommandOutput,
   ListChangeSetsCommandInput,
   ListChangeSetsCommandOutput,
+  ListHookResultsCommandInput,
+  ListHookResultsCommandOutput,
 } from '@aws-sdk/client-cloudformation';
 import {
   paginateDescribeEvents,
@@ -170,6 +172,7 @@ import {
   DescribeTypeCommand,
   GetHookResultCommand,
   ListChangeSetsCommand,
+  ListHookResultsCommand,
 } from '@aws-sdk/client-cloudformation';
 import type { OperationEvent } from '@aws-sdk/client-cloudformation/dist-types/models/models_0';
 import {
@@ -536,6 +539,7 @@ export interface ICloudFormationClient {
   waitUntilStackRefactorExecuteComplete(input: DescribeStackRefactorCommandInput): Promise<WaiterResult>;
   getHookResult(input: GetHookResultCommandInput): Promise<GetHookResultCommandOutput>;
   listChangeSets(input: ListChangeSetsCommandInput): Promise<ListChangeSetsCommandOutput>;
+  listHookResults(input: ListHookResultsCommandInput): Promise<ListHookResultsCommandOutput>;
 }
 
 export interface ICloudWatchLogsClient {
@@ -903,6 +907,8 @@ export class SDK {
       getHookResult: (input: GetHookResultCommandInput): Promise<GetHookResultCommandOutput> =>
         client.send(new GetHookResultCommand(input)),
       listChangeSets: (input) => client.send(new ListChangeSetsCommand(input)),
+      listHookResults: (input: ListHookResultsCommandInput): Promise<ListHookResultsCommandOutput> =>
+        client.send(new ListHookResultsCommand(input)),
     };
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
@@ -1,4 +1,4 @@
-import type { ChangeSetSummary, Stack } from '@aws-sdk/client-cloudformation';
+import type { ChangeSetSummary, HookResultSummary, Stack } from '@aws-sdk/client-cloudformation';
 import { ChangeSetStatus, ChangeType } from '@aws-sdk/client-cloudformation';
 import type { ChangeSetResourceError } from './changeset-error-fetcher';
 import { ChangeSetResourceErrorFetcher } from './changeset-error-fetcher';
@@ -10,6 +10,7 @@ import type { EnvironmentResources } from '../environment';
 import type { IoHelper } from '../io/private/io-helper';
 import type { ISourceTracer } from '../source-tracing/private/source-tracing';
 import { PollRange, StackEventPoller } from '../stack-events';
+import { formatHookResultDetails, isFailedHookStatus } from '../stack-events/hook-result-details';
 import type { ResourceError, ResourceErrors } from '../stack-events/resource-errors';
 import { StackStatus } from '../stack-events/stack-status';
 
@@ -315,8 +316,9 @@ export class CloudFormationStackDiagnoser {
   /**
    * Try to read the resource-specific reasons for a changeset failure from `DescribeEvents`.
    *
-   * If we couldn't read the events or there are 0 errors returned by that API, return a generic
-   * error.
+   * If we couldn't read the events or there are 0 errors returned by that API, check whether
+   * the change set was failed by CloudFormation Hooks and report those. Otherwise, return a
+   * generic error.
    */
   private async _reportChangeSetFailureFromEvents(changeSet: ChangeSetSummary, detectedBy: StackProblemSource): Promise<StackDiagnosis> {
     const ev = await new ChangeSetResourceErrorFetcher(this.props.sdk, this.props.envResources)
@@ -337,7 +339,77 @@ export class CloudFormationStackDiagnoser {
       await this.props.ioHelper.defaults.warn(ev.message);
     }
 
+    // The change set may have been failed by a CloudFormation Hook (e.g. a Lambda Hook
+    // targeting change set operations). Those failures don't produce events; their
+    // details are only available through the hook results APIs.
+    const hookErrors = await this._changeSetHookErrors(changeSet);
+    if (hookErrors.length > 0) {
+      return {
+        type: 'problem',
+        detectedBy,
+        problems: await this.enhanceErrors(hookErrors),
+      };
+    }
+
     return this._nonSpecificChangeSetError(changeSet, detectedBy);
+  }
+
+  /**
+   * Find the hooks that failed this change set, and return their failure details as resource errors.
+   *
+   * Failures of hooks with failure mode WARN don't fail a change set, so those are excluded.
+   * Returns an empty array if hook results can't be listed (e.g. for lack of permissions).
+   */
+  private async _changeSetHookErrors(changeSet: ChangeSetSummary): Promise<ResourceError[]> {
+    let hookResults: HookResultSummary[];
+    try {
+      hookResults = (await this.cfn.listHookResults({
+        TargetType: 'CHANGE_SET',
+        TargetId: changeSet.ChangeSetId,
+      })).HookResults ?? [];
+    } catch (e: any) {
+      await this.props.ioHelper.defaults.debug(`Could not list hook results for change set ${changeSet.ChangeSetName}: ${e.message}`);
+      return [];
+    }
+
+    const failedHooks = hookResults.filter((r) => isFailedHookStatus(r.Status) && r.FailureMode === 'FAIL');
+
+    const errors: ResourceError[] = [];
+    for (const hook of failedHooks) {
+      const details = await this._hookResultDetails(hook);
+      errors.push({
+        // It's about the stack, not a specific resource
+        logicalId: undefined,
+        message: `Hook '${hook.TypeName ?? 'unknown'}' failed${details ? `: ${details}` : ''}`,
+        errorCode: 'HookFailed',
+        parentStackLogicalIds: this.parentStackLogicalIds,
+        stackArn: changeSet.StackId ?? '',
+        physicalId: changeSet.StackId,
+        resourceType: 'AWS::CloudFormation::Stack',
+      });
+    }
+    return errors;
+  }
+
+  /**
+   * Get the failure details for a hook result summary.
+   *
+   * Tries `GetHookResult` first, which includes annotations (Guard Hooks). Falls back
+   * to the summary itself, whose `HookStatusReason` carries the details for other hooks.
+   */
+  private async _hookResultDetails(hook: HookResultSummary): Promise<string | undefined> {
+    if (hook.HookResultId) {
+      try {
+        const result = await this.cfn.getHookResult({ HookResultId: hook.HookResultId });
+        const details = formatHookResultDetails(result);
+        if (details) {
+          return details;
+        }
+      } catch (e: any) {
+        await this.props.ioHelper.defaults.debug(`Could not fetch hook result ${hook.HookResultId}: ${e.message}`);
+      }
+    }
+    return formatHookResultDetails(hook);
   }
 
   private async enhanceErrors(errs: readonly ResourceError[]): Promise<TracedResourceError[]> {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/hook-result-details.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/hook-result-details.ts
@@ -1,0 +1,66 @@
+import type { GetHookResultCommandOutput, HookResultSummary } from '@aws-sdk/client-cloudformation';
+
+/**
+ * The relevant parts of a hook result, common to `GetHookResult` outputs and
+ * `ListHookResults` summaries.
+ */
+export type HookResultDetails = Pick<GetHookResultCommandOutput, 'Status' | 'HookStatusReason' | 'Annotations'> | HookResultSummary;
+
+/**
+ * Format the failure details of a hook result into a human-readable string.
+ *
+ * - Guard Hooks report their details as annotations; failed annotations are
+ *   formatted as a list of non-compliant rules.
+ * - Other hooks (e.g. Lambda Hooks or custom hooks) don't emit annotations; their
+ *   details live in the top-level `HookStatusReason` of the hook result, which is
+ *   usually more detailed than the `HookStatusReason` found on stack events.
+ *
+ * Returns `undefined` if the result carries no failure details.
+ */
+export function formatHookResultDetails(result: HookResultDetails): string | undefined {
+  const annotations = ('Annotations' in result ? result.Annotations : undefined) ?? [];
+  const failedAnnotations = annotations.filter((a) => a.Status === 'FAILED');
+
+  if (failedAnnotations.length > 0) {
+    const lines: string[] = ['NonCompliant Rules:', ''];
+    for (const annotation of failedAnnotations) {
+      if (annotation.AnnotationName) {
+        lines.push(`[${annotation.AnnotationName}]`);
+      }
+      if (annotation.StatusMessage) {
+        lines.push(`• ${normalizeHookMessage(annotation.StatusMessage)}`);
+      }
+      if (annotation.RemediationMessage) {
+        lines.push(`Remediation: ${normalizeHookMessage(annotation.RemediationMessage)}`);
+      }
+      lines.push('');
+    }
+    return lines.join('\n').trimEnd();
+  }
+
+  // No annotations (e.g. a Lambda Hook): fall back to the hook result's own status reason
+  if (isFailedHookStatus(result.Status) && result.HookStatusReason) {
+    return normalizeHookMessage(result.HookStatusReason);
+  }
+
+  return undefined;
+}
+
+/**
+ * Whether the given hook status represents a failure
+ */
+export function isFailedHookStatus(status: string | undefined): boolean {
+  return status === 'HOOK_COMPLETE_FAILED' || status === 'HOOK_FAILED';
+}
+
+/**
+ * Trims leading/trailing whitespace, collapses all internal whitespace
+ * (including newlines) to a single space, and truncates to `maxChars`
+ * characters, appending `[...truncated]` when the original was longer.
+ */
+export function normalizeHookMessage(message: string, maxChars: number = 400): string {
+  const normalized = message.trim().replace(/\s+/g, ' ');
+  return normalized.length > maxChars
+    ? normalized.substring(0, maxChars) + '[...truncated]'
+    : normalized;
+}

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import * as util from 'node:util';
 import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import { formatHookResultDetails } from './hook-result-details';
 import { StackEventPoller, PollRange } from './stack-event-poller';
 import { StackProgressMonitor } from './stack-progress-monitor';
 import type { StackActivity } from '../../payloads/stack-activity';
@@ -244,45 +245,17 @@ export class StackActivityMonitor {
   }
 
   /**
-   * Trims leading/trailing whitespace, collapses all internal whitespace
-   * (including newlines) to a single space, and truncates to `maxChars`
-   * characters, appending `[...truncated]` when the original was longer.
+   * Fetches hook failure details via the GetHookResult API and formats them into
+   * a human-readable string.
+   *
+   * For Guard Hooks the details come from the failed annotations; for other hooks
+   * (e.g. Lambda Hooks) they come from the hook result's own status reason.
+   * Returns undefined if the fetch fails or the result carries no failure details.
    */
-  private normalizeMessage(message: string, maxChars: number = 400): string {
-    const normalized = message.trim().replace(/\s+/g, ' ');
-    return normalized.length > maxChars
-      ? normalized.substring(0, maxChars) + '[...truncated]'
-      : normalized;
-  }
-
-  /**
-   * Fetches Guard Hook annotation details via GetHookResult API and formats them
-   * into a human-readable string. Returns undefined if the fetch fails or there
-   * are no failed annotations.
-   */
-  private async fetchGuardHookAnnotations(hookInvocationId: string): Promise<string | undefined> {
+  private async fetchHookResultDetails(hookInvocationId: string): Promise<string | undefined> {
     try {
       const result = await this.cfn.getHookResult({ HookResultId: hookInvocationId });
-      const annotations = result.Annotations ?? [];
-      const failedAnnotations = annotations.filter((a) => a.Status === 'FAILED');
-      if (failedAnnotations.length === 0) {
-        return undefined;
-      }
-
-      const lines: string[] = ['NonCompliant Rules:', ''];
-      for (const annotation of failedAnnotations) {
-        if (annotation.AnnotationName) {
-          lines.push(`[${annotation.AnnotationName}]`);
-        }
-        if (annotation.StatusMessage) {
-          lines.push(`• ${this.normalizeMessage(annotation.StatusMessage)}`);
-        }
-        if (annotation.RemediationMessage) {
-          lines.push(`Remediation: ${this.normalizeMessage(annotation.RemediationMessage)}`);
-        }
-        lines.push('');
-      }
-      return lines.join('\n').trimEnd();
+      return formatHookResultDetails(result);
     } catch (e: any) {
       const errorMessage = e instanceof Error ? e.message : String(e);
 
@@ -306,7 +279,7 @@ export class StackActivityMonitor {
         );
       } else {
         await this.ioHelper.defaults.warn(
-          util.format('Failed to fetch Guard Hook details for invocation %s: %s', hookInvocationId, errorMessage),
+          util.format('Failed to fetch Hook details for invocation %s: %s', hookInvocationId, errorMessage),
         );
       }
 
@@ -325,11 +298,11 @@ export class StackActivityMonitor {
     for (const resourceEvent of pollEvents) {
       this.progressMonitor.process(resourceEvent);
 
-      // If this is a failed Guard Hook event with an invocation ID, fetch annotations
+      // If this is a failed hook event with an invocation ID, fetch the failure details
       if (resourceEvent.event.HookInvocationId) {
-        const annotations = await this.fetchGuardHookAnnotations(resourceEvent.event.HookInvocationId);
-        if (annotations) {
-          resourceEvent.event.HookStatusReason = annotations;
+        const details = await this.fetchHookResultDetails(resourceEvent.event.HookInvocationId);
+        if (details) {
+          resourceEvent.event.HookStatusReason = details;
         }
       }
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
@@ -1,6 +1,8 @@
 import {
   ChangeSetStatus,
   DescribeStackResourcesCommand,
+  GetHookResultCommand,
+  ListHookResultsCommand,
   ResourceStatus,
 } from '@aws-sdk/client-cloudformation';
 import { LookupEventsCommand } from '@aws-sdk/client-cloudtrail';
@@ -483,6 +485,175 @@ describe('CloudFormationStackDiagnoser', () => {
           },
         ],
       } satisfies StackDiagnosis);
+    });
+  });
+
+  describe('change set hook failures', () => {
+    const CS_ARN = 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/my-cs/00000000-0000-0000-0000-000000000000';
+    const STACK_ARN = 'arn:aws:cloudformation:us-east-1:123456789012:stack/MyStack/123';
+    const HOOK_RESULT_ID = '00000000-0000-0000-0000-000000000000';
+    const LAMBDA_HOOK_REASON = '22dict Ingress May Not Allow All IPs to Non-HTTP(s) or Syslog Ports, ';
+
+    function failedChangeSet() {
+      return {
+        ChangeSetId: CS_ARN,
+        ChangeSetName: 'my-cs',
+        StackId: STACK_ARN,
+        StackName: 'MyStack',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: 'Change set creation failed. The following hook(s) failed: [Example::CFNHook::Full]',
+      };
+    }
+
+    function lambdaHookResultSummary() {
+      return {
+        HookResultId: HOOK_RESULT_ID,
+        InvocationPoint: 'PRE_PROVISION' as const,
+        FailureMode: 'FAIL' as const,
+        TypeName: 'Example::CFNHook::Full',
+        Status: 'HOOK_COMPLETE_FAILED' as const,
+        HookStatusReason: LAMBDA_HOOK_REASON,
+        TargetType: 'CHANGE_SET' as const,
+        TargetId: CS_ARN,
+      };
+    }
+
+    test('surfaces the detailed HookStatusReason of a failed Lambda hook (no annotations)', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).resolves({
+        HookResults: [lambdaHookResultSummary()],
+      });
+      mockCloudFormationClient.on(GetHookResultCommand).resolves({
+        HookResultId: HOOK_RESULT_ID,
+        InvocationPoint: 'PRE_PROVISION',
+        FailureMode: 'FAIL',
+        TypeName: 'Example::CFNHook::Full',
+        OriginalTypeName: 'AWS::Hooks::LambdaHook',
+        Status: 'HOOK_COMPLETE_FAILED',
+        HookStatusReason: LAMBDA_HOOK_REASON,
+        Target: {
+          TargetType: 'CHANGE_SET',
+          TargetTypeName: 'CHANGE_SET',
+          TargetId: CS_ARN,
+          Action: 'CREATE',
+        },
+        Annotations: [],
+      } as any);
+
+      const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
+
+      expect(mockCloudFormationClient).toHaveReceivedCommandWith(ListHookResultsCommand, {
+        TargetType: 'CHANGE_SET',
+        TargetId: CS_ARN,
+      });
+      assertProblem(result);
+      expect(result.problems).toEqual([expect.objectContaining({
+        errorCode: 'HookFailed',
+        message: `Hook 'Example::CFNHook::Full' failed: ${LAMBDA_HOOK_REASON.trim()}`,
+        stackArn: STACK_ARN,
+      })]);
+    });
+
+    test('formats annotations of a failed Guard hook', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).resolves({
+        HookResults: [{ ...lambdaHookResultSummary(), TypeName: 'Private::Guard::TestHook' }],
+      });
+      mockCloudFormationClient.on(GetHookResultCommand).resolves({
+        HookResultId: HOOK_RESULT_ID,
+        Status: 'HOOK_COMPLETE_FAILED',
+        Annotations: [{
+          AnnotationName: 'AWS_S3_Bucket_AccessControl',
+          Status: 'FAILED',
+          StatusMessage: 'Check was not compliant.',
+          RemediationMessage: 'AccessControl is deprecated',
+        }],
+      } as any);
+
+      const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
+
+      assertProblem(result);
+      expect(result.problems[0].message).toContain("Hook 'Private::Guard::TestHook' failed");
+      expect(result.problems[0].message).toContain('NonCompliant Rules:');
+      expect(result.problems[0].message).toContain('[AWS_S3_Bucket_AccessControl]');
+      expect(result.problems[0].message).toContain('Remediation: AccessControl is deprecated');
+    });
+
+    test('falls back to the summary HookStatusReason when GetHookResult fails', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).resolves({
+        HookResults: [lambdaHookResultSummary()],
+      });
+      mockCloudFormationClient.on(GetHookResultCommand).rejects(new Error('not authorized'));
+
+      const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
+
+      assertProblem(result);
+      expect(result.problems).toEqual([expect.objectContaining({
+        errorCode: 'HookFailed',
+        message: `Hook 'Example::CFNHook::Full' failed: ${LAMBDA_HOOK_REASON.trim()}`,
+      })]);
+    });
+
+    test('ignores failed hooks with failure mode WARN', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).resolves({
+        HookResults: [{ ...lambdaHookResultSummary(), FailureMode: 'WARN' }],
+      });
+
+      const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
+
+      // Falls through to the non-specific change set error
+      assertProblem(result);
+      expect(result.problems).toEqual([expect.objectContaining({
+        message: expect.stringContaining('The following hook(s) failed'),
+      })]);
+      expect(result.problems[0].errorCode).not.toEqual('HookFailed');
+    });
+
+    test('reports the non-specific change set error when ListHookResults fails', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).rejects(new Error('not authorized'));
+
+      const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
+
+      assertProblem(result);
+      expect(result.problems).toEqual([expect.objectContaining({
+        message: expect.stringContaining('The following hook(s) failed'),
+      })]);
+    });
+
+    test('errors from DescribeEvents take precedence over hook results', async () => {
+      fakeCfn.createStackSync({ StackName: 'MyStack' });
+      fakeCfn.createChangeSetSync({
+        StackName: 'MyStack',
+        ChangeSetName: 'my-cs',
+        Status: 'FAILED',
+        StatusReason: 'AWS::EarlyValidation failed',
+      });
+      fakeCfn.accessChangeSet('MyStack', 'my-cs').changeSetFailureEvents = [{
+        EventId: 'evt-1',
+        StackId: STACK_ARN,
+        OperationType: 'CREATE_CHANGESET',
+        EventType: 'VALIDATION_ERROR',
+        LogicalResourceId: 'BadPolicy',
+        ResourceType: 'AWS::IAM::Policy',
+        Timestamp: new Date(),
+        ValidationFailureMode: 'FAIL',
+        ValidationName: 'PROPERTY_VALIDATION',
+        ValidationStatus: 'FAILED',
+        ValidationStatusReason: 'Required property [PolicyDocument] not found',
+        ValidationPath: '/Resources/BadPolicy/Properties',
+      }];
+      mockCloudFormationClient.on(ListHookResultsCommand).resolves({
+        HookResults: [lambdaHookResultSummary()],
+      });
+
+      const result = await makeDiagnoser().diagnoseChangeSet({
+        ChangeSetName: 'my-cs',
+        StackName: 'MyStack',
+        Status: ChangeSetStatus.FAILED,
+        StatusReason: 'AWS::EarlyValidation failed',
+      });
+
+      assertProblem(result);
+      expect(result.problems).toEqual([expect.objectContaining({ logicalId: 'BadPolicy' })]);
+      expect(mockCloudFormationClient).not.toHaveReceivedCommand(ListHookResultsCommand);
     });
   });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
@@ -444,7 +444,7 @@ describe('GuardHook GetHookResult fetching', () => {
     expect(ioHost.notify).toHaveBeenNthCalledWith(2,
       expect.objectContaining({
         level: 'warn',
-        message: `Failed to fetch Guard Hook details for invocation ${hookInvocationId}: ${errorMessage}`,
+        message: `Failed to fetch Hook details for invocation ${hookInvocationId}: ${errorMessage}`,
       }),
     );
     expect(ioHost.notify).toHaveBeenNthCalledWith(3,
@@ -546,7 +546,7 @@ describe('GuardHook GetHookResult fetching', () => {
     );
   });
 
-  test('keeps original HookStatusReason when annotations are empty', async () => {
+  test('keeps original HookStatusReason when hook result has no annotations and no status reason', async () => {
     const hookInvocationId = 'empty-annotations-id';
     const originalMessage = 'Template failed validation.';
 
@@ -577,6 +577,68 @@ describe('GuardHook GetHookResult fetching', () => {
         data: expect.objectContaining({
           event: expect.objectContaining({
             HookStatusReason: originalMessage,
+          }),
+        }),
+      }),
+    );
+  });
+
+  test('surfaces HookStatusReason from GetHookResult when annotations are empty (e.g. Lambda hook)', async () => {
+    const hookInvocationId = '00000000-0000-0000-0000-000000000000';
+    const detailedReason = 'Some detailed reason returned by the Lambda Hook';
+    const eventReason = 'Hook failed with message: see hook results for details';
+
+    mockCloudFormationClient.on(GetHookResultCommand).resolvesOnce({
+      HookResultId: hookInvocationId,
+      InvocationPoint: 'PRE_PROVISION',
+      FailureMode: 'FAIL',
+      TypeName: 'Example::CFNHook::Full',
+      OriginalTypeName: 'AWS::Hooks::LambdaHook',
+      TypeVersionId: '00000001',
+      TypeArn: 'arn:aws:cloudformation:us-east-1:000000000000:type/hook/Example-CFNHook-Full/00000001/aws-hooks/AWS-Hooks-LambdaHook/00000001.00000001',
+      Status: 'HOOK_COMPLETE_FAILED',
+      HookStatusReason: detailedReason,
+      InvokedAt: new Date('2026-07-21T13:34:30.599000+00:00'),
+      Target: {
+        TargetType: 'CHANGE_SET',
+        TargetTypeName: 'CHANGE_SET',
+        TargetId: 'arn:aws:cloudformation:us-east-1:000000000000:changeSet/hook-con-t-example/00000000-0000-0000-0000-000000000000',
+        Action: 'CREATE',
+      },
+      Annotations: [],
+    } as any);
+
+    mockCloudFormationClient.on(DescribeStackEventsCommand).resolvesOnce({
+      StackEvents: [
+        {
+          ...event(101),
+          LogicalResourceId: 'SomeResource',
+          ResourceType: 'AWS::EC2::SecurityGroup',
+          ResourceStatus: ResourceStatus.UPDATE_IN_PROGRESS,
+          HookStatus: 'HOOK_COMPLETE_FAILED',
+          HookType: 'Example::CFNHook::Full',
+          HookInvocationId: hookInvocationId,
+          HookStatusReason: eventReason,
+        },
+      ],
+    });
+
+    await eventually(() => expect(mockCloudFormationClient).toHaveReceivedCommand(DescribeStackEventsCommand), 2);
+    await monitor.stop();
+
+    // GetHookResult IS called ...
+    expect(mockCloudFormationClient).toHaveReceivedCommandWith(GetHookResultCommand, {
+      HookResultId: hookInvocationId,
+    });
+
+    // ... and the detailed HookStatusReason from the GetHookResult response
+    // must be surfaced on the event, even though there are no annotations.
+    expect(ioHost.notify).toHaveBeenCalledWith(
+      expect.objectContaining({
+        code: 'CDK_TOOLKIT_I5502',
+        data: expect.objectContaining({
+          event: expect.objectContaining({
+            HookStatusReason: expect.stringContaining(detailedReason.trim()),
           }),
         }),
       }),


### PR DESCRIPTION
Fixes #

CloudFormation Hooks that don't emit annotations — notably `AWS::Hooks::LambdaHook` and other custom hooks — failed deployments without ever showing the user why. The detailed failure reason lives in the `HookStatusReason` of the `GetHookResult` response, but the CLI only extracted failed Guard Hook annotations from that response and discarded everything else, so users were left with the generic "see hook results for details" message from the stack event. Hooks that fail change set creation (`TargetType: CHANGE_SET`) were worse off still: that code path never consulted the hook result APIs at all and reported only the change set's status reason.

The annotation formatting is extracted into a shared helper that falls back to the hook result's own `HookStatusReason` when there are no failed annotations, because for non-Guard hooks that field is the only place the details exist. The stack activity monitor uses this helper when enriching failed hook events. The change set diagnoser gains a step that runs after `DescribeEvents` yields nothing: it lists failed hooks via `ListHookResults`, fetches each result for annotations, and reports the details as diagnosis problems before falling back to the generic change set error. Only hooks with failure mode `FAIL` are considered, since `WARN` hooks cannot have caused the change set failure. Both lookups degrade gracefully to the previous behavior when the APIs are unavailable, so no new permissions are required; the deploy role's `AWSCloudFormationReadOnlyAccess` policy already covers `ListHookResults`.

### Before/After

A Lambda Hook targeting change set operations fails the deployment. Before, the user only sees which hook failed, not why (illustrative output):

```
❌  MyStack failed: Failed to create change set cdk-deploy-change-set: Change set creation failed. The following hook(s) failed: [Example::CFNHook::Full]
```

After, the detailed reason returned by the hook is fetched from the hook result APIs and included:

```
❌  MyStack failed: Failed to create change set cdk-deploy-change-set:
MyStack  (AWS::CloudFormation::Stack)
  Hook 'Example::CFNHook::Full' failed: Ingress must not allow 0.0.0.0/0 to non-HTTP(s) ports
```

The same applies to hooks failing during stack deployment (`RESOURCE`/`STACK` targets). Before, the event line carried only the generic reason:

```
MyStack | 0/2 | 2:34:30 PM | CREATE_IN_PROGRESS | AWS::EC2::SecurityGroup | IngressSG Hook failed with message: see hook results for details
```

After, the event is enriched with the hook result's status reason, the same way Guard Hook annotations already were:

```
MyStack | 0/2 | 2:34:30 PM | CREATE_IN_PROGRESS | AWS::EC2::SecurityGroup | IngressSG Ingress must not allow 0.0.0.0/0 to non-HTTP(s) ports
```

### Testing

Verified with unit tests for both code paths (a repro test using the reported hook result payload failed before the fix and passes after; the full toolkit-lib suite passes), and a new integration test that deploys a real Lambda Hook targeting change set operations and asserts the detailed reason appears in the `cdk deploy` output. The integration test has not been run against AWS yet and will be exercised by the PR build.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
