### PR TITLE
fix(cli): recognize the AI_AGENT convention and more coding agents

### DIFF
--- a/packages/aws-cdk/lib/cli/util/guess-agent.ts
+++ b/packages/aws-cdk/lib/cli/util/guess-agent.ts
@@ -5,24 +5,38 @@
  * Variables that merely indicate an agent-capable IDE or environment
  * (e.g. CURSOR_TRACE_ID, REPL_ID) do not: a human typing in such a terminal
  * would be misdetected.
+ *
+ * Each entry links to the documentation or source code that establishes the variable.
  */
 const AGENT_ENV_VARS = [
-  // Generic convention adopted by multiple agents
+  // https://github.com/vercel/detect-agent/blob/3ab1df1e4eaae153cf66f4a5018e4c5854855212/README.md#the-ai_agent-standard
   'AI_AGENT',
+  // Amp, Crush, Goose, opencode; e.g. https://github.com/charmbracelet/crush/blob/7d78d7422a92918441a68d01d96d48fa3b9fd9db/internal/shell/shell.go#L46
   'AGENT',
-
-  'CLAUDECODE', // Claude Code
-  'CODEX_THREAD_ID', // OpenAI Codex CLI
+  // https://code.claude.com/docs/en/env-vars#variables
+  'CLAUDECODE',
+  // https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/protocol/src/shell_environment.rs#L7
+  'CODEX_THREAD_ID',
+  // https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/core/src/spawn.rs#L26
   'CODEX_SANDBOX',
+  // https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/core/src/unified_exec/process_manager.rs#L93
   'CODEX_CI',
-  'CURSOR_AGENT', // Cursor CLI
-  'VSCODE_AGENT', // VS Code agent-aware terminal
-  'CLINE_ACTIVE', // Cline
-  'GEMINI_CLI', // Gemini CLI
-  'OPENCODE', // opencode
-  'COPILOT_CLI', // GitHub Copilot CLI; Copilot in VS Code sets no envvar
-  'AUGMENT_AGENT', // Augment
-  'QWEN_CODE', // Qwen Code
+  // https://cursor.com/docs/agent/terminal#disable-heavy-prompts-for-cursor-sessions
+  'CURSOR_AGENT',
+  // https://code.visualstudio.com/updates/v1_121#_agentaware-terminal-commands
+  'VSCODE_AGENT',
+  // https://github.com/cline/cline/blob/16875140fbc7bae51aad79c203837b4f51e54aa5/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts#L31
+  'CLINE_ACTIVE',
+  // https://google-gemini.github.io/gemini-cli/docs/tools/shell.html#environment-variables
+  'GEMINI_CLI',
+  // https://github.com/anomalyco/opencode/blob/b155b15694dbcc6768f11d2f25cc2bdd1f738ab4/packages/opencode/src/index.ts#L76
+  'OPENCODE',
+  // https://github.com/github/copilot-cli/blob/3f9c5e1ce792150a852804132e2b08c58e9a8e95/changelog.md#L1971
+  'COPILOT_CLI',
+  // https://docs.augmentcode.com/cli/reference#shell-environment
+  'AUGMENT_AGENT',
+  // https://github.com/QwenLM/qwen-code/blob/099a71c9364473303adb31e0dfb5f488b31634d9/packages/core/src/services/shellExecutionService.ts#L806
+  'QWEN_CODE',
 ];
 
 /**
@@ -37,6 +51,7 @@ export function guessAgent(): true | undefined {
   }
 
   // Amazon Q CLI and Kiro identify themselves in the value of AWS_EXECUTION_ENV
+  // https://github.com/aws/amazon-q-developer-cli/blob/15cc8f3cd18c4272925ce1c7053268eedff1ea0a/crates/chat-cli/src/cli/chat/consts.rs#L31
   const awsExecutionEnv = (process.env.AWS_EXECUTION_ENV ?? '').toLocaleLowerCase();
   if (awsExecutionEnv.includes('amazonq') || awsExecutionEnv.includes('kiro')) {
     return true;

--- a/packages/aws-cdk/lib/cli/util/guess-agent.ts
+++ b/packages/aws-cdk/lib/cli/util/guess-agent.ts
@@ -1,3 +1,29 @@
+/**
+ * Environment variables that indicate an AI agent is executing the command.
+ *
+ * Only variables set by the agent itself when running commands belong here.
+ * Variables that merely indicate an agent-capable IDE or environment
+ * (e.g. CURSOR_TRACE_ID, REPL_ID) do not: a human typing in such a terminal
+ * would be misdetected.
+ */
+const AGENT_ENV_VARS = [
+  // Generic convention adopted by multiple agents
+  'AI_AGENT',
+  'AGENT',
+
+  'CLAUDECODE', // Claude Code
+  'CODEX_THREAD_ID', // OpenAI Codex CLI
+  'CODEX_SANDBOX',
+  'CODEX_CI',
+  'CURSOR_AGENT', // Cursor CLI
+  'VSCODE_AGENT', // VS Code agent-aware terminal
+  'CLINE_ACTIVE', // Cline
+  'GEMINI_CLI', // Gemini CLI
+  'OPENCODE', // opencode
+  'COPILOT_CLI', // GitHub Copilot CLI; Copilot in VS Code sets no envvar
+  'AUGMENT_AGENT', // Augment
+  'QWEN_CODE', // Qwen Code
+];
 
 /**
  * Guess whether we're being executed by an AI agent
@@ -6,35 +32,15 @@
  * with `yes` or `don't know`.
  */
 export function guessAgent(): true | undefined {
+  if (AGENT_ENV_VARS.some((envVar) => process.env[envVar])) {
+    return true;
+  }
+
+  // Amazon Q CLI and Kiro identify themselves in the value of AWS_EXECUTION_ENV
   const awsExecutionEnv = (process.env.AWS_EXECUTION_ENV ?? '').toLocaleLowerCase();
   if (awsExecutionEnv.includes('amazonq') || awsExecutionEnv.includes('kiro')) {
     return true;
   }
-
-  if (process.env.CLAUDECODE) {
-    return true;
-  }
-
-  // Expecting CODEX_SANDBOX, CODEX_THREAD_ID
-  if (Object.keys(process.env).some(x => x.startsWith('CODEX_'))) {
-    return true;
-  }
-
-  if (process.env.CURSOR_AGENT) {
-    return true;
-  }
-
-  // https://code.visualstudio.com/updates/v1_121#_agentaware-terminal-commands
-  if (process.env.VSCODE_AGENT) {
-    return true;
-  }
-
-  // Cline -- not sure if it sets these, but users might to configure Cline.
-  if (Object.keys(process.env).some(x => x.startsWith('CLINE_'))) {
-    return true;
-  }
-
-  // Copilot doesn't set an envvar (at least not in VS Code)
 
   return undefined;
 }

