### PR TITLE
fix(toolkit-lib): downstream stack selection uses wrong key for nested stacks

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts
@@ -140,7 +140,7 @@ async function includeDownstreamStacks(
 
     for (const [id, stack] of allStacks) {
       // Select this stack if it's not selected yet AND it depends on a stack that's in the selected set
-      if (!selectedStacks.has(id) && (stack.dependencies || []).some(dep => selectedStacks.has(dep.id))) {
+      if (!selectedStacks.has(id) && (stack.dependencies || []).some(dep => selectedStacks.has(dep.hierarchicalId))) {
         selectedStacks.set(id, stack);
         added.push(id);
         madeProgress = true;

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/stack-selection-expand.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/stack-selection-expand.test.ts
@@ -1,0 +1,69 @@
+import { ExpandStackSelection, StackSelectionStrategy } from '../../../lib/api/cloud-assembly';
+import { Toolkit } from '../../../lib/toolkit';
+import { TestIoHost } from '../../_helpers';
+import type { TestStackArtifact } from '../../_helpers/test-cloud-assembly-source';
+import { TestCloudAssemblySource } from '../../_helpers/test-cloud-assembly-source';
+
+const ioHost = new TestIoHost();
+const toolkit = new Toolkit({ ioHost });
+
+beforeEach(() => {
+  ioHost.notifySpy.mockClear();
+});
+
+// Regression test: a stack's hierarchicalId (used to key the internal
+// selection maps) is `manifest.displayName ?? id`. When a stack has an
+// explicit displayName that differs from its artifact id (as happens for
+// stacks inside nested assemblies/stages), `includeDownstreamStacks` used
+// to look up dependents by the dependency's raw `id` instead of its
+// `hierarchicalId`, so it never found a match and silently failed to pull
+// in downstream stacks - even though the symmetric `includeUpstreamStacks`
+// correctly used hierarchicalId all along.
+describe('downstream/upstream stack expansion with a non-trivial displayName', () => {
+  const DEPENDENCY: TestStackArtifact = {
+    stackName: 'DependencyStack',
+    displayName: 'CustomDisplayName',
+  };
+  const DOWNSTREAM: TestStackArtifact = {
+    stackName: 'DownstreamStack',
+    depends: ['DependencyStack'],
+  };
+
+  test('DOWNSTREAM expansion pulls in a stack that depends on the selected stack', async () => {
+    // GIVEN
+    const cx = new TestCloudAssemblySource({
+      stacks: [DEPENDENCY, DOWNSTREAM],
+    });
+
+    // WHEN: select only the dependency by its hierarchicalId (displayName), expand downstream
+    const stacks = await toolkit.list(cx, {
+      stacks: {
+        patterns: ['CustomDisplayName'],
+        strategy: StackSelectionStrategy.PATTERN_MATCH,
+        expand: ExpandStackSelection.DOWNSTREAM,
+      },
+    });
+
+    // THEN: the dependent stack must be included, not just the matched one
+    expect(stacks.map(s => s.id).sort()).toEqual(['CustomDisplayName', 'DownstreamStack']);
+  });
+
+  test('UPSTREAM expansion pulls in the stack a selected stack depends on', async () => {
+    // GIVEN
+    const cx = new TestCloudAssemblySource({
+      stacks: [DEPENDENCY, DOWNSTREAM],
+    });
+
+    // WHEN: select only the downstream stack, expand upstream
+    const stacks = await toolkit.list(cx, {
+      stacks: {
+        patterns: ['DownstreamStack'],
+        strategy: StackSelectionStrategy.PATTERN_MATCH,
+        expand: ExpandStackSelection.UPSTREAM,
+      },
+    });
+
+    // THEN: the dependency stack must be included
+    expect(stacks.map(s => s.id).sort()).toEqual(['CustomDisplayName', 'DownstreamStack']);
+  });
+});


### PR DESCRIPTION
fixes #1834

### Reason for this change

\`includeDownstreamStacks\` (\`packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-assembly.ts\`) computes the transitive closure of stacks that depend on the selected set — this is what powers \`expand: ExpandStackSelection.DOWNSTREAM\`, the default expansion behavior for \`cdk deploy\`/\`cdk destroy\` when \`--exclusively\` is not passed.

```ts
for (const [id, stack] of allStacks) {
  if (!selectedStacks.has(id) && (stack.dependencies || []).some(dep => selectedStacks.has(dep.id))) {
```

\`selectedStacks\`/\`allStacks\` are both keyed by \`hierarchicalId\` (\`manifest.displayName ?? id\`) — see \`indexByHierarchicalId\` and \`extendStacks\` just above, which build these maps via \`stack.hierarchicalId\`. But the lookup here checks the dependency's raw \`.id\`, not its \`.hierarchicalId\`. For a stack whose \`displayName\` differs from its \`id\` (stacks inside nested assemblies/stages, e.g. CDK Pipelines), this lookup never matches, so a stack that genuinely depends on a selected stack is silently dropped from the expanded selection.

This was masked for ordinary flat apps, where \`displayName\` is unset and \`id === hierarchicalId\`.

The symmetric \`includeUpstreamStacks\` a few lines below already does this correctly:

```ts
for (const dependencyId of stack.dependencies.map(x => x.manifest.displayName ?? x.id)) {
  if (!selectedStacks.has(dependencyId) && allStacks.has(dependencyId)) {
```

### Description of changes

Switches \`dep.id\` to \`dep.hierarchicalId\` (the existing getter on \`CloudArtifact\`, equivalent to \`includeUpstreamStacks\`'s inline \`manifest.displayName ?? id\` expression) in \`includeDownstreamStacks\`.

### Description of how you validated changes

Added \`test/api/cloud-assembly/stack-selection-expand.test.ts\` with two regression tests, using \`Toolkit.list()\` end-to-end through a \`TestCloudAssemblySource\` fixture: a dependency stack with an explicit \`displayName\` distinct from its \`stackName\`/id, and a second stack that depends on it.

- \`DOWNSTREAM\` expansion (selecting the dependency by its hierarchicalId, expecting the dependent stack to be pulled in) — **fails on the pre-fix code** (dependent stack silently missing from the result) and passes with the fix.
- \`UPSTREAM\` expansion (the symmetric, already-correct case) — passes both before and after, confirming the fix doesn't change that path's behavior.

Ran the full \`test/api/cloud-assembly/\`, \`test/actions/list.test.ts\`, and the rest of \`test/actions/\` (deploy, diff, synth, drift, rollback, hotswap) — all pass except \`bootstrap.test.ts\`, which fails identically with or without this change due to a missing \`bootstrap-template.yaml\` asset that's only copied by a full \`yarn build\`, not a bare \`tsc --build\` compile — unrelated to this change.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — internal stack-selection helper, fully covered by the new unit tests exercising the public \`Toolkit.list()\` API end-to-end)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license