### PR TITLE
fix(cli): bootstrap FilePublishingRoleDefaultPolicy KMS permission when FileAssetsBucketKmsKeyId is an ARN

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap-template.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/bootstrap/bootstrap-template.test.ts
@@ -74,4 +74,38 @@ describe('bootstrap template', () => {
   test('has the same values for BootstrapVersion Parameter and Output', async () => {
     expect(template.Outputs.BootstrapVersion.Value).toEqual(template.Resources.CdkBootstrapVersion.Properties.Value);
   });
+
+  test('uses FileAssetsBucketKmsKeyId directly when it is already an ARN', async () => {
+    // The parameter description allows FileAssetsBucketKmsKeyId to be either a key ID or a key ARN.
+    // Verify the condition that distinguishes the two forms exists.
+    expect(template.Conditions.HasCustomKmsKeyArn).toEqual({
+      'Fn::Equals': [
+        'arn',
+        { 'Fn::Select': [0, { 'Fn::Split': [':', { Ref: 'FileAssetsBucketKmsKeyId' }] }] },
+      ],
+    });
+
+    // Locate the KMS statement in the FilePublishingRoleDefaultPolicy.
+    const statements = template.Resources.FilePublishingRoleDefaultPolicy.Properties.PolicyDocument.Statement;
+    const kmsStatement = statements.find(
+      (stmt: any) => Array.isArray(stmt.Action) && stmt.Action.includes('kms:Decrypt'),
+    );
+    expect(kmsStatement).toBeDefined();
+
+    // When a custom key is supplied, an ARN value must be used verbatim (no 'key/${...}' wrapping),
+    // while a bare key ID keeps the constructed 'arn:...:key/${...}' form.
+    expect(kmsStatement.Resource).toEqual({
+      'Fn::If': [
+        'CreateNewKey',
+        { 'Fn::Sub': '${FileAssetsBucketEncryptionKey.Arn}' },
+        {
+          'Fn::If': [
+            'HasCustomKmsKeyArn',
+            { 'Fn::Sub': '${FileAssetsBucketKmsKeyId}' },
+            { 'Fn::Sub': 'arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${FileAssetsBucketKmsKeyId}' },
+          ],
+        },
+      ],
+    });
+  });
 });

--- a/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
+++ b/packages/aws-cdk/lib/api/bootstrap/bootstrap-template.yaml
@@ -103,6 +103,17 @@ Conditions:
     Fn::Equals:
       - 'AWS_MANAGED_KEY'
       - Ref: FileAssetsBucketKmsKeyId
+  # FileAssetsBucketKmsKeyId may be either a bare key ID or a full key ARN (see the
+  # parameter description). Detect the ARN form by checking whether the first ':'-delimited
+  # token is 'arn', so we don't wrap an ARN inside another 'arn:...:key/...' construction.
+  HasCustomKmsKeyArn:
+    Fn::Equals:
+      - 'arn'
+      - Fn::Select:
+          - 0
+          - Fn::Split:
+              - ':'
+              - Ref: FileAssetsBucketKmsKeyId
   ShouldCreatePermissionsBoundary:
     Fn::Equals:
       - 'true'
@@ -539,7 +550,10 @@ Resources:
               Fn::If:
                 - CreateNewKey
                 - Fn::Sub: "${FileAssetsBucketEncryptionKey.Arn}"
-                - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${FileAssetsBucketKmsKeyId}
+                - Fn::If:
+                    - HasCustomKmsKeyArn
+                    - Fn::Sub: "${FileAssetsBucketKmsKeyId}"
+                    - Fn::Sub: arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${FileAssetsBucketKmsKeyId}
         Version: '2012-10-17'
       Roles:
         - Ref: FilePublishingRole


### PR DESCRIPTION
Fixes #921

### Description

`FileAssetsBucketKmsKeyId`'s parameter description explicitly allows either a KMS key ID **or** a full key ARN. However, the bootstrap template unconditionally built the KMS resource ARN for the `FilePublishingRoleDefaultPolicy` as:

```
arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${FileAssetsBucketKmsKeyId}
```

When a (cross-account) key ARN is passed as the parameter value, this produces a malformed nested ARN — `arn:...:key/arn:aws:kms:...` — and therefore an invalid IAM policy statement, so the file publishing role can't use the key.

This adds a CFN `HasCustomKmsKeyArn` condition that detects the ARN form by checking whether the first `:`-delimited token of the value is `arn` (`Fn::Equals` + `Fn::Select` + `Fn::Split`). When the value is already an ARN it is used verbatim as the resource; a bare key ID keeps the existing `arn:...:key/${...}` construction. The `CreateNewKey` and `AWS_MANAGED_KEY` paths are unchanged.

Extended `bootstrap-template.test.ts` to assert the new condition and the nested `Fn::If` on the KMS statement resource. Bootstrap template/api tests pass (58 tests).

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
