### PR TITLE
fix(toolkit-lib): hotswap deployments fail with TypeError when a nested stack output joins a List<> parameter

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/evaluate-cloudformation-template.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/evaluate-cloudformation-template.ts
@@ -82,6 +82,18 @@ export class LazyLookupExport implements LookupExport {
 export class CfnEvaluationException extends Error {
 }
 
+function assertEvaluatesToArray(intrinsic: string, value: any): asserts value is any[] {
+  if (!Array.isArray(value)) {
+    throw new CfnEvaluationException(`${intrinsic}: expected an array, got ${JSON.stringify(value)}`);
+  }
+}
+
+function assertEvaluatesToString(intrinsic: string, value: any): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new CfnEvaluationException(`${intrinsic}: expected a string, got ${JSON.stringify(value)}`);
+  }
+}
+
 export interface ResourceDefinition {
   readonly LogicalId: string;
   readonly Type: string;
@@ -239,16 +251,19 @@ export class EvaluateCloudFormationTemplate {
 
       async 'Fn::Join'(separator: string, args: any[]): Promise<string> {
         const evaluatedArgs = await self.evaluateCfnExpression(args);
+        assertEvaluatesToArray('Fn::Join', evaluatedArgs);
         return evaluatedArgs.join(separator);
       }
 
-      async 'Fn::Split'(separator: string, args: any): Promise<string> {
+      async 'Fn::Split'(separator: string, args: any): Promise<string[]> {
         const evaluatedArgs = await self.evaluateCfnExpression(args);
+        assertEvaluatesToString('Fn::Split', evaluatedArgs);
         return evaluatedArgs.split(separator);
       }
 
       async 'Fn::Select'(index: number, args: any[]): Promise<string> {
         const evaluatedArgs = await self.evaluateCfnExpression(args);
+        assertEvaluatesToArray('Fn::Select', evaluatedArgs);
         return evaluatedArgs[index];
       }
 
@@ -449,7 +464,7 @@ export class EvaluateCloudFormationTemplate {
       const evaluateCfnTemplate = await this.createNestedEvaluateCloudFormationTemplate(
         dependantStack.physicalName,
         dependantStack.generatedTemplate,
-        dependantStack.generatedTemplate.Parameters!,
+        this.template.Resources?.[logicalId]?.Properties?.Parameters ?? {},
       );
 
       // Split Outputs.<refName> into 'Outputs' and '<refName>' and recursively call evaluate

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/evaluate-cloudformation-template.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloudformation/evaluate-cloudformation-template.test.ts
@@ -241,6 +241,98 @@ describe('evaluateCfnExpression', () => {
     });
   });
 
+  describe('intrinsic type guards', () => {
+    const template: Template = {};
+    const evaluateCfnTemplate = createEvaluateCloudFormationTemplate(template);
+
+    test('Fn::Join throws CfnEvaluationException when args evaluate to non-array', async () => {
+      const err = await evaluateCfnTemplate.evaluateCfnExpression({ 'Fn::Join': ['||', { Type: 'List<String>' }] })
+        .catch((e: any) => e);
+      expect(err).toBeInstanceOf(CfnEvaluationException);
+      expect(err.message).toContain('Fn::Join');
+      expect(err.message).toContain('{"Type":"List<String>"}');
+    });
+
+    test('Fn::Split throws CfnEvaluationException when args evaluate to non-string', async () => {
+      const err = await evaluateCfnTemplate.evaluateCfnExpression({ 'Fn::Split': ['|', ['a', 'b']] })
+        .catch((e: any) => e);
+      expect(err).toBeInstanceOf(CfnEvaluationException);
+      expect(err.message).toContain('Fn::Split');
+      expect(err.message).toContain('["a","b"]');
+    });
+
+    test('Fn::Select throws CfnEvaluationException when args evaluate to non-array', async () => {
+      const err = await evaluateCfnTemplate.evaluateCfnExpression({ 'Fn::Select': [0, 'not-an-array'] })
+        .catch((e: any) => e);
+      expect(err).toBeInstanceOf(CfnEvaluationException);
+      expect(err.message).toContain('Fn::Select');
+      expect(err.message).toContain('"not-an-array"');
+    });
+  });
+
+  describe('nested stack parameter resolution', () => {
+    test('resolves nested stack output that joins a List<> parameter using parent parameter values', async () => {
+      const nestedTemplate: Template = {
+        Parameters: {
+          ListParam: { Type: 'AWS::SSM::Parameter::Value<List<String>>' },
+        },
+        Outputs: {
+          JoinedOutput: {
+            Value: { 'Fn::Join': ['||', { Ref: 'ListParam' }] },
+          },
+        },
+      };
+
+      const parentTemplate: Template = {
+        Resources: {
+          NestedStack: {
+            Type: 'AWS::CloudFormation::Stack',
+            Properties: {
+              Parameters: {
+                ListParam: ['val1', 'val2', 'val3'],
+              },
+            },
+          },
+        },
+      };
+
+      const evaluator = new EvaluateCloudFormationTemplate({
+        template: parentTemplate,
+        stackName: 'parent-stack',
+        parameters: {},
+        account: '0123456789',
+        region: 'ap-south-east-2',
+        partition: 'aws',
+        sdk,
+        stackArtifact: {} as any,
+        nestedStacks: {
+          NestedStack: {
+            physicalName: 'parent-stack-NestedStack-123',
+            deployedTemplate: nestedTemplate,
+            generatedTemplate: nestedTemplate,
+            nestedStackTemplates: {},
+          },
+        },
+      });
+
+      mockCloudFormationClient.on(ListStackResourcesCommand).resolves({
+        StackResourceSummaries: [{
+          LogicalResourceId: 'NestedStack',
+          PhysicalResourceId: 'parent-stack-NestedStack-123',
+          ResourceType: 'AWS::CloudFormation::Stack',
+          ResourceStatus: 'CREATE_COMPLETE',
+          LastUpdatedTimestamp: new Date(),
+        }],
+      });
+
+      const result = await evaluator.evaluateCfnExpression({
+        'Fn::GetAtt': ['NestedStack', 'Outputs.JoinedOutput'],
+      });
+
+      expect(result).toEqual('val1||val2||val3');
+    });
+  });
+
   describe('resolving Fn::ImportValue', () => {
     const template: Template = {};
     const evaluateCfnTemplate = createEvaluateCloudFormationTemplate(template);


### PR DESCRIPTION
Fixes #1829

Hotswap deployments crash with an uncaught `TypeError: evaluatedArgs.join is not a function` when a nested stack output uses `Fn::Join` on a `List<>`-typed parameter. The nested-stack evaluator was seeded with parameter declarations (e.g. `{"Type": "AWS::SSM::Parameter::Value<List<String>>"}`) instead of the values from the parent resource's `Properties.Parameters`, and the resulting `TypeError` escaped the `CfnEvaluationException`-only handler, aborting the deployment instead of falling back to CloudFormation.

Two-part fix:

1. Seed the nested evaluator with `Properties.Parameters` from the parent resource, so `Ref` resolves to actual values.
2. Add `assertEvaluatesToArray` / `assertEvaluatesToString` guards to `Fn::Join`, `Fn::Split`, and `Fn::Select`, throwing `CfnEvaluationException` (caught, triggers CloudFormation fallback) instead of a raw `TypeError`. The guards are required even with the seed fix: a nested stack resource without `Properties.Parameters` seeds `{}`, `Ref` falls through to the declaration's `Default` (a non-array), and only the guard prevents the crash.

Known limitation: CloudFormation's nested-stack `Parameters` map is `Map<String, String>`, so list values arrive as `"val1,val2,val3"` and fall back to CloudFormation instead of hotswapping (possible follow-up).

---

- [x] Unit tests added/updated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
