### PR TITLE
fix(cli): recognize the AI_AGENT convention and more coding agents

### DIFF
--- a/packages/aws-cdk/lib/cli/util/guess-agent.ts
+++ b/packages/aws-cdk/lib/cli/util/guess-agent.ts
@@ -1,3 +1,29 @@
+/**
+ * Environment variables that indicate an AI agent is executing the command.
+ *
+ * Only variables set by the agent itself when running commands belong here.
+ * Variables that merely indicate an agent-capable IDE or environment
+ * (e.g. CURSOR_TRACE_ID, REPL_ID) do not: a human typing in such a terminal
+ * would be misdetected.
+ */
+const AGENT_ENV_VARS = [
+  // Generic convention adopted by multiple agents
+  'AI_AGENT',
+  'AGENT',
+
+  'CLAUDECODE', // Claude Code
+  'CODEX_THREAD_ID', // OpenAI Codex CLI
+  'CODEX_SANDBOX',
+  'CODEX_CI',
+  'CURSOR_AGENT', // Cursor CLI
+  'VSCODE_AGENT', // VS Code agent-aware terminal
+  'CLINE_ACTIVE', // Cline
+  'GEMINI_CLI', // Gemini CLI
+  'OPENCODE', // opencode
+  'COPILOT_CLI', // GitHub Copilot CLI; Copilot in VS Code sets no envvar
+  'AUGMENT_AGENT', // Augment
+  'QWEN_CODE', // Qwen Code
+];
 
 /**
  * Guess whether we're being executed by an AI agent
@@ -6,35 +32,15 @@
  * with `yes` or `don't know`.
  */
 export function guessAgent(): true | undefined {
+  if (AGENT_ENV_VARS.some((envVar) => process.env[envVar])) {
+    return true;
+  }
+
+  // Amazon Q CLI and Kiro identify themselves in the value of AWS_EXECUTION_ENV
   const awsExecutionEnv = (process.env.AWS_EXECUTION_ENV ?? '').toLocaleLowerCase();
   if (awsExecutionEnv.includes('amazonq') || awsExecutionEnv.includes('kiro')) {
     return true;
   }
-
-  if (process.env.CLAUDECODE) {
-    return true;
-  }
-
-  // Expecting CODEX_SANDBOX, CODEX_THREAD_ID
-  if (Object.keys(process.env).some(x => x.startsWith('CODEX_'))) {
-    return true;
-  }
-
-  if (process.env.CURSOR_AGENT) {
-    return true;
-  }
-
-  // https://code.visualstudio.com/updates/v1_121#_agentaware-terminal-commands
-  if (process.env.VSCODE_AGENT) {
-    return true;
-  }
-
-  // Cline -- not sure if it sets these, but users might to configure Cline.
-  if (Object.keys(process.env).some(x => x.startsWith('CLINE_'))) {
-    return true;
-  }
-
-  // Copilot doesn't set an envvar (at least not in VS Code)
 
   return undefined;
 }

--- a/packages/aws-cdk/test/cli/util/guess-agent.test.ts
+++ b/packages/aws-cdk/test/cli/util/guess-agent.test.ts
@@ -1,0 +1,61 @@
+import { guessAgent } from '../../../lib/cli/util/guess-agent';
+
+// Replace the environment wholesale, so tests are unaffected by the
+// agent (if any) running this test suite
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = process.env;
+  process.env = { PATH: originalEnv.PATH };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+test.each([
+  ['AI_AGENT', 'claude-code'],
+  ['AGENT', '1'],
+  ['CLAUDECODE', '1'],
+  ['CODEX_THREAD_ID', 'thread-123'],
+  ['CODEX_SANDBOX', '1'],
+  ['CODEX_CI', '1'],
+  ['CURSOR_AGENT', '1'],
+  ['VSCODE_AGENT', '1'],
+  ['CLINE_ACTIVE', 'true'],
+  ['GEMINI_CLI', '1'],
+  ['OPENCODE', '1'],
+  ['COPILOT_CLI', '1'],
+  ['AUGMENT_AGENT', '1'],
+  ['QWEN_CODE', '1'],
+])('detects %s', (envVar, value) => {
+  process.env[envVar] = value;
+  expect(guessAgent()).toBe(true);
+});
+
+test.each([
+  ['AmazonQ-For-CLI Version/1.23.1'],
+  ['kiro'],
+])('detects AWS_EXECUTION_ENV %s', (value) => {
+  process.env.AWS_EXECUTION_ENV = value;
+  expect(guessAgent()).toBe(true);
+});
+
+test('returns undefined without agent variables', () => {
+  expect(guessAgent()).toBeUndefined();
+});
+
+test('an empty value does not count', () => {
+  process.env.CLAUDECODE = '';
+  expect(guessAgent()).toBeUndefined();
+});
+
+test.each([
+  // User configuration for these tools does not mean they are running the command
+  ['CODEX_HOME', '/home/user/.codex'],
+  ['CLINE_API_KEY', 'secret'],
+  ['AWS_EXECUTION_ENV', 'AWS_Lambda_nodejs22.x'],
+])('does not misdetect %s', (envVar, value) => {
+  process.env[envVar] = value;
+  expect(guessAgent()).toBeUndefined();
+});


### PR DESCRIPTION
Restructures `guessAgent()` into a single env-var list and adds more to that list. 


**What changed:**
- Checks the emerging generic convention first: `AI_AGENT` ([proposed by Vercel](https://github.com/vercel/vercel/tree/main/packages/detect-agent), [set by Claude Code since v2.1.120](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)) and `AGENT` (set by [Amp](https://github.com/sourcegraph/amp), [Crush](https://github.com/charmbracelet/crush/blob/main/internal/shell/shell.go), [Goose](https://github.com/block/goose), [opencode](https://github.com/sst/opencode)) 
- Adds missing agents: [Gemini CLI](https://github.com/google-gemini/gemini-cli) (`GEMINI_CLI`), [opencode](https://github.com/sst/opencode) (`OPENCODE`), [GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/use-copilot-cli) (`COPILOT_CLI`), [Augment](https://docs.augmentcode.com/cli/overview) (`AUGMENT_AGENT`), [Qwen Code](https://github.com/QwenLM/qwen-code) (`QWEN_CODE`)
- `CODEX_*` → the specific vars [Codex sets](https://github.com/openai/codex) (`CODEX_THREAD_ID`, `CODEX_SANDBOX`, `CODEX_CI`; `CODEX_HOME` is user configuration), `CLINE_*` → `CLINE_ACTIVE` (what [Cline](https://github.com/cline/cline) actually sets; `CLINE_API_KEY` in a shell profile is not an agent)

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license