### PR TITLE
fix(toolkit-lib): disable aws-cdk-lib's built-in template validation in unit tests

### DIFF
--- a/packages/@aws-cdk/integ-runner/package.json
+++ b/packages/@aws-cdk/integ-runner/package.json
@@ -44,7 +44,7 @@
     "@types/yargs": "^17.0.35",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.262.0",
+    "aws-cdk-lib": "2.262.1",
     "commit-and-tag-version": "^12",
     "constructs": "^10",
     "eslint": "^9",

--- a/packages/@aws-cdk/toolkit-lib/package.json
+++ b/packages/@aws-cdk/toolkit-lib/package.json
@@ -55,7 +55,7 @@
     "@types/split2": "^4.2.3",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "aws-cdk-lib": "2.262.0",
+    "aws-cdk-lib": "2.262.1",
     "aws-sdk-client-mock": "^4.1.0",
     "aws-sdk-client-mock-jest": "^4.1.0",
     "commit-and-tag-version": "^12",

--- a/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-setup-after-env.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/_helpers/jest-setup-after-env.ts
@@ -27,6 +27,13 @@ import { isPromise } from 'util/types';
  *
  */
 
+// Disable aws-cdk-lib's built-in CloudFormation template validation
+// (CloudFormationValidatePlugin, added in 2.262.0). It initializes a WASM
+// rules engine on first synth in every test process, which costs multiple
+// seconds per test file and can exceed the test timeout on small runners.
+// These tests exercise the toolkit, not aws-cdk-lib's template linter.
+process.env.CDK_VALIDATION = 'false';
+
 let tmpDir: string;
 let oldDir: string;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -415,7 +415,7 @@ __metadata:
     "@types/yargs": "npm:^17.0.35"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
-    aws-cdk-lib: "npm:2.262.0"
+    aws-cdk-lib: "npm:2.262.1"
     chalk: "npm:^4"
     chokidar: "npm:^4"
     commit-and-tag-version: "npm:^12"
@@ -555,7 +555,7 @@ __metadata:
     "@types/split2": "npm:^4.2.3"
     "@typescript-eslint/eslint-plugin": "npm:^8"
     "@typescript-eslint/parser": "npm:^8"
-    aws-cdk-lib: "npm:2.262.0"
+    aws-cdk-lib: "npm:2.262.1"
     aws-sdk-client-mock: "npm:^4.1.0"
     aws-sdk-client-mock-jest: "npm:^4.1.0"
     cdk-from-cfn: "npm:^0.317.0"
@@ -1483,13 +1483,6 @@ __metadata:
     "@smithy/types": "npm:^4.16.1"
     tslib: "npm:^2.6.2"
   checksum: 10c0/e698ce740d0bfe4726c09dfa0e2d4c63b69ba6f2b33752d4c8d9085ac407b1237fbfc97c0d1ae3ba0668b1c7cb3ad520404fc65767fe689bcdac4cd6a40c126f
-  languageName: node
-  linkType: hard
-
-"@aws/cloudformation-validate@npm:1.5.0-beta":
-  version: 1.5.0-beta
-  resolution: "@aws/cloudformation-validate@npm:1.5.0-beta"
-  checksum: 10c0/3a7c118f3f5f4111ff262d8cba92aca8e19fdad62bc84529744a13602059e3fe949a923739531e4c06d27feb5a2a10344948e1443f73ea34005e8b4f28a57595
   languageName: node
   linkType: hard
 
@@ -5412,31 +5405,6 @@ __metadata:
       built: true
   languageName: unknown
   linkType: soft
-
-"aws-cdk-lib@npm:2.262.0":
-  version: 2.262.0
-  resolution: "aws-cdk-lib@npm:2.262.0"
-  dependencies:
-    "@aws-cdk/asset-awscli-v1": "npm:2.2.282"
-    "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.2"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.6"
-    "@aws-cdk/cloud-assembly-schema": "npm:^54.11.0"
-    "@aws/cloudformation-validate": "npm:1.5.0-beta"
-    "@balena/dockerignore": "npm:^1.0.2"
-    case: "npm:1.6.3"
-    fs-extra: "npm:^11.3.6"
-    ignore: "npm:^5.3.2"
-    jsonschema: "npm:^1.5.0"
-    mime-types: "npm:^2.1.35"
-    minimatch: "npm:^10.2.5"
-    punycode: "npm:^2.3.1"
-    semver: "npm:^7.8.5"
-    yaml: "npm:1.10.3"
-  peerDependencies:
-    constructs: ^10.5.0
-  checksum: 10c0/ff2c65607e743d279b5b1a8e6733081d9703d9e45bb513551a2ca378435f940ce6c1fafaa29bb49ca12e9d10247067acacf1140d260532fdf67510dc0a72fcc4
-  languageName: node
-  linkType: hard
 
 "aws-cdk-lib@npm:2.262.1":
   version: 2.262.1


### PR DESCRIPTION
## Summary

The `codecov` workflow has failed on every run of `main` since #1705 merged. with a random subset of toolkit-lib unit tests exceeding the 10000ms jest timeout each run.

### Problem
#1705 bumped `aws-cdk-lib` 2.260.0 → 2.262.0, which introduced `CloudFormationValidatePlugin` in commit https://github.com/aws/aws-cdk/commit/023c5bf54816e5a0bdea355944d3db4a4d718bf9 — a built-in template validator backed by the `@aws/cloudformation-validate` WASM Rego engine — that auto-registers and runs inside every `app.synth()`. Ran a test grid using Claude and found that initializing the engine costs ~1.3–2s per process (measured; ~80% WASM execution in a CPU profile, vs ~110ms total synth on 2.260.0/2.261.0). Jest's per-file module registry means every test file that synthesizes re-pays that cost. On the 4-core codecov runner (`aws-cdk_ubuntu-latest_4-core`, `maxWorkers: 80%`, coverage instrumentation) the first synth in a file takes longer than the `testTimeout: 10000`. The `build` workflow survives only because it runs on a 16-core runner.

### Fix
- Upgrade `aws-cdk-lib` to **2.262.1**, which honors `CDK_VALIDATION=false` for the built-in validator (aws/aws-cdk#38378; 2.262.0 ignored it). Measured: synth drops from ~1.6s back to ~0.2s with the env var set.
- Set `process.env.CDK_VALIDATION = 'false'` in toolkit-lib's jest setup (`jest-setup-after-env.ts`). These tests exercise the toolkit, not aws-cdk-lib's template linter, so running a WASM rules pass per test file is pure overhead even when it doesn't time out.

`integ-runner`'s pin moves 2.262.0 → 2.262.1 as well (`yarn up` updates the exact pin repo-wide; it's a devDependency there, not bundled).

Verified locally: full `@aws-cdk/toolkit-lib:build` passes (1877 passed, 1 skipped), previously-timing-out files (`rollback`, `drift`) back to normal timings.

A passing `codecov` job on this PR will also help to validate that this change actually worked.

### Checklist
- [x] Unit tests added/updated (jest setup change; full suite passes)
- [ ] Integration tests added/updated — n/a, test-infra only
- [x] No manual edits to generated files (`package.json` pins updated via `yarn up` + `yarn projen`)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license