### PR TITLE
fix(cdk-assets-lib): bucket ownership cache ignores expectedAccount, can silently bypass the cross-account safety check

### DIFF
--- a/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/files.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/private/handlers/files.ts
@@ -306,7 +306,11 @@ class BucketInformation {
     bucket: string,
     expectedAccount?: string,
   ): Promise<BucketOwnership> {
-    return cached(this.ownerships, bucket, async () => {
+    // The result depends on `expectedAccount` as well as `bucket`, so the cache key must
+    // include both -- otherwise a call without an expected account (or with a different one)
+    // would incorrectly reuse a result computed for a different expected account.
+    const cacheKey = `${bucket}:${expectedAccount ?? ''}`;
+    return cached(this.ownerships, cacheKey, async () => {
       const anyAccount = await this._bucketOwnership(s3, bucket);
 
       switch (anyAccount) {

--- a/packages/@aws-cdk/cdk-assets-lib/test/files.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/files.test.ts
@@ -439,3 +439,39 @@ test('succeeds when bucket doesnt belong to us but doesnt contain account id - c
 
   await expect(pub.publish()).resolves.not.toThrow();
 });
+
+test('bucket ownership cache does not leak allowCrossAccount:true result into a later allowCrossAccount:false publish for the same bucket', async () => {
+  // Two assets in this manifest both publish to the same bucket ('some_bucket'),
+  // via a single shared AssetPublishing (and therefore shared BucketInformation cache).
+  const s3 = mockClient(S3Client);
+  s3.on(ListObjectsV2Command).resolves({ Contents: undefined });
+  s3.on(GetBucketLocationCommand).callsFake((req) => {
+    if (req.ExpectedBucketOwner) {
+      // Simulate a bucket that is actually owned by someone else: accessible
+      // without an expected-owner check, but access is denied once we assert
+      // the expected account.
+      const err = new Error('Access Denied');
+      err.name = 'AccessDenied';
+      throw err;
+    }
+    return {};
+  });
+
+  const manifest = AssetManifest.fromPath(mockfs.path('/types/cdk.out'));
+  const [firstAsset, secondAsset] = manifest.entries;
+
+  const pub = new AssetPublishing(manifest, { aws, throwOnError: false });
+
+  // First publish call allows cross account -- this populates the bucket ownership
+  // cache with a "MINE" result that was never checked against an expected account.
+  await pub.publishEntry(firstAsset, { allowCrossAccount: true });
+  expect(pub.failures).toHaveLength(0);
+
+  // Second publish call, for a *different* asset going to the *same bucket*, disallows
+  // cross account publishing. It must independently detect that the bucket doesn't
+  // belong to us and fail loudly -- it must not reuse the first call's cached result.
+  await pub.publishEntry(secondAsset, { allowCrossAccount: false });
+
+  expect(pub.failures).toHaveLength(1);
+  expect(pub.failures[0].error.message).toContain('UNEXPECTED BUCKET OWNER DETECTED');
+});


### PR DESCRIPTION
### Reason for this change

Fixes #1858.

`BucketInformation.bucketOwnership()` caches its result keyed only on the bucket name, but the result also depends on the `expectedAccount` parameter, which drives the cross-account safety check (the `❗❗ UNEXPECTED BUCKET OWNER DETECTED ❗❗` error). Because the cache is scoped to the lifetime of an `AssetPublishing`/`IHandlerHost` instance, an earlier call for a bucket made with `allowCrossAccount: true` (no expected-account check) poisons the cache: a later call for the *same bucket name* made with `allowCrossAccount: false` reuses the earlier `MINE` result and never runs the expected-account check, silently skipping the safety error it's meant to raise.

This is reachable through the public `AssetPublishing.publishEntry()` API, which lets callers publish individual assets with independent `PublishOptions` against a shared host/cache — any caller publishing multiple assets destined for the same bucket name with differing `allowCrossAccount` settings across calls can have the check silently skipped.

### Description of changes

- `BucketInformation.bucketOwnership()` now keys its cache on a compound `` `${bucket}:${expectedAccount ?? ''}` `` key instead of `bucket` alone, so different `expectedAccount` values for the same bucket are never conflated.

### Description of how you validated changes

Added a regression test in `files.test.ts` that publishes two assets destined for the same bucket via a shared `AssetPublishing` instance — the first with `allowCrossAccount: true`, the second with `allowCrossAccount: false` against a bucket the S3 mock reports as inaccessible once an expected owner is asserted. Verified the new test fails against the old code (no failure recorded — the safety check is silently skipped) and passes with the fix (the second call correctly fails with "UNEXPECTED BUCKET OWNER DETECTED"). Ran the full `cdk-assets-lib` unit test suite: 100/100 pass, coverage thresholds met.

### Checklist

- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk-cli/blob/main/docs/DESIGN_GUIDELINES.md)

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license