### PR TITLE
fix(cli): version check trusts stale registry mirrors and recommends non-upgrades

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -244,7 +244,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
 
     // Do PSAs here
     if (shouldDisplayVersionMessage()) {
-      await displayVersionMessage(ioHelper);
+      await displayVersionMessage(ioHelper, { agent: proxyAgent });
     }
 
     await refreshNotices;
@@ -323,6 +323,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         return doctor({
           ioHelper,
           settings: configuration.settings,
+          agent: proxyAgent,
         });
 
       case 'lsp':

--- a/packages/aws-cdk/lib/cli/display-version.ts
+++ b/packages/aws-cdk/lib/cli/display-version.ts
@@ -1,3 +1,4 @@
+import type * as https from 'node:https';
 import * as path from 'path';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 import chalk from 'chalk';
@@ -6,7 +7,7 @@ import * as semver from 'semver';
 import type { IoHelper } from '../api-private';
 import { cdkCacheDir, versionNumber } from '../util';
 import { formatAsBanner } from './util/console-formatters';
-import { execNpmView } from './util/npm';
+import { fetchNpmVersionInfo } from './util/npm';
 
 const ONE_DAY_IN_SECONDS = 1 * 24 * 60 * 60;
 
@@ -64,28 +65,39 @@ export class VersionCheckTTL {
 
 // Export for unit testing only.
 // Don't use directly, use displayVersionMessage() instead.
-export async function getVersionMessages(currentVersion: string, cacheFile: VersionCheckTTL): Promise<string[]> {
+export async function getVersionMessages(currentVersion: string, cacheFile: VersionCheckTTL, agent?: https.Agent): Promise<string[]> {
   if (!(await cacheFile.hasExpired())) {
     return [];
   }
 
-  const packageInfo = await execNpmView(currentVersion);
+  const packageInfo = await fetchNpmVersionInfo(currentVersion, agent);
   const latestVersion = packageInfo.latestVersion;
   await cacheFile.update(JSON.stringify(packageInfo));
 
-  // If the latest version is the same as the current version, there is no need to display a message
-  if (semver.eq(latestVersion, currentVersion)) {
-    return [];
+  const versionMessages: string[] = [];
+
+  // Warn if the version currently in use has been deprecated, even if the
+  // latest version is not newer (e.g. an accidentally published version that
+  // was deprecated and requires a downgrade).
+  if (packageInfo.deprecated) {
+    versionMessages.push(chalk.red(packageInfo.deprecated));
   }
 
-  const versionMessage = [
-    packageInfo.deprecated ? `${chalk.red(packageInfo.deprecated as string)}` : undefined,
-    `Newer version of CDK is available [${chalk.green(latestVersion as string)}]`,
-    getMajorVersionUpgradeMessage(currentVersion),
-    'Upgrade recommended (npm install -g aws-cdk)',
-  ].filter(Boolean) as string[];
+  // Only recommend an upgrade if the latest version is strictly newer than the
+  // current one. This guards against stale or bogus registry metadata.
+  if (semver.gt(latestVersion, currentVersion)) {
+    versionMessages.push(`Newer version of CDK is available [${chalk.green(latestVersion)}]`);
+    const majorUpgradeMessage = getMajorVersionUpgradeMessage(currentVersion);
+    if (majorUpgradeMessage) {
+      versionMessages.push(majorUpgradeMessage);
+    }
+  }
 
-  return versionMessage;
+  if (versionMessages.length > 0) {
+    versionMessages.push('Upgrade recommended (npm install -g aws-cdk)');
+  }
+
+  return versionMessages;
 }
 
 function getMajorVersionUpgradeMessage(currentVersion: string): string | void {
@@ -99,13 +111,41 @@ export function shouldDisplayVersionMessage(): boolean {
   return !!process.stdout.isTTY && !process.env.CDK_DISABLE_VERSION_CHECK;
 }
 
+/**
+ * Options for {@link displayVersionMessage}
+ */
+export interface DisplayVersionMessageOptions {
+  /**
+   * The version of the CLI that is currently running
+   *
+   * @default - the version of this package
+   */
+  readonly currentVersion?: string;
+
+  /**
+   * The cache used to limit how often the version check runs
+   *
+   * @default - a TTL cache in the CDK cache directory
+   */
+  readonly versionCheckCache?: VersionCheckTTL;
+
+  /**
+   * The agent used for the network request to the npm registry
+   *
+   * Use this to set up a proxy connection.
+   *
+   * @default - the shared global node agent
+   */
+  readonly agent?: https.Agent;
+}
+
 export async function displayVersionMessage(
   ioHelper: IoHelper,
-  currentVersion = versionNumber(),
-  versionCheckCache?: VersionCheckTTL,
+  options: DisplayVersionMessageOptions = {},
 ): Promise<void> {
   try {
-    const versionMessages = await getVersionMessages(currentVersion, versionCheckCache ?? new VersionCheckTTL());
+    const currentVersion = options.currentVersion ?? versionNumber();
+    const versionMessages = await getVersionMessages(currentVersion, options.versionCheckCache ?? new VersionCheckTTL(), options.agent);
     for (const e of formatAsBanner(versionMessages)) {
       await ioHelper.defaults.info(e);
     }

--- a/packages/aws-cdk/lib/cli/util/npm.ts
+++ b/packages/aws-cdk/lib/cli/util/npm.ts
@@ -1,34 +1,108 @@
-import { exec as _exec } from 'child_process';
-import { promisify } from 'util';
+import type { ClientRequest } from 'node:http';
+import type { Agent, RequestOptions } from 'node:https';
+import * as https from 'node:https';
 import { ToolkitError } from '@aws-cdk/toolkit-lib';
 
-const exec = promisify(_exec);
+const NPM_REGISTRY_ROOT = 'https://registry.npmjs.org';
+const REQUEST_TIMEOUT_MS = 3_000;
 
-/* c8 ignore start */
-export async function execNpmView(currentVersion: string) {
-  try {
-    // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
-    const [latestResult, currentResult] = await Promise.all([
-      exec('npm view aws-cdk@latest version', { timeout: 3000 }),
-      exec(`npm view aws-cdk@${currentVersion} name version deprecated --json`, { timeout: 3000 }),
-    ]);
+/**
+ * Version information about the `aws-cdk` package, as reported by the npm registry
+ */
+export interface NpmVersionInfo {
+  /**
+   * The version the `latest` dist-tag points to
+   */
+  readonly latestVersion: string;
 
-    if (latestResult.stderr && latestResult.stderr.trim().length > 0) {
-      throw new ToolkitError('NpmViewLatestFailed', `npm view command for latest version failed: ${latestResult.stderr.trim()}`);
-    }
-    if (currentResult.stderr && currentResult.stderr.trim().length > 0) {
-      throw new ToolkitError('NpmViewCurrentFailed', `npm view command for current version failed: ${currentResult.stderr.trim()}`);
-    }
-
-    const latestVersion = latestResult.stdout.trim();
-    const currentInfo = JSON.parse(currentResult.stdout);
-
-    return {
-      latestVersion: latestVersion,
-      deprecated: currentInfo.deprecated,
-    };
-  } catch (err: unknown) {
-    throw err;
-  }
+  /**
+   * The deprecation message of the currently running version, if it is deprecated
+   */
+  readonly deprecated?: string;
 }
-/* c8 ignore stop */
+
+/**
+ * Query the public npm registry for version information about the `aws-cdk` package.
+ *
+ * This deliberately queries `registry.npmjs.org` directly (rather than shelling out
+ * to `npm view`, which honors the local npm configuration), so that stale metadata
+ * from corporate registry mirrors or the local npm cache cannot produce bogus
+ * upgrade recommendations.
+ */
+export async function fetchNpmVersionInfo(currentVersion: string, agent?: Agent): Promise<NpmVersionInfo> {
+  // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
+  const [latestInfo, currentInfo] = await Promise.all([
+    getJson(`${NPM_REGISTRY_ROOT}/aws-cdk/latest`, agent),
+    // The running version may not exist on the registry (e.g. developer builds),
+    // in which case we simply have no deprecation information for it.
+    getJson(`${NPM_REGISTRY_ROOT}/aws-cdk/${encodeURIComponent(currentVersion)}`, agent, { allowNotFound: true }),
+  ]);
+
+  if (typeof latestInfo?.version !== 'string') {
+    throw new ToolkitError('NpmRegistryUnexpectedResponse', 'npm registry response for aws-cdk@latest did not contain a version');
+  }
+
+  return {
+    latestVersion: latestInfo.version,
+    deprecated: typeof currentInfo?.deprecated === 'string' ? currentInfo.deprecated : undefined,
+  };
+}
+
+interface GetJsonOptions {
+  /**
+   * Resolve to `undefined` on a 404 response instead of failing
+   *
+   * @default false
+   */
+  readonly allowNotFound?: boolean;
+}
+
+function getJson(url: string, agent?: Agent, options: GetJsonOptions = {}): Promise<any> {
+  const requestOptions: RequestOptions = {
+    agent,
+    headers: { Accept: 'application/json' },
+  };
+
+  return new Promise((resolve, reject) => {
+    let req: ClientRequest | undefined;
+
+    const timer = setTimeout(() => {
+      if (req) {
+        req.destroy(new ToolkitError('NpmRegistryRequestTimeout', `request to ${url} timed out after ${REQUEST_TIMEOUT_MS}ms`));
+      }
+    }, REQUEST_TIMEOUT_MS);
+    timer.unref();
+
+    req = https.get(url, requestOptions, (res) => {
+      if (res.statusCode === 404 && options.allowNotFound) {
+        res.resume(); // discard the response body
+        resolve(undefined);
+        return;
+      }
+      if (res.statusCode !== 200) {
+        res.resume(); // discard the response body
+        reject(new ToolkitError('NpmRegistryHttpError', `request to ${url} failed with status code ${res.statusCode}`));
+        return;
+      }
+
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => {
+        rawData += chunk;
+      });
+      res.on('end', () => {
+        try {
+          resolve(JSON.parse(rawData));
+        } catch (e: any) {
+          reject(ToolkitError.withCause('NpmRegistryParseError', `could not parse response from ${url}: ${e.message}`, e));
+        }
+      });
+      res.on('error', (e) => {
+        reject(ToolkitError.withCause('NpmRegistryResponseError', `response from ${url} failed: ${e.message}`, e));
+      });
+    });
+    req.on('error', (e) => {
+      reject(ToolkitError.withCause('NpmRegistryNetworkError', `request to ${url} failed: ${e.message}`, e));
+    });
+  });
+}

--- a/packages/aws-cdk/lib/commands/doctor.ts
+++ b/packages/aws-cdk/lib/commands/doctor.ts
@@ -1,3 +1,4 @@
+import type * as https from 'node:https';
 import * as process from 'process';
 import * as cxapi from '@aws-cdk/cx-api';
 import chalk from 'chalk';
@@ -16,16 +17,25 @@ export interface DoctorOptions {
    * @default - configuration is not reported
    */
   readonly settings?: Settings;
+
+  /**
+   * The agent used for the network request of the version check
+   *
+   * Use this to set up a proxy connection.
+   *
+   * @default - the shared global node agent
+   */
+  readonly agent?: https.Agent;
 }
 
-export async function doctor({ ioHelper, settings }: DoctorOptions): Promise<number> {
+export async function doctor({ ioHelper, settings, agent }: DoctorOptions): Promise<number> {
   let exitStatus: number = 0;
   for (const verification of verifications) {
     if (!await verification(ioHelper, settings)) {
       exitStatus = -1;
     }
   }
-  await displayVersionMessage(ioHelper);
+  await displayVersionMessage(ioHelper, { agent });
   return exitStatus;
 }
 

--- a/packages/aws-cdk/test/cli/util/npm.test.ts
+++ b/packages/aws-cdk/test/cli/util/npm.test.ts
@@ -1,0 +1,82 @@
+import nock from 'nock';
+import { fetchNpmVersionInfo } from '../../../lib/cli/util/npm';
+
+const REGISTRY = 'https://registry.npmjs.org';
+
+beforeEach(() => {
+  nock.disableNetConnect();
+});
+
+afterEach(() => {
+  nock.cleanAll();
+  nock.enableNetConnect();
+});
+
+test('returns latest version and deprecation info for the current version', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(200, { name: 'aws-cdk', version: '2.1133.0' })
+    .get('/aws-cdk/3.0.0')
+    .reply(200, { name: 'aws-cdk', version: '3.0.0', deprecated: 'This version was published accidentally.' });
+
+  await expect(fetchNpmVersionInfo('3.0.0')).resolves.toEqual({
+    latestVersion: '2.1133.0',
+    deprecated: 'This version was published accidentally.',
+  });
+});
+
+test('returns no deprecation info when the current version is not deprecated', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(200, { name: 'aws-cdk', version: '2.1133.0' })
+    .get('/aws-cdk/2.1000.0')
+    .reply(200, { name: 'aws-cdk', version: '2.1000.0' });
+
+  await expect(fetchNpmVersionInfo('2.1000.0')).resolves.toEqual({
+    latestVersion: '2.1133.0',
+    deprecated: undefined,
+  });
+});
+
+test('tolerates the current version not existing on the registry', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(200, { name: 'aws-cdk', version: '2.1133.0' })
+    .get('/aws-cdk/0.0.0')
+    .reply(404, { error: 'Not found' });
+
+  await expect(fetchNpmVersionInfo('0.0.0')).resolves.toEqual({
+    latestVersion: '2.1133.0',
+    deprecated: undefined,
+  });
+});
+
+test('fails when the latest version request returns a non-200 status', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(500, 'Internal Server Error')
+    .get('/aws-cdk/2.1000.0')
+    .reply(200, { name: 'aws-cdk', version: '2.1000.0' });
+
+  await expect(fetchNpmVersionInfo('2.1000.0')).rejects.toThrow(/status code 500/);
+});
+
+test('fails when the registry returns invalid JSON', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(200, 'not json')
+    .get('/aws-cdk/2.1000.0')
+    .reply(200, { name: 'aws-cdk', version: '2.1000.0' });
+
+  await expect(fetchNpmVersionInfo('2.1000.0')).rejects.toThrow(/could not parse response/);
+});
+
+test('fails when the registry response has no version', async () => {
+  nock(REGISTRY)
+    .get('/aws-cdk/latest')
+    .reply(200, { name: 'aws-cdk' })
+    .get('/aws-cdk/2.1000.0')
+    .reply(200, { name: 'aws-cdk', version: '2.1000.0' });
+
+  await expect(fetchNpmVersionInfo('2.1000.0')).rejects.toThrow(/did not contain a version/);
+});

--- a/packages/aws-cdk/test/cli/version.test.ts
+++ b/packages/aws-cdk/test/cli/version.test.ts
@@ -87,7 +87,7 @@ describe('version message', () => {
     const mockCache = new VersionCheckTTL(tmpfile());
     jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
 
-    jest.spyOn(npm, 'execNpmView').mockResolvedValue({
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
       latestVersion: '2.0.0',
       deprecated: undefined,
     });
@@ -102,7 +102,7 @@ describe('version message', () => {
     const mockCache = new VersionCheckTTL(tmpfile());
     jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
 
-    jest.spyOn(npm, 'execNpmView').mockResolvedValue({
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
       latestVersion: '2.1000.0',
       deprecated: undefined,
     });
@@ -118,7 +118,7 @@ describe('version message', () => {
     const mockCache = new VersionCheckTTL(tmpfile());
     jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
 
-    jest.spyOn(npm, 'execNpmView').mockResolvedValue({
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
       latestVersion: '2.0.0',
       deprecated: 'This version is deprecated.',
     });
@@ -131,13 +131,44 @@ describe('version message', () => {
     const mockCache = new VersionCheckTTL(tmpfile());
     jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
 
-    jest.spyOn(npm, 'execNpmView').mockResolvedValue({
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
       latestVersion: '1.0.0',
       deprecated: undefined,
     });
 
     const messages = await getVersionMessages('1.0.0', mockCache);
     expect(messages).toEqual([]);
+  });
+
+  test('Does not print message when registry reports an older latest version', async () => {
+    const mockCache = new VersionCheckTTL(tmpfile());
+    jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
+
+    // e.g. stale metadata from a registry mirror
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
+      latestVersion: '1.5.0',
+      deprecated: undefined,
+    });
+
+    const messages = await getVersionMessages('2.0.0', mockCache);
+    expect(messages).toEqual([]);
+  });
+
+  test('Prints deprecation and upgrade recommendation when current version is deprecated, even if latest is older', async () => {
+    const mockCache = new VersionCheckTTL(tmpfile());
+    jest.spyOn(mockCache, 'hasExpired').mockResolvedValue(true);
+
+    // e.g. an accidentally published version that was deprecated;
+    // the fix is a downgrade to the latest version
+    jest.spyOn(npm, 'fetchNpmVersionInfo').mockResolvedValue({
+      latestVersion: '2.1133.0',
+      deprecated: 'This version was published accidentally. Please use 2.x.x instead.',
+    });
+
+    const messages = await getVersionMessages('3.0.0', mockCache);
+    expect(messages.some(msg => msg.includes('This version was published accidentally'))).toBeTruthy();
+    expect(messages.some(msg => msg.includes('Upgrade recommended (npm install -g aws-cdk)'))).toBeTruthy();
+    expect(messages.some(msg => msg.includes('Newer version of CDK is available'))).toBeFalsy();
   });
 });
 


### PR DESCRIPTION
Fixes #

A user reported that the CLI version check recommended upgrading to 3.0.0, a version that was accidentally published and has since been deprecated, while npmjs.com already pointed `latest` back at 2.x. The check shelled out to `npm view`, which honors the local npm configuration, so a stale corporate registry mirror or npm cache could feed it bogus metadata. Because the check only tested that latest differs from the current version, any bogus value was presented as an upgrade recommendation.

The check now queries `registry.npmjs.org` directly over HTTPS, following the same pattern as the notices data source, so stale mirrors and local npm caches can no longer influence the result. It reuses the CLI's existing proxy agent to keep working behind corporate proxies, and no longer depends on an `npm` binary being on the PATH. It is also faster, since the previous implementation spawned two npm subprocesses inside a 3-second timeout.

As defense in depth, an upgrade is now only recommended when the reported latest version is strictly newer than the running one. The deprecation warning for the running version is kept independent of that comparison, so users on a deprecated version (like the accidental 3.0.0) are still told to move off it even though that means a downgrade.

The running version may legitimately not exist on the registry (developer builds), in which case the check proceeds without deprecation info instead of failing.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
