### PR TITLE
fix(cli): REVERT hotswap fallback deployments use standard mode

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -359,7 +359,6 @@ export async function deployStack(options: DeployStackOptions, ioHelper: IoHelpe
       await ioHelper.defaults.info('Falling back to doing a full deployment');
       options.sdk.appendCustomUserAgent('cdk-hotswap/fallback');
       deploymentMethod = deploymentMethod.fallback;
-      options = { ...options, express: true };
     } else {
       return {
         type: 'did-deploy-stack',

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -1455,7 +1455,7 @@ describe('express mode', () => {
     });
   });
 
-  test('hotswap fallback enables express mode automatically', async () => {
+  test('hotswap fallback uses standard mode', async () => {
     // GIVEN - hotswap returns undefined (failure), triggering fallback
     (tryHotswapDeployment as jest.Mock).mockResolvedValue(undefined);
 
@@ -1465,16 +1465,16 @@ describe('express mode', () => {
       deploymentMethod: { method: 'hotswap', fallback: { method: 'change-set' } },
     });
 
-    // THEN - the fallback change-set deployment uses express mode
+    // THEN
     expect(mockCloudFormationClient).toHaveReceivedCommandWith(CreateChangeSetCommand, {
       ...expect.anything,
       DeploymentConfig: expect.objectContaining({
-        Mode: 'EXPRESS',
+        Mode: 'STANDARD',
       }),
     } as CreateChangeSetCommandInput);
   });
 
-  test('hotswap fallback with method=direct enables express mode automatically', async () => {
+  test('hotswap fallback with method=direct uses standard mode', async () => {
     // GIVEN - hotswap returns undefined (failure), triggering fallback
     (tryHotswapDeployment as jest.Mock).mockResolvedValue(undefined);
 
@@ -1484,11 +1484,11 @@ describe('express mode', () => {
       deploymentMethod: { method: 'hotswap', fallback: { method: 'direct' } },
     });
 
-    // THEN - the fallback direct deployment uses express mode
+    // THEN
     expect(mockCloudFormationClient).toHaveReceivedCommandWith(CreateStackCommand, {
       ...expect.anything,
       DeploymentConfig: expect.objectContaining({
-        Mode: 'EXPRESS',
+        Mode: 'STANDARD',
       }),
     } as CreateStackCommandInput);
   });


### PR DESCRIPTION
When express mode was released, hotswap fallback deployments were updated to use express mode. This change was technically breaking and should not have been made, hotswap fallback deployments are being reverted to using standard mode. 

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
