### PR TITLE
fix(toolkit-lib): hotswap silently drops empty-string Lambda Description

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/lambda-functions.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/lambda-functions.ts
@@ -234,9 +234,8 @@ async function evaluateLambdaFunctionProps(
     }
   }
 
-  const configurations =
-    description !== undefined || environment !== undefined ? { description, environment } : undefined;
-  return code !== undefined || configurations !== undefined ? { code, configurations } : undefined;
+  const configurations = description !== undefined || environment ? { description, environment } : undefined;
+  return code || configurations ? { code, configurations } : undefined;
 }
 
 interface LambdaFunctionCode {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/lambda-functions.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/lambda-functions.ts
@@ -234,8 +234,9 @@ async function evaluateLambdaFunctionProps(
     }
   }
 
-  const configurations = description || environment ? { description, environment } : undefined;
-  return code || configurations ? { code, configurations } : undefined;
+  const configurations =
+    description !== undefined || environment !== undefined ? { description, environment } : undefined;
+  return code !== undefined || configurations !== undefined ? { code, configurations } : undefined;
 }
 
 interface LambdaFunctionCode {

--- a/packages/@aws-cdk/toolkit-lib/test/api/hotswap/lambda-functions-hotswap-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/hotswap/lambda-functions-hotswap-deployments.test.ts
@@ -797,6 +797,65 @@ describe.each([HotswapMode.FALL_BACK, HotswapMode.HOTSWAP_ONLY])('%p mode', (hot
   );
 
   test(
+    'calls the updateLambdaConfiguration() API when a Lambda function Description is changed to an empty string',
+    async () => {
+      // GIVEN
+      setup.setCurrentCfnStackTemplate({
+        Resources: {
+          Func: {
+            Type: 'AWS::Lambda::Function',
+            Properties: {
+              Code: {
+                S3Bucket: 's3-bucket',
+                S3Key: 's3-key',
+              },
+              FunctionName: 'my-function',
+              Description: 'Old Description',
+            },
+            Metadata: {
+              'aws:asset:path': 'asset-path',
+            },
+          },
+        },
+      });
+      const cdkStackArtifact = setup.cdkStackArtifactOf({
+        template: {
+          Resources: {
+            Func: {
+              Type: 'AWS::Lambda::Function',
+              Properties: {
+                Code: {
+                  S3Bucket: 's3-bucket',
+                  S3Key: 's3-key',
+                },
+                FunctionName: 'my-function',
+                Description: '',
+              },
+              Metadata: {
+                'aws:asset:path': 'asset-path',
+              },
+            },
+          },
+        },
+      });
+
+      // WHEN
+      const deployStackResult = await hotswapMockSdkProvider.tryHotswapDeployment(hotswapMode, cdkStackArtifact);
+
+      // THEN
+      // Regression test: Description is a falsy-but-meaningful value here. A prior
+      // `description || environment` check treated an empty-string Description the
+      // same as "no Description change", silently skipping the API call while still
+      // reporting the hotswap as successful (or a no-op), instead of clearing it.
+      expect(deployStackResult).not.toBeUndefined();
+      expect(mockLambdaClient).toHaveReceivedCommandWith(UpdateFunctionConfigurationCommand, {
+        FunctionName: 'my-function',
+        Description: '',
+      });
+    },
+  );
+
+  test(
     'calls the updateLambdaConfiguration() API when it receives difference in Environment field of a Lambda function',
     async () => {
       // GIVEN


### PR DESCRIPTION
fixes #1830

### Reason for this change

`evaluateLambdaFunctionProps` (`packages/@aws-cdk/toolkit-lib/lib/api/hotswap/lambda-functions.ts`) decided whether a hotswappable Lambda config change existed with:

```ts
const configurations = description || environment ? { description, environment } : undefined;
return code || configurations ? { code, configurations } : undefined;
```

`description` is `string | undefined`, set only when `Description` was actually part of the classified property diff. An empty string `""` is a real, meaningful new value (e.g. a user clearing a Lambda's description) — but `||` can't distinguish it from "not set," since `""` is falsy in JS.

When the *only* hotswappable change on a Lambda is `Description -> ""` (no `Code`/`Environment` change), `configurations` becomes `undefined`, so the function returns `undefined`. The caller (`isHotswappableLambdaFunctionChange`) reads that as "nothing to do here" and drops the resource change entirely — it isn't even reported as non-hotswappable. If that was the deployment's only change, `tryHotswapDeployment` ends up with an empty `hotswappableChanges` list, which is reported to the user as `noOp: true` (nothing to hotswap) or a clean success — while the Lambda's `Description` in AWS silently never gets updated. This is infrastructure drift with no error, warning, or fallback to a full CloudFormation deployment.

### Description of changes

Switches both truthiness checks to `!== undefined`, matching how `code`/`description`/`environment` are actually populated in the loop above (only ever assigned when that property appeared in the diff). This mirrors the existing correct pattern already used a few lines below for applying the update (`lambdaCodeChange.configurations.description !== undefined`).

### Description of how you validated changes

Added a regression test, `'calls the updateLambdaConfiguration() API when a Lambda function Description is changed to an empty string'`, to `test/api/hotswap/lambda-functions-hotswap-deployments.test.ts` (both `FALL_BACK` and `HOTSWAP_ONLY` modes, matching the file's existing `describe.each` pattern). Verified it fails on the pre-fix code (the expected `UpdateFunctionConfigurationCommand` is never sent) and passes with the fix.

Full hotswap suite: `test/api/hotswap/` — 285 passed, no regressions.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — logic-only change to a helper function already covered by extensive unit tests; no new resource type or cross-service interaction)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license