### PR TITLE
fix(toolkit-lib): allowCrossAccountAssetPublishing cache ignores which stack's environment it was computed for

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts
@@ -321,7 +321,12 @@ export class Deployments {
 
   private readonly publisherCache = new Map<cdk_assets.AssetManifest, Map<string, cdk_assets.AssetPublishing>>();
 
-  private _allowCrossAccountAssetPublishing: boolean | undefined;
+  // Cache by resolved environment: this Deployments instance is reused across every
+  // stack in a single `cdk deploy` invocation, and stacks can target different
+  // accounts/regions. determineAllowCrossAccountAssetPublishing() reads that specific
+  // environment's bootstrap stack, so caching a single un-keyed value would silently
+  // reuse the first stack's environment's answer for every other stack's environment.
+  private readonly allowCrossAccountAssetPublishingCache = new Map<string, boolean>();
 
   private readonly ioHelper: IoHelper;
 
@@ -744,11 +749,18 @@ export class Deployments {
   }
 
   private async allowCrossAccountAssetPublishingForEnv(stack: cxapi.CloudFormationStackArtifact): Promise<boolean> {
-    if (this._allowCrossAccountAssetPublishing === undefined) {
-      const env = await this.envs.accessStackForReadOnlyStackOperations(stack);
-      this._allowCrossAccountAssetPublishing = await determineAllowCrossAccountAssetPublishing(env.sdk, this.ioHelper, this.props.toolkitStackName);
+    const resolvedEnvironment = await this.envs.resolveStackEnvironment(stack);
+    const envKey = `${resolvedEnvironment.account}:${resolvedEnvironment.region}`;
+
+    const cached = this.allowCrossAccountAssetPublishingCache.get(envKey);
+    if (cached !== undefined) {
+      return cached;
     }
-    return this._allowCrossAccountAssetPublishing;
+
+    const env = await this.envs.accessStackForReadOnlyStackOperations(stack);
+    const allowed = await determineAllowCrossAccountAssetPublishing(env.sdk, this.ioHelper, this.props.toolkitStackName);
+    this.allowCrossAccountAssetPublishingCache.set(envKey, allowed);
+    return allowed;
   }
 
   /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -12,6 +12,7 @@ import { GetParameterCommand } from '@aws-sdk/client-ssm';
 import { CloudFormationStack } from '../../../lib/api/cloudformation';
 import { Deployments } from '../../../lib/api/deployments';
 import * as cfnApi from '../../../lib/api/deployments/cfn-api';
+import { determineAllowCrossAccountAssetPublishing } from '../../../lib/api/deployments/checks';
 import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
 import { ToolkitInfo } from '../../../lib/api/toolkit-info';
 import { testStack } from '../../_helpers/assembly';
@@ -29,6 +30,7 @@ import { FakeCloudformationStack } from '../_helpers/fake-cloudformation-stack';
 
 jest.mock('../../../lib/api/deployments/deploy-stack');
 jest.mock('../../../lib/api/deployments/asset-publishing');
+jest.mock('../../../lib/api/deployments/checks');
 
 let sdkProvider: MockSdkProvider;
 let sdk: MockSdk;
@@ -1341,6 +1343,44 @@ describe('cachedPublisher', () => {
     const second = (deployments as any).cachedPublisher(manifest, env, 'StackA');
 
     expect(second).toBe(first);
+  });
+});
+
+describe('allowCrossAccountAssetPublishingForEnv', () => {
+  // Regression test: the cross-account-asset-publishing answer used to be cached in a
+  // single un-keyed instance field, so the first stack's environment's answer was
+  // silently reused for every other stack's environment on the same Deployments
+  // instance (which is reused for every stack in one `cdk deploy` invocation).
+  test('does not reuse the answer across different environments', async () => {
+    sdkProvider.forEnvironment = jest.fn().mockImplementation(() => ({ sdk: new MockSdk() }));
+    const mockDetermine = determineAllowCrossAccountAssetPublishing as jest.Mock;
+    mockDetermine.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    const stackA = testStack({ stackName: 'StackA', env: 'aws://111111111111/us-east-1' });
+    const stackB = testStack({ stackName: 'StackB', env: 'aws://222222222222/eu-west-1' });
+
+    const allowedForA = await (deployments as any).allowCrossAccountAssetPublishingForEnv(stackA);
+    const allowedForB = await (deployments as any).allowCrossAccountAssetPublishingForEnv(stackB);
+
+    expect(allowedForA).toBe(false);
+    expect(allowedForB).toBe(true);
+    expect(mockDetermine).toHaveBeenCalledTimes(2);
+  });
+
+  test('reuses the cached answer for repeat calls with the same environment', async () => {
+    sdkProvider.forEnvironment = jest.fn().mockImplementation(() => ({ sdk: new MockSdk() }));
+    const mockDetermine = determineAllowCrossAccountAssetPublishing as jest.Mock;
+    mockDetermine.mockResolvedValueOnce(true);
+
+    const stackA = testStack({ stackName: 'StackA', env: 'aws://111111111111/us-east-1' });
+    const stackAAgain = testStack({ stackName: 'StackA', env: 'aws://111111111111/us-east-1' });
+
+    const first = await (deployments as any).allowCrossAccountAssetPublishingForEnv(stackA);
+    const second = await (deployments as any).allowCrossAccountAssetPublishingForEnv(stackAAgain);
+
+    expect(first).toBe(true);
+    expect(second).toBe(true);
+    expect(mockDetermine).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
fixes #1883

### Reason for this change

`Deployments.allowCrossAccountAssetPublishingForEnv()` (`packages/@aws-cdk/toolkit-lib/lib/api/deployments/deployments.ts`) caches its result in a single un-keyed instance field:

```ts
private _allowCrossAccountAssetPublishing: boolean | undefined;

private async allowCrossAccountAssetPublishingForEnv(stack: cxapi.CloudFormationStackArtifact): Promise<boolean> {
  if (this._allowCrossAccountAssetPublishing === undefined) {
    const env = await this.envs.accessStackForReadOnlyStackOperations(stack);
    this._allowCrossAccountAssetPublishing = await determineAllowCrossAccountAssetPublishing(env.sdk, this.ioHelper, this.props.toolkitStackName);
  }
  return this._allowCrossAccountAssetPublishing; // stack's own environment ignored on a cache hit
}
```

`determineAllowCrossAccountAssetPublishing` reads the *target environment's* bootstrap stack (`CDKToolkit`'s `BootstrapVersion`/`BucketName`) and its answer is intrinsically per-account/per-region — it returns `false` only when that specific environment has a staging bucket **and** an old (`< 21`) bootstrap version.

**Reachability, stated honestly:** this is directly reachable via ordinary CLI usage, no programmatic toolkit-lib reuse needed. `deploy()` (`toolkit.ts`) creates one `Deployments` instance per `deploymentsForAction('deploy')` call and reuses it for every stack in `stackCollection.stackArtifacts` — so a plain `cdk deploy StackA StackB` (or `cdk deploy '*'`) where StackA and StackB target different accounts/regions with different bootstrap states hits this on the very first multi-stack, multi-environment deploy. `publishSingleAsset` calls `allowCrossAccountAssetPublishingForEnv(options.stack)` once per asset (line 743), so whichever stack's asset publishes first determines the answer applied to every other stack for the rest of the invocation.

Two concrete outcomes depending on stack order:
- StackA (old bootstrap, correctly `false`) publishes first → StackB (properly bootstrapped, should be `true`) gets a spurious cross-account-publishing failure on an otherwise valid deploy.
- StackA (properly bootstrapped, `true`) publishes first → StackB (old bootstrap, should be `false`) silently skips the safety check `determineAllowCrossAccountAssetPublishing` exists to enforce, and an asset can be published to the wrong account without the protection ever running against StackB's actual environment.

This is the same class of bug as #1838, fixed for the neighboring `publisherCache` field in #1839 — that fix's own comment explains exactly why environment-keying is required here too; `_allowCrossAccountAssetPublishing` sits a few lines below it and was simply missed.

### Description of changes

Replaces the single `boolean | undefined` field with a `Map<string, boolean>` keyed by `${account}:${region}` (same key shape `cachedPublisher` already uses), resolved once per call via `this.envs.resolveStackEnvironment(stack)` before checking the cache.

### Description of how you validated changes

Added two tests against `allowCrossAccountAssetPublishingForEnv` in `cloudformation-deployments.test.ts`, mirroring the existing `cachedPublisher` regression tests:
- `'does not reuse the answer across different environments'` — two stacks in different accounts/regions, `determineAllowCrossAccountAssetPublishing` mocked to return a different value per call; asserts each stack gets its own environment's answer and the underlying check runs twice. **Fails on the pre-fix code** (confirmed locally): the second stack's call returns the first stack's cached answer instead of its own.
- `'reuses the cached answer for repeat calls with the same environment'` — confirms the legitimate caching behavior (same environment) is preserved and the underlying check only runs once.

Ran the full `test/api/deployments/` suite (210 tests) — all pass, no regressions. `eslint --fix` clean.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (not applicable — internal caching bug in a helper class; a live multi-account integration test isn't part of the existing CLI integ suite's environment model, and the unit tests directly exercise the caching behavior that was broken)
- [x] No manual edits to generated files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
