### PR TITLE
fix(toolkit-lib): stack progress monitor double-counts the stack itself when a cleanup phase occurs

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-progress-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-progress-monitor.ts
@@ -17,6 +17,16 @@ export class StackProgressMonitor {
   private resourcesPrevCompleteState: Record<string, string> = {};
 
   /**
+   * Logical IDs for which we've already counted a `_COMPLETE_CLEANUP_IN_PROGRESS` event
+   *
+   * The stack's own cleanup-in-progress event and its subsequent terminal
+   * `_COMPLETE` event share the same LogicalResourceId (the stack itself). We
+   * only reserve one slot in `resourcesTotal` for that resource, so we must not
+   * count both events towards `resourcesDone`.
+   */
+  private readonly cleanupInProgressIds = new Set<string>();
+
+  /**
    * Count of resources that have reported a _COMPLETE status
    */
   private resourcesDone: number = 0;
@@ -99,18 +109,26 @@ export class StackProgressMonitor {
     if (status.endsWith('_COMPLETE_CLEANUP_IN_PROGRESS')) {
       // The stack
       this.resourcesDone++;
+      this.cleanupInProgressIds.add(event.LogicalResourceId);
     }
 
     if (status.endsWith('_COMPLETE')) {
-      const prevState = this.resourcesPrevCompleteState[event.LogicalResourceId];
-      if (!prevState) {
-        this.resourcesDone++;
+      if (this.cleanupInProgressIds.has(event.LogicalResourceId)) {
+        // We already counted this resource's completion when its
+        // `_COMPLETE_CLEANUP_IN_PROGRESS` event came in -- this terminal
+        // `_COMPLETE` event is not a new completion, just don't double-count it.
+        this.cleanupInProgressIds.delete(event.LogicalResourceId);
       } else {
-        // If we completed this before and we're completing it AGAIN, means we're rolling back.
-        // Protect against silly underflow.
-        this.resourcesDone--;
-        if (this.resourcesDone < 0) {
-          this.resourcesDone = 0;
+        const prevState = this.resourcesPrevCompleteState[event.LogicalResourceId];
+        if (!prevState) {
+          this.resourcesDone++;
+        } else {
+          // If we completed this before and we're completing it AGAIN, means we're rolling back.
+          // Protect against silly underflow.
+          this.resourcesDone--;
+          if (this.resourcesDone < 0) {
+            this.resourcesDone = 0;
+          }
         }
       }
       this.resourcesPrevCompleteState[event.LogicalResourceId] = status;

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/progress-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/progress-monitor.test.ts
@@ -1,4 +1,4 @@
-import { ResourceStatus } from '@aws-sdk/client-cloudformation';
+import { ResourceStatus, StackStatus } from '@aws-sdk/client-cloudformation';
 import { StackProgressMonitor } from '../../../lib/api/stack-events';
 
 let TIMESTAMP: number;
@@ -138,3 +138,42 @@ test('will count backwards when resource is first completed and then rolled back
   expect(stackProgress.formatted).toStrictEqual('0/4');
 });
 
+test('does not double-count the stack when it goes through a CLEANUP_IN_PROGRESS phase before COMPLETE', () => {
+  const stackProgress = new StackProgressMonitor(3);
+
+  // The stack's own cleanup-in-progress event and its terminal COMPLETE event
+  // share the same LogicalResourceId (the stack itself).
+  stackProgress.process({
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      // The AWS SDK types a stack's own StackEvent.ResourceStatus as `ResourceStatus`, but
+      // in practice a root stack event carries `StackStatus` values like this one.
+      ResourceStatus: StackStatus.UPDATE_COMPLETE_CLEANUP_IN_PROGRESS as unknown as ResourceStatus,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
+  });
+
+  expect(stackProgress.formatted).toStrictEqual('1/4');
+
+  stackProgress.process({
+    parentStackLogicalIds: [],
+    event: {
+      LogicalResourceId: 'stack1',
+      ResourceStatus: ResourceStatus.UPDATE_COMPLETE,
+      Timestamp: new Date(TIMESTAMP),
+      ResourceType: 'AWS::CloudFormation::Stack',
+      StackId: '',
+      EventId: '',
+      StackName: 'stack-name',
+    },
+  });
+
+  // Without the fix this would overshoot to 2/4, even though there is only
+  // one slot reserved in the total for the stack's own completion.
+  expect(stackProgress.formatted).toStrictEqual('1/4');
+});


### PR DESCRIPTION
### Reason for this change

Fixes #1856.

`StackProgressMonitor.process()` (which renders the `[N/M]` progress counter during `cdk deploy`) double-counts the deploying stack's own completion whenever the deployment goes through a CloudFormation cleanup phase, causing the counter to overshoot the total, e.g. `[43/42]`.

A stack's own `*_COMPLETE_CLEANUP_IN_PROGRESS` status event and its subsequent terminal `*_COMPLETE` event share the same `LogicalResourceId` (the stack itself). The cleanup event increments `resourcesDone` but is never recorded in `resourcesPrevCompleteState`, so when the terminal `COMPLETE` event for that same logical ID arrives, it's treated as a brand-new completion and increments `resourcesDone` again — even though the constructor only reserves one extra slot in `resourcesTotal` for the stack's own completion.

### Description of changes

- Track the set of logical IDs that were already counted via a `*_COMPLETE_CLEANUP_IN_PROGRESS` event.
- When a matching terminal `*_COMPLETE` event arrives for one of those IDs, skip the redundant `resourcesDone` increment/rollback-decrement (it was already accounted for), just clear the tracking and record the final state for future rollback detection.
- Left the existing rollback-detection logic (`resourcesPrevCompleteState`) untouched for all other resources.

### Description of how you validated changes

Added a regression test reproducing the exact sequence that triggers the bug: `UPDATE_COMPLETE_CLEANUP_IN_PROGRESS` followed by `UPDATE_COMPLETE` for the same stack logical ID. Verified the new test fails against the old code (asserts `1/4`, old code produces `2/4`) and passes with the fix. Ran the full `stack-events` test directory and the broader `toolkit-lib` unit test suite — no regressions (the handful of unrelated failures in the full suite are pre-existing local build-artifact issues, e.g. a missing `bootstrap-template.yaml`, unrelated to this change).

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk-cli/blob/main/docs/DESIGN_GUIDELINES.md)

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license