### PR TITLE
fix(toolkit-lib): every change-set deployment announces "waiting in review for manual execution (--no-execute)" although the change set is executed

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -132,17 +132,17 @@ export interface DeployStackOptions {
   readonly deploymentMethod?: DeploymentMethod;
 
   /**
-   * Whether to announce a change set that is created but deliberately not
-   * executed (change-set method with `execute: false`) as waiting for manual
+   * Whether the caller will execute the change set created by this deployment
+   * afterwards (the internal first phase of a two-phase deploy).
+   *
+   * When a change set is created without being executed (change-set method
+   * with `execute: false`) and this is false, the change set is the user's
+   * final artifact (`--no-execute`) and is announced as waiting for manual
    * execution.
    *
-   * Set to false when the change set is the internal first phase of an
-   * executing deployment (two-phase deploy), where the announcement would be
-   * misleading: the change set is about to be executed.
-   *
-   * @default true
+   * @default false
    */
-  readonly announceNoExecuteChangeSet?: boolean;
+  readonly willExecuteChangeSet?: boolean;
 
   /**
    * The collection of extra parameters
@@ -497,7 +497,7 @@ class FullCloudFormationDeployment {
     }
 
     if (!execute) {
-      if (this.options.announceNoExecuteChangeSet ?? true) {
+      if (!this.options.willExecuteChangeSet) {
         await this.ioHelper.defaults.info(format(
           'Changeset %s created and waiting in review for manual execution (--no-execute)',
           changeSetDescription.ChangeSetId,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -484,10 +484,6 @@ class FullCloudFormationDeployment {
     }
 
     if (!execute) {
-      await this.ioHelper.defaults.info(format(
-        'Changeset %s created and waiting in review for manual execution (--no-execute)',
-        changeSetDescription.ChangeSetId,
-      ));
       return {
         type: 'did-deploy-stack',
         noOp: false,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -132,6 +132,19 @@ export interface DeployStackOptions {
   readonly deploymentMethod?: DeploymentMethod;
 
   /**
+   * Whether to announce a change set that is created but deliberately not
+   * executed (change-set method with `execute: false`) as waiting for manual
+   * execution.
+   *
+   * Set to false when the change set is the internal first phase of an
+   * executing deployment (two-phase deploy), where the announcement would be
+   * misleading: the change set is about to be executed.
+   *
+   * @default true
+   */
+  readonly announceNoExecuteChangeSet?: boolean;
+
+  /**
    * The collection of extra parameters
    * (in addition to those used for assets)
    * to pass to the deployed template.
@@ -484,6 +497,12 @@ class FullCloudFormationDeployment {
     }
 
     if (!execute) {
+      if (this.options.announceNoExecuteChangeSet ?? true) {
+        await this.ioHelper.defaults.info(format(
+          'Changeset %s created and waiting in review for manual execution (--no-execute)',
+          changeSetDescription.ChangeSetId,
+        ));
+      }
       return {
         type: 'did-deploy-stack',
         noOp: false,

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from 'node:crypto';
-import { format } from 'node:util';
 import * as cdk_assets from '@aws-cdk/cdk-assets-lib';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import chalk from 'chalk';
@@ -97,6 +96,19 @@ export interface DeployStackOptions {
    * @default - Change set with default options
    */
   readonly deploymentMethod?: DeploymentMethod;
+
+  /**
+   * Whether to announce a change set that is created but deliberately not
+   * executed (change-set method with `execute: false`) as waiting for manual
+   * execution.
+   *
+   * Set to false when the change set is the internal first phase of an
+   * executing deployment (two-phase deploy), where the announcement would be
+   * misleading: the change set is about to be executed.
+   *
+   * @default true
+   */
+  readonly announceNoExecuteChangeSet?: boolean;
 
   /**
    * Force deployment, even if the deployed template is identical to the one we are about to deploy.
@@ -417,6 +429,7 @@ export class Deployments {
       envResources: env.resources,
       tags: options.tags,
       deploymentMethod: options.deploymentMethod,
+      announceNoExecuteChangeSet: options.announceNoExecuteChangeSet,
       forceDeployment: options.forceDeployment,
       parameters: options.parameters,
       usePreviousParameters: options.usePreviousParameters,
@@ -450,6 +463,12 @@ export class Deployments {
     const result = await this.deployStack({
       ...options,
       deploymentMethod: { ...options.deploymentMethod, execute: false },
+      // Announce the created change set only when the user explicitly asked
+      // for --no-execute (the change set is the final result). When this
+      // prepare is the internal first phase of an executing deployment
+      // (cleanupOnNoOp), the change set is about to be executed and the
+      // announcement would be misleading.
+      announceNoExecuteChangeSet: !options.cleanupOnNoOp,
     });
 
     // With execute: false, the only possible result type is did-deploy-stack
@@ -464,14 +483,6 @@ export class Deployments {
     if (result.noOp && options.cleanupOnNoOp) {
       const changeSetName = options.deploymentMethod.changeSetName ?? DEFAULT_DEPLOY_CHANGE_SET_NAME;
       await this.cleanupChangeSet(options.stack, changeSetName, options.stackEventPollingInterval);
-    }
-
-    // Announce the created change set only when the user explicitly asked for
-    // --no-execute (the change set is the final result). When the caller forced
-    // execute: false internally (two-phase deploy), the change set is about to
-    // be executed and the announcement would be misleading.
-    if (!result.noOp && !options.cleanupOnNoOp) {
-      await announceChangeSetAwaitingExecution(this.ioHelper, result.changeSet?.ChangeSetId);
     }
 
     return result;
@@ -819,15 +830,4 @@ class ParallelSafeAssetProgress extends BasePublishProgressListener {
 
 function suffixWithErrors(msg: string, errors?: string[]) {
   return errors && errors.length > 0 ? `${msg}: ${errors.join(', ')}` : msg;
-}
-
-/**
- * Announce a change set that was deliberately created without being executed
- * (--no-execute) and is now waiting for manual execution.
- */
-export async function announceChangeSetAwaitingExecution(ioHelper: IoHelper, changeSetId: string | undefined): Promise<void> {
-  await ioHelper.defaults.info(format(
-    'Changeset %s created and waiting in review for manual execution (--no-execute)',
-    changeSetId,
-  ));
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { format } from 'node:util';
 import * as cdk_assets from '@aws-cdk/cdk-assets-lib';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
 import chalk from 'chalk';
@@ -465,6 +466,14 @@ export class Deployments {
       await this.cleanupChangeSet(options.stack, changeSetName, options.stackEventPollingInterval);
     }
 
+    // Announce the created change set only when the user explicitly asked for
+    // --no-execute (the change set is the final result). When the caller forced
+    // execute: false internally (two-phase deploy), the change set is about to
+    // be executed and the announcement would be misleading.
+    if (!result.noOp && !options.cleanupOnNoOp) {
+      await announceChangeSetAwaitingExecution(this.ioHelper, result.changeSet?.ChangeSetId);
+    }
+
     return result;
   }
 
@@ -810,4 +819,15 @@ class ParallelSafeAssetProgress extends BasePublishProgressListener {
 
 function suffixWithErrors(msg: string, errors?: string[]) {
   return errors && errors.length > 0 ? `${msg}: ${errors.join(', ')}` : msg;
+}
+
+/**
+ * Announce a change set that was deliberately created without being executed
+ * (--no-execute) and is now waiting for manual execution.
+ */
+export async function announceChangeSetAwaitingExecution(ioHelper: IoHelper, changeSetId: string | undefined): Promise<void> {
+  await ioHelper.defaults.info(format(
+    'Changeset %s created and waiting in review for manual execution (--no-execute)',
+    changeSetId,
+  ));
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -98,17 +98,20 @@ export interface DeployStackOptions {
   readonly deploymentMethod?: DeploymentMethod;
 
   /**
-   * Whether to announce a change set that is created but deliberately not
-   * executed (change-set method with `execute: false`) as waiting for manual
-   * execution.
+   * Whether the caller will execute the change set created by this deployment
+   * afterwards (the internal first phase of a two-phase deploy).
    *
-   * Set to false when the change set is the internal first phase of an
-   * executing deployment (two-phase deploy), where the announcement would be
-   * misleading: the change set is about to be executed.
+   * Only relevant when the change set is created without being executed
+   * (change-set method with `execute: false`):
+   * - `false`: the change set is the user's final artifact (`--no-execute`);
+   *   it is announced as waiting for manual execution, and `prepareStack()`
+   *   keeps it even if it contains no changes.
+   * - `true`: the change set is about to be executed by the caller; it is not
+   *   announced, and `prepareStack()` cleans it up if it contains no changes.
    *
-   * @default true
+   * @default false
    */
-  readonly announceNoExecuteChangeSet?: boolean;
+  readonly willExecuteChangeSet?: boolean;
 
   /**
    * Force deployment, even if the deployed template is identical to the one we are about to deploy.
@@ -182,17 +185,6 @@ export interface PrepareStackOptions extends Omit<DeployStackOptions, 'deploymen
    * The change-set deployment method to use.
    */
   readonly deploymentMethod: ChangeSetDeployment;
-
-  /**
-   * Whether to clean up the change set if it has no changes.
-   *
-   * Set to true when the caller forced execute: false internally
-   * (two-phase deploy). Set to false when the user explicitly
-   * asked for --no-execute (prepare-change-set).
-   *
-   * @default false
-   */
-  readonly cleanupOnNoOp?: boolean;
 }
 
 export interface RollbackStackOptions {
@@ -429,7 +421,7 @@ export class Deployments {
       envResources: env.resources,
       tags: options.tags,
       deploymentMethod: options.deploymentMethod,
-      announceNoExecuteChangeSet: options.announceNoExecuteChangeSet,
+      willExecuteChangeSet: options.willExecuteChangeSet,
       forceDeployment: options.forceDeployment,
       parameters: options.parameters,
       usePreviousParameters: options.usePreviousParameters,
@@ -463,12 +455,6 @@ export class Deployments {
     const result = await this.deployStack({
       ...options,
       deploymentMethod: { ...options.deploymentMethod, execute: false },
-      // Announce the created change set only when the user explicitly asked
-      // for --no-execute (the change set is the final result). When this
-      // prepare is the internal first phase of an executing deployment
-      // (cleanupOnNoOp), the change set is about to be executed and the
-      // announcement would be misleading.
-      announceNoExecuteChangeSet: !options.cleanupOnNoOp,
     });
 
     // With execute: false, the only possible result type is did-deploy-stack
@@ -478,9 +464,10 @@ export class Deployments {
       return undefined;
     }
 
-    // Clean up empty change sets if requested (i.e. when the caller forced
-    // execute: false internally, not when the user explicitly asked for --no-execute).
-    if (result.noOp && options.cleanupOnNoOp) {
+    // Clean up empty change sets that are about to be superseded by the
+    // executing second phase. A user-requested --no-execute keeps its change
+    // set even when empty: the change set is the user's final artifact.
+    if (result.noOp && options.willExecuteChangeSet) {
       const changeSetName = options.deploymentMethod.changeSetName ?? DEFAULT_DEPLOY_CHANGE_SET_NAME;
       await this.cleanupChangeSet(options.stack, changeSetName, options.stackEventPollingInterval);
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra';
 import type { DeploymentMethod } from '../../actions/deploy';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { Deployments } from '../deployments';
-import { announceChangeSetAwaitingExecution, assertIsSuccessfulDeployStackResult } from '../deployments';
+import { assertIsSuccessfulDeployStackResult } from '../deployments';
 import { DiffFormatter } from '../diff';
 import { IO, type IoHelper } from '../io/private';
 import type { Tag } from '../tags';
@@ -227,13 +227,6 @@ export class ResourceImporter {
       });
 
       assertIsSuccessfulDeployStackResult(result);
-
-      // With --no-execute, the change set is created but purposely not executed,
-      // so announce it as awaiting manual execution.
-      const method = options.deploymentMethod;
-      if (method?.method === 'change-set' && method.execute === false && result.changeSet) {
-        await announceChangeSetAwaitingExecution(this.ioHelper, result.changeSet.ChangeSetId);
-      }
 
       const message = result.noOp
         ? '✅  %s (no changes)'

--- a/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/resource-import/importer.ts
@@ -8,7 +8,7 @@ import * as fs from 'fs-extra';
 import type { DeploymentMethod } from '../../actions/deploy';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { Deployments } from '../deployments';
-import { assertIsSuccessfulDeployStackResult } from '../deployments';
+import { announceChangeSetAwaitingExecution, assertIsSuccessfulDeployStackResult } from '../deployments';
 import { DiffFormatter } from '../diff';
 import { IO, type IoHelper } from '../io/private';
 import type { Tag } from '../tags';
@@ -227,6 +227,13 @@ export class ResourceImporter {
       });
 
       assertIsSuccessfulDeployStackResult(result);
+
+      // With --no-execute, the change set is created but purposely not executed,
+      // so announce it as awaiting manual execution.
+      const method = options.deploymentMethod;
+      if (method?.method === 'change-set' && method.execute === false && result.changeSet) {
+        await announceChangeSetAwaitingExecution(this.ioHelper, result.changeSet.ChangeSetId);
+      }
 
       const message = result.noOp
         ? '✅  %s (no changes)'

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -911,7 +911,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
         ? await deployments.prepareStack({
           ...sharedDeployOptions,
           deploymentMethod: options.deploymentMethod,
-          cleanupOnNoOp: isExecutingChangeSetDeployment(options.deploymentMethod),
+          willExecuteChangeSet: isExecutingChangeSetDeployment(options.deploymentMethod),
         })
         : undefined;
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -123,6 +123,56 @@ test('prepareStack calls deployStack with execute: false and returns successful 
   }));
 });
 
+test('prepareStack announces the change set when the user asked for --no-execute', async () => {
+  // GIVEN
+  (deployStack as jest.Mock).mockResolvedValue({
+    type: 'did-deploy-stack',
+    noOp: false,
+    deleteFailures: [],
+    stabilizingResources: [],
+    outputs: {},
+    stackArn: 'arn:stack',
+    changeSet: { ChangeSetId: 'arn:change-set', Status: 'CREATE_COMPLETE' },
+  });
+
+  // WHEN — no cleanupOnNoOp means the change set is the final result (--no-execute)
+  await deployments.prepareStack({
+    stack: testStack({ stackName: 'boop' }),
+    deploymentMethod: { method: 'change-set', execute: false },
+  });
+
+  // THEN
+  expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
+  }));
+});
+
+test('prepareStack does not announce the change set for the internal prepare of an executing deployment', async () => {
+  // GIVEN
+  (deployStack as jest.Mock).mockResolvedValue({
+    type: 'did-deploy-stack',
+    noOp: false,
+    deleteFailures: [],
+    stabilizingResources: [],
+    outputs: {},
+    stackArn: 'arn:stack',
+    changeSet: { ChangeSetId: 'arn:change-set', Status: 'CREATE_COMPLETE' },
+  });
+
+  // WHEN — cleanupOnNoOp marks this prepare as the internal first phase of
+  // a two-phase (create + execute) deployment
+  await deployments.prepareStack({
+    stack: testStack({ stackName: 'boop' }),
+    deploymentMethod: { method: 'change-set' },
+    cleanupOnNoOp: true,
+  });
+
+  // THEN
+  expect(ioHost.notifySpy).not.toHaveBeenCalledWith(expect.objectContaining({
+    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
+  }));
+});
+
 test('prepareStack returns undefined for non-success results', async () => {
   // GIVEN
   (deployStack as jest.Mock).mockResolvedValue({

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -123,7 +123,7 @@ test('prepareStack calls deployStack with execute: false and returns successful 
   }));
 });
 