--- a/packages/aws-cdk/test/cli/util/guess-agent.test.ts
+++ b/packages/aws-cdk/test/cli/util/guess-agent.test.ts
@@ -1,0 +1,49 @@
+import { guessAgent } from '../../../lib/cli/util/guess-agent';
+
+// Replace the environment wholesale, so tests are unaffected by the
+// agent (if any) running this test suite
+let originalEnv: NodeJS.ProcessEnv;
+
+beforeEach(() => {
+  originalEnv = process.env;
+  process.env = { PATH: originalEnv.PATH };
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+});
+
+test('detects agent environment variables', () => {
+  const agentVars = [
+    'AI_AGENT', 'AGENT',
+    'CLAUDECODE', 'CODEX_THREAD_ID', 'CODEX_SANDBOX', 'CODEX_CI',
+    'CURSOR_AGENT', 'VSCODE_AGENT', 'CLINE_ACTIVE', 'GEMINI_CLI',
+    'OPENCODE', 'COPILOT_CLI', 'AUGMENT_AGENT', 'QWEN_CODE',
+  ];
+
+  for (const envVar of agentVars) {
+    process.env = { PATH: originalEnv.PATH, [envVar]: '1' };
+    expect(guessAgent()).toBe(true);
+  }
+});
+
+test('detects Amazon Q and Kiro in AWS_EXECUTION_ENV', () => {
+  for (const value of ['AmazonQ-For-CLI Version/1.23.1', 'kiro']) {
+    process.env.AWS_EXECUTION_ENV = value;
+    expect(guessAgent()).toBe(true);
+  }
+});
+
+test('returns undefined in a clean environment', () => {
+  expect(guessAgent()).toBeUndefined();
+});
+
+test.each([
+  ['CLAUDECODE', ''],
+  ['CODEX_HOME', '/home/user/.codex'],
+  ['CLINE_API_KEY', 'secret'],
+  ['AWS_EXECUTION_ENV', 'AWS_Lambda_nodejs22.x'],
+])('does not misdetect %s=%s', (envVar, value) => {
+  process.env[envVar] = value;
+  expect(guessAgent()).toBeUndefined();
+});


