### PR TITLE
fix(toolkit-lib): fail gc on ECR tagging permission errors

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
@@ -3,6 +3,7 @@ import type { ImageIdentifier } from '@aws-sdk/client-ecr';
 import type { Tag } from '@aws-sdk/client-s3';
 import chalk from 'chalk';
 import type { IECRClient, IS3Client, SDK, SdkProvider } from '../aws-auth/private';
+import { isAccessDeniedError } from '../aws-auth/util';
 import { DEFAULT_TOOLKIT_STACK_NAME, ToolkitInfo } from '../toolkit-info';
 import { ProgressPrinter } from './progress-printer';
 import { ActiveAssetCache, BackgroundStackRefresh, refreshStacks } from './stack-refresh';
@@ -478,7 +479,12 @@ export class GarbageCollector {
             imageTag: img.buildImageTag(i),
           });
         } catch (error) {
-          // This is a false negative -- an isolated asset is untagged
+          // A permission error (e.g. a missing ecr:PutImage) would otherwise be
+          // swallowed here and make gc silently no-op, so surface it instead.
+          if (isAccessDeniedError(error)) {
+            throw error;
+          }
+          // Otherwise this is a false negative -- an isolated asset is untagged
           // likely due to an imageTag collision. We can safely ignore,
           // and the isolated asset will be tagged next time.
           await this.ioHelper.defaults.debug(`Warning: unable to tag image ${JSON.stringify(img.tags)} with ${img.buildImageTag(i)} due to the following error: ${error}`);

--- a/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
@@ -366,6 +366,31 @@ describe('ECR Garbage Collection', () => {
     expect(ecrClient).toHaveReceivedCommandTimes(BatchDeleteImageCommand, 0);
   });
 
+  test('rollbackBufferDays > 0 -- tagging fails on a permission error instead of silently continuing', async () => {
+    mockTheToolkitInfo({
+      Outputs: [
+        {
+          OutputKey: 'BootstrapVersion',
+          OutputValue: '999',
+        },
+      ],
+    });
+
+    // The role is missing ecr:PutImage, so tagging raises AccessDeniedException.
+    const accessDenied = new Error('User is not authorized to perform: ecr:PutImage');
+    accessDenied.name = 'AccessDeniedException';
+    mockECRClient.on(PutImageCommand).rejects(accessDenied);
+
+    garbageCollector = gc({
+      type: 'ecr',
+      rollbackBufferDays: 3,
+      action: 'full',
+    });
+
+    // gc must surface the permission error rather than silently no-op
+    await expect(garbageCollector.garbageCollect()).rejects.toThrow(/ecr:PutImage/);
+  });
+
   test('createdAtBufferDays > 0', async () => {
     mockTheToolkitInfo({
       Outputs: [


### PR DESCRIPTION
Fixes #347

`parallelTagEcr` in toolkit-lib's `garbage-collector.ts` caught every error from `ecr:PutImage`. The intent was to ignore the benign imageTag-collision false negative (the isolated asset simply gets tagged on the next run), but it also swallowed `AccessDeniedException`. As a result, when the role is missing the `ecr:PutImage` permission, `cdk gc` silently no-ops — no images are tagged or deleted, yet the command reports success.

This change rethrows on access-denied errors (using the existing `isAccessDeniedError` helper, which already handles the `AccessDenied` / `AccessDeniedException` phrasing differences across services), so `cdk gc` fails as expected on a permission problem. The benign collision case is still ignored.

Verified with a new unit test in `garbage-collection.test.ts` (`ecr:PutImage` rejects with `AccessDeniedException` → `garbageCollect()` rejects); the full garbage-collection suite passes (29/29).

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
