### PR TITLE
fix(toolkit-lib): clean up the diff change set when early validation fails

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -227,27 +227,9 @@ async function createChangeSetAndCleanup(
   const changeSetId = changeSet.Id ?? options.changeSetName;
   const stackId = changeSet.StackId ?? options.stack.stackName;
 
-  // Remove the change set (and, for a brand new stack, the empty stack that a
-  // CREATE change set leaves in REVIEW_IN_PROGRESS). This has to run whether the
-  // change set succeeds or fails validation: otherwise a change set that fails
-  // early validation is orphaned and leaves the stack stuck in REVIEW_IN_PROGRESS,
-  // which then blocks subsequent change set creation.
-  const cleanup = async () => {
-    await cleanupOldChangeset(options.cfn, ioHelper, changeSetId, stackId);
-
-    if (!options.exists) {
-      await ioHelper.defaults.debug(format('Deleting empty stack created by diff changeset: %s', stackId));
-      await options.cfn.deleteStack({
-        StackName: stackId,
-        ClientRequestToken: randomUUID(),
-      });
-    }
-  };
-
-  let createdChangeSet: ChangeSetReport;
   try {
     // Fetching all pages if we'll execute, so we can have the correct change count when monitoring.
-    createdChangeSet = await new ChangeSetDescriber({
+    return await new ChangeSetDescriber({
       cfn: options.cfn,
       ioHelper,
       stackNameOrArn: stackId,
@@ -260,22 +242,24 @@ async function createChangeSetAndCleanup(
     // otherwise consumes this error at debug level before falling back to a
     // template-only diff, so without this the reason is invisible unless -v is set.
     await ioHelper.defaults.warn(format('Change set %s failed: %s', changeSetId, e));
-
-    // Best-effort cleanup so a failed change set doesn't leak (which would leave a
-    // new stack stuck in REVIEW_IN_PROGRESS). Deletion can legitimately fail -- e.g.
-    // missing cloudformation:DeleteChangeSet/DeleteStack permissions -- so we log
-    // that but must not let it mask the original failure surfaced above.
-    try {
-      await cleanup();
-    } catch (cleanupError) {
-      await ioHelper.defaults.warn(format('Failed to clean up change set %s after a creation error: %s', changeSetId, cleanupError));
-    }
     throw e;
+  } finally {
+    // Always clean up the change set (and, for a brand new stack, the empty stack a
+    // CREATE change set leaves in REVIEW_IN_PROGRESS) whether or not creation
+    // succeeded. Otherwise a change set that fails early validation is orphaned and
+    // leaves the stack stuck in REVIEW_IN_PROGRESS, which blocks subsequent change
+    // set creation. The failure reason has already been surfaced above, so a cleanup
+    // error can surface on its own.
+    await cleanupOldChangeset(options.cfn, ioHelper, changeSetId, stackId);
+
+    if (!options.exists) {
+      await ioHelper.defaults.debug(format('Deleting empty stack created by diff changeset: %s', stackId));
+      await options.cfn.deleteStack({
+        StackName: stackId,
+        ClientRequestToken: randomUUID(),
+      });
+    }
   }
-
-  await cleanup();
-
-  return createdChangeSet;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -256,12 +256,19 @@ async function createChangeSetAndCleanup(
       diagnoser: options.diagnoser,
     });
   } catch (e) {
-    // Best-effort cleanup so a failed change set doesn't leak; don't let a
-    // cleanup failure mask the original creation/validation error.
+    // Surface why the change set failed. createDiffChangeSet (the only caller)
+    // otherwise consumes this error at debug level before falling back to a
+    // template-only diff, so without this the reason is invisible unless -v is set.
+    await ioHelper.defaults.warn(format('Change set %s failed: %s', changeSetId, e));
+
+    // Best-effort cleanup so a failed change set doesn't leak (which would leave a
+    // new stack stuck in REVIEW_IN_PROGRESS). Deletion can legitimately fail -- e.g.
+    // missing cloudformation:DeleteChangeSet/DeleteStack permissions -- so we log
+    // that but must not let it mask the original failure surfaced above.
     try {
       await cleanup();
     } catch (cleanupError) {
-      await ioHelper.defaults.debug(format('Failed to clean up change set after a creation error: %s', cleanupError));
+      await ioHelper.defaults.warn(format('Failed to clean up change set %s after a creation error: %s', changeSetId, cleanupError));
     }
     throw e;
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/cfn-api.ts
@@ -223,32 +223,50 @@ async function createChangeSetAndCleanup(
   });
 
   await ioHelper.defaults.debug(format('Initiated creation of changeset: %s; waiting for it to finish creating...', changeSet.Id));
-  // Fetching all pages if we'll execute, so we can have the correct change count when monitoring.
-  const createdChangeSet = await new ChangeSetDescriber({
-    cfn: options.cfn,
-    ioHelper,
-    stackNameOrArn: changeSet.StackId ?? options.stack.stackName,
-    changeSetNameOrArn: changeSet.Id ?? options.changeSetName,
-  }).waitAndThrowOnProblem({
-    diagnoser: options.diagnoser,
-  });
 
-  await cleanupOldChangeset(
-    options.cfn,
-    ioHelper,
-    changeSet.Id ?? options.changeSetName,
-    changeSet.StackId ?? options.stack.stackName,
-  );
+  const changeSetId = changeSet.Id ?? options.changeSetName;
+  const stackId = changeSet.StackId ?? options.stack.stackName;
 
-  // If the stack didn't exist before, creating a CREATE changeset will have
-  // put it in REVIEW_IN_PROGRESS state. Delete the empty stack to clean up.
-  if (!options.exists) {
-    await ioHelper.defaults.debug(format('Deleting empty stack created by diff changeset: %s', changeSet.StackId ?? options.stack.stackName));
-    await options.cfn.deleteStack({
-      StackName: changeSet.StackId ?? options.stack.stackName,
-      ClientRequestToken: randomUUID(),
+  // Remove the change set (and, for a brand new stack, the empty stack that a
+  // CREATE change set leaves in REVIEW_IN_PROGRESS). This has to run whether the
+  // change set succeeds or fails validation: otherwise a change set that fails
+  // early validation is orphaned and leaves the stack stuck in REVIEW_IN_PROGRESS,
+  // which then blocks subsequent change set creation.
+  const cleanup = async () => {
+    await cleanupOldChangeset(options.cfn, ioHelper, changeSetId, stackId);
+
+    if (!options.exists) {
+      await ioHelper.defaults.debug(format('Deleting empty stack created by diff changeset: %s', stackId));
+      await options.cfn.deleteStack({
+        StackName: stackId,
+        ClientRequestToken: randomUUID(),
+      });
+    }
+  };
+
+  let createdChangeSet: ChangeSetReport;
+  try {
+    // Fetching all pages if we'll execute, so we can have the correct change count when monitoring.
+    createdChangeSet = await new ChangeSetDescriber({
+      cfn: options.cfn,
+      ioHelper,
+      stackNameOrArn: stackId,
+      changeSetNameOrArn: changeSetId,
+    }).waitAndThrowOnProblem({
+      diagnoser: options.diagnoser,
     });
+  } catch (e) {
+    // Best-effort cleanup so a failed change set doesn't leak; don't let a
+    // cleanup failure mask the original creation/validation error.
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      await ioHelper.defaults.debug(format('Failed to clean up change set after a creation error: %s', cleanupError));
+    }
+    throw e;
   }
+
+  await cleanup();
 
   return createdChangeSet;
 }

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { CreateChangeSetCommand, DeleteStackCommand, DescribeChangeSetCommand, DescribeStacksCommand, GetTemplateCommand, ListStacksCommand } from '@aws-sdk/client-cloudformation';
+import { CreateChangeSetCommand, DeleteChangeSetCommand, DeleteStackCommand, DescribeChangeSetCommand, DescribeStacksCommand, GetTemplateCommand, ListStacksCommand } from '@aws-sdk/client-cloudformation';
 import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import chalk from 'chalk';
 import { DiffMethod } from '../../lib/actions/diff';
@@ -441,6 +441,42 @@ describe('diff', () => {
         stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
         method: DiffMethod.ChangeSet({ fallbackToTemplate: false }),
       })).rejects.toThrow(/Could not create a change set, and '--method=change-set' was specified/);
+    });
+
+    test('ChangeSet diff cleans up the failed change set and empty stack when validation fails', async () => {
+      // GIVEN - a new stack whose CREATE change set fails early validation
+      // (e.g. a resource that already exists), which would otherwise leave the
+      // change set orphaned and the stack stuck in REVIEW_IN_PROGRESS.
+      jest.spyOn(deployments.Deployments.prototype, 'stackExists').mockResolvedValue(false);
+      mockCloudFormationClient.on(DescribeStacksCommand).resolves({ Stacks: [] });
+      mockSSMClient.on(GetParameterCommand).resolves({ Parameter: { Value: '99' } });
+      mockCloudFormationClient.on(CreateChangeSetCommand).resolves({
+        Id: 'arn:aws:cloudformation:us-east-1:123456789012:changeSet/cdk-diff-change-set/abc',
+        StackId: 'arn:aws:cloudformation:us-east-1:123456789012:stack/Stack1/def',
+      });
+      mockCloudFormationClient.on(DescribeChangeSetCommand).resolves({
+        Status: 'FAILED',
+        StatusReason: "Resource of type 'AWS::S3::Bucket' with identifier 'mybucket' already exists.",
+        ExecutionStatus: 'UNAVAILABLE',
+        Changes: [],
+      });
+
+      // WHEN - the diff falls back to a template diff (default fallbackToTemplate = true)
+      const cx = await cdkOutFixture(toolkit, 'stack-with-bucket');
+      await toolkit.diff(cx, {
+        stacks: { strategy: StackSelectionStrategy.ALL_STACKS },
+        method: DiffMethod.ChangeSet(),
+      });
+
+      // THEN - the failed change set is deleted and the empty stack is cleaned up
+      const deleteChangeSetCalls = mockCloudFormationClient.commandCalls(DeleteChangeSetCommand);
+      expect(deleteChangeSetCalls.length).toBeGreaterThan(0);
+      expect(deleteChangeSetCalls[0].args[0].input).toEqual(expect.objectContaining({
+        ChangeSetName: expect.stringContaining('cdk-diff-change-set'),
+      }));
+
+      const deleteStackCalls = mockCloudFormationClient.commandCalls(DeleteStackCommand);
+      expect(deleteStackCalls.length).toBeGreaterThan(0);
     });
 
     test('ChangeSet diff method creates changeset for new stacks when fallBackToTemplate = false', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/actions/diff.test.ts
@@ -477,6 +477,12 @@ describe('diff', () => {
 
       const deleteStackCalls = mockCloudFormationClient.commandCalls(DeleteStackCommand);
       expect(deleteStackCalls.length).toBeGreaterThan(0);
+
+      // AND - the reason the change set failed is surfaced (not just hidden behind -v)
+      expect(ioHost.notifySpy).toHaveBeenCalledWith(expect.objectContaining({
+        level: 'warn',
+        message: expect.stringContaining('failed'),
+      }));
     });
 
     test('ChangeSet diff method creates changeset for new stacks when fallBackToTemplate = false', async () => {


### PR DESCRIPTION
Fixes #1767

When a `cdk diff` change set fails early validation (e.g. a resource that already exists), `createChangeSetAndCleanup` in `toolkit-lib`'s `cfn-api.ts` threw from `waitAndThrowOnProblem` before the change-set and empty-stack cleanup could run. That orphaned the change set and left a new stack stuck in `REVIEW_IN_PROGRESS`, which then blocked subsequent change-set creation and forced the user to delete it manually in the console.

This change runs the cleanup on the failure path too — deleting the change set and, for a brand new stack, the empty review stack — as a best-effort step that does not mask the original validation error. Successful diffs are unchanged.

Verified with a new unit test in `diff.test.ts` (change set fails validation → `DeleteChangeSet` and `DeleteStack` are called); the full `diff.test.ts` suite passes (22/22).

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