-test('prepareStack lets deployStack announce the change set when the user asked for --no-execute', async () => {
+test('prepareStack passes willExecuteChangeSet through to deployStack', async () => {
   // GIVEN
   (deployStack as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack',
@@ -135,22 +135,25 @@ test('prepareStack lets deployStack announce the change set when the user asked 
     changeSet: { ChangeSetId: 'arn:change-set', Status: 'CREATE_COMPLETE' },
   });
 
-  // WHEN — no cleanupOnNoOp means the change set is the final result (--no-execute)
+  // WHEN — willExecuteChangeSet marks this prepare as the internal first
+  // phase of a two-phase (create + execute) deployment
   await deployments.prepareStack({
     stack: testStack({ stackName: 'boop' }),
-    deploymentMethod: { method: 'change-set', execute: false },
+    deploymentMethod: { method: 'change-set' },
+    willExecuteChangeSet: true,
   });
 
-  // THEN
+  // THEN — deployStack suppresses the "waiting in review for manual
+  // execution (--no-execute)" announcement based on this flag
   expect(deployStack).toHaveBeenCalledWith(
     expect.objectContaining({
-      announceNoExecuteChangeSet: true,
+      willExecuteChangeSet: true,
     }),
     expect.anything(),
   );
 });
 
-test('prepareStack suppresses the change set announcement for the internal prepare of an executing deployment', async () => {
+test('prepareStack leaves willExecuteChangeSet unset for a user-requested --no-execute prepare', async () => {
   // GIVEN
   (deployStack as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack',
@@ -162,21 +165,14 @@ test('prepareStack suppresses the change set announcement for the internal prepa
     changeSet: { ChangeSetId: 'arn:change-set', Status: 'CREATE_COMPLETE' },
   });
 
-  // WHEN — cleanupOnNoOp marks this prepare as the internal first phase of
-  // a two-phase (create + execute) deployment
+  // WHEN — no willExecuteChangeSet means the change set is the final result (--no-execute)
   await deployments.prepareStack({
     stack: testStack({ stackName: 'boop' }),
-    deploymentMethod: { method: 'change-set' },
-    cleanupOnNoOp: true,
+    deploymentMethod: { method: 'change-set', execute: false },
   });
 
-  // THEN
-  expect(deployStack).toHaveBeenCalledWith(
-    expect.objectContaining({
-      announceNoExecuteChangeSet: false,
-    }),
-    expect.anything(),
-  );
+  // THEN — deployStack announces the change set as awaiting manual execution
+  expect((deployStack as jest.Mock).mock.calls[0][0].willExecuteChangeSet).toBeUndefined();
 });
 
 test('prepareStack returns undefined for non-success results', async () => {
@@ -215,7 +211,7 @@ test('prepareStack forwards stackEventPollingInterval to cleanupChangeSet as the
   await deployments.prepareStack({
     stack: testStack({ stackName: 'boop' }),
     deploymentMethod: { method: 'change-set' },
-    cleanupOnNoOp: true,
+    willExecuteChangeSet: true,
     stackEventPollingInterval: 10_000,
   });
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -123,7 +123,7 @@ test('prepareStack calls deployStack with execute: false and returns successful 
   }));
 });
 
-test('prepareStack announces the change set when the user asked for --no-execute', async () => {
+test('prepareStack lets deployStack announce the change set when the user asked for --no-execute', async () => {
   // GIVEN
   (deployStack as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack',
@@ -142,12 +142,15 @@ test('prepareStack announces the change set when the user asked for --no-execute
   });
 
   // THEN
-  expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
-    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
-  }));
+  expect(deployStack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      announceNoExecuteChangeSet: true,
+    }),
+    expect.anything(),
+  );
 });
 
