### PR TITLE
fix(toolkit-lib): NoStack masks the real error when a new stack fails to deploy

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/stack-helpers.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloudformation/stack-helpers.ts
@@ -68,16 +68,6 @@ export class CloudFormationStack {
   }
 
   /**
-   * Returns the Stack object returned from the CloudFormation service response that this decorating object wraps
-   */
-  public get wrapped(): Stack {
-    if (!this.stack) {
-      throw new ToolkitError('NoStack', 'CloudFormationStack object does not hold a stack');
-    }
-    return this.stack;
-  }
-
-  /**
    * Retrieve the stack's deployed template
    *
    * Cached, so will only be retrieved once. Will return an empty

--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deploy-stack.ts
@@ -45,6 +45,7 @@ import { invalidateHotswapTemplateCache, readHotswapTemplateCache } from '../hot
 import type { IoHelper } from '../io/private';
 import type { ResourcesToImport } from '../resource-import';
 import { StackActivityMonitor } from '../stack-events';
+import type { ResourceErrors } from '../stack-events/resource-errors';
 
 export interface DeployStackOptions {
   /**
@@ -719,7 +720,7 @@ class FullCloudFormationDeployment {
     });
     await monitor.start();
 
-    let finalState = this.cloudFormationStack;
+    let finalState: CloudFormationStack;
     try {
       const successStack = await waitForStackDeploy(this.cfn, this.ioHelper, this.stackName, this.options.stackEventPollingInterval);
 
@@ -729,15 +730,12 @@ class FullCloudFormationDeployment {
       }
       finalState = successStack;
     } catch (e: any) {
-      // If this is a deployment error, route the diagnosis and error reporting through the central code for that
+      // Deployment errors get replaced by a diagnosis of the underlying resource failures, which says more.
+      // Any other error, and any failure to diagnose, leaves `e` to propagate as it is.
       if (ToolkitError.isDeploymentError(e)) {
-        const diagnosis = await this.diagnoser.diagnoseFromErrorCollection(monitor.errors, finalState.wrapped, true, {
-          rollbackEnabled: this.options.rollback !== false,
-        });
-        diagnosis.throwOnError();
+        await this.diagnoseDeploymentFailure(stackArn, monitor.errors);
       }
 
-      // Otherwise rethrow the current error and hope it has enough information.
       throw e;
     } finally {
       await monitor.stop();
@@ -751,6 +749,31 @@ class FullCloudFormationDeployment {
       deleteFailures: this.update ? monitor.deleteFailures : [],
       stabilizingResources: monitor.stabilizingResources,
     };
+  }
+
+  /**
+   * Throw a `DeploymentError` describing why the deployment failed, if we can establish that
+   *
+   * Returns normally when no cause could be established, leaving the caller's original error as the better
+   * one to report.
+   */
+  private async diagnoseDeploymentFailure(stackArn: string, errors: ResourceErrors): Promise<void> {
+    // Describe the stack as it is now. The pre-deploy description held by this class is either absent (the
+    // stack is being created) or describes a state the deployment has since left.
+    const deployedState = await this.cfn.describeStacks({ StackName: stackArn })
+      .then((response) => response.Stacks?.[0])
+      .catch(async (e) => {
+        await this.ioHelper.defaults.debug(`Could not describe ${stackArn} to diagnose the failure: ${formatErrorMessage(e)}`);
+        return undefined;
+      });
+    if (!deployedState) {
+      return;
+    }
+
+    const diagnosis = await this.diagnoser.diagnoseFromErrorCollection(errors, deployedState, true, {
+      rollbackEnabled: this.options.rollback !== false,
+    });
+    diagnosis.throwOnError();
   }
 
   /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-error-surfacing.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-error-surfacing.test.ts
