### PR TITLE
docs(toolkit-lib): fix resource import mapping docs to say keys are logical IDs

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -77,15 +77,15 @@ export type ResourceIdentifiers = { [resourceType: string]: string[][] };
 type ResourceIdentifierProperties = Record<string, string>;
 
 /**
- * Mapping of CDK resources (L1 constructs) to physical resources to be imported
- * in their place, example:
+ * Mapping of CDK resources (by their CloudFormation logical ID) to physical
+ * resources to be imported in their place, example:
  *
  * ```
  * {
- *   "MyStack/MyS3Bucket/Resource": {
+ *   "MyS3Bucket1A2B3C4D": {
  *     "BucketName": "my-manually-created-s3-bucket"
  *   },
- *   "MyStack/MyVpc/Resource": {
+ *   "MyVpc5E6F7G8H": {
  *     "VpcId": "vpc-123456789"
  *   }
  * }
@@ -192,7 +192,7 @@ export class ResourceImporter {
    * Based on the provided resource mapping, prepare CFN structures for import (template,
    * ResourcesToImport structure) and perform the import operation (CloudFormation deployment)
    *
-   * @param importMap - Mapping from CDK construct tree path to physical resource import identifiers
+   * @param importMap - Mapping from CloudFormation logical ID to physical resource import identifiers
    * @param options - Options to pass to CloudFormation deploy operation
    */
   public async importResourcesFromMap(importMap: ImportMap, options: ImportDeploymentOptions = {}) {


### PR DESCRIPTION
### Problem

Two doc comments in `packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts` describe the resource mapping keys as CDK construct tree paths:

- `importResourcesFromMap`: `@param importMap - Mapping from CDK construct tree path to physical resource import identifiers`
- The `ResourceMap` type doc, whose example uses construct-path keys such as `"MyStack/MyS3Bucket/Resource"`

The implementation matches the mapping keys against CloudFormation **logical IDs** (`resource.logicalId` in `askForResourceIdentifiers`, `loadResourceIdentifiers` and `makeResourcesToImport`; the type is also declared as `{ [logicalResource: string]: ... }`, and `ImportMap.resourceMap` is documented as "Mapping logical IDs to physical names"). Following the doc comment and using construct paths as keys in `--resource-mapping` / `--resource-mapping-inline` results in `Unrecognized resource identifiers` and zero resources imported. The confusion is compounded by the interactive display (`describeResource`), which shows construct paths.

### Fix

Correct both doc comments to say the keys are CloudFormation logical IDs, and use logical-ID keys in the `ResourceMap` example.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
