### PR TITLE
chore: aws-cdk-lib upgrade workflow fails on yarn age gate

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -23,6 +23,7 @@ import { YarnVersion } from './projenrc/yarn-version';
 // #region shared config
 
 const TYPESCRIPT_VERSION = '5.9';
+const DEPENDENCY_COOLDOWN = 3;
 
 /**
  * Global note on customizeReference
@@ -295,7 +296,7 @@ const repoProject = new yarn.Monorepo({
   },
 
   depsUpgradeOptions: {
-    cooldown: 3,
+    cooldown: DEPENDENCY_COOLDOWN,
     workflowOptions: {
       schedule: pj.javascript.UpgradeDependenciesSchedule.WEEKLY,
     },
@@ -1368,6 +1369,7 @@ cli.with(tools.zip);
 
 new pj.javascript.UpgradeDependencies(cli, {
   include: ['aws-cdk-lib'],
+  cooldown: DEPENDENCY_COOLDOWN,
   semanticCommit: 'feat',
   pullRequestTitle: 'upgrade aws-cdk-lib',
   target: 'minor',
@@ -1705,9 +1707,9 @@ cliInteg.gitignore.addPatterns('npm-shrinkwrap.json');
 // since those are normally patches on top of already "cold" versions.
 const dependabotCooldown = 7;
 
-// for PRs resolving security alerts we accept a shorter cooldown
+// for PRs resolving security alerts we accept the shorter standard cooldown
 // given those are normally patch versions on top of already "cold" versions.
-const dependabotSecurityCooldown = 3;
+const dependabotSecurityCooldown = DEPENDENCY_COOLDOWN;
 
 new pj.YamlFile(repo, '.github/dependabot.yml', {
   obj: {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1369,7 +1369,7 @@ cli.with(tools.zip);
 
 new pj.javascript.UpgradeDependencies(cli, {
   include: ['aws-cdk-lib'],
-  cooldown: DEPENDENCY_COOLDOWN,
+  cooldown: 1, // we trust aws-cdk-lib (it's us!) more than other deps, but 1 day wait time is still a good idea
   semanticCommit: 'feat',
   pullRequestTitle: 'upgrade aws-cdk-lib',
   target: 'minor',

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -300,7 +300,8 @@
       "description": "upgrade aws-cdk-lib",
       "env": {
         "CI": "0",
-        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false"
+        "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
+        "YARN_NPM_MINIMAL_AGE_GATE": "4320"
       },
       "steps": [
         {
@@ -310,6 +311,7 @@
             "npm-check-updates@20",
             "--upgrade",
             "--target=minor",
+            "--cooldown=3",
             "--peer",
             "--no-deprecated",
             "--dep=dev,prod,peer,optional",

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -301,7 +301,7 @@
       "env": {
         "CI": "0",
         "YARN_ENABLE_IMMUTABLE_INSTALLS": "false",
-        "YARN_NPM_MINIMAL_AGE_GATE": "4320"
+        "YARN_NPM_MINIMAL_AGE_GATE": "1440"
       },
       "steps": [
         {
@@ -311,7 +311,7 @@
             "npm-check-updates@20",
             "--upgrade",
             "--target=minor",
-            "--cooldown=3",
+            "--cooldown=1",
             "--peer",
             "--no-deprecated",
             "--dep=dev,prod,peer,optional",


### PR DESCRIPTION
The `aws-cdk-lib` upgrade workflow started failing because yarn now enforces a minimal package age gate of 1 day by default. `npm-check-updates` had no cooldown configured for that workflow, so it happily selected a version younger than the gate, which yarn then refused to install.

Setting the ncu cooldown to 1 day makes it agree with yarn, so it only ever proposes versions yarn will accept. One day is deliberately shorter than the cooldown we use for third party dependencies — we trust `aws-cdk-lib` more since it's ours — but still long enough to avoid picking up a release that gets yanked immediately.

The repeated cooldown value is also extracted into a shared `DEPENDENCY_COOLDOWN` constant, used by the monorepo upgrade workflow and the dependabot security cooldown, which both keep their existing 3 day value.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
