### PR TITLE
fix(toolkit-lib): refactor digest ignores the properties of resources that have a DependsOn attribute

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/refactoring/digest.ts
@@ -95,7 +95,10 @@ export function hashObject(obj: any): string {
 
 /**
  * Removes sub-properties containing Ref or Fn::GetAtt to avoid hashing
- * references themselves but keeps the property structure.
+ * references themselves but keeps the property structure. `DependsOn`
+ * keys are also excluded from hashing: they only contain logical IDs of
+ * dependencies, which are rename-sensitive and already accounted for via
+ * the digests of the dependencies themselves.
  */
 function stripReferences(value: any, exports: { [p: string]: { stackName: string; value: any } }): any {
   if (!value || typeof value !== 'object') return value;
@@ -107,9 +110,6 @@ function stripReferences(value: any, exports: { [p: string]: { stackName: string
   }
   if ('Fn::GetAtt' in value) {
     return { __cloud_ref__: 'Fn::GetAtt' };
-  }
-  if ('DependsOn' in value) {
-    return { __cloud_ref__: 'DependsOn' };
   }
   if ('Fn::ImportValue' in value) {
     const exp = exports[value['Fn::ImportValue']];
@@ -130,6 +130,9 @@ function stripReferences(value: any, exports: { [p: string]: { stackName: string
   }
   const result: any = {};
   for (const [k, v] of Object.entries(value)) {
+    if (k === 'DependsOn') {
+      continue;
+    }
     result[k] = stripReferences(v, exports);
   }
   return result;

--- a/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/refactoring/refactoring.test.ts
@@ -259,6 +259,63 @@ describe(computeResourceDigests, () => {
     expect(result['Stack1.Topic1']).not.toEqual(result['Stack1.Topic2']);
   });
 
+  test('different resources - DependsOn with different properties', () => {
+    const template = {
+      Resources: {
+        Bucket1: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { Prop: 'my-bucket' },
+        },
+        // These topics have the same dependency, but different properties.
+        // Therefore, they should have different digests.
+        Topic1: {
+          Type: 'AWS::SNS::Topic',
+          DependsOn: 'Bucket1',
+          Properties: {
+            DisplayName: 'topic-one',
+          },
+        },
+        Topic2: {
+          Type: 'AWS::SNS::Topic',
+          DependsOn: 'Bucket1',
+          Properties: {
+            DisplayName: 'topic-two',
+          },
+        },
+      },
+    };
+    const result = computeResourceDigests(makeStacks([template]));
+    expect(result['Stack1.Topic1']).not.toEqual(result['Stack1.Topic2']);
+  });
+
+  test('different resources - DependsOn with different deletion policies', () => {
+    const template = {
+      Resources: {
+        Bucket1: {
+          Type: 'AWS::S3::Bucket',
+          Properties: { Prop: 'my-bucket' },
+        },
+        // These queues have the same dependency and the same properties,
+        // but different deletion policies. Therefore, they should have
+        // different digests.
+        Q1: {
+          Type: 'AWS::SQS::Queue',
+          DependsOn: 'Bucket1',
+          Properties: { QueueName: 'my-queue' },
+          DeletionPolicy: 'Retain',
+        },
+        Q2: {
+          Type: 'AWS::SQS::Queue',
+          DependsOn: 'Bucket1',
+          Properties: { QueueName: 'my-queue' },
+          DeletionPolicy: 'Delete',
+        },
+      },
+    };
+    const result = computeResourceDigests(makeStacks([template]));
+    expect(result['Stack1.Q1']).not.toEqual(result['Stack1.Q2']);
+  });
+
   test('almost identical resources - dependency via different intrinsic functions', () => {
     const template = {
       Resources: {


### PR DESCRIPTION
Fixes #1811

### Problem

`cdk refactor` detects moved resources by computing a digest for each resource: `hash(type + properties + digests of dependencies)`. Before hashing, `stripReferences` replaces references (`Ref`, `Fn::GetAtt`, `Fn::ImportValue`) with fixed markers so that digests remain stable when dependencies are renamed. It treats `DependsOn` the same way:

```ts
if ('DependsOn' in value) {
  return { __cloud_ref__: 'DependsOn' };
}
```

But `stripReferences` is applied to the entire resource object (`{ Type, Properties, DependsOn, ... }`), so any resource with a top-level `DependsOn` attribute has its whole body replaced by the marker: its `Properties`, `DeletionPolicy`, etc. contribute nothing to the digest. This causes:

- **Spurious ambiguities:** two resources of the same type with the same dependencies but different properties get the same digest and are reported as ambiguous (or can be paired as a move) even though their properties distinguish them unambiguously.
- **Dry-run passes, execution fails:** a moved resource whose properties also changed (e.g. the auto-created security group of an `ecs.FargateService`, whose `GroupDescription` is derived from the construct path and which CDK attaches `DependsOn` to) passes `--dry-run` as a pure move, and then the execution is rejected by CloudFormation: `[CREATE_FAILED] Resource ... does not match the destination resource's properties.`

### Fix

Instead of replacing the whole object with a marker, `stripReferences` now skips the `DependsOn` key and hashes the remaining keys. This keeps digests rename-stable: `DependsOn` only contains logical IDs of dependencies, which are rename-sensitive, and the dependencies themselves already contribute to the digest through the dependency digests (`ResourceGraph` includes `DependsOn` edges).

Note on behavior: resources that were previously matched purely on `type + dependencies` are now matched only if their properties (and other attributes) are also equal. This changes refactor detection results only in cases that were previously wrong: either a mismatch that CloudFormation would reject at execution time, or an incorrect pairing.

### Testing

New unit tests in `test/api/refactoring/refactoring.test.ts`:

- Same type, same `DependsOn`, different properties → different digests (previously equal; this is the false positive).
- Same type, same `DependsOn`, same properties, different `DeletionPolicy` → different digests (shows the entire resource body was being masked, not just `Properties`).

The existing `DependsOn` digest tests (identical resources up to dependency names; different resources via different dependencies) pass unchanged, confirming rename stability is preserved.

Verified against a real AWS environment, using SNS topics with `DependsOn` on a bucket, moved into a new construct scope:

- CLI 2.1135.0 (released): two topics with different `DisplayName`s are reported as ambiguous; with a single topic whose `DisplayName` changes together with the move, the dry-run reports a clean move and the execution fails with `[CREATE_FAILED] Resource TopicA... does not match the destination resource's properties.`
- This branch: the property-changed topic is correctly classified as a removal plus an addition at dry-run time (with the existing clear error "A refactor operation cannot add, remove or update resources"), the spurious ambiguity is gone, and a pure move (no property changes) of both topics is still detected and executed successfully end-to-end:

```
Refactoring...
✅  Stack refactor complete
Deploying updated stacks to finalize refactor...
...
✅  RefactorDigestRepro (no changes)
```

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
