### PR TITLE
chore(cli-integ): cc-hotswap tests fail because Bedrock Agents is in maintenance mode

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/lib/regions.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/regions.ts
@@ -51,18 +51,3 @@ export const STACK_REFACTORING_REGIONS = allBut([
   'mx-central-1',
 ]);
 
-/**
- * Regions that don't support AWS::Bedrock::Agent
- */
-export const BEDROCK_AGENT_REGIONS = allBut([
-  'af-south-1',
-  'ap-east-1',
-  'ap-southeast-3',
-  'ap-southeast-4',
-  'ap-southeast-5',
-  'ap-southeast-7',
-  'ca-west-1',
-  'il-central-1',
-  'mx-central-1',
-  'us-west-1',
-]);

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
@@ -35,7 +35,6 @@ if (process.env.PACKAGE_LAYOUT_VERSION === '1') {
     aws_bedrockagentcore: bedrockagentcore,
     aws_events: events,
     aws_dynamodb: dynamodb,
-    aws_bedrock: bedrock,
     Stack
   } = require('aws-cdk-lib');
 }
@@ -789,17 +788,27 @@ class CloudControlHotswapStack extends cdk.Stack {
     cdk.Tags.of(queue).add('DynamoTableArn', table.tableArn);
     cdk.Tags.of(queue).add('DynamicTag', process.env.DYNAMIC_CC_PROPERTY_VALUE ?? 'original');
 
-    // Bedrock Agent — hotswapped via CCAPI, references the DynamoDB table name
-    const agentRole = new iam.Role(this, 'AgentRole', {
-      assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
-    });
-    const agent = new bedrock.CfnAgent(this, 'Agent', {
-      agentName: `${cdk.Stack.of(this).stackName}-agent`.substring(0, 40),
-      agentResourceRoleArn: agentRole.roleArn,
-      instruction: process.env.DYNAMIC_CC_PROPERTY_VALUE
-        ? `You help query the table ${table.tableName}. ${process.env.DYNAMIC_CC_PROPERTY_VALUE}. ${process.env.DYNAMIC_CC_PROPERTY_VALUE_2 ?? 'original'}`
-        : `You help query the table ${table.tableName}. original. original`,
-      foundationModel: 'anthropic.claude-instant-v1',
+    // CloudWatch Dashboard — hotswapped via CCAPI, references the DynamoDB table name.
+    // (This used to be an AWS::Bedrock::Agent, but Bedrock Agents Classic went into
+    // maintenance mode on 2026-07-30 and CreateAgent is rejected in accounts without
+    // prior service usage, which includes fresh test environments:
+    // https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html)
+    const dashboard = new cdk.CfnResource(this, 'Dashboard', {
+      type: 'AWS::CloudWatch::Dashboard',
+      properties: {
+        DashboardName: `${cdk.Stack.of(this).stackName}-dashboard`.substring(0, 40),
+        DashboardBody: this.toJsonString({
+          widgets: [{
+            type: 'text',
+            x: 0, y: 0, width: 24, height: 2,
+            properties: {
+              markdown: process.env.DYNAMIC_CC_PROPERTY_VALUE
+                ? `Table ${table.tableName}. ${process.env.DYNAMIC_CC_PROPERTY_VALUE}. ${process.env.DYNAMIC_CC_PROPERTY_VALUE_2 ?? 'original'}`
+                : `Table ${table.tableName}. original. original`,
+            },
+          }],
+        }),
+      },
     });
 
     // Events Rule — hotswapped via CCAPI, references the ElastiCache cache ARN
@@ -811,7 +820,7 @@ class CloudControlHotswapStack extends cdk.Stack {
     });
 
     new cdk.CfnOutput(this, 'QueueUrl', { value: queue.queueUrl });
-    new cdk.CfnOutput(this, 'AgentName', { value: agent.ref });
+    new cdk.CfnOutput(this, 'DashboardName', { value: dashboard.ref });
     new cdk.CfnOutput(this, 'RuleName', { value: rule.ruleName });
   }
 }

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-caches-template.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-caches-template.integtest.ts
@@ -1,7 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { integTest, withDefaultFixture } from '../../../lib';
-import { BEDROCK_AGENT_REGIONS } from '../../../lib/regions';
 
 jest.setTimeout(5 * 60 * 1000);
 
