### PR TITLE
fix(cli): cdk flags --set leaks synthesized cloud assembly directories

### DIFF
--- a/packages/aws-cdk/lib/commands/flags/operations.ts
+++ b/packages/aws-cdk/lib/commands/flags/operations.ts
@@ -43,6 +43,8 @@ export class FlagOperations {
   private allStacks: CloudFormationStackArtifact[];
   private queue: PQueue;
   private baselineTempDir?: string;
+  private originalTempDir?: string;
+  private modifiedTempDir?: string;
 
   constructor(
     private readonly flags: FeatureFlag[],
@@ -278,21 +280,26 @@ export class FlagOperations {
     const cdkJson = await JSON.parse(await fs.readFile(path.join(process.cwd(), 'cdk.json'), 'utf-8'));
     const app = cdkJson.app;
 
+    this.originalTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-original-'));
     const source = await this.toolkit.fromCdkApp(app, {
       contextStore: memoryContext,
-      outdir: fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-original-')),
+      outdir: this.originalTempDir,
     });
 
     const updateObj = await this.buildUpdateObject(flagNames, params, baseContextValues);
-    if (!updateObj) return false;
+    if (!updateObj) {
+      await this.cleanupTempDirectories();
+      return false;
+    }
 
     await memoryContext.update(updateObj);
     const cx = await this.toolkit.synth(source);
     const assembly = cx.cloudAssembly;
 
+    this.modifiedTempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-temp-'));
     const modifiedSource = await this.toolkit.fromCdkApp(app, {
       contextStore: memoryContext,
-      outdir: fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-temp-')),
+      outdir: this.modifiedTempDir,
     });
 
     const modifiedCx = await this.toolkit.synth(modifiedSource);
@@ -378,10 +385,14 @@ export class FlagOperations {
 
   /** Removes temporary directories created during flag operations */
   private async cleanupTempDirectories(): Promise<void> {
-    const originalDir = path.join(process.cwd(), 'original');
-    const tempDir = path.join(process.cwd(), 'temp');
-    await fs.remove(originalDir);
-    await fs.remove(tempDir);
+    if (this.originalTempDir) {
+      await fs.remove(this.originalTempDir);
+      this.originalTempDir = undefined;
+    }
+    if (this.modifiedTempDir) {
+      await fs.remove(this.modifiedTempDir);
+      this.modifiedTempDir = undefined;
+    }
   }
 
   /** Actually modifies the cdk.json file with the new flag values */

--- a/packages/aws-cdk/test/commands/flag-operations.test.ts
+++ b/packages/aws-cdk/test/commands/flag-operations.test.ts
@@ -430,6 +430,66 @@ describe('processFlagsCommand', () => {
     requestResponseSpy.mockRestore();
   });
 
+  test('cleans up the real temp directories created during prototyping when the user cancels', async () => {
+    // Regression test: cleanupTempDirectories() used to delete
+    // `${cwd}/original` and `${cwd}/temp`, but the directories actually
+    // created by prototypeChanges() are `mkdtemp`-generated paths under
+    // os.tmpdir() (prefixed `cdk-original-`/`cdk-temp-`). Those paths were
+    // never stored anywhere, so every `cdk flags --set` invocation leaked
+    // two real synthesized-cloud-assembly directories into the OS temp dir.
+    const cdkJsonPath = await createCdkJsonFile();
+    setupMockToolkitForPrototyping(mockToolkit);
+
+    const tmpEntriesBefore = fs.readdirSync(os.tmpdir());
+
+    const requestResponseSpy = jest.spyOn(ioHelper, 'requestResponse');
+    requestResponseSpy.mockResolvedValue(false);
+
+    const options: FlagsOptions = {
+      FLAGNAME: ['@aws-cdk/core:testFlag'],
+      set: true,
+      value: 'true',
+    };
+
+    const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
+    await expect(flagOperations.processFlagsCommand()).rejects.toThrow('Flag update cancelled');
+
+    const leakedEntries = fs.readdirSync(os.tmpdir())
+      .filter(entry => !tmpEntriesBefore.includes(entry))
+      .filter(entry => entry.startsWith('cdk-original-') || entry.startsWith('cdk-temp-'));
+    expect(leakedEntries).toEqual([]);
+
+    await cleanupCdkJsonFile(cdkJsonPath);
+    requestResponseSpy.mockRestore();
+  });
+
+  test('cleans up the real temp directories created during prototyping when the user accepts', async () => {
+    const cdkJsonPath = await createCdkJsonFile();
+    setupMockToolkitForPrototyping(mockToolkit);
+
+    const tmpEntriesBefore = fs.readdirSync(os.tmpdir());
+
+    const requestResponseSpy = jest.spyOn(ioHelper, 'requestResponse');
+    requestResponseSpy.mockResolvedValue(true);
+
+    const options: FlagsOptions = {
+      FLAGNAME: ['@aws-cdk/core:testFlag'],
+      set: true,
+      value: 'true',
+    };
+
+    const flagOperations = new FlagCommandHandler(mockFlagsData, ioHelper, options, mockToolkit);
+    await flagOperations.processFlagsCommand();
+
+    const leakedEntries = fs.readdirSync(os.tmpdir())
+      .filter(entry => !tmpEntriesBefore.includes(entry))
+      .filter(entry => entry.startsWith('cdk-original-') || entry.startsWith('cdk-temp-'));
+    expect(leakedEntries).toEqual([]);
+
+    await cleanupCdkJsonFile(cdkJsonPath);
+    requestResponseSpy.mockRestore();
+  });
+
   test('does not resynthesize when setting flag to same value as current context', async () => {
     const cdkJsonPath = await createCdkJsonFile({
       '@aws-cdk/core:testFlag': true,


### PR DESCRIPTION
fixes #1832

### Reason for this change

`FlagOperations.prototypeChanges()` (`packages/aws-cdk/lib/commands/flags/operations.ts`) creates two synthesis output directories via `fs.mkdtempSync(path.join(os.tmpdir(), 'cdk-original-'))` and `'cdk-temp-'`, but never stores the returned paths anywhere.

`cleanupTempDirectories()`, called after the user accepts or declines the confirmation prompt, instead removes `path.join(process.cwd(), 'original')` and `path.join(process.cwd(), 'temp')` — paths that were never created by this code path at all. It is effectively a no-op, and every `cdk flags --set` (or `--recommended`/`--default`/`--all`) invocation leaves two full synthesized cloud-assembly directories behind in the OS temp directory, indefinitely.

### Description of changes

- Adds `originalTempDir`/`modifiedTempDir` instance fields, following the same pattern this class already uses for `baselineTempDir` on the `setSafeFlags` code path.
- `prototypeChanges()` now stores each `mkdtemp` path on `this` instead of discarding it.
- `cleanupTempDirectories()` now removes the actual stored paths (and resets the fields), instead of the unrelated `${cwd}/original` / `${cwd}/temp` paths.
- Also calls `cleanupTempDirectories()` on the early "nothing to update" return inside `prototypeChanges()` (e.g. "flag is already set to the specified value") — that path returns `false` before `handleUserResponse()` (the only other place cleanup was wired up) is ever called, so `originalTempDir` would otherwise still leak even after fixing the main paths.

### Description of how you validated changes

Added two regression tests to `test/commands/flag-operations.test.ts` (`'cleans up the real temp directories created during prototyping when the user cancels'` / `'...when the user accepts'`) that snapshot `os.tmpdir()` before and after a full `cdk flags --set` invocation and assert no `cdk-original-*`/`cdk-temp-*` entries remain. `fs.mkdtempSync` is not mocked in this suite, so these tests exercise real filesystem directory creation/cleanup, not just the mocked toolkit calls.

Verified both new tests fail against the pre-fix code (real leaked directories detected in `os.tmpdir()`) and pass with the fix. Ran the full `flag-operations.test.ts` suite 3x with jest's randomized test order (58 tests each run) plus a scan of `os.tmpdir()` after each run — zero leaked entries across all runs.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — filesystem-only bug in a CLI-internal helper, fully covered by the new unit tests)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license