### PR TITLE
feat(toolkit-lib): add watchValidate action and cdk validate --watch

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/watch/index.ts
@@ -1,4 +1,5 @@
 import type { DeploymentMethod, BaseDeployOptions } from '../deploy';
+import type { ValidateOptions } from '../validate';
 
 /**
  * Options that control which files the watch loop observes.
@@ -41,6 +42,12 @@ export interface WatchOptions extends WatchFileOptions, BaseDeployOptions {
    * @default HotswapDeployment
    */
   readonly deploymentMethod?: DeploymentMethod;
+}
+
+/**
+ * Options for watch-validate mode.
+ */
+export interface WatchValidateOptions extends WatchFileOptions, ValidateOptions {
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -676,9 +676,17 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    */
   public async validate(cx: ICloudAssemblySource, options: ValidateOptions = {}): Promise<ValidateResult> {
     const ioHelper = asIoHelper(this.ioHost, 'validate');
-    const selectStacks = stacksOpt(options);
+    await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
+    return await this._validate(assembly, options);
+  }
 
-    await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
+  /**
+   * Helper to allow validate being called with an already-produced assembly,
+   * e.g. as part of the watch action which reuses the startup assembly.
+   */
+  private async _validate(assembly: StackAssembly, options: ValidateOptions = {}): Promise<ValidateResult> {
+    const ioHelper = asIoHelper(this.ioHost, 'validate');
+    const selectStacks = stacksOpt(options);
 
     const stacks = await assembly.selectStacksV2(selectStacks);
 
@@ -1193,19 +1201,21 @@ export class Toolkit extends CloudAssemblySourceBuilder {
    * This function returns immediately, starting a watcher in the background.
    */
   public async watchValidate(cx: ICloudAssemblySource, options: WatchValidateOptions = {}): Promise<IWatcher> {
-    const ioHelper = asIoHelper(this.ioHost, 'watch');
+    const ioHelper = asIoHelper(this.ioHost, 'validate');
 
     return this._watch(cx, options, {
       command: 'cdk validate',
       activity: 'validation',
-      invoke: async () => {
-        try {
-          await this.validate(cx, options);
-        } catch (e: any) {
-          // Report and continue watching: synth errors are expected while the
-          // user is mid-edit, and validation must resume on the next change.
-          await ioHelper.defaults.error(formatErrorMessage(e));
+      // `_watch` runs this inside `invokeSafe`, which reports (and swallows)
+      // failures so the loop survives synth errors while the user is mid-edit.
+      invoke: async (initialAssembly) => {
+        // Reuse the initial assembly, for the same reason as watchDeploy()
+        if (initialAssembly) {
+          await this._validate(initialAssembly, options);
+          return;
         }
+        await using assembly = await synthAndMeasure(ioHelper, cx, stacksOpt(options));
+        await this._validate(assembly, options);
       },
     });
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -59,7 +59,7 @@ import type { RefactorOptions } from '../actions/refactor';
 import { type RollbackOptions } from '../actions/rollback';
 import { type SynthOptions } from '../actions/synth';
 import type { ValidateOptions, ValidateResult } from '../actions/validate';
-import type { IWatcher, WatchFileOptions, WatchOptions } from '../actions/watch';
+import type { IWatcher, WatchFileOptions, WatchOptions, WatchValidateOptions } from '../actions/watch';
 import { countAssemblyResults } from './private/count-assembly-results';
 import { WATCH_EXCLUDE_DEFAULTS } from '../actions/watch/private';
 import { EnvironmentAccess } from '../api';
@@ -1179,6 +1179,34 @@ export class Toolkit extends CloudAssemblySourceBuilder {
       onBatchStart: async () => cloudWatchLogMonitor?.deactivate(),
       onBatchEnd: async () => cloudWatchLogMonitor?.activate(),
       onDispose: async () => cloudWatchLogMonitor?.deactivate(),
+    });
+  }
+
+  /**
+   * Continuously observe project files and validate the selected stacks
+   * automatically when changes are detected.
+   *
+   * Never deploys: each iteration re-synthesizes the app and runs the same
+   * checks as the `validate` action (policy plugin reports and, unless
+   * disabled, online CloudFormation validation).
+   *
+   * This function returns immediately, starting a watcher in the background.
+   */
+  public async watchValidate(cx: ICloudAssemblySource, options: WatchValidateOptions = {}): Promise<IWatcher> {
+    const ioHelper = asIoHelper(this.ioHost, 'watch');
+
+    return this._watch(cx, options, {
+      command: 'cdk validate',
+      activity: 'validation',
+      invoke: async () => {
+        try {
+          await this.validate(cx, options);
+        } catch (e: any) {
+          // Report and continue watching: synth errors are expected while the
+          // user is mid-edit, and validation must resume on the next change.
+          await ioHelper.defaults.error(formatErrorMessage(e));
+        }
+      },
     });
   }
 

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
@@ -1,0 +1,191 @@
+// We need to mock the chokidar library, used by 'cdk watch'
+// This needs to happen ABOVE the import statements due to quirks with how jest works
+// Apparently, they hoist jest.mock commands just below the import statements so we
+// need to make sure that the constants they access are initialized before the imports.
+const mockChokidarWatcherOn = jest.fn();
+const mockChokidarWatcherClose = jest.fn();
+const fakeChokidarWatcher = {
+  on: mockChokidarWatcherOn,
+  close: mockChokidarWatcherClose,
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+} satisfies Partial<ReturnType<typeof import('chokidar')['watch']>>;
+const fakeChokidarWatcherOn = {
+  get readyCallback(): () => Promise<void> {
+    expect(mockChokidarWatcherOn.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const firstCall = mockChokidarWatcherOn.mock.calls[0];
+    expect(firstCall[0]).toBe('ready');
+    return firstCall[1];
+  },
+
+  get fileEventCallback(): (
+  event: 'add' | 'addDir' | 'change' | 'unlink' | 'unlinkDir',
+  path: string,
+  ) => Promise<void> {
+    expect(mockChokidarWatcherOn.mock.calls.length).toBeGreaterThanOrEqual(2);
+    const secondCall = mockChokidarWatcherOn.mock.calls[1];
+    expect(secondCall[0]).not.toBe('ready');
+    return secondCall[1];
+  },
+};
+
+const mockChokidarWatch = jest.fn();
+jest.mock('chokidar', () => ({
+  watch: mockChokidarWatch,
+}));
+
+import { StackSelectionStrategy } from '../../lib/api/cloud-assembly';
+import { Toolkit } from '../../lib/toolkit';
+import { builderFixture, TestIoHost } from '../_helpers';
+
+const ioHost = new TestIoHost();
+const toolkit = new Toolkit({ ioHost });
+const validateSpy = jest.spyOn(toolkit, 'validate').mockResolvedValue({
+  conclusion: 'success',
+  pluginReports: [],
+});
+const deploySpy = jest.spyOn(toolkit as any, '_deploy').mockResolvedValue({});
+
+beforeEach(() => {
+  ioHost.notifySpy.mockClear();
+  ioHost.requestSpy.mockClear();
+  jest.clearAllMocks();
+
+  mockChokidarWatch.mockReturnValue(fakeChokidarWatcher);
+  // on() in chokidar's Watcher returns 'this'
+  mockChokidarWatcherOn.mockReturnValue(fakeChokidarWatcher);
+});
+
+describe('watchValidate', () => {
+  test('runs an initial validation on the ready event', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.watchValidate(cx, { include: [] });
+
+    // WHEN
+    await fakeChokidarWatcherOn.readyCallback();
+
+    // THEN
+    expect(validateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('validates again on a file change', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.watchValidate(cx, { include: [] });
+    await fakeChokidarWatcherOn.readyCallback();
+
+    // WHEN
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'app.ts');
+
+    // THEN
+    expect(validateSpy).toHaveBeenCalledTimes(
+      1 // from ready event
+      + 1, // from file event
+    );
+  });
+
+  test('never deploys', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.watchValidate(cx, { include: [] });
+
+    // WHEN
+    await fakeChokidarWatcherOn.readyCallback();
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'app.ts');
+
+    // THEN
+    expect(deploySpy).not.toHaveBeenCalled();
+  });
+
+  test('passes validate options through to each invocation', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const options = {
+      include: [],
+      online: false,
+      stacks: { patterns: ['Stack1'], strategy: StackSelectionStrategy.PATTERN_MATCH },
+    };
+    await toolkit.watchValidate(cx, options);
+
+    // WHEN
+    await fakeChokidarWatcherOn.readyCallback();
+
+    // THEN
+    expect(validateSpy).toHaveBeenCalledWith(cx, expect.objectContaining({
+      online: false,
+      stacks: { patterns: ['Stack1'], strategy: StackSelectionStrategy.PATTERN_MATCH },
+    }));
+  });
+
+  test('keeps watching after a validation error', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    validateSpy.mockRejectedValueOnce(new Error('synth failed mid-edit'));
+    await toolkit.watchValidate(cx, { include: [] });
+
+    // WHEN: the initial validation fails ...
+    await fakeChokidarWatcherOn.readyCallback();
+
+    // THEN: the error is reported ...
+    expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'error',
+      message: expect.stringContaining('synth failed mid-edit'),
+    }));
+
+    // ... and the loop is still alive: the next file change validates again
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'app.ts');
+    expect(validateSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test('batches file changes that arrive during a validation', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    await toolkit.watchValidate(cx, { include: [] });
+    await fakeChokidarWatcherOn.readyCallback();
+
+    // Simulate a slow validation so subsequent changes queue up
+    let resolveValidation!: () => void;
+    validateSpy.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveValidation = () => resolve({ conclusion: 'success', pluginReports: [] });
+    }));
+
+    // WHEN: a file change starts the slow validation ...
+    const firstEvent = fakeChokidarWatcherOn.fileEventCallback('change', 'file1.ts');
+    await new Promise((r) => setTimeout(r, 10));
+
+    // ... and more changes arrive while it is still running
+    const queuedEvents = [
+      fakeChokidarWatcherOn.fileEventCallback('change', 'file2.ts'),
+      fakeChokidarWatcherOn.fileEventCallback('unlink', 'file3.ts'),
+    ];
+
+    resolveValidation();
+    // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
+    await Promise.all([firstEvent, ...queuedEvents]);
+
+    // THEN: the queued changes are batched into a single follow-up validation
+    expect(validateSpy).toHaveBeenCalledTimes(
+      1 // from ready event
+      + 1 // from the first file event
+      + 1, // from the batched queued events
+    );
+  });
+
+  test('returns a watcher that can be disposed', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const watcher = await toolkit.watchValidate(cx, { include: [] });
+
+    expect(mockChokidarWatcherClose).not.toHaveBeenCalled();
+
+    // WHEN
+    // eslint-disable-next-line @cdklabs/promiseall-no-unbounded-parallelism
+    await Promise.all([
+      watcher.waitForEnd(),
+      watcher.dispose(),
+    ]);
+
+    // THEN
+    expect(mockChokidarWatcherClose).toHaveBeenCalled();
+  });
+});

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
@@ -1,7 +1,7 @@
 // We need to mock the chokidar library, used by 'cdk watch'
