### PR TITLE
fix(cloudformation-diff): security group rule diff ignores which group a rule belongs to

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/network/security-group-rule.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/network/security-group-rule.ts
@@ -48,7 +48,8 @@ export class SecurityGroupRule {
   }
 
   public equal(other: SecurityGroupRule) {
-    return this.ipProtocol === other.ipProtocol
+    return this.groupId === other.groupId
+        && this.ipProtocol === other.ipProtocol
         && this.fromPort === other.fromPort
         && this.toPort === other.toPort
         && peerEqual(this.peer, other.peer);

--- a/packages/@aws-cdk/cloudformation-diff/test/network/detect-changes.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/network/detect-changes.test.ts
@@ -74,3 +74,62 @@ test('detect addition of all types of rules', () => {
     ],
   });
 });
+
+test('detect a rule moving from one security group to a different one', () => {
+  // A rule with the same protocol/port/peer moves from WebSG to DbSG between the
+  // old and new templates. This must be reported as a removal from WebSG and an
+  // addition to DbSG -- it must not be treated as unchanged just because the
+  // rule's shape (ignoring which group it's attached to) happens to match.
+  const oldTemplate = template({
+    WebSG: resource('AWS::EC2::SecurityGroup', {
+      SecurityGroupIngress: [
+        {
+          CidrIp: '10.0.0.0/24',
+          FromPort: 22,
+          ToPort: 22,
+          IpProtocol: 'tcp',
+        },
+      ],
+    }),
+    DbSG: resource('AWS::EC2::SecurityGroup', {}),
+  });
+
+  const newTemplate = template({
+    WebSG: resource('AWS::EC2::SecurityGroup', {}),
+    DbSG: resource('AWS::EC2::SecurityGroup', {
+      SecurityGroupIngress: [
+        {
+          CidrIp: '10.0.0.0/24',
+          FromPort: 22,
+          ToPort: 22,
+          IpProtocol: 'tcp',
+        },
+      ],
+    }),
+  });
+
+  // WHEN
+  const diff = fullDiff(oldTemplate, newTemplate);
+
+  // THEN
+  expect(diff.securityGroupChanges.toJson()).toEqual({
+    ingressRuleAdditions: [
+      {
+        groupId: '${DbSG.GroupId}',
+        ipProtocol: 'tcp',
+        fromPort: 22,
+        toPort: 22,
+        peer: { kind: 'cidr-ip', ip: '10.0.0.0/24' },
+      },
+    ],
+    ingressRuleRemovals: [
+      {
+        groupId: '${WebSG.GroupId}',
+        ipProtocol: 'tcp',
+        fromPort: 22,
+        toPort: 22,
+        peer: { kind: 'cidr-ip', ip: '10.0.0.0/24' },
+      },
+    ],
+  });
+});


### PR DESCRIPTION
Closes #1871

### Reason for this change

`SecurityGroupRule.equal()` compares `ipProtocol`, `fromPort`, `toPort`, and `peer`, but not `groupId`. This method is used to match rules between the old and new template when computing ingress/egress diffs.

As a result, a rule that moves from one security group to a different one — while keeping the same protocol/port/peer — is treated as unchanged, and the diff silently drops both the removal from the old group and the addition to the new group. This can mask a real permission change (e.g. widening which resource has a given network rule) from `cdk diff` output.

### Description of changes

Add `groupId` to the equality comparison in `SecurityGroupRule.equal()`, so a rule moving between groups is correctly reported as a removal + addition.

### Description of how you validated changes

Added a test (`detect a rule moving from one security group to a different one`) that moves an identical-shaped ingress rule from `WebSG` to `DbSG` and asserts the diff reports it as a removal from `WebSG` and an addition to `DbSG`.

```
PASS test/network/detect-changes.test.ts
  ✓ detect addition of all types of rules
  ✓ detect a rule moving from one security group to a different one
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md#design-guidelines)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.*