@@ -33,7 +32,7 @@ integTest(
     const cacheFile = path.join(fixture.integTestDir, 'cdk.out', '.hotswap-cache', `${fullStackName}.json`);
     expect(fs.existsSync(cacheFile)).toBe(true);
 
-    // THEN - second hotswap changes only the Agent (via DYNAMIC_CC_PROPERTY_VALUE_2).
+    // THEN - second hotswap changes only the Dashboard (via DYNAMIC_CC_PROPERTY_VALUE_2).
     // If the cache is used, the diff is against the cached template, only 1 resource should be hotswapped.
     const deployOutput = await fixture.cdkDeploy(stackName, {
       options: ['--hotswap'],
@@ -48,7 +47,7 @@ integTest(
     // should only see one hotswapped message in output
     const hotswapCount = (deployOutput.match(/hotswapped!/g) || []).length;
     expect(hotswapCount).toBe(1);
-  }, { aws: { regions: BEDROCK_AGENT_REGIONS } }),
+  }),
 );
 
 integTest(

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-cloudcontrol-based-resources.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/hotswap/cdk-hotswap-deployment-supports-cloudcontrol-based-resources.integtest.ts
@@ -1,6 +1,5 @@
 import { DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
 import { integTest, withDefaultFixture } from '../../../lib';
-import { BEDROCK_AGENT_REGIONS } from '../../../lib/regions';
 
 jest.setTimeout(2 * 60 * 60_000); // Includes the time to acquire locks, worst-case single-threaded runtime
 
@@ -33,7 +32,7 @@ integTest(
     );
 
     const queueUrl = response.Stacks?.[0].Outputs?.find((output) => output.OutputKey === 'QueueUrl')?.OutputValue;
-    const agentName = response.Stacks?.[0].Outputs?.find((output) => output.OutputKey === 'AgentName')?.OutputValue;
+    const dashboardName = response.Stacks?.[0].Outputs?.find((output) => output.OutputKey === 'DashboardName')?.OutputValue;
     const ruleName = response.Stacks?.[0].Outputs?.find((output) => output.OutputKey === 'RuleName')?.OutputValue;
 
     // THEN
@@ -45,7 +44,7 @@ integTest(
     expect(deployOutput).toMatch(/hotswapped!/);
     // Verify all three CCAPI-based resources were hotswapped
     expect(queueUrl).toBeDefined();
-    expect(agentName).toBeDefined();
+    expect(dashboardName).toBeDefined();
     expect(ruleName).toBeDefined();
-  }, { aws: { regions: BEDROCK_AGENT_REGIONS } }),
+  }),
 );


### PR DESCRIPTION
The two Cloud Control hotswap integration tests started failing everywhere on 2026-07-31. Amazon Bedrock Agents (now "Bedrock Agents Classic") entered maintenance mode on 2026-07-30: accounts without prior service usage in the last 12 months get an `AccessDeniedException` from `CreateAgent` with the message "Bedrock Agents is in Maintenance Mode. New agent creation is not available for accounts without prior service usage." (see https://docs.aws.amazon.com/bedrock/latest/userguide/agents-classic-maintenance-mode.html). Fresh or recycled Atmosphere environments never have that usage history, allowlisting is automatic, and there is no exception process — so `AWS::Bedrock::Agent` can never be created again in our test accounts.

The `AWS::Bedrock::Agent` in the `cc-hotswap` test app is therefore replaced with an `AWS::CloudWatch::Dashboard`, which is also routed through the Cloud Control hotswap path and keeps the coverage that mattered here: a CCAPI resource whose hotswapped property is built from a reference to another resource in the stack, so attribute resolution during hotswap is still exercised. The dashboard markdown carries the DynamoDB table name plus both dynamic values, mirroring what the agent instruction did, which keeps the "cache is used, only one resource is hotswapped" assertion meaningful.

With that gone, no test needs to be pinned to regions where Bedrock Agents is available, so the `BEDROCK_AGENT_REGIONS` list is removed and both tests now run in all Atmosphere regions. Hotswap support for `AWS::Bedrock::Agent` in `toolkit-lib` is deliberately left in place: existing customers with prior usage can still deploy those agents, they just cannot be created in new accounts.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
