### PR TITLE
feat(cli): default to errors-only progress when run by an AI agent

### DIFF
--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -413,7 +413,10 @@ $ cdk deploy --progress errors-only
 ```
 
 The `errors-only` mode is recommended for AI agents and other automated consumers, where progress
-updates are not useful and consume tokens.
+updates are not useful and consume tokens. If the CLI detects it is being run by an AI agent
+and no progress preference is configured, it defaults to `errors-only` automatically. Pass an
+explicit `--progress`, set the `progress` key in `cdk.json`, or enable verbose logging (`-v`)
+to override the detection.
 
 Alternatively, the `progress` key can be specified in the project config (`cdk.json`).
 

--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -30,6 +30,7 @@ import { Deployments } from '../api/deployments';
 import { HotswapMode } from '../api/hotswap';
 import type { Settings } from '../api/settings';
 import { contextHandler as context } from '../commands/context';
+import { StackActivityProgress } from '../commands/deploy';
 import { docs } from '../commands/docs';
 import { doctor } from '../commands/doctor';
 import { FlagCommandHandler } from '../commands/flags/flags';
@@ -114,6 +115,12 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
         _: argv._ as [Command, ...string[]], // TypeScript at its best
       },
     });
+
+  // Progress updates are wasted tokens for AI agents
+  if (guessAgent() && !argv.verbose && configuration.settings.get(['progress']) === undefined) {
+    ioHost.stackProgress = StackActivityProgress.ERRORS_ONLY;
+    await ioHost.defaults.info('AI agent detected, using --progress "errors-only" (set --progress or the "progress" key in cdk.json to change)');
+  }
 
   // Always create and use ProxyAgent to support configuration via env vars
   const proxyAgent = await new ProxyAgentProvider(ioHelper).create({

--- a/packages/aws-cdk/test/cli/cli.test.ts
+++ b/packages/aws-cdk/test/cli/cli.test.ts
@@ -4,6 +4,7 @@ import * as cdkToolkitModule from '../../lib/cli/cdk-toolkit';
 import { exec } from '../../lib/cli/cli';
 import { CliIoHost } from '../../lib/cli/io-host';
 import { Configuration } from '../../lib/cli/user-configuration';
+import { StackActivityProgress } from '../../lib/commands/deploy';
 import { TestIoHost } from '../_helpers/io-host';
 
 // Store original version module exports so we don't conflict with other tests
@@ -100,6 +101,12 @@ jest.mock('../../lib/cli/parse-command-line-arguments', () => ({
     const verboseIndex = args.findIndex((arg: string) => arg === '--verbose');
     if (verboseIndex !== -1 && args[verboseIndex + 1]) {
       result = { ...result, verbose: parseInt(args[verboseIndex + 1], 10) };
+    }
+
+    // Handle progress flag
+    const progressIndex = args.findIndex((arg: string) => arg === '--progress');
+    if (progressIndex !== -1 && args[progressIndex + 1]) {
+      result = { ...result, progress: args[progressIndex + 1] };
     }
 
     if (args.includes('--yes')) {
@@ -607,6 +614,80 @@ describe('publish-assets command tests', () => {
         concurrency: 4,
       }),
     );
+  });
+});
+
+describe('AI agent progress auto-default', () => {
+  let originalEnv: Record<string, string | undefined>;
+  let originalFromArgsAndFiles: typeof Configuration.fromArgsAndFiles;
+  let deploySpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Clear all env vars that guessAgent() detects, so the test environment doesn't interfere
+    originalEnv = {};
+    for (const key of Object.keys(process.env)) {
+      if (['CLAUDECODE', 'CURSOR_AGENT', 'VSCODE_AGENT', 'AWS_EXECUTION_ENV'].includes(key)
+        || key.startsWith('CODEX_') || key.startsWith('CLINE_')) {
+        originalEnv[key] = process.env[key];
+        delete process.env[key];
+      }
+    }
+    // A Configuration mock that reflects the command line arguments, like the real one
+    originalFromArgsAndFiles = Configuration.fromArgsAndFiles;
+    Configuration.fromArgsAndFiles = jest.fn().mockImplementation((_ioHelper: any, props: any) => ({
+      loadConfigFiles: jest.fn().mockResolvedValue(undefined),
+      settings: {
+        get: jest.fn().mockImplementation((key: string[]) =>
+          key[0] === 'progress' ? props?.commandLineArguments?.progress : undefined),
+      },
+      context: {
+        get: jest.fn().mockReturnValue([]),
+      },
+    }));
+    deploySpy = jest.spyOn(cdkToolkitModule.CdkToolkit.prototype, 'deploy').mockResolvedValue();
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+    Configuration.fromArgsAndFiles = originalFromArgsAndFiles;
+    deploySpy.mockRestore();
+  });
+
+  test('defaults to errors-only progress when an agent is detected', async () => {
+    process.env.CLAUDECODE = '1';
+
+    await exec(['deploy']);
+
+    expect(CliIoHost.instance().stackProgress).toBe(StackActivityProgress.ERRORS_ONLY);
+  });
+
+  test('does not change progress when no agent is detected', async () => {
+    await exec(['deploy']);
+
+    expect(CliIoHost.instance().stackProgress).not.toBe(StackActivityProgress.ERRORS_ONLY);
+  });
+
+  test('an explicit progress preference wins over agent detection', async () => {
+    process.env.CLAUDECODE = '1';
+
+    await exec(['deploy', '--progress', 'events']);
+
+    expect(CliIoHost.instance().stackProgress).toBe(StackActivityProgress.EVENTS);
+  });
+
+  test('verbose mode wins over agent detection', async () => {
+    process.env.CLAUDECODE = '1';
+
+    await exec(['deploy', '-v']);
+
+    expect(CliIoHost.instance().stackProgress).not.toBe(StackActivityProgress.ERRORS_ONLY);
   });
 });
 


### PR DESCRIPTION
Follow-up to #1800, when the CLI detects it is being run by an AI agent (`guessAgent()`) and no progress preference is configured anywhere, it defaults to `--progress errors-only`.

- An explicit `--progress` or a `progress` key in `cdk.json`/`~/.cdk.json` always wins
- Verbose logging (`-v`) also disables the detection
- When the default kicks in, a one-line info notice explains it and how to override, so the behavior is discoverable

**Design decisions:**
- No feature flag: this follows the existing precedent of environment-adaptive output defaults (TTY/CI/Windows fallbacks), with the `-v` escape hatch and visible notice covering the human-in-agent-terminal case

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license