### PR TITLE
fix(cli): refactor fails on stacks with bundled assets

### DIFF
--- a/packages/aws-cdk/lib/cli/user-configuration.ts
+++ b/packages/aws-cdk/lib/cli/user-configuration.ts
@@ -55,6 +55,7 @@ const BUNDLING_COMMANDS = [
   Command.WATCH,
   Command.IMPORT,
   Command.PUBLISH_ASSETS,
+  Command.REFACTOR,
 ];
 
 export type Arguments = {

--- a/packages/aws-cdk/test/cli/configuration.test.ts
+++ b/packages/aws-cdk/test/cli/configuration.test.ts
@@ -108,6 +108,16 @@ test('bundling stacks defaults to ** for watch', async () => {
   expect(settings.get(['bundlingStacks'])).toEqual(['**']);
 });
 
+test('bundling stacks defaults to ** for refactor', async () => {
+  // GIVEN
+  const settings = await commandLineArgumentsToSettings(ioHelper, {
+    _: [Command.REFACTOR],
+  });
+
+  // THEN
+  expect(settings.get(['bundlingStacks'])).toEqual(['**']);
+});
+
 test('bundling stacks with deploy exclusively', async () => {
   // GIVEN
   const settings = await commandLineArgumentsToSettings(ioHelper, {


### PR DESCRIPTION
Fixes #1810

### Problem

`BUNDLING_COMMANDS` in `packages/aws-cdk/lib/cli/user-configuration.ts` is the explicit list of CLI commands that perform asset bundling during synthesis. `refactor` is not in it, so the synthesis performed by `cdk refactor` skips bundling for all stacks. For bundled assets like `NodejsFunction`, the asset hash (and therefore the `S3Key` in the synthesized template) is then computed from the source directory instead of the bundled output, so it differs from the deployed template. The refactor operation sees this as a property modification and CloudFormation rejects it:

```
❌  Refactor failed: Refactor creation: [CREATE_COMPLETE] Property changes detected during execution of refactor action <uuid> for refactor <uuid>
```

This happens even for a pure construct-tree move with no code changes. `import` was deliberately added to this list for the same reason (it also compares the synthesized template against the deployed one); `refactor` was added later and never included.

### Fix

Add `Command.REFACTOR` to `BUNDLING_COMMANDS`, so that the synthesis performed by `cdk refactor` bundles assets the same way `cdk deploy` does, and the synthesized template matches the deployed one when nothing but the construct tree changed.

### Testing

- New unit test in `test/cli/configuration.test.ts`: `bundlingStacks` defaults to `['**']` for the `refactor` command (same pattern as the existing `deploy`/`watch` tests).
- Verified against a real AWS environment, with a deployed stack containing a `NodejsFunction` moved into a new construct scope (no code changes):
  - CLI 2.1135.0 (released): the refactor execution fails with the error above (the stack rolls back and stays on the old logical IDs).
  - This branch: the same refactor succeeds end-to-end; the finalizing deployment reports no changes and the resources are on their new logical IDs afterwards:

```
Refactoring...
✅  Stack refactor complete
Deploying updated stacks to finalize refactor...
...
✅  RefactorBundlingRepro (no changes)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
