### PR TITLE
chore(cli-integ): integ workflow cannot check out pull requests from forks

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -42,10 +42,11 @@ jobs:
     steps:
       - name: Checkout
         id: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
+          allow-unsafe-pr-checkout: true
       - name: Fetch tags from origin repo
         id: fetch_tags_from_origin_repo
         run: |-

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -384,12 +384,16 @@ export class CdkCliIntegTestsWorkflow extends Component {
       steps: [
         {
           name: 'Checkout',
-          uses: 'actions/checkout@v6',
+          uses: 'actions/checkout@v7',
           with: {
             // IMPORTANT! This must be `head.sha` not `head.ref`, otherwise we
             // are vulnerable to a TOCTOU attack.
-            ref: '${{ github.event.pull_request.head.sha }}',
-            repository: '${{ github.event.pull_request.head.repo.full_name }}',
+            'ref': '${{ github.event.pull_request.head.sha }}',
+            'repository': '${{ github.event.pull_request.head.repo.full_name }}',
+            // Need to allow forks, the workflow has been reviewed and getting OIDC credentials is the point
+            // Other credentials are environment protected
+            // @see https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target
+            'allow-unsafe-pr-checkout': true,
           },
         },
         // We used to fetch tags from the repo using 'checkout', but if it's a fork


### PR DESCRIPTION
This unblocks the CLI integration test workflow, which can no longer check out the head commit of a pull request from a fork.

`actions/checkout` now refuses that by default, on both v6 and v7, because checking out fork code from a `pull_request_target` workflow means running untrusted code in a privileged context. Our integ workflow does exactly that on purpose: it exists to run a contributor's changes against real AWS environments, so checking out the fork head is the whole point and the workflow cannot function without it. We therefore opt back in with `allow-unsafe-pr-checkout` and leave a comment recording why.

This is safe for the same reasons it was before the input existed. The workflow already pins the checkout to `head.sha` rather than `head.ref` to avoid a TOCTOU attack where the branch is moved after approval, obtaining OIDC credentials for a throwaway test environment is the intended outcome, and every other credential the workflow touches sits behind a GitHub environment protection rule that requires a maintainer to approve the run.

The bump from v6 to v7 is incidental tidiness rather than a requirement — the new input is available in both — but since we are touching this step anyway it may as well move to the current major.

### Checklist
- [x] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version: https://github.com/actions/checkout/releases/tag/v7.0.0

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
