### PR TITLE
fix(cli): reject non-numeric ids in cdk acknowledge

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -256,8 +256,18 @@ export class CdkToolkit {
   }
 
   public async acknowledge(noticeId: string) {
+    const issueNumber = Number(noticeId);
+    if (!Number.isInteger(issueNumber)) {
+      throw new ToolkitError(
+        'InvalidAcknowledgementId',
+        `Invalid notice ID '${noticeId}': 'cdk acknowledge' only accepts numeric notice IDs (e.g. 'cdk acknowledge 12345'). ` +
+        'Scoped construct warnings such as \'@aws-cdk/aws-ecs:minHealthyPercent\' are acknowledged in code with ' +
+        'Annotations.of(scope).acknowledgeWarning(\'<id>\').',
+      );
+    }
+
     const acks = new Set(this.props.configuration.context.get('acknowledged-issue-numbers') ?? []);
-    acks.add(Number(noticeId));
+    acks.add(issueNumber);
     this.props.configuration.context.set('acknowledged-issue-numbers', Array.from(acks));
     await this.props.configuration.saveContext();
   }

--- a/packages/aws-cdk/test/commands/acknowledge.test.ts
+++ b/packages/aws-cdk/test/commands/acknowledge.test.ts
@@ -29,4 +29,16 @@ describe('acknowledge command', () => {
     // THEN
     expect(configuration.context.get('acknowledged-issue-numbers')).toEqual([12345]);
   });
+
+  test('acknowledging a scoped construct warning id throws and does not corrupt the context', async () => {
+    // WHEN / THEN
+    await expect(toolkit.acknowledge('@aws-cdk/aws-ecs:minHealthyPercent')).rejects.toThrow(/numeric notice IDs/i);
+
+    // AND the context is not corrupted with a `null` entry
+    expect(configuration.context.get('acknowledged-issue-numbers')).toBeUndefined();
+  });
+
+  test('acknowledging a non-numeric id throws', async () => {
+    await expect(toolkit.acknowledge('not-a-number')).rejects.toThrow(/Invalid notice ID/i);
+  });
 });


### PR DESCRIPTION
Fixes #248

`cdk acknowledge <id>` ran its argument through `Number()`, so a scoped construct warning id such as `@aws-cdk/aws-ecs:minHealthyPercent` became `NaN` and was serialized as `null` into `acknowledged-issue-numbers` in `cdk.context.json` — corrupting the file, while the warning still displayed.

`cdk acknowledge` is for numeric notice IDs; scoped construct warnings are acknowledged in code via `Annotations.of(scope).acknowledgeWarning('<id>')`. This validates the id is a numeric notice id and fails fast with a clear, actionable error instead of silently writing `null`:

```
Invalid notice ID '@aws-cdk/aws-ecs:minHealthyPercent': 'cdk acknowledge' only accepts numeric notice IDs (e.g. 'cdk acknowledge 12345'). Scoped construct warnings such as '@aws-cdk/aws-ecs:minHealthyPercent' are acknowledged in code with Annotations.of(scope).acknowledgeWarning('<id>').
```

Numeric IDs are unchanged. Added unit tests (a scoped id throws and leaves the context uncorrupted; a non-numeric id throws) — `acknowledge.test.ts` passes (3/3).

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
