### PR TITLE
fix(cli): gc 'print'/'tag' progress no longer shows NaN% or misleading '0 assets'

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/garbage-collector.ts
@@ -23,6 +23,11 @@ const DAY = 24 * 60 * 60 * 1000; // Number of milliseconds in a day
 export type GcAsset = ImageAsset | ObjectAsset;
 
 /**
+ * The set of actions that garbage collection can perform.
+ */
+export type GcAction = 'print' | 'tag' | 'delete-tagged' | 'full';
+
+/**
  * An image asset that lives in the bootstrapped ECR Repository
  */
 export class ImageAsset {
@@ -129,7 +134,7 @@ interface GarbageCollectorProps {
    * The action to perform. Specify this if you want to perform a truncated set
    * of actions available.
    */
-  readonly action: 'print' | 'tag' | 'delete-tagged' | 'full';
+  readonly action: GcAction;
 
   /**
    * The type of asset to garbage collect.
@@ -257,7 +262,7 @@ export class GarbageCollector {
     const ecr = sdk.ecr();
     const repo = await this.bootstrapRepositoryName(sdk, this.bootstrapStackName);
     const numImages = await this.numImagesInRepo(ecr, repo);
-    const printer = new ProgressPrinter(this.ioHelper, numImages, 1000);
+    const printer = new ProgressPrinter(this.ioHelper, numImages, 1000, this.props.action);
 
     await this.ioHelper.defaults.debug(`Found bootstrap repo ${repo} with ${numImages} images`);
 
@@ -315,6 +320,13 @@ export class GarbageCollector {
           await this.parallelUntagEcr(ecr, repo, untaggables);
         }
 
+        // The 'print' action does not tag or delete anything, so report the assets that
+        // are eligible for garbage collection. Otherwise the output reads as "0 assets"
+        // and looks like gc found nothing to do (see #625).
+        if (this.props.action === 'print') {
+          printer.reportEligibleAsset(isolated);
+        }
+
         printer.reportScannedAsset(batch.length);
       }
     } catch (err: any) {
@@ -331,7 +343,7 @@ export class GarbageCollector {
     const s3 = sdk.s3();
     const bucket = await this.bootstrapBucketName(sdk, this.bootstrapStackName);
     const numObjects = await this.numObjectsInBucket(s3, bucket);
-    const printer = new ProgressPrinter(this.ioHelper, numObjects, 1000);
+    const printer = new ProgressPrinter(this.ioHelper, numObjects, 1000, this.props.action);
 
     await this.ioHelper.defaults.debug(`Found bootstrap bucket ${bucket} with ${numObjects} objects`);
 
@@ -390,6 +402,13 @@ export class GarbageCollector {
 
         if (this.permissionToTag && untaggables.length > 0) {
           await this.parallelUntagS3(s3, bucket, untaggables);
+        }
+
+        // The 'print' action does not tag or delete anything, so report the assets that
+        // are eligible for garbage collection. Otherwise the output reads as "0 assets"
+        // and looks like gc found nothing to do (see #625).
+        if (this.props.action === 'print') {
+          printer.reportEligibleAsset(isolated);
         }
 
         printer.reportScannedAsset(batch.length);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/progress-printer.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/garbage-collection/progress-printer.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import type { GcAsset as GCAsset } from './garbage-collector';
+import type { GcAction, GcAsset as GCAsset } from './garbage-collector';
 import { ToolkitError } from '../../toolkit/toolkit-error';
 import type { IoHelper } from '../io/private';
 
@@ -11,11 +11,14 @@ export class ProgressPrinter {
   private taggedAssetsSizeMb: number;
   private deletedAssets: number;
   private deletedAssetsSizeMb: number;
+  private eligibleAssets: number;
+  private eligibleAssetsSizeMb: number;
+  private action: GcAction;
   private interval: number;
   private setInterval?: ReturnType<typeof setTimeout>;
   private isPaused: boolean;
 
-  constructor(ioHelper: IoHelper, totalAssets: number, interval?: number) {
+  constructor(ioHelper: IoHelper, totalAssets: number, interval?: number, action: GcAction = 'full') {
     this.ioHelper = ioHelper;
     this.totalAssets = totalAssets;
     this.assetsScanned = 0;
@@ -23,12 +26,27 @@ export class ProgressPrinter {
     this.taggedAssetsSizeMb = 0;
     this.deletedAssets = 0;
     this.deletedAssetsSizeMb = 0;
+    this.eligibleAssets = 0;
+    this.eligibleAssetsSizeMb = 0;
+    this.action = action;
     this.interval = interval ?? 10_000;
     this.isPaused = false;
   }
 
   public reportScannedAsset(amt: number) {
     this.assetsScanned += amt;
+  }
+
+  /**
+   * Report assets that are eligible for garbage collection (i.e. isolated assets
+   * that are not referenced by any deployed stack). Used by the `print` action,
+   * which does not tag or delete anything, so that the output reflects what gc
+   * found instead of always reporting 0 assets.
+   */
+  public reportEligibleAsset(assets: GCAsset[]) {
+    this.eligibleAssets += assets.length;
+    const sizeInBytes = assets.reduce((total, asset) => total + asset.size, 0);
+    this.eligibleAssetsSizeMb += sizeInBytes / 1_048_576;
   }
 
   public reportTaggedAsset(assets: GCAsset[]) {
@@ -75,7 +93,23 @@ export class ProgressPrinter {
   }
 
   private print() {
-    const percentage = ((this.assetsScanned / this.totalAssets) * 100).toFixed(2);
+    // Guard against dividing by zero: an empty bucket/repo (or the final flush of one)
+    // has totalAssets === 0, which would produce "NaN%" and make gc look broken (#625).
+    const percentage = this.totalAssets > 0
+      ? ((this.assetsScanned / this.totalAssets) * 100).toFixed(2)
+      : '100.00';
+
+    // The 'print' action does not tag or delete anything, so report the assets that
+    // are eligible for garbage collection rather than always reporting "0 tagged, 0 deleted".
+    if (this.action === 'print') {
+      if (this.eligibleAssetsSizeMb >= 1000) {
+        void this.ioHelper.defaults.info(chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.eligibleAssets} assets (${(this.eligibleAssetsSizeMb / 1000).toFixed(2)} GiB) eligible for deletion.`));
+      } else {
+        void this.ioHelper.defaults.info(chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.eligibleAssets} assets (${this.eligibleAssetsSizeMb.toFixed(2)} MiB) eligible for deletion.`));
+      }
+      return;
+    }
+
     // print in MiB until we hit at least 1 GiB of data tagged/deleted
     if (Math.max(this.taggedAssetsSizeMb, this.deletedAssetsSizeMb) >= 1000) {
       void this.ioHelper.defaults.info(chalk.green(`[${percentage}%] ${this.assetsScanned} files scanned: ${this.taggedAsset} assets (${(this.taggedAssetsSizeMb / 1000).toFixed(2)} GiB) tagged, ${this.deletedAssets} assets (${(this.deletedAssetsSizeMb / 1000).toFixed(2)} GiB) deleted.`));

--- a/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/garbage-collection/garbage-collection.test.ts
@@ -1076,6 +1076,7 @@ describe('ProgressPrinter', () => {
     setInterval = jest.spyOn(global, 'setInterval');
     clearInterval = jest.spyOn(global, 'clearInterval');
 
+    ioHost.clear();
     progressPrinter = new ProgressPrinter(ioHost.asHelper('gc'), 0, 1000);
   });
 
@@ -1090,6 +1091,48 @@ describe('ProgressPrinter', () => {
 
     expect(setInterval).toHaveBeenCalledTimes(1);
     expect(() => progressPrinter.start()).toThrow('ProgressPrinter is already running. Stop it first using the stop() method before starting it again.');
+  });
+
+  test('does not report NaN% when there are no assets to scan (#625)', () => {
+    // totalAssets is 0 (empty bucket/repo). The final flush would otherwise divide 0/0.
+    progressPrinter = new ProgressPrinter(ioHost.asHelper('gc'), 0, 1000);
+
+    progressPrinter.stop(); // prints one last time
+
+    const printed = ioHost.messages.map(m => m.message).join('\n');
+    expect(printed).not.toContain('NaN');
+    expect(printed).toContain('[100.00%]');
+  });
+
+  test('reports a real percentage when total is known', () => {
+    progressPrinter = new ProgressPrinter(ioHost.asHelper('gc'), 10, 1000);
+
+    progressPrinter.reportScannedAsset(5);
+    progressPrinter.stop();
+
+    const printed = ioHost.messages.map(m => m.message).join('\n');
+    expect(printed).not.toContain('NaN');
+    expect(printed).toContain('[50.00%]');
+  });
+
+  test('print action reports assets eligible for deletion instead of "0 tagged, 0 deleted" (#625)', () => {
+    progressPrinter = new ProgressPrinter(ioHost.asHelper('gc'), 2, 1000, 'print');
+
+    // 2 isolated assets of 1 MiB each are eligible for garbage collection.
+    progressPrinter.reportEligibleAsset([
+      { size: 1_048_576 } as any,
+      { size: 1_048_576 } as any,
+    ]);
+    progressPrinter.reportScannedAsset(2);
+    progressPrinter.stop();
+
+    const printed = ioHost.messages.map(m => m.message).join('\n');
+    expect(printed).not.toContain('NaN');
+    expect(printed).toContain('[100.00%]');
+    expect(printed).toContain('2 assets');
+    expect(printed).toContain('eligible for deletion');
+    // The misleading "0 assets ... tagged, 0 assets ... deleted" line should not be shown for the print action.
+    expect(printed).not.toContain('tagged');
   });
 });
 


### PR DESCRIPTION
Fixes #625

### Problem

Running `cdk gc --action print` (and `--action tag` on a bucket/repo that was already tagged) produced output that made users believe garbage collection was broken, even though it was working:

```
[NaN%] 0 files scanned: 0 assets (0.00 MiB) tagged, 0 assets (0.00 MiB) deleted.
[100.00%] 13 files scanned: 0 assets (0.00 MiB) tagged, 0 assets (0.00 MiB) deleted.
[NaN%] 0 files scanned: 0 assets (0.00 MiB) tagged, 0 assets (0.00 MiB) deleted.
```

Two things are wrong:

1. **`[NaN%]`** — `ProgressPrinter.print()` computes `assetsScanned / totalAssets`. For an empty bucket/repo (or the final flush of one) `totalAssets` is `0`, so `0 / 0` renders as `NaN%`.
2. **"0 assets tagged, 0 assets deleted"** — the `print` action intentionally never tags or deletes, so those counters are always `0`. The message therefore reads as "nothing to do" even when stale/isolated assets exist and would be collected.

### Fix

- Guard the percentage math so an environment with nothing to scan reports `[100.00%]` instead of `[NaN%]`.
- For the `print` action, report the assets that are **eligible** for garbage collection (isolated assets not referenced by any deployed stack) — e.g. `N assets (X MiB) eligible for deletion` — instead of the misleading `0 tagged, 0 deleted` line. The `tag` / `delete-tagged` / `full` output is unchanged.

This is a messaging/counter clarity fix only; garbage-collection semantics are unchanged.

Added unit tests under the gc test suite covering the NaN guard, a known-total percentage, and the print-action eligible-asset messaging.

Follow-up (not in this PR): a repeated `tag` run reports `0 tagged` because the assets are already tagged; clarifying that "already tagged" state is a separate, larger change and left for a follow-up.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