-test('prepareStack does not announce the change set for the internal prepare of an executing deployment', async () => {
+test('prepareStack suppresses the change set announcement for the internal prepare of an executing deployment', async () => {
   // GIVEN
   (deployStack as jest.Mock).mockResolvedValue({
     type: 'did-deploy-stack',
@@ -168,9 +171,12 @@ test('prepareStack does not announce the change set for the internal prepare of 
   });
 
   // THEN
-  expect(ioHost.notifySpy).not.toHaveBeenCalledWith(expect.objectContaining({
-    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
-  }));
+  expect(deployStack).toHaveBeenCalledWith(
+    expect.objectContaining({
+      announceNoExecuteChangeSet: false,
+    }),
+    expect.anything(),
+  );
 });
 
 test('prepareStack returns undefined for non-success results', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -993,6 +993,35 @@ test('not executed and no error if --no-execute is given', async () => {
   expect(mockCloudFormationClient).not.toHaveReceivedCommand(ExecuteChangeSetCommand);
 });
 
+test('announces the change set as awaiting manual execution if --no-execute is given', async () => {
+  // WHEN
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'change-set', execute: false },
+  });
+
+  // THEN
+  expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
+  }));
+});
+
+test('does not announce the change set if the announcement is suppressed', async () => {
+  // WHEN — announceNoExecuteChangeSet: false marks this change set as the
+  // internal first phase of an executing deployment
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'change-set', execute: false },
+    announceNoExecuteChangeSet: false,
+  });
+
+  // THEN
+  expect(mockCloudFormationClient).not.toHaveReceivedCommand(ExecuteChangeSetCommand);
+  expect(ioHost.notifySpy).not.toHaveBeenCalledWith(expect.objectContaining({
+    message: expect.stringContaining('waiting in review for manual execution (--no-execute)'),
+  }));
+});
+
 test('empty change set is deleted if --execute is given', async () => {
   givenNoUpdatesAreToBePerformed();
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -1006,13 +1006,13 @@ test('announces the change set as awaiting manual execution if --no-execute is g
   }));
 });
 
