### PR TITLE
fix(cli): deployments skipped even though changes exist when previous deployment was with hotswap

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -40,7 +40,7 @@ import { changeSetHasNoChanges } from '../diagnosing/stack-diagnoser';
 import type { EnvironmentResources, StringWithoutPlaceholders } from '../environment';
 import { HotswapPropertyOverrides, ICON, createHotswapPropertyOverrides } from '../hotswap/common';
 import { tryHotswapDeployment } from '../hotswap/hotswap-deployments';
-import { invalidateHotswapTemplateCache } from '../hotswap/hotswap-template-cache';
+import { invalidateHotswapTemplateCache, readHotswapTemplateCache } from '../hotswap/hotswap-template-cache';
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
@@ -926,6 +926,18 @@ async function canSkipDeploy(
   if (cloudFormationStack.stackStatus.isFailure) {
     await ioHelper.defaults.debug(`${deployName}: stack is in a failure state`);
     return false;
+  }
+
+  if (deployStackOptions.deploymentMethod?.method === 'hotswap') {
+    const hotswapCache = await readHotswapTemplateCache(
+      deployStackOptions.stack.assembly.directory,
+      deployStackOptions.stack.stackName,
+      deployStackOptions.stack.template,
+    );
+    if (hotswapCache && JSON.stringify(deployStackOptions.stack.template) !== JSON.stringify(hotswapCache.deployedRootTemplate)) {
+      await ioHelper.defaults.debug(`${deployName}: template has changed in relation to last successful hotswap deployment`);
+      return false;
+    }
   }
 
   // We can skip deploy

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { format } from 'node:util';
 import type * as cxapi from '@aws-cdk/cloud-assembly-api';
+import { diffTemplate } from '@aws-cdk/cloudformation-diff';
 import type {
   CreateChangeSetCommandInput,
   CreateStackCommandInput,
@@ -44,7 +45,6 @@ import { invalidateHotswapTemplateCache, readHotswapTemplateCache } from '../hot
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
-import { diffTemplate } from '@aws-cdk/cloudformation-diff';
 
 export interface DeployStackOptions {
   /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -44,6 +44,7 @@ import { invalidateHotswapTemplateCache, readHotswapTemplateCache } from '../hot
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
+import { diffTemplate } from '@aws-cdk/cloudformation-diff';
 
 export interface DeployStackOptions {
   /**
@@ -934,7 +935,7 @@ async function canSkipDeploy(
       deployStackOptions.stack.stackName,
       deployStackOptions.stack.template,
     );
-    if (hotswapCache && JSON.stringify(deployStackOptions.stack.template) !== JSON.stringify(hotswapCache.deployedRootTemplate)) {
+    if (hotswapCache && diffTemplate(hotswapCache.deployedRootTemplate, deployStackOptions.stack.template).differenceCount > 0) {
       await ioHelper.defaults.debug(`${deployName}: template has changed in relation to last successful hotswap deployment`);
       return false;
     }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -929,16 +929,15 @@ async function canSkipDeploy(
     return false;
   }
 
-  if (deployStackOptions.deploymentMethod?.method === 'hotswap') {
-    const hotswapCache = await readHotswapTemplateCache(
-      deployStackOptions.stack.assembly.directory,
-      deployStackOptions.stack.stackName,
-      deployStackOptions.stack.template,
-    );
-    if (hotswapCache && diffTemplate(hotswapCache.deployedRootTemplate, deployStackOptions.stack.template).differenceCount > 0) {
-      await ioHelper.defaults.debug(`${deployName}: template has changed in relation to last successful hotswap deployment`);
-      return false;
-    }
+  // treat template in the hotswap cache as the source of truth
+  const hotswapCache = await readHotswapTemplateCache(
+    deployStackOptions.stack.assembly.directory,
+    deployStackOptions.stack.stackName,
+    deployStackOptions.stack.template,
+  );
+  if (hotswapCache && diffTemplate(hotswapCache.deployedRootTemplate, deployStackOptions.stack.template).differenceCount > 0) {
+    await ioHelper.defaults.debug(`${deployName}: template has changed in relation to last successful hotswap deployment`);
+    return false;
   }
 
   // We can skip deploy

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -677,7 +677,7 @@ test('deploy is not skipped if notificationArns are different', async () => {
   expect(mockCloudFormationClient).toHaveReceivedCommand(CreateChangeSetCommand);
 });
 
-test('deploy is not skipped if we are deploying with hotswap and there is a change from the last hotswap deployment', async () => {
+test('deploy is not skipped if we are deploying and there is a change from the last hotswap deployment', async () => {
   // GIVEN
   // The synthesized template matches what CloudFormation currently has stored, so every normal
   // canSkipDeploy check would say "skip". But a previous hotswap mutated the live resources without
@@ -693,13 +693,12 @@ test('deploy is not skipped if we are deploying with hotswap and there is a chan
   // WHEN
   await testDeployStack({
     ...standardDeployStackArguments(),
-    deploymentMethod: { method: 'hotswap' },
   });
 
   // THEN
   // canSkipDeploy consulted the hotswap cache and returned false, so we proceeded to attempt the hotswap
   expect(readHotswapTemplateCache).toHaveBeenCalled();
-  expect(tryHotswapDeployment).toHaveBeenCalled();
+  expect(mockCloudFormationClient).toHaveReceivedCommand(CreateChangeSetCommand);
 });
 
 test('deploy is skipped if no changes detected between current and previous hotswap templates', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -32,6 +32,7 @@ import { NoBootstrapStackEnvironmentResources } from '../../../lib/api/environme
 import { tryHotswapDeployment } from '../../../lib/api/hotswap/hotswap-deployments';
 import {
   invalidateHotswapTemplateCache,
+  readHotswapTemplateCache,
   writeHotswapTemplateCache,
 } from '../../../lib/api/hotswap/hotswap-template-cache';
 import { StackArtifactSourceTracer } from '../../../lib/api/source-tracing/private/stack-source-tracing';
@@ -674,6 +675,31 @@ test('deploy is not skipped if notificationArns are different', async () => {
 
   // THEN
   expect(mockCloudFormationClient).toHaveReceivedCommand(CreateChangeSetCommand);
+});
+
+test('deploy is not skipped if we are deploying with hotswap and there is a change from the last hotswap deployment', async () => {
+  // GIVEN
+  // The synthesized template matches what CloudFormation currently has stored, so every normal
+  // canSkipDeploy check would say "skip". But a previous hotswap mutated the live resources without
+  // updating the CFN template, and the hotswap cache recorded that different template. The live
+  // resources therefore no longer match what we are about to deploy, so we must not skip.
+  givenStackExists();
+  givenTemplateIs(defaultTargetTemplate());
+  (readHotswapTemplateCache as jest.Mock).mockResolvedValue({
+    deployedRootTemplate: { Resources: { Different: { Type: 'Test::Resource::Type' } } },
+    nestedStacks: {},
+  });
+
+  // WHEN
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'hotswap' },
+  });
+
+  // THEN
+  // canSkipDeploy consulted the hotswap cache and returned false, so we proceeded to attempt the hotswap
+  expect(readHotswapTemplateCache).toHaveBeenCalled();
+  expect(tryHotswapDeployment).toHaveBeenCalled();
 });
 
 test('if existing stack failed to create, it is deleted and recreated', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -702,6 +702,27 @@ test('deploy is not skipped if we are deploying with hotswap and there is a chan
   expect(tryHotswapDeployment).toHaveBeenCalled();
 });
 
+test('deploy is skipped if no changes detected between current and previous hotswap templates', async () => {
+  // GIVEN
+  givenStackExists();
+  givenTemplateIs(defaultTargetTemplate());
+  (readHotswapTemplateCache as jest.Mock).mockResolvedValue({
+    deployedRootTemplate: defaultTargetTemplate(),
+    nestedStacks: {},
+  });
+
+  // WHEN
+  await testDeployStack({
+    ...standardDeployStackArguments(),
+    deploymentMethod: { method: 'hotswap' },
+  });
+
+  // THEN
+  // canSkipDeploy consulted the hotswap cache and returned true, we don't attempt to hotswap
+  expect(readHotswapTemplateCache).toHaveBeenCalled();
+  expect(tryHotswapDeployment).toHaveBeenCalledTimes(0);
+});
+
 test('if existing stack failed to create, it is deleted and recreated', async () => {
   // GIVEN
   givenStackExists({

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack.test.ts
@@ -696,7 +696,7 @@ test('deploy is not skipped if we are deploying and there is a change from the l
   });
 
   // THEN
-  // canSkipDeploy consulted the hotswap cache and returned false, so we proceeded to attempt the hotswap
+  // canSkipDeploy consulted the hotswap cache and returned false, so we proceeded to attempt to deploy
   expect(readHotswapTemplateCache).toHaveBeenCalled();
   expect(mockCloudFormationClient).toHaveReceivedCommand(CreateChangeSetCommand);
 });


### PR DESCRIPTION
When making multiple hotswap deployments in a row, hotswap should compare between the template currently being deployed and the last hotswap template. This happens properly most of the time, however when a change is made that would cause the template being hotswapped to be the same as the template in CloudFormation, `canSkipDeploy` was not checking the cached hotswap template and did not register that a change could be deployed via hotswap. 
Updates the behavior of `canSkipDeploy` so it checks the hotswap cache if we are deploying with hotswap and does not skip the hotswap deployment if the cached hotswap template and the template currently being deployed differ. 
This also applies when performing a Cloudformation deployment after performing a hotswap deployment.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
