### PR TITLE
fix(cdk-assets-lib): pLimit.dispose() doesn't stop new jobs from starting

### DIFF
--- a/packages/@aws-cdk/cdk-assets-lib/lib/private/p-limit.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/lib/private/p-limit.ts
@@ -10,6 +10,9 @@ export function pLimit(concurrency: number): PLimit {
   let stopped = false;
 
   function dispatch() {
+    if (stopped) {
+      return;
+    }
     if (activeCount < concurrency && queue.length > 0) {
       const [fac, resolve, reject] = queue.shift()!;
       activeCount++;
@@ -41,6 +44,10 @@ export function pLimit(concurrency: number): PLimit {
 
   const ret = <A>(promiseFactory: PromiseFactory<A>) => {
     return new Promise<A>((resolve, reject) => {
+      if (stopped) {
+        reject(new Error('Task has been cancelled'));
+        return;
+      }
       queue.push([promiseFactory, resolve, reject]);
       dispatch();
     });

--- a/packages/@aws-cdk/cdk-assets-lib/test/private/p-limit.test.ts
+++ b/packages/@aws-cdk/cdk-assets-lib/test/private/p-limit.test.ts
@@ -43,6 +43,23 @@ test('new jobs arent started after dispose is called', async () => {
   expect(started).toBeLessThanOrEqual(3);
 });
 
+test('no new job is started once dispose is called, even with a free slot', async () => {
+  const limit = pLimit(1);
+
+  limit.dispose();
+
+  let ran = false;
+  await expect(
+    limit(async () => {
+      ran = true;
+    }),
+  ).rejects.toThrow(/cancelled/);
+
+  // activeCount was 0 and concurrency is 1, so before the fix dispatch()
+  // would start this job immediately despite dispose() having been called.
+  expect(ran).toBe(false);
+});
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }


### PR DESCRIPTION
Closes #1876

### Reason for this change

`pLimit()`'s `dispose()` method is documented and tested to stop new jobs from starting, but `dispatch()` (called every time a new task is submitted) never checked the `stopped` flag - only `resumeNext()` (which runs when an *already-active* job finishes) did. So a task submitted after `dispose()` would start immediately whenever a concurrency slot happened to be free at submission time, silently violating `dispose()`'s contract.

### Description of changes

- `dispatch()` now returns immediately if `stopped` is true, so no new job starts after `dispose()`.
- `ret()` now rejects immediately with `'Task has been cancelled'` if a task is submitted after `dispose()`, so callers don't hang waiting on a promise that would otherwise never settle (queued-but-never-dispatched).
- Added a regression test to `test/private/p-limit.test.ts` that fails before the fix (job runs despite `dispose()`) and passes after.

### Description of how you validated changes

Ran the full `@aws-cdk/cdk-assets-lib` test suite locally - all 104 tests across 14 suites pass, including the new regression test and the existing `p-limit.test.ts` tests.

```
Test Suites: 14 passed, 14 total
Tests:       104 passed, 104 total
```

### Checklist
- [x] My code adheres to the [CONTRIBUTING GUIDE](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md) and [DESIGN GUIDELINES](https://github.com/aws/aws-cdk-cli/blob/main/CONTRIBUTING.md#design-guidelines)

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*