-test('does not announce the change set if the announcement is suppressed', async () => {
-  // WHEN — announceNoExecuteChangeSet: false marks this change set as the
-  // internal first phase of an executing deployment
+test('does not announce the change set if the caller will execute it afterwards', async () => {
+  // WHEN — willExecuteChangeSet marks this change set as the internal first
+  // phase of an executing deployment
   await testDeployStack({
     ...standardDeployStackArguments(),
     deploymentMethod: { method: 'change-set', execute: false },
-    announceNoExecuteChangeSet: false,
+    willExecuteChangeSet: true,
   });
 
   // THEN

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -2369,7 +2369,7 @@ class WorkGraphDeploymentActions implements WorkGraphActions {
       ? await this.deployments.prepareStack({
         ...sharedDeployOptions,
         deploymentMethod: this.options.deploymentMethod,
-        cleanupOnNoOp: isExecutingChangeSetDeployment(this.options.deploymentMethod),
+        willExecuteChangeSet: isExecutingChangeSetDeployment(this.options.deploymentMethod),
       })
       : undefined;
 


### PR DESCRIPTION
Fixes #1815

### Problem

Since #1273, the deploy action always creates the change set upfront (to get an accurate diff for the approval prompt) by calling `Deployments.prepareStack()`, which internally forces `execute: false`, and then executes the prepared change set in a second phase. `deploy-stack.ts` prints

```
Changeset ... created and waiting in review for manual execution (--no-execute)
```

whenever `execute` is `false`, so every change-set deployment with actual changes now prints this message and then executes the change set anyway. The message is misleading: `--no-execute` was never requested, and the change set does not wait for anything. This also surfaces in flows that deploy internally, e.g. the finalizing deployment after `cdk import`.

### Fix

`deploy-stack.ts` cannot know whether `execute: false` is user-requested or the internal first phase of an executing deployment, so the caller now tells it, via a single intent-revealing option: `willExecuteChangeSet` (default `false`: the change set is the user's final artifact). Both behaviors that depend on this intent are derived from the one flag:

- `deploy-stack.ts` announces a created-but-not-executed change set as waiting for manual execution only when `willExecuteChangeSet` is not set (this is the fix);
- `Deployments.prepareStack()` cleans up an empty change set only when `willExecuteChangeSet` is set (this replaces the former `cleanupOnNoOp` option, which encoded the same fact under a behavior-specific name).

The deploy flows (the toolkit deploy action and the CLI's deploy flow, which share `prepareStack`) pass `willExecuteChangeSet: isExecutingChangeSetDeployment(deploymentMethod)`; `prepareStack` passes the flag through to `deployStack` unchanged. The default preserves today's behavior for every other caller, including `cdk import --no-execute`, which keeps its announcement without any change to the importer.

The option lives on the internal `DeployStackOptions` interfaces (`api/deployments` is not part of the toolkit-lib public API), so there is no public API change.

### Alternative considered

An alternative implementation was initially committed (e2c6083): removing the announcement from `deploy-stack.ts` entirely and emitting it from the callers that know the user's intent (`prepareStack` and the resource importer). Its appeal is that it structurally removes `deploy-stack`'s ability to assert a user intent it cannot know.

It was replaced with the current approach because:

- the announcement stays at a single emission site, at the moment the change set is created;
- the importer is left untouched (`cdk import --no-execute` keeps its announcement via the default, instead of re-implementing it);
- the default preserves today's behavior for every caller of `deployStack` with `execute: false`.

Both directions are kept in the branch history.

### Testing

- New unit tests in `test/api/deployments/deploy-stack.test.ts`: with `execute: false`, the change set is announced as awaiting manual execution by default, and not announced with `willExecuteChangeSet: true`.
- New unit tests in `test/api/deployments/cloudformation-deployments.test.ts`: `prepareStack` passes `willExecuteChangeSet` through to `deployStack` unchanged (set for the internal prepare of an executing deployment, unset for a user-requested `--no-execute` prepare).
- Verified against a real AWS environment:
  - CLI 2.1135.0 (released): a plain `cdk deploy` with changes prints the misleading message and then executes the change set.
  - This branch: the same deploys (both a stack creation and an update with changes) print no such message and execute normally; `cdk deploy --method=prepare-change-set` still prints the message and leaves the change set unexecuted (stack `UPDATE_COMPLETE` and unchanged, change set `CREATE_COMPLETE`/`AVAILABLE`).

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
