### PR TITLE
fix(cloudformation-diff): DependsOn changes are invisible for lists of two or more

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/util.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/util.ts
@@ -105,13 +105,16 @@ function dependsOnEqual(lvalue: any, rvalue: any): boolean {
     if (lvalue.length !== rvalue.length) {
       return false;
     }
-    for (let i = 0 ; i < lvalue.length ; i++) {
-      for (let j = 0 ; j < lvalue.length ; j++) {
-        if ((!deepEqual(lvalue[i], rvalue[j])) && (j === lvalue.length - 1)) {
-          return false;
-        }
-        break;
+    // Match each element of lvalue with a distinct element of rvalue. Elements are
+    // consumed as they are matched, so duplicates are compared by multiplicity.
+    // Neither input is mutated: only the local copy of indices is.
+    const unmatched = rvalue.map((_, i) => i);
+    for (const l of lvalue) {
+      const at = unmatched.findIndex((i) => deepEqual(l, rvalue[i]));
+      if (at === -1) {
+        return false;
       }
+      unmatched.splice(at, 1);
     }
     return true;
   }

--- a/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
@@ -402,6 +402,65 @@ describe('fullDiff tests that include changeset', () => {
     expect(differences.resources.differenceCount).toBe(1);
   });
 
+  test.each([
+    [['SomeResource', 'AnotherResource'], ['ThirdResource', 'FourthResource']],
+    [['SomeResource', 'AnotherResource'], ['SomeResource', 'FourthResource']],
+    [['SomeResource', 'AnotherResource', 'ThirdResource'], ['AnotherResource', 'ThirdResource', 'FourthResource']],
+    [['SomeResource', 'SomeResource'], ['SomeResource', 'AnotherResource']],
+  ])('same-length DependsOn arrays with different elements are unequal: %j vs %j', (before, after) => {
+    // GIVEN
+    const currentTemplate = {
+      Resources: {
+        BucketResource: {
+          Type: 'AWS::S3::Bucket',
+          DependsOn: before,
+        },
+      },
+    };
+
+    // WHEN
+    const newTemplate = {
+      Resources: {
+        BucketResource: {
+          Type: 'AWS::S3::Bucket',
+          DependsOn: after,
+        },
+      },
+    };
+
+    // THEN
+    let differences = fullDiff(currentTemplate, newTemplate, {});
+    expect(differences.resources.differenceCount).toBe(1);
+
+    differences = fullDiff(newTemplate, currentTemplate, {});
+    expect(differences.resources.differenceCount).toBe(1);
+  });
+
+  test('DependsOn arrays with the same elements in a different order are equal, and inputs are not mutated', () => {
+    // GIVEN
+    const before = ['SomeResource', 'AnotherResource', 'SomeResource'];
+    const after = ['SomeResource', 'SomeResource', 'AnotherResource'];
+    const currentTemplate = {
+      Resources: {
+        BucketResource: { Type: 'AWS::S3::Bucket', DependsOn: before },
+      },
+    };
+    const newTemplate = {
+      Resources: {
+        BucketResource: { Type: 'AWS::S3::Bucket', DependsOn: after },
+      },
+    };
+
+    // WHEN
+    const differences = fullDiff(currentTemplate, newTemplate, {});
+
+    // THEN
+    expect(differences.resources.differenceCount).toBe(0);
+    // the comparison must not reorder the caller's arrays (see #1575)
+    expect(before).toEqual(['SomeResource', 'AnotherResource', 'SomeResource']);
+    expect(after).toEqual(['SomeResource', 'SomeResource', 'AnotherResource']);
+  });
+
   test('arrays that differ only in element order are considered unequal outside of DependsOn expressions', () => {
     // GIVEN
     const currentTemplate = {


### PR DESCRIPTION
Fixes #1822

### Reason for this change

`dependsOnEqual` compares two `DependsOn` arrays "irrespective of element order", but the inner loop ends in an unconditional `break`, so it only ever runs for `j = 0`. Its single `return false` is guarded by `j === lvalue.length - 1`, which on that one iteration is only true for a one-element array. Any two same-length arrays with two or more entries therefore compare as equal, whatever they contain — the length check is the only comparison that survives.

The user-visible effect: `cdk diff` reports no change for a resource whose dependency list was rewritten, as long as the entry count stays the same. CDK emits multi-element `DependsOn` routinely (a single `lambda.Function` produces two entries, as #1602 noted), so this is a realistic shape.

### Description of changes

Replaced the loop with a multiplicity-preserving match: each element on the left must find a distinct, not-yet-consumed element on the right. That is the order-insensitive comparison the original comment describes, and it also handles duplicates correctly (`['A','A']` vs `['A','B']` is now unequal).

Neither input array is reordered — only a local array of indices is mutated — so the no-mutation property established by #1575 / #1602 is preserved. There is an explicit test for that.

The three behaviours the suite already covered are unchanged: reordering is equal, differing lengths are unequal, and `'A'` vs `['A']` is equal (handled by the branch above this one).

This surfaces changes that `cdk diff` currently hides. It does not invent differences: every newly reported change is a real edit to the template.

### Description of how you validated changes

- Five new tests in `template-and-changeset-diff-merger.test.ts`, next to the existing `DependsOn` cases: four parameterised cases for same-length-but-different arrays (2 elements fully replaced, 2 elements partially replaced, 3 elements, and a duplicate-sensitivity case), plus one asserting reorder-equality with no mutation of the caller's arrays.
- All four of the new "unequal" cases **fail on `main`** and pass with this change — confirmed by stashing the `lib` change and re-running.
- Full package suite: 151 tests passing.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