@@ -1,0 +1,149 @@
+import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import { deployStack } from '../../../lib/api/deployments/deploy-stack';
+import type { DeployStackOptions as DeployStackApiOptions } from '../../../lib/api/deployments/deploy-stack';
+import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
+import { NoBootstrapStackEnvironmentResources } from '../../../lib/api/environment';
+import { StackArtifactSourceTracer } from '../../../lib/api/source-tracing/private/stack-source-tracing';
+import { ToolkitError } from '../../../lib/toolkit/toolkit-error';
+import { testStack } from '../../_helpers/assembly';
+import { FakeCloudFormation } from '../../_helpers/fake-aws/fake-cloudformation';
+import { advanceTime } from '../../_helpers/fake-time';
+import {
+  mockCloudFormationClient,
+  mockResolvedEnvironment,
+  MockSdk,
+  MockSdkProvider,
+  restoreSdkMocksToDefault,
+} from '../../_helpers/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+
+jest.mock('../../../lib/api/deployments/checks', () => ({
+  determineAllowCrossAccountAssetPublishing: jest.fn().mockResolvedValue(true),
+}));
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
+
+const FAILING_STACK = testStack({
+  stackName: 'freshstack',
+  template: {
+    Resources: {
+      Bad: {
+        Type: 'Test::Fake::Resource',
+        Properties: { Fail: true },
+      },
+    },
+  },
+});
+
+let sdk: MockSdk;
+let sdkProvider: MockSdkProvider;
+const fakeCfn = new FakeCloudFormation();
+
+beforeEach(() => {
+  fakeCfn.reset();
+  sdkProvider = new MockSdkProvider();
+  sdk = new MockSdk();
+  sdk.getUrlSuffix = () => Promise.resolve('amazonaws.com');
+  restoreSdkMocksToDefault();
+  fakeCfn.installUsingAwsMock(mockCloudFormationClient);
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+function standardDeployStackArguments(stack: CloudFormationStackArtifact): DeployStackApiOptions {
+  const resolvedEnvironment = mockResolvedEnvironment();
+  return {
+    stack,
+    sdk,
+    sdkProvider,
+    resolvedEnvironment,
+    envResources: new NoBootstrapStackEnvironmentResources(resolvedEnvironment, sdk, ioHelper),
+    diagnoser: new CloudFormationStackDiagnoser({
+      sdk,
+      sourceTracer: new StackArtifactSourceTracer(stack),
+      ioHelper,
+      topLevelStackHierarchicalId: stack.hierarchicalId,
+    }),
+  };
+}
+
+describe.each(['change-set', 'direct'] as const)('a failing %s deployment of a new stack', (method) => {
+  test('reports the CloudFormation failure rather than an internal NoStack error', async () => {
+    // GIVEN - a stack that does not exist yet, so the pre-deploy lookup holds no stack at all
+    const deployment = advanceTime(deployStack({
+      ...standardDeployStackArguments(FAILING_STACK),
+      deploymentMethod: { method },
+    }, ioHelper));
+
+    // THEN - either the resource-level diagnosis or the status the stack ended up in, but something
+    // that names the actual failure
+    await expect(deployment).rejects.toThrow(/freshstack\/Bad|ROLLBACK_COMPLETE/);
+    await expect(deployment).rejects.not.toThrow(/does not hold a stack/);
+    await expect(deployment).rejects.toMatchObject({ name: 'DeploymentError' });
+  });
+
+  test('reports the CloudFormation failure when rollback is disabled', async () => {
+    // GIVEN - without rollback the stack stays CREATE_FAILED rather than rolling back, reaching the
+    // diagnoser through a different status
+    const deployment = advanceTime(deployStack({
+      ...standardDeployStackArguments(FAILING_STACK),
+      deploymentMethod: { method },
+      rollback: false,
+    }, ioHelper));
+
+    // THEN
+    await expect(deployment).rejects.toThrow(/freshstack\/Bad|CREATE_FAILED/);
+    await expect(deployment).rejects.not.toThrow(/does not hold a stack/);
+  });
+});
+
+test('a failing update of an existing stack still reports the CloudFormation failure', async () => {
+  // GIVEN - the same failure without the absent-stack path, guarding against a fix that only works
+  // when the stack is missing
+  fakeCfn.createStackSync({ StackName: 'freshstack' });
+
+  // WHEN
+  const deployment = advanceTime(deployStack({
+    ...standardDeployStackArguments(FAILING_STACK),
+    deploymentMethod: { method: 'change-set' },
+  }, ioHelper));
+
+  // THEN
+  await expect(deployment).rejects.toThrow(/freshstack\/Bad|UPDATE_ROLLBACK_COMPLETE/);
+  await expect(deployment).rejects.not.toThrow(/does not hold a stack/);
+});
+
+test('a failed lookup while diagnosing leaves the deployment error intact', async () => {
+  // GIVEN - describing the deployed stack fails while we are trying to diagnose why the deployment
+  // failed. Diagnosis is best-effort, so this must not replace the deployment error.
+  const debugIoHost = new TestIoHost('debug');
+  const realClient = sdk.cloudFormation();
+  jest.spyOn(sdk, 'cloudFormation').mockReturnValue({
+    ...realClient,
+    describeStacks: async (input) => {
+      if (input.StackName?.startsWith('arn:')) {
+        throw new ToolkitError('Throttling', 'Rate exceeded');
+      }
+      return realClient.describeStacks(input);
+    },
+  });
+
+  // WHEN
+  const deployment = advanceTime(deployStack({
+    ...standardDeployStackArguments(FAILING_STACK),
+    deploymentMethod: { method: 'change-set' },
+  }, debugIoHost.asHelper('deploy')));
+
+  // THEN
+  await expect(deployment).rejects.toThrow(/ROLLBACK_COMPLETE/);
+  await expect(deployment).rejects.not.toThrow(/Rate exceeded/);
+  await expect(deployment).rejects.toMatchObject({ name: 'DeploymentError' });
+
+  // ...and the swallowed lookup failure is still visible to anyone debugging
+  debugIoHost.expectMessage({ level: 'debug', containing: 'Rate exceeded' });
+});


### PR DESCRIPTION
Relates to #1802

First of two PRs, split per review feedback on #1803. This is the error-masking half; the stale `DescribeStacks` read follows separately.

## The bug

`monitorDeployment` passed `finalState.wrapped` to the diagnoser from inside its catch block. `finalState` is still the *pre-deploy* lookup at that point, which holds no stack when the deployment was creating one from scratch — so the `wrapped` getter threw `NoStack`. Because that happened while evaluating an **argument**, it replaced the deployment error being reported:

```
NoStack: CloudFormationStack object does not hold a stack
```

Every failed deployment of a new stack was affected, not only the ones from the stale-read bug in #1802. A plain resource failure that rolled the stack back reported `NoStack` instead of naming the resource, and the diagnoser's CloudTrail enrichment was discarded.

## What changed

Diagnosis is an *enrichment* of the deployment error — it can only ever replace that error with something that says more. The old code broke that in two ways, and the guard for a third was missing. It now lives in one helper that holds to the invariant:

```ts
} catch (e: any) {
  // Deployment errors get replaced by a diagnosis of the underlying resource failures, which says more.
  // Any other error, and any failure to diagnose, leaves `e` to propagate as it is.
  if (ToolkitError.isDeploymentError(e)) {
    await this.diagnoseDeploymentFailure(stackArn, monitor.errors);
  }

  throw e;
}
```

- **Describe the stack that was actually deployed.** The pre-deploy description is absent when creating and stale when updating, and the diagnoser reads the status off it.
- **A failed describe returns without throwing**, leaving the original error to propagate rather than replacing it with something less useful. This answers the *"but this can also fail... what then?"* comment.
- **The lookup failure is logged at debug**, matching `stack-diagnoser.ts:163` — a throttled or access-denied diagnosis was previously invisible even under `-v`.

Two consequences worth calling out, both of which shrink the surface rather than grow it:

- `finalState`'s initialiser is now provably dead — the try block either assigns or throws, and the catch always rethrows — so the mutable local that meant two different things at two points in the method no longer starts life holding a pre-deploy value. That's what made this bug representable in the first place.
- With the helper describing the stack directly rather than through `CloudFormationStack.lookup(...).wrapped`, the `wrapped` getter has **no callers left anywhere in the repo**, so it's removed. The class whose throwing getter caused this no longer has one.

## Testing

New `deploy-stack-error-surfacing.test.ts`, 6 cases: a failing create via change-set and direct, each with rollback on and off; a failing update of an existing stack (guards against a fix that only works when the stack is missing); and a describe that fails mid-diagnosis, asserting the original `ROLLBACK_COMPLETE` error survives and the swallowed failure is still visible at debug level.

Written before the fix — 5 of the 6 failed at `stack-helpers.ts:75` via the catch block, and the existing-stack case passed both before and after. Each subsequent cleanup was verified load-bearing by reverting it and confirming a specific test failed.

Full `toolkit-lib` suite passes (1905 tests). No integ test: no new resource types or cross-service interactions.

## Follow-ups, deliberately not here

- `waitForStackDeploy` already holds the settled `CloudFormationStack` from `stabilizeStack` and discards it when throwing, so this helper re-describes the same stack. Worth fixing — the CFN client is configured with 7 retries capped at 15s, so on a throttled account that redundant read can add up to ~60s per failed stack, on precisely the path where throttling is the likely cause. It needs a `cfn-api.ts` signature change, so it's out of scope for this PR.
- Moving diagnosis into `CloudFormationStackDiagnoser` (so callers never hold a raw `Stack`) needs `Diagnosis.throwOnError()` split into `throwOnError`/`throwOnProblem` first. Otherwise a diagnoser-owned lookup failure surfaces as `ErrorDiagnosisFailed` and masks the real error — this same bug class through a different door.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
