### PR TITLE
fix(aws-cdk): remove SIGINT listener leak in TelemetrySession

### DIFF
--- a/packages/aws-cdk/lib/cli/telemetry/session.ts
+++ b/packages/aws-cdk/lib/cli/telemetry/session.ts
@@ -61,6 +61,7 @@ export class TelemetrySession {
   private client: ITelemetrySink;
   private _sessionInfo?: SessionSchema;
   private _commandSpan?: IMessageSpan<EventResult>;
+  private sigintListener?: () => void;
   private _nextEventCounters?: Record<string, number>;
   private count = 0;
   private loadTime?: number;
@@ -119,17 +120,24 @@ export class TelemetrySession {
 
     // If SIGINT has a listener installed, its default behavior will be removed (Node.js will no longer exit).
     // This ensures that on SIGINT we process safely close the telemetry session before exiting.
-    process.on('SIGINT', async () => {
-      try {
-        await this.end({
-          name: USER_INTERRUPTED_CODE,
-          message: ABORTED_ERROR_MESSAGE,
-        });
-      } catch (e: any) {
-        await this.ioHost.defaults.trace(`Ending Telemetry failed: ${e.message}`);
-      }
-      process.exit(1);
-    });
+    // The listener is removed in end() -- without that, every begin() call (e.g. one per
+    // exec() invocation in a long-running host process) would permanently add another
+    // listener to the process-global SIGINT emitter, leaking the retained TelemetrySession
+    // (and everything it references) for the lifetime of the process.
+    this.sigintListener = () => {
+      void (async () => {
+        try {
+          await this.end({
+            name: USER_INTERRUPTED_CODE,
+            message: ABORTED_ERROR_MESSAGE,
+          });
+        } catch (e: any) {
+          await this.ioHost.defaults.trace(`Ending Telemetry failed: ${e.message}`);
+        }
+        process.exit(1);
+      })();
+    };
+    process.on('SIGINT', this.sigintListener);
 
     // Begin the session span
     this._commandSpan = await this.ioHost.asIoHelper().span(CLI_PRIVATE_SPAN.COMMAND).begin({});
@@ -221,6 +229,10 @@ export class TelemetrySession {
    * and notifies with an optional error message in the data.
    */
   public async end(error?: ErrorDetails) {
+    if (this.sigintListener) {
+      process.removeListener('SIGINT', this.sigintListener);
+      this.sigintListener = undefined;
+    }
     await this._commandSpan?.end({ error });
     // Ideally span.end() should no-op if called twice, but that is not the case right now
     this._commandSpan = undefined;

--- a/packages/aws-cdk/test/cli/telemetry/session.test.ts
+++ b/packages/aws-cdk/test/cli/telemetry/session.test.ts
@@ -127,6 +127,39 @@ describe('TelemetrySession', () => {
     expect(spanEndSpy).toHaveBeenCalledTimes(1);
   });
 
+  test('begin() registers exactly one SIGINT listener, and end() removes it', async () => {
+    // GIVEN begin() was already called once in beforeEach
+    const before = process.listenerCount('SIGINT');
+
+    // WHEN
+    await session.end();
+
+    // THEN
+    expect(process.listenerCount('SIGINT')).toBe(before - 1);
+  });
+
+  test('repeated begin()/end() cycles do not accumulate SIGINT listeners', async () => {
+    // GIVEN begin() was already called once in beforeEach; end it to get to a clean baseline
+    await session.end();
+    const baseline = process.listenerCount('SIGINT');
+
+    // WHEN -- simulate many exec() invocations in a single long-running process
+    for (let i = 0; i < 20; i++) {
+      const client = new IoHostTelemetrySink({ ioHost });
+      const s = new TelemetrySession({
+        ioHost,
+        client,
+        arguments: { _: ['deploy'], STACKS: ['MyStack'] },
+        context: new Context(),
+      });
+      await s.begin();
+      await s.end();
+    }
+
+    // THEN -- no net growth, and nowhere near Node's default max-listener warning threshold (10)
+    expect(process.listenerCount('SIGINT')).toBe(baseline);
+  });
+
   test('end flushes events', async () => {
     // GIVEN
     await session.emit({


### PR DESCRIPTION
fixes #1862

### Reason for this change

`TelemetrySession.begin()` registers a listener on the process-global `SIGINT` event every time it's called:

```ts
process.on('SIGINT', async () => {
  try {
    await this.end({ name: USER_INTERRUPTED_CODE, message: ABORTED_ERROR_MESSAGE });
  } catch (e: any) {
    await this.ioHost.defaults.trace(`Ending Telemetry failed: ${e.message}`);
  }
  process.exit(1);
});
```

Nothing ever removes it. Each closure retains the full `TelemetrySession` -- `ioHost`, the telemetry `client`, sanitized session info -- so every `begin()` call in a process that runs more than once without exiting (e.g. driving the CLI's `exec()` programmatically, or this repo's own in-process test suite: `cli.test.ts`, `cli-commands.test.ts`, `deploy-options.test.ts`, `import-options.test.ts`, `diff-options.test.ts`, ...) permanently leaks another retained object graph. Past 10 accumulated listeners you'd see Node's `MaxListenersExceededWarning`. It's also a latent correctness bug: if SIGINT ever fires with multiple accumulated listeners, all of them race to `end()` and `process.exit()`.

### Description of changes

- `TelemetrySession` now stores the SIGINT listener it registers in `begin()` on a private field.
- `end()` (already called on both the normal-completion path in `cli.ts`'s `.finally()` and the SIGINT path itself) now removes that listener before doing anything else, so a session's listener is cleaned up exactly once regardless of which path ended it.

### Testing

Added two tests to `test/cli/telemetry/session.test.ts`:
- `begin()` registers exactly one SIGINT listener, and `end()` removes it — asserts the delta is exactly -1.
- A repeated begin()/end() cycle test (20 iterations, simulating 20 `exec()` calls in one long-running host process) asserts `process.listenerCount('SIGINT')` returns to baseline every time, i.e. no net growth.

Full `test/cli/telemetry/session.test.ts` (34 tests) and `test/cli/io-host/` (91 tests) suites pass. (Note: several unrelated `test/cli/*` suites currently fail to run locally on a fresh checkout due to a pre-existing missing-build-artifact issue -- `@aws-cdk/cdk-explorer` not being built and `build-info.json` not being generated -- unrelated to this change; verified the failures are all in that category and none mention telemetry/session.)

### Checklist

- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — no new AWS resource types or cross-service interactions)
- [x] No manual edits to generated files

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license