-// This needs to happen ABOVE the import statements due to quirks with how jest works
-// Apparently, they hoist jest.mock commands just below the import statements so we
-// need to make sure that the constants they access are initialized before the imports.
+// This needs to happen ABOVE the import statements because
+// jest.mock commands are hoisted just below the import statements,
+// which would otherwise bring in the real chokidar.
 const mockChokidarWatcherOn = jest.fn();
 const mockChokidarWatcherClose = jest.fn();
 const fakeChokidarWatcher = {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/watch-validate.test.ts
@@ -39,7 +39,9 @@ import { builderFixture, TestIoHost } from '../_helpers';
 
 const ioHost = new TestIoHost();
 const toolkit = new Toolkit({ ioHost });
-const validateSpy = jest.spyOn(toolkit, 'validate').mockResolvedValue({
+// watchValidate reuses the assembly produced by the watch loop and calls the
+// private `_validate(assembly, options)` directly, so we spy on that.
+const validateSpy = jest.spyOn(toolkit as any, '_validate').mockResolvedValue({
   conclusion: 'success',
   pluginReports: [],
 });
@@ -111,7 +113,8 @@ describe('watchValidate', () => {
     await fakeChokidarWatcherOn.readyCallback();
 
     // THEN
-    expect(validateSpy).toHaveBeenCalledWith(cx, expect.objectContaining({
+    // match anything but null or undefined, since we are only testing for options here
+    expect(validateSpy).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
       online: false,
       stacks: { patterns: ['Stack1'], strategy: StackSelectionStrategy.PATTERN_MATCH },
     }));
@@ -143,15 +146,23 @@ describe('watchValidate', () => {
     await toolkit.watchValidate(cx, { include: [] });
     await fakeChokidarWatcherOn.readyCallback();
 
-    // Simulate a slow validation so subsequent changes queue up
+    // Simulate a slow validation so subsequent changes queue up. `started`
+    // resolves once the validation is actually running (each iteration first
+    // synthesizes, so we cannot rely on a fixed delay), and `resolveValidation`
+    // lets us release it on demand.
     let resolveValidation!: () => void;
+    let signalStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      signalStarted = resolve;
+    });
     validateSpy.mockImplementationOnce(() => new Promise((resolve) => {
       resolveValidation = () => resolve({ conclusion: 'success', pluginReports: [] });
+      signalStarted();
     }));
 
     // WHEN: a file change starts the slow validation ...
     const firstEvent = fakeChokidarWatcherOn.fileEventCallback('change', 'file1.ts');
-    await new Promise((r) => setTimeout(r, 10));
+    await started;
 
     // ... and more changes arrive while it is still running
     const queuedEvents = [
@@ -187,5 +198,29 @@ describe('watchValidate', () => {
 
     // THEN
     expect(mockChokidarWatcherClose).toHaveBeenCalled();
+  });
+
+  test('reuses the startup assembly for the initial validation, re-produces on file changes', async () => {
+    // GIVEN
+    const cx = await builderFixture(toolkit, 'stack-with-role');
+    const produceSpy = jest.spyOn(cx, 'produce');
+
+    await toolkit.watchValidate(cx, { include: [] });
+
+    // WHEN: initial validation (ready event) ...
+    await fakeChokidarWatcherOn.readyCallback();
+    const producesAfterReady = produceSpy.mock.calls.length;
+
+    // ... then two file-change iterations
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'app.ts');
+    await fakeChokidarWatcherOn.fileEventCallback('change', 'lib.ts');
+    const producesTotal = produceSpy.mock.calls.length;
+
+    // THEN: the initial validation reuses the assembly produced at watch startup
+    // (fresh by definition), so no extra synth happens for it; every file-change
+    // iteration re-produces so the changes are picked up.
+    expect(validateSpy).toHaveBeenCalledTimes(3);
+    expect(producesAfterReady).toBe(1); // startup produce, reused by the initial validation
+    expect(producesTotal).toBe(3); // startup + one per file-change iteration
   });
 });

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -627,11 +627,15 @@ export class CdkToolkit {
     // Implicitly switch 'debug' mode to true; more stack traces = more useful.
     this.props.cloudExecutable.switchOnDebugging();
 
-    if (options.watch) {
-      return this.validateWatch(options);
+    // `watch` is a CLI-only flag; strip it before crossing into toolkit-lib so
+    // it does not leak into the library's validate action.
+    const { watch, ...validateOptions } = options;
+
+    if (watch) {
+      return this.validateWatch(validateOptions);
     }
 
-    const result = await this.toolkit.validate(this.props.cloudExecutable, options);
+    const result = await this.toolkit.validate(this.props.cloudExecutable, validateOptions);
     return result.conclusion === 'failure' ? 1 : 0;
   }
 
@@ -642,7 +646,7 @@ export class CdkToolkit {
    * The files to observe are configured with the "watch" key of `cdk.json`,
    * exactly like `cdk deploy --watch`.
    */
-  private async validateWatch(options: CliValidateOptions): Promise<void> {
+  private async validateWatch(options: ValidateOptions): Promise<void> {
     const rootDir = path.dirname(path.resolve(PROJECT_CONFIG));
 
     const watchSettings: { include?: string | string[]; exclude?: string | string[] } | undefined =
@@ -650,7 +654,7 @@ export class CdkToolkit {
     if (!watchSettings) {
       throw new ToolkitError(
         'WatchConfigMissing',
-        "Cannot use the 'watch' command without specifying at least one directory to monitor. " +
+        "Cannot use '--watch' without specifying at least one directory to monitor. " +
         'Make sure to add a "watch" key to your cdk.json',
       );
     }

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -623,12 +623,56 @@ export class CdkToolkit {
   /**
    * Validate synthesized templates against policy rules
    */
-  public async validate(options: ValidateOptions): Promise<number> {
+  public async validate(options: CliValidateOptions): Promise<number | void> {
     // Implicitly switch 'debug' mode to true; more stack traces = more useful.
     this.props.cloudExecutable.switchOnDebugging();
 
+    if (options.watch) {
+      return this.validateWatch(options);
+    }
+
     const result = await this.toolkit.validate(this.props.cloudExecutable, options);
     return result.conclusion === 'failure' ? 1 : 0;
+  }
+
+  /**
+   * Continuously validate the project, re-synthesizing and re-validating on
+   * every file change. Never deploys.
+   *
+   * The files to observe are configured with the "watch" key of `cdk.json`,
+   * exactly like `cdk deploy --watch`.
+   */
+  private async validateWatch(options: CliValidateOptions): Promise<void> {
+    const rootDir = path.dirname(path.resolve(PROJECT_CONFIG));
+
+    const watchSettings: { include?: string | string[]; exclude?: string | string[] } | undefined =
+      this.props.configuration.settings.get(['watch']);
+    if (!watchSettings) {
+      throw new ToolkitError(
+        'WatchConfigMissing',
+        "Cannot use the 'watch' command without specifying at least one directory to monitor. " +
+        'Make sure to add a "watch" key to your cdk.json',
+      );
+    }
+
+    const include = this.patternsArrayForWatch(watchSettings.include, {
+      defaultPattern: '**',
+      returnDefaultIfEmpty: true,
+    });
+    // Pass the user's excludes explicitly; toolkit-lib always appends the
+    // outdir, dot-file, and node_modules excludes on top of these.
+    const exclude = this.patternsArrayForWatch(watchSettings.exclude, {
+      defaultPattern: '',
+      returnDefaultIfEmpty: false,
+    });
+
+    const watcher = await this.toolkit.watchValidate(this.props.cloudExecutable.uncachedSource(), {
+      ...options,
+      watchDir: rootDir,
+      include,
+      exclude,
+    });
+    return watcher.waitForEnd();
   }
 
   /**
@@ -1581,6 +1625,18 @@ interface CfnDeployOptions {
    * @default true
    */
   readonly rollback?: boolean;
+}
+
+/**
+ * Options for the validate command
+ */
+export interface CliValidateOptions extends ValidateOptions {
+  /**
+   * Continuously observe the project files, and re-validate automatically when changes are detected
+   *
+   * @default false
+   */
+  readonly watch?: boolean;
 }
 
 interface WatchOptions extends Omit<CfnDeployOptions, 'execute'> {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -234,7 +234,8 @@ export async function makeConfig(): Promise<CliConfig> {
             type: 'boolean',
             desc: 'Continuously observe the project files, ' +
               'and validate the given stack(s) automatically when changes are detected. ' +
-              'Never deploys',
+              'Never deploys. Consider pairing with --no-online to skip CloudFormation ' +
+              'validation on every change',
           },
         },
         arg: {

--- a/packages/aws-cdk/lib/cli/cli-config.ts
+++ b/packages/aws-cdk/lib/cli/cli-config.ts
@@ -230,6 +230,12 @@ export async function makeConfig(): Promise<CliConfig> {
         description: 'Validate synthesized CloudFormation templates against policy rules',
         options: {
           online: { type: 'boolean', desc: 'Submit templates to CloudFormation for early validation (requires AWS credentials)', default: true },
+          watch: {
+            type: 'boolean',
+            desc: 'Continuously observe the project files, ' +
+              'and validate the given stack(s) automatically when changes are detected. ' +
+              'Never deploys',
+          },
         },
         arg: {
           name: 'STACKS',

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -624,7 +624,7 @@
         },
         "watch": {
           "type": "boolean",
-          "desc": "Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys"
+          "desc": "Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys. Consider pairing with --no-online to skip CloudFormation validation on every change"
         }
       },
       "arg": {

--- a/packages/aws-cdk/lib/cli/cli-type-registry.json
+++ b/packages/aws-cdk/lib/cli/cli-type-registry.json
@@ -621,6 +621,10 @@
           "type": "boolean",
           "desc": "Submit templates to CloudFormation for early validation (requires AWS credentials)",
           "default": true
+        },
+        "watch": {
+          "type": "boolean",
+          "desc": "Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys"
         }
       },
       "arg": {

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -465,6 +465,7 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         return cli.validate({
           stacks: specificStacksOrAllRecursively(args.STACKS),
           online: args.online,
+          watch: args.watch,
         });
 
       case 'diagnose':

--- a/packages/aws-cdk/lib/cli/convert-to-user-input.ts
+++ b/packages/aws-cdk/lib/cli/convert-to-user-input.ts
@@ -158,6 +158,7 @@ export function convertYargsToUserInput(args: any): UserInput {
     case 'validate':
       commandOptions = {
         online: args.online,
+        watch: args.watch,
         STACKS: args.STACKS,
       };
       break;
@@ -491,6 +492,7 @@ export function convertConfigToUserInput(config: any): UserInput {
   };
   const validateOptions = {
     online: config.validate?.online,
+    watch: config.validate?.watch,
   };
   const diagnoseOptions = {
     toolkitStackName: config.diagnose?.toolkitStackName,

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -653,7 +653,7 @@ export function parseCommandLineArguments(args: Array<string>): any {
         .option('watch', {
           default: undefined,
           type: 'boolean',
-          desc: 'Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys',
+          desc: 'Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys. Consider pairing with --no-online to skip CloudFormation validation on every change',
         }),
     )
     .command('diagnose [STACKS..]', 'Find the root cause(s) of stack deployment failures', (yargs: Argv) =>

--- a/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
+++ b/packages/aws-cdk/lib/cli/parse-command-line-arguments.ts
@@ -644,11 +644,17 @@ export function parseCommandLineArguments(args: Array<string>): any {
         }),
     )
     .command('validate [STACKS..]', 'Validate synthesized CloudFormation templates against policy rules', (yargs: Argv) =>
-      yargs.option('online', {
-        default: true,
-        type: 'boolean',
-        desc: 'Submit templates to CloudFormation for early validation (requires AWS credentials)',
-      }),
+      yargs
+        .option('online', {
+          default: true,
+          type: 'boolean',
+          desc: 'Submit templates to CloudFormation for early validation (requires AWS credentials)',
+        })
+        .option('watch', {
+          default: undefined,
+          type: 'boolean',
+          desc: 'Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys',
+        }),
     )
     .command('diagnose [STACKS..]', 'Find the root cause(s) of stack deployment failures', (yargs: Argv) =>
       yargs

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1033,7 +1033,7 @@ export interface ValidateOptions {
   readonly online?: boolean;
 
   /**
-   * Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys
+   * Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys. Consider pairing with --no-online to skip CloudFormation validation on every change
    *
    * @default - undefined
    */

--- a/packages/aws-cdk/lib/cli/user-input.ts
+++ b/packages/aws-cdk/lib/cli/user-input.ts
@@ -1033,6 +1033,13 @@ export interface ValidateOptions {
   readonly online?: boolean;
 
   /**
+   * Continuously observe the project files, and validate the given stack(s) automatically when changes are detected. Never deploys
+   *
+   * @default - undefined
+   */
+  readonly watch?: boolean;
+
+  /**
    * Positional argument for validate
    */
   readonly STACKS?: Array<string>;

--- a/packages/aws-cdk/lib/cxapp/cloud-executable.ts
+++ b/packages/aws-cdk/lib/cxapp/cloud-executable.ts
@@ -59,6 +59,22 @@ export class CloudExecutable implements ICloudAssemblySource {
   }
 
   /**
+   * An `ICloudAssemblySource` that re-synthesizes on every `produce()` call.
+   *
+   * The `CloudExecutable` itself caches the assembly after the first synthesis
+   * (appropriate for one-shot commands). Watch modes call `produce()` on every
+   * file-change iteration and need a fresh assembly each time.
+   */
+  public uncachedSource(): ICloudAssemblySource {
+    return {
+      produce: async () => {
+        const synthesisResult = await this.synthesize(false);
+        return new BorrowedAssembly(synthesisResult.assembly);
+      },
+    };
+  }
+
+  /**
    * Return whether there is an app command from the configuration
    */
   public get hasApp() {

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -67,7 +67,7 @@ import * as cxapi from '@aws-cdk/cloud-assembly-api';
 import * as cxschema from '@aws-cdk/cloud-assembly-schema';
 import { Manifest, RequireApproval } from '@aws-cdk/cloud-assembly-schema';
 import type { DeploymentMethod } from '@aws-cdk/toolkit-lib';
-import { Toolkit } from '@aws-cdk/toolkit-lib';
+import { StackSelectionStrategy, Toolkit } from '@aws-cdk/toolkit-lib';
 import type { CloudFormationClientResolvedConfig, CreateChangeSetInput, CreateChangeSetOutput, DeleteChangeSetInput, DeleteChangeSetOutput, DescribeChangeSetInput, DescribeChangeSetOutput, ServiceInputTypes, ServiceOutputTypes } from '@aws-sdk/client-cloudformation';
 import { CreateChangeSetCommand, DeleteChangeSetCommand, DescribeChangeSetCommand, DescribeStacksCommand, GetTemplateCommand, StackStatus } from '@aws-sdk/client-cloudformation';
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
@@ -2221,6 +2221,96 @@ describe('watch', () => {
         );
       });
     });
+  });
+});
+
+describe('validate --watch', () => {
+  let watchValidateSpy: jest.SpyInstance;
+  const fakeWatcher = {
+    dispose: jest.fn().mockResolvedValue(undefined),
+    waitForEnd: jest.fn().mockResolvedValue(undefined),
+    [Symbol.asyncDispose]: jest.fn().mockResolvedValue(undefined),
+  };
+
+  beforeEach(() => {
+    watchValidateSpy = jest.spyOn(Toolkit.prototype, 'watchValidate').mockResolvedValue(fakeWatcher);
+  });
+
+  test("fails when no 'watch' settings are found", async () => {
+    const toolkit = defaultToolkitSetup();
+
+    await expect(() => {
+      return toolkit.validate({
+        stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+        watch: true,
+      });
+    }).rejects.toThrow(
+      "Cannot use the 'watch' command without specifying at least one directory to monitor. " +
+      'Make sure to add a "watch" key to your cdk.json',
+    );
+
+    expect(watchValidateSpy).not.toHaveBeenCalled();
+  });
+
+  test('delegates to toolkit-lib watchValidate with the validate options', async () => {
+    cloudExecutable.configuration.settings.set(['watch'], {});
+    const toolkit = defaultToolkitSetup();
+
+    await toolkit.validate({
+      stacks: { patterns: ['Test-Stack-A-Display-Name'], strategy: StackSelectionStrategy.PATTERN_MATCH },
+      online: false,
+      watch: true,
+    });
+
+    expect(watchValidateSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        stacks: { patterns: ['Test-Stack-A-Display-Name'], strategy: StackSelectionStrategy.PATTERN_MATCH },
+        online: false,
+        include: ['**'],
+        exclude: [],
+      }),
+    );
+    expect(fakeWatcher.waitForEnd).toHaveBeenCalled();
+  });
+
+  test("passes the 'watch' include and exclude settings from cdk.json", async () => {
+    cloudExecutable.configuration.settings.set(['watch'], {
+      include: ['lib/**'],
+      exclude: ['lib/generated/**'],
+    });
+    const toolkit = defaultToolkitSetup();
+
+    await toolkit.validate({
+      stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+      watch: true,
+    });
+
+    expect(watchValidateSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        include: ['lib/**'],
+        exclude: ['lib/generated/**'],
+      }),
+    );
+  });
+
+  test('passes an uncached assembly source so every iteration re-synthesizes', async () => {
+    cloudExecutable.configuration.settings.set(['watch'], {});
+    const toolkit = defaultToolkitSetup();
+
+    await toolkit.validate({
+      stacks: { patterns: [], strategy: StackSelectionStrategy.ALL_STACKS },
+      watch: true,
+    });
+
+    // The source handed to watchValidate must re-synthesize on every produce().
+    const source = watchValidateSpy.mock.calls[0][0];
+    const synthesizeSpy = jest.spyOn(cloudExecutable, 'synthesize');
+    await source.produce();
+    await source.produce();
+    expect(synthesizeSpy).toHaveBeenCalledTimes(2);
+    expect(synthesizeSpy).toHaveBeenCalledWith(false);
   });
 });
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -2245,7 +2245,7 @@ describe('validate --watch', () => {
         watch: true,
       });
     }).rejects.toThrow(
-      "Cannot use the 'watch' command without specifying at least one directory to monitor. " +
+      "Cannot use '--watch' without specifying at least one directory to monitor. " +
       'Make sure to add a "watch" key to your cdk.json',
     );
 


### PR DESCRIPTION
#1762 

Adds a watch mode for validation that continuously re-synthesizes and re-validates the app on file changes. It never deploys.

### toolkit-lib
- New public `Toolkit.watchValidate(cx, options)` returning `IWatcher`, built on the private `_watch` combinator. Each iteration runs the `validate` action.
- New `WatchValidateOptions` composing `WatchFileOptions` with `ValidateOptions`.
- Validation errors (e.g. synth failures mid-edit) are reported and swallowed so the watch loop survives and re-validates on the next change.

### CLI
- New `--watch` flag on `cdk validate`.
- `CdkToolkit.validate()` delegates to `toolkit.watchValidate()` when watch is requested, reading include/exclude from the same `"watch"` key in `cdk.json` as `cdk deploy --watch`, and passing an uncached assembly source so every iteration re-synthesizes.

### Usage
```
cdk validate --unstable=validate --watch [STACKS..] [--no-online]
```

### Testing
Tested on sample app for:
- `cdk validate --watch`
 - Test on online validation (S3 bucket name conflict) 
- `cdk validate --watch --no-online`
 - Test on annotation (S3 encryption policy)

Ensured stack re-validated after syntax and validation errors.

<img width="739" height="198" alt="Screenshot 2026-07-28 at 16 35 49" src="https://github.com/user-attachments/assets/d991626b-6465-4c6c-928d-bd842f13d45f" />
<img width="740" height="416" alt="Screenshot 2026-07-28 at 16 35 23" src="https://github.com/user-attachments/assets/0aa6b5cd-dd4e-4e85-82db-45f3b5aa1144" />
<img width="669" height="373" alt="Screenshot 2026-07-28 at 19 46 52" src="https://github.com/user-attachments/assets/2e2059fd-1938-42ae-8444-f2d55f9b0b00" />




### Checklist
- [x] Unit tests added/updated (toolkit-lib `watch-validate.test.ts`, `cdk-toolkit.test.ts`)
- [ ] Integration tests added/updated (not deploying new resource types)
- [x] No manual edits to generated files (parser regenerated)

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
