### PR TITLE
fix(toolkit-lib): drift numResourcesUnchecked ignores UNKNOWN-status resources

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/drift/drift-formatter.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/drift/drift-formatter.ts
@@ -93,6 +93,20 @@ export class DriftFormatter {
   }
 
   /**
+   * Resources that were not checked for drift: either CloudFormation returned
+   * no drift record for them at all, or it returned one with an UNKNOWN
+   * status (e.g. due to missing permissions or lack of drift-detection
+   * support for that resource type).
+   */
+  private getUncheckedResources(): string[] {
+    const drifts = this.resourceDriftResults;
+    return Array.from(this.allStackResources.keys()).filter((logicalId) => {
+      const drift = drifts.find((d) => d.LogicalResourceId === logicalId);
+      return !drift || drift.StackResourceDriftStatus === StackResourceDriftStatus.UNKNOWN;
+    });
+  }
+
+  /**
    * Format the stack drift detection results
    */
   public formatStackDrift(): DriftFormatterOutput {
@@ -110,7 +124,7 @@ export class DriftFormatter {
       const finalResult = chalk.green('No drift detected\n');
       return {
         numResourcesWithDrift: 0,
-        numResourcesUnchecked: this.allStackResources.size - this.resourceDriftResults.length,
+        numResourcesUnchecked: this.getUncheckedResources().length,
         stackHeader,
         unchecked: formatterOutput.unchecked,
         summary: finalResult,
@@ -120,7 +134,7 @@ export class DriftFormatter {
     const finalResult = chalk.yellow(`\n${actualDrifts.length} resource${actualDrifts.length === 1 ? '' : 's'} ${actualDrifts.length === 1 ? 'has' : 'have'} drifted from their expected configuration\n`);
     return {
       numResourcesWithDrift: actualDrifts.length,
-      numResourcesUnchecked: this.allStackResources.size - this.resourceDriftResults.length,
+      numResourcesUnchecked: this.getUncheckedResources().length,
       stackHeader,
       unchanged: formatterOutput.unchanged,
       unchecked: formatterOutput.unchecked,
@@ -161,10 +175,7 @@ export class DriftFormatter {
     }
 
     // Process all unchecked and unknown resources
-    const uncheckedResources = Array.from(this.allStackResources.keys()).filter((logicalId) => {
-      const drift = drifts.find((d) => d.LogicalResourceId === logicalId);
-      return !drift || drift.StackResourceDriftStatus === StackResourceDriftStatus.UNKNOWN;
-    });
+    const uncheckedResources = this.getUncheckedResources();
     if (uncheckedResources.length > 0) {
       unchecked = this.printSectionHeader('Unchecked Resources');
       for (const logicalId of uncheckedResources) {

--- a/packages/@aws-cdk/toolkit-lib/test/api/drift/drift.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/drift/drift.test.ts
@@ -806,6 +806,14 @@ describe('formatStackDrift', () => {
     // UNKNOWN resources should be treated as unchecked, not as drift
     expect(result.unchecked).toContain('AWS::IAM::Role');
     expect(result.unchecked).toContain('Resource2');
+
+    // Regression test: numResourcesUnchecked used to be computed as
+    // `allStackResources.size - resourceDriftResults.length`, which only
+    // counts resources CloudFormation returned no drift record for at all.
+    // Resource2 has a drift record (status UNKNOWN), so that formula
+    // reported 0 unchecked here even though `unchecked` (above) lists it -
+    // a self-contradictory summary vs. detail output.
+    expect(result.numResourcesUnchecked).toBe(1);
   });
 
   test('formatting with only UNKNOWN drift status', () => {
@@ -868,6 +876,10 @@ describe('formatStackDrift', () => {
     expect(result.unchecked).toContain('Resource1');
     expect(result.unchecked).toContain('AWS::IAM::Role');
     expect(result.unchecked).toContain('Resource2');
+
+    // Both resources have UNKNOWN-status drift records (not missing entirely),
+    // so the naive size-minus-length formula previously reported 0 here.
+    expect(result.numResourcesUnchecked).toBe(2);
   });
 
   test('filters out AWS::CDK::Metadata resources from drift count', () => {


### PR DESCRIPTION
fixes #1836

### Reason for this change

\`DriftFormatter.formatStackDrift()\` (\`packages/@aws-cdk/toolkit-lib/lib/api/drift/drift-formatter.ts\`) computed:

```ts
numResourcesUnchecked: this.allStackResources.size - this.resourceDriftResults.length,
```

This only counts resources CloudFormation returned **no drift record for at all**. But the printed \"Unchecked Resources\" text section (\`formatStackDriftChanges\`, a few lines below) uses different, more complete logic — it also treats a resource as unchecked if it **has** a drift record whose status is \`UNKNOWN\`:

```ts
const uncheckedResources = Array.from(this.allStackResources.keys()).filter((logicalId) => {
  const drift = drifts.find((d) => d.LogicalResourceId === logicalId);
  return !drift || drift.StackResourceDriftStatus === StackResourceDriftStatus.UNKNOWN;
});
```

\`UNKNOWN\` is a real, common CloudFormation status (missing permissions, resource type without full drift-detection support, throttling — there's already error-handling elsewhere in this codebase specifically for it).

Net effect: a resource with an \`UNKNOWN\`-status drift record is listed under \"Unchecked Resources\" in the detailed output, but doesn't count toward \`numResourcesUnchecked\`. That field feeds \`Toolkit.driftAll\`'s final summary line in \`toolkit.ts\`:

```ts
const totalUnchecked = Object.values(allDriftResults).reduce((total, current) => total + (current.numResourcesUnchecked ?? 0), 0);
await driftSpan.end(\`\n✨  Number of resources with drift: \${totalDrifts}\${totalUnchecked ? \` (\${totalUnchecked} unchecked)\` : ''}\`);
```

...so if the *only* unchecked resources have \`UNKNOWN\` status (rather than being entirely missing from the results), \`totalUnchecked\` is 0 and the \`(N unchecked)\` suffix is silently dropped — even though the detailed output right above it explicitly lists an unchecked resource. Self-contradictory CLI output that can give false confidence everything was verified.

### Description of changes

Extracts the unchecked-resource computation into a single \`getUncheckedResources()\` private helper, used by both:
- the numeric \`numResourcesUnchecked\` field (both branches of \`formatStackDrift\`), and
- the printed \"Unchecked Resources\" list (\`formatStackDriftChanges\`, previously duplicating the same filter inline)

so the count and the list are computed from one source of truth and can't diverge again.

### Description of how you validated changes

Added assertions to the two existing tests that already construct \`UNKNOWN\`-status fixtures (\`'formatting with UNKNOWN drift status'\` and \`'formatting with only UNKNOWN drift status'\` in \`test/api/drift/drift.test.ts\`) — they exercised the \`unchecked\` text output but never checked \`numResourcesUnchecked\`. Verified both new assertions fail on the pre-fix code (expected 1 / 2, got 0 in both cases) and pass with the fix.

Ran the full \`test/api/drift/\` and \`test/actions/drift.test.ts\` suites — 27 passed, no regressions. \`eslint --fix\` clean.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — pure output-formatting bug in a helper class, fully covered by unit tests)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license