### PR TITLE
fix(toolkit-lib): asset publisher cache ignores environment on cache hit

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -319,7 +319,7 @@ export class Deployments {
    */
   private readonly deployStackSdkProvider: SdkProvider;
 
-  private readonly publisherCache = new Map<cdk_assets.AssetManifest, cdk_assets.AssetPublishing>();
+  private readonly publisherCache = new Map<cdk_assets.AssetManifest, Map<string, cdk_assets.AssetPublishing>>();
 
   private _allowCrossAccountAssetPublishing: boolean | undefined;
 
@@ -783,7 +783,19 @@ export class Deployments {
   }
 
   private cachedPublisher(assetManifest: cdk_assets.AssetManifest, env: cxapi.Environment, stackName?: string) {
-    const existing = this.publisherCache.get(assetManifest);
+    // Cache by both the manifest and the resolved environment: an AssetManifest object is
+    // normally only ever seen with a single environment, but if the same instance is ever
+    // passed in for a different account/region (e.g. a long-lived Deployments/Toolkit reusing
+    // the same parsed cloud assembly to deploy to multiple accounts), we must not silently
+    // reuse a publisher built with the wrong account's credentials for asset uploads.
+    const envKey = `${env.account}:${env.region}`;
+    let byEnv = this.publisherCache.get(assetManifest);
+    if (!byEnv) {
+      byEnv = new Map();
+      this.publisherCache.set(assetManifest, byEnv);
+    }
+
+    const existing = byEnv.get(envKey);
     if (existing) {
       return existing;
     }
@@ -794,7 +806,7 @@ export class Deployments {
       aws: new PublishingAws(this.assetSdkProvider, env),
       progressListener: new ParallelSafeAssetProgress(prefix, this.ioHelper),
     });
-    this.publisherCache.set(assetManifest, publisher);
+    byEnv.set(envKey, publisher);
     return publisher;
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -1,3 +1,4 @@
+import { AssetManifest } from '@aws-cdk/cdk-assets-lib';
 import {
   ContinueUpdateRollbackCommand,
   DescribeStackEventsCommand,
@@ -1311,6 +1312,35 @@ describe('stackExists', () => {
     expect(mockForEnvironment).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({
       assumeRoleArn: expectedRoleArn,
     }));
+  });
+});
+
+describe('cachedPublisher', () => {
+  // Regression test: the publisher cache used to be keyed only by the AssetManifest
+  // object, so if the same AssetManifest instance were ever passed in for two different
+  // environments (e.g. a long-lived Deployments instance reused to deploy the same
+  // synthesized cloud assembly to two different AWS accounts), the second call would
+  // silently reuse the first publisher - built with the first account's credentials -
+  // to build/publish/check assets against what should be an entirely different account.
+  test('does not reuse a publisher across different environments for the same AssetManifest', () => {
+    const manifest = new AssetManifest('/tmp/assets', { version: '1.0.0', files: {}, dockerImages: {} } as any);
+    const envA = { name: 'aws://111111111111/us-east-1', account: '111111111111', region: 'us-east-1' };
+    const envB = { name: 'aws://222222222222/eu-west-1', account: '222222222222', region: 'eu-west-1' };
+
+    const publisherA = (deployments as any).cachedPublisher(manifest, envA, 'StackA');
+    const publisherB = (deployments as any).cachedPublisher(manifest, envB, 'StackB');
+
+    expect(publisherA).not.toBe(publisherB);
+  });
+
+  test('reuses the cached publisher for repeat calls with the same environment', () => {
+    const manifest = new AssetManifest('/tmp/assets', { version: '1.0.0', files: {}, dockerImages: {} } as any);
+    const env = { name: 'aws://111111111111/us-east-1', account: '111111111111', region: 'us-east-1' };
+
+    const first = (deployments as any).cachedPublisher(manifest, env, 'StackA');
+    const second = (deployments as any).cachedPublisher(manifest, env, 'StackA');
+
+    expect(second).toBe(first);
   });
 });
 


### PR DESCRIPTION
fixes #1838

### Reason for this change

\`Deployments.cachedPublisher()\` (\`packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts\`) caches an \`AssetPublishing\` instance keyed only by the \`AssetManifest\` object identity:

```ts
private readonly publisherCache = new Map<cdk_assets.AssetManifest, cdk_assets.AssetPublishing>();

private cachedPublisher(assetManifest: cdk_assets.AssetManifest, env: cxapi.Environment, stackName?: string) {
  const existing = this.publisherCache.get(assetManifest);
  if (existing) {
    return existing; // env silently discarded on a cache hit
  }
  const publisher = new cdk_assets.AssetPublishing(assetManifest, {
    aws: new PublishingAws(this.assetSdkProvider, env), // env only honored on cache miss
    ...
  });
  this.publisherCache.set(assetManifest, publisher);
  return publisher;
}
```

\`buildSingleAsset\`/\`publishSingleAsset\`/\`isSingleAssetPublished\` each resolve the calling stack's environment fresh and pass it in — the parameter exists to bind the publisher (and the \`PublishingAws\`/role-assumption context it wraps, i.e. **which AWS account's credentials get used for S3/ECR asset operations**) to the correct account/region. But it's a \"trust the first caller forever\" cache: a second call for the same \`AssetManifest\` object with a *different* \`env\` silently reuses the first call's publisher/credentials instead.

**Reachability, stated honestly:** under standard single-invocation \`cdk deploy\`/\`cdk destroy\` CLI usage this isn't triggered, because each stack's asset manifest is freshly parsed via \`AssetManifest.fromFile()\` (confirmed non-memoizing by reading \`cdk-assets-lib/lib/asset-manifest.ts\`), so each stack naturally gets a distinct \`AssetManifest\` object. It **is** reachable through supported programmatic \`toolkit-lib\` usage — a long-lived \`Deployments\`/\`Toolkit\` instance that reuses the same synthesized cloud assembly's parsed \`AssetManifest\` objects to deploy to more than one account/region without re-synthesizing between calls (e.g. deploying one app to multiple accounts by switching credentials). In that scenario, asset builds/publishes/existence-checks for the second account would silently run under the first account's credentials — a real, silent-failure-mode security/correctness defect in code with zero prior test coverage.

### Description of changes

Changes \`publisherCache\` from \`Map<AssetManifest, AssetPublishing>\` to \`Map<AssetManifest, Map<string, AssetPublishing>>\`, keying the inner map by \`${env.account}:${env.region}\`. A publisher is now only ever reused for a call with the exact same manifest *and* the exact same resolved environment.

### Description of how you validated changes

Added two tests directly against \`cachedPublisher\` (accessed via the existing test file's \`Deployments\` instance):
- \`'does not reuse a publisher across different environments for the same AssetManifest'\` — calls \`cachedPublisher\` with the same manifest but two different envs, asserts the returned publishers are different objects. **Fails on the pre-fix code**: the assertion failure output shows the second call's returned publisher still carrying the first call's progress-listener prefix (\`\"StackA: \"\`) even though it was called with \`stackName: 'StackB'\` — a concrete, visible confirmation of the cross-environment leak.
- \`'reuses the cached publisher for repeat calls with the same environment'\` — confirms the legitimate caching behavior (same manifest + same env) is preserved.

Ran the full \`test/api/deployments/\` suite (194 tests) and \`test/actions/deploy*\` (54 tests) — all pass, no regressions. \`eslint --fix\` clean (also auto-sorted the new import).

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — internal caching bug in a helper class; the scenario that triggers it, direct programmatic toolkit-lib reuse across environments, is exercised by the new unit tests, and standard CLI integration tests wouldn't reach this path per the reachability note above)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license