### PR DESCRIPTION
Restructures `guessAgent()` into a single env-var list and adds more to that list.


**What changed:**

- Checks the emerging generic convention first:
  - `AI_AGENT` — [proposed by Vercel](https://github.com/vercel/detect-agent/blob/3ab1df1e4eaae153cf66f4a5018e4c5854855212/README.md#the-ai_agent-standard), [set by Claude Code since v2.1.120](https://github.com/anthropics/claude-code/blob/770933ea1ad2fa7b858191e397a65e6644771c64/CHANGELOG.md#L2349)
  - `AGENT` — set by Amp, [Crush](https://github.com/charmbracelet/crush/blob/7d78d7422a92918441a68d01d96d48fa3b9fd9db/internal/shell/shell.go#L46), [Goose](https://github.com/block/goose), [opencode](https://github.com/anomalyco/opencode/blob/b155b15694dbcc6768f11d2f25cc2bdd1f738ab4/packages/opencode/src/index.ts#L75)
- Adds missing agents:
  - `GEMINI_CLI` — [Gemini CLI](https://google-gemini.github.io/gemini-cli/docs/tools/shell.html#environment-variables)
  - `OPENCODE` — [opencode](https://github.com/anomalyco/opencode/blob/b155b15694dbcc6768f11d2f25cc2bdd1f738ab4/packages/opencode/src/index.ts#L76)
  - `COPILOT_CLI` — [GitHub Copilot CLI](https://github.com/github/copilot-cli/blob/3f9c5e1ce792150a852804132e2b08c58e9a8e95/changelog.md#L1971)
  - `AUGMENT_AGENT` — [Augment](https://docs.augmentcode.com/cli/reference#shell-environment)
  - `QWEN_CODE` — [Qwen Code](https://github.com/QwenLM/qwen-code/blob/099a71c9364473303adb31e0dfb5f488b31634d9/packages/core/src/services/shellExecutionService.ts#L806)
- `CODEX_*` → the specific vars Codex sets ([`CODEX_THREAD_ID`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/protocol/src/shell_environment.rs#L7), [`CODEX_SANDBOX`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/core/src/spawn.rs#L26), [`CODEX_CI`](https://github.com/openai/codex/blob/4a942885c8b4745757a9f86ad2075e16c42483c5/codex-rs/core/src/unified_exec/process_manager.rs#L93); `CODEX_HOME` is user configuration)
- `CLINE_*` → [`CLINE_ACTIVE`](https://github.com/cline/cline/blob/16875140fbc7bae51aad79c203837b4f51e54aa5/apps/vscode/src/hosts/vscode/terminal/VscodeTerminalRegistry.ts#L31) (what Cline actually sets; `CLINE_API_KEY` in a shell profile is not an agent)

The same references are now in the code, next to each variable.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license