### PR TITLE
chore: migrate repo tooling and docs from ts-node to tsx

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -116,10 +116,6 @@
       "type": "build"
     },
     {
-      "name": "ts-node",
-      "type": "build"
-    },
-    {
       "name": "tsx",
       "type": "build"
     },

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -74,8 +74,17 @@
       "steps": [
         {
           "execArgs": [
-            "ts-node",
-            "--project",
+            "tsc",
+            "--noEmit",
+            "-p",
+            "projenrc/tsconfig.json"
+          ],
+          "name": "typecheck"
+        },
+        {
+          "execArgs": [
+            "tsx",
+            "--tsconfig",
             "projenrc/tsconfig.json",
             ".projenrc.ts"
           ]

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -231,6 +231,7 @@ const repoProject = new yarn.Monorepo({
   description: "Monorepo for the AWS CDK's CLI",
   repository: 'https://github.com/aws/aws-cdk-cli',
 
+  runner: pj.typescript.TypeScriptRunner.tsx(),
   defaultReleaseBranch: 'main',
   typescriptVersion: TYPESCRIPT_VERSION,
   devDeps: [
@@ -1260,7 +1261,6 @@ const cli = configureProject(
       'jest-mock',
       'nock@13',
       'sinon',
-      'ts-node',
       'ts-mock-imports',
       'tsx',
     ],
@@ -1513,6 +1513,7 @@ const integRunner = configureProject(
       '@types/yargs',
       'constructs@^10',
       '@aws-cdk/integ-tests-alpha@2.184.1-alpha.0',
+      'ts-node', // integ-runner defaults to ts-node to execute test fixtures
     ],
     tsconfig: {
       compilerOptions: {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "prettier": "^2.8",
     "projen": "^0.101.20",
     "semver": "^7.8.5",
-    "ts-node": "^10.9.2",
     "tsx": "^4.23.1",
     "typescript": "5.9"
   },

--- a/packages/@aws-cdk/cdk-explorer/lib/core/cdk-config.ts
+++ b/packages/@aws-cdk/cdk-explorer/lib/core/cdk-config.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
  * The subset of `cdk.json` the explorer cares about.
  *
  * `app` is the command CDK runs to produce a cloud assembly (e.g.
- * `npx ts-node bin/app.ts`). We need it to invoke `Toolkit.synth()`
+ * `npx tsx bin/app.ts`). We need it to invoke `Toolkit.synth()`
  * via `fromCdkApp`.
  */
 export interface CdkConfig {

--- a/packages/@aws-cdk/cdk-explorer/test/core/cdk-config.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/cdk-config.test.ts
@@ -19,8 +19,8 @@ function writeCdkJson(dir: string, contents: string): void {
 describe('readCdkConfig', () => {
   test('returns the app command when present', () => {
     withTempDir((dir) => {
-      writeCdkJson(dir, JSON.stringify({ app: 'npx ts-node bin/app.ts' }));
-      expect(readCdkConfig(dir)).toEqual({ app: 'npx ts-node bin/app.ts' });
+      writeCdkJson(dir, JSON.stringify({ app: 'npx tsx bin/app.ts' }));
+      expect(readCdkConfig(dir)).toEqual({ app: 'npx tsx bin/app.ts' });
     });
   });
 

--- a/packages/@aws-cdk/cdk-explorer/test/core/synth-runner.test.ts
+++ b/packages/@aws-cdk/cdk-explorer/test/core/synth-runner.test.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { AssemblyError, ContextLookupsDisabledError, LockError, ToolkitError, type Toolkit } from '@aws-cdk/toolkit-lib';
 import { runSynth } from '../../lib/core/synth-runner';
 
-const APP = 'npx ts-node bin/app.ts';
+const APP = 'npx tsx bin/app.ts';
 
 interface FakeCachedAssembly {
   dispose: jest.Mock;

--- a/packages/@aws-cdk/integ-runner/.projen/deps.json
+++ b/packages/@aws-cdk/integ-runner/.projen/deps.json
@@ -135,6 +135,10 @@
       "type": "build"
     },
     {
+      "name": "ts-node",
+      "type": "build"
+    },
+    {
       "name": "typescript",
       "version": "5.9",
       "type": "build"

--- a/packages/@aws-cdk/integ-runner/.projen/tasks.json
+++ b/packages/@aws-cdk/integ-runner/.projen/tasks.json
@@ -89,7 +89,7 @@
             "--peer",
             "--no-deprecated",
             "--dep=dev,prod,peer,optional",
-            "--filter=@cdklabs/eslint-plugin,@types/jest,@types/yargs,aws-cdk-lib,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,node-backpack,nx,projen,ts-jest,@aws-cdk/aws-service-spec,proxy-agent"
+            "--filter=@cdklabs/eslint-plugin,@types/jest,@types/yargs,aws-cdk-lib,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,jest,license-checker,node-backpack,nx,projen,ts-jest,ts-node,@aws-cdk/aws-service-spec,proxy-agent"
           ]
         }
       ]

--- a/packages/@aws-cdk/integ-runner/package.json
+++ b/packages/@aws-cdk/integ-runner/package.json
@@ -63,6 +63,7 @@
     "prettier": "^2.8",
     "projen": "^0.101.20",
     "ts-jest": "^29.4.12",
+    "ts-node": "^10.9.2",
     "typescript": "5.9"
   },
   "dependencies": {

--- a/packages/@aws-cdk/toolkit-lib/README.md
+++ b/packages/@aws-cdk/toolkit-lib/README.md
@@ -346,7 +346,7 @@ With the CDK Toolkit Library you can use these CDK apps by providing the `app` s
 declare const cdk: Toolkit;
 
 // TypeScript
-await cdk.fromCdkApp("ts-node app.ts");
+await cdk.fromCdkApp("tsx app.ts");
 
 // Python
 await cdk.fromCdkApp("python app.py");

--- a/packages/aws-cdk/.projen/deps.json
+++ b/packages/aws-cdk/.projen/deps.json
@@ -193,10 +193,6 @@
       "type": "build"
     },
     {
-      "name": "ts-node",
-      "type": "build"
-    },
-    {
       "name": "tsx",
       "type": "build"
     },

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -106,7 +106,7 @@
             "--peer",
             "--no-deprecated",
             "--dep=dev,prod,peer,optional",
-            "--filter=@cdklabs/eslint-plugin,@types/jest,@types/mockery,@types/picomatch,@types/promptly,@types/semver,@types/sinon,@types/yazl,aws-sdk-client-mock,aws-sdk-client-mock-jest,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-mock,license-checker,node-backpack,nx,projen,sinon,ts-jest,ts-mock-imports,ts-node,tsx,cdk-from-cfn,enquirer,fast-glob,picomatch,promptly,proxy-agent,semver,yazl"
+            "--filter=@cdklabs/eslint-plugin,@types/jest,@types/mockery,@types/picomatch,@types/promptly,@types/semver,@types/sinon,@types/yazl,aws-sdk-client-mock,aws-sdk-client-mock-jest,esbuild,eslint-config-prettier,eslint-import-resolver-typescript,eslint-plugin-import,eslint-plugin-jest,eslint-plugin-jsdoc,eslint-plugin-prettier,fast-check,jest,jest-environment-node,jest-mock,license-checker,node-backpack,nx,projen,sinon,ts-jest,ts-mock-imports,tsx,cdk-from-cfn,enquirer,fast-glob,picomatch,promptly,proxy-agent,semver,yazl"
           ]
         }
       ]

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -1884,24 +1884,32 @@ environment variable `CI=true`. This can be forced by passing the `--ci` flag. B
 sends most of its logs to `stderr`, but when `ci=true` it will send the logs to `stdout` instead.
 When terminal width cannot be detected, `cdk diff` tables render unbounded; set [`COLUMNS`](#environment) to constrain their width.
 
-### Changing the default TypeScript transpiler
+### Changing how TypeScript apps are executed
 
-The ts-node package used to synthesize and deploy CDK apps supports an alternate transpiler that might improve transpile times. The SWC transpiler is written in Rust and has no type checking. The SWC transpiler should be enabled by experienced TypeScript developers.
+The CDK CLI does not run your TypeScript code itself. It executes the command configured
+under the `app` key in `cdk.json` (see [JSON Configuration files](#json-configuration-files))
+and reads the resulting cloud assembly. This means you are free to choose any tool to
+execute your TypeScript app.
 
-To enable the SWC transpiler, install the package in the CDK app.
-
-```sh
-npm i -D @swc/core @swc/helpers regenerator-runtime
-```
-
-And, update the `tsconfig.json` file to add the `ts-node` property.
+Projects created with `cdk init` use [tsx](https://tsx.is/) to execute the app, with a
+separate `tsc` invocation for type checking:
 
 ```json
 {
-  "ts-node": {
-    "swc": true
-  }
+  "app": "npx tsc && npx tsx bin/my-app.ts"
 }
 ```
 
-The documentation may be found at <https://typestrong.org/ts-node/docs/swc/>
+To use a different runner (for example [ts-node](https://typestrong.org/ts-node/), possibly
+with its [SWC integration](https://typestrong.org/ts-node/docs/swc/) for faster transpilation),
+install it as a dev dependency and update the `app` command accordingly:
+
+```json
+{
+  "app": "npx ts-node --prefer-ts-exts bin/my-app.ts"
+}
+```
+
+If synthesis feels slow, the type checking step is usually the biggest contributor. You can
+remove `npx tsc &&` from the `app` command and run type checking separately (e.g. in CI or
+your editor) to speed up iteration.

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -83,7 +83,6 @@
     "sinon": "^19.0.5",
     "ts-jest": "^29.4.12",
     "ts-mock-imports": "^1.3.19",
-    "ts-node": "^10.9.2",
     "tsx": "^4.23.1",
     "typescript": "5.9"
   },

--- a/projenrc/next-version.ts
+++ b/projenrc/next-version.ts
@@ -8,8 +8,6 @@ import * as semver from 'semver';
  * of the version and append `-test.0`.
  */
 async function main() {
-  const args = process.argv.slice(2);
-
   // This is the current version
   const currentVersion = process.env.VERSION ?? '';
 
@@ -81,7 +79,7 @@ async function main() {
   console.log(bump);
 }
 
-function maybeRc(version: string) {
+function maybeRc(version: string): string | undefined {
   if (process.env.TESTING_CANDIDATE === 'true') {
     // To make an rc version for testing, we set the last component (either
     // patch or prerelease version) to 999.
@@ -97,6 +95,7 @@ function maybeRc(version: string) {
       return version.replace(new RegExp('\\.' + patch + '$'), '.999');
     }
   }
+  return undefined;
 }
 
 type BumpType = 'major' | 'minor' | 'patch' | 'none';

--- a/yarn.lock
+++ b/yarn.lock
@@ -438,6 +438,7 @@ __metadata:
     projen: "npm:^0.101.20"
     proxy-agent: "npm:^6.5.0"
     ts-jest: "npm:^29.4.12"
+    ts-node: "npm:^10.9.2"
     typescript: "npm:5.9"
     workerpool: "npm:^6"
     yargs: "npm:^16"
@@ -5395,7 +5396,6 @@ __metadata:
     prettier: "npm:^2.8"
     projen: "npm:^0.101.20"
     semver: "npm:^7.8.5"
-    ts-node: "npm:^10.9.2"
     tsx: "npm:^4.23.1"
     typescript: "npm:5.9"
   dependenciesMeta:
@@ -5530,7 +5530,6 @@ __metadata:
     strip-ansi: "npm:^6"
     ts-jest: "npm:^29.4.12"
     ts-mock-imports: "npm:^1.3.19"
-    ts-node: "npm:^10.9.2"
     tsx: "npm:^4.23.1"
     typescript: "npm:5.9"
     wrap-ansi: "npm:^7"


### PR DESCRIPTION
Completes the repository's migration from ts-node to tsx as the tool that executes TypeScript directly.

The projen runner now uses tsx with a separate `tsc --noEmit` typecheck step, because tsx transpiles without type checking and we don't want to lose that safety net for `.projenrc.ts`. As a consequence of the now-enforced typecheck, `projenrc/next-version.ts` needed small fixes (an unused variable and an implicit `undefined` return). ts-node is removed from the root and `aws-cdk` dev dependencies since nothing uses it anymore; it is kept explicitly in `integ-runner`, which still defaults to ts-node for executing test fixtures.

Documentation and code references follow suit: the `toolkit-lib` README and `cdk-explorer` comments/tests now show tsx-based `app` commands, matching what `cdk init` generates today. The "Changing the default TypeScript transpiler" section in the `aws-cdk` README was rewritten because it documented a ts-node/SWC setup that no longer applies to freshly initialized projects. It now explains that the CLI simply runs the `app` command from `cdk.json`, shows the tsx-based default, and keeps ts-node/SWC as a documented alternative.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
