### PR TITLE
refactor(cli): scope IoHost listeners via suppressMessages decorator

### DIFF
--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -10,7 +10,7 @@ import chalk from 'chalk';
 import * as chokidar from 'chokidar';
 import { type EventName, EVENTS } from 'chokidar/handler.js';
 import * as fs from 'fs-extra';
-import { CliIoHost } from './io-host';
+import { CliIoHost, suppressMessages } from './io-host';
 import type { Configuration } from './user-configuration';
 import { PROJECT_CONFIG } from './user-configuration';
 import type { ActionLessRequest, IMessageSpan, IoHelper } from '../../lib/api-private';
@@ -225,21 +225,17 @@ export class CdkToolkit {
     });
   }
 
+  @suppressMessages(
+    IO.CDK_TOOLKIT_I1001, // Starting Synthesis (trace)
+    IO.CDK_TOOLKIT_I1000, // ✨ Synthesis time (info)
+  )
   public async metadata(stackName: string, json: boolean) {
-    this.ioHost.once(
+    const dispose = this.ioHost.once(
       IO.CDK_TOOLKIT_I2901,
       (msg) => ({
         action: 'metadata',
         message: serializeStructure(msg.data.stacks[0]?.metadata ?? {}, json),
       }),
-    );
-    this.ioHost.once(
-      IO.CDK_TOOLKIT_I1001,
-      () => ({ preventDefault: true }),
-    );
-    this.ioHost.once(
-      IO.CDK_TOOLKIT_I1000,
-      () => ({ preventDefault: true }),
     );
 
     try {
@@ -251,7 +247,7 @@ export class CdkToolkit {
         },
       });
     } finally {
-      this.ioHost.removeAllListeners();
+      dispose();
     }
   }
 
@@ -471,7 +467,9 @@ export class CdkToolkit {
     // toolkit-lib emits the approval request (I5060) without mentioning
     // `--require-approval`. The CLI owns that flag, so it adds the framing here.
     // Both deploy paths resolve through this host, so one listener covers both.
-    this.ioHost.rewrite(IO.CDK_TOOLKIT_I5060, (msg) => {
+    // Disposed in the finally below: `deploy()` can run repeatedly (watch mode),
+    // and each run must register a rewrite for its own `requireApproval` value.
+    const disposeRewrite = this.ioHost.rewrite(IO.CDK_TOOLKIT_I5060, (msg) => {
       const updateTypeText = msg.data.permissionChangeType !== PermissionChangeType.NONE
         ? 'security-sensitive updates'
         : 'updates';
@@ -612,7 +610,7 @@ export class CdkToolkit {
 
       await this.ioHost.asIoHelper().defaults.info(`\n✨  Total time: ${formatTime(Date.now() - startSynthTime)}s\n`);
     } finally {
-      this.ioHost.removeAllListeners();
+      disposeRewrite();
     }
   }
 
@@ -1025,6 +1023,15 @@ export class CdkToolkit {
     }
   }
 
+  // The destroy action runs through toolkit-lib.
+  // Suppress its new status messages to keep the output as it was before.
+  @suppressMessages(
+    IO.CDK_TOOLKIT_I1001, // Starting Synthesis (trace)
+    IO.CDK_TOOLKIT_I1000, // ✨ Synthesis time (info)
+    IO.CDK_TOOLKIT_I7101, // Starting Destroy (trace)
+    IO.CDK_TOOLKIT_I7001, // per-stack Destroy time (trace)
+    IO.CDK_TOOLKIT_I7000, // ✨ Destroy time (info)
+  )
   public async destroy(options: DestroyOptions) {
     // Keep the "deployed" wording when a destroy runs as part of a deploy.
     const action = options.fromDeploy ? 'deploy' : 'destroy';
@@ -1033,26 +1040,21 @@ export class CdkToolkit {
       this.ioHost.stackProgress = StackActivityProgress.EVENTS;
     }
 
-    // The destroy action runs through toolkit-lib.
-    // Use listeners to keep the messages as they were before.
-    this.ioHost.on(IO.CDK_TOOLKIT_I1001, () => ({ preventDefault: true })); // Starting Synthesis (trace)
-    this.ioHost.on(IO.CDK_TOOLKIT_I1000, () => ({ preventDefault: true })); // ✨ Synthesis time (info)
-    this.ioHost.on(IO.CDK_TOOLKIT_I7101, () => ({ preventDefault: true })); // Starting Destroy (trace)
-    this.ioHost.on(IO.CDK_TOOLKIT_I7001, () => ({ preventDefault: true })); // per-stack Destroy time (trace)
-    this.ioHost.on(IO.CDK_TOOLKIT_I7000, () => ({ preventDefault: true })); // ✨ Destroy time (info)
-    // The success line was `info` in the historical `cdk destroy`, not `result`.
-    this.ioHost.on(IO.CDK_TOOLKIT_I7900, () => ({ level: 'info' })); // ✅ <stack>: destroyed
+    const disposers = [
+      // The success line was `info` in the historical `cdk destroy`, not `result`.
+      this.ioHost.on(IO.CDK_TOOLKIT_I7900, () => ({ level: 'info' })), // ✅ <stack>: destroyed
 
-    // toolkit-lib logs a declined confirmation (E7010) and returns gracefully.
-    // The CLI surfaces a decline as a non-zero, soft exit instead: throwing from
-    // the listener both suppresses the log and aborts the command (the top-level
-    // renders `AbortError` as "Deletion cancelled").
-    this.ioHost.on(IO.CDK_TOOLKIT_E7010, () => {
-      throw new AbortError('DestroyAborted', 'Deletion cancelled');
-    });
+      // toolkit-lib logs a declined confirmation (E7010) and returns gracefully.
+      // The CLI surfaces a decline as a non-zero, soft exit instead: throwing from
+      // the listener both suppresses the log and aborts the command (the top-level
+      // renders `AbortError` as "Deletion cancelled").
+      this.ioHost.on(IO.CDK_TOOLKIT_E7010, () => {
+        throw new AbortError('DestroyAborted', 'Deletion cancelled');
+      }),
+    ];
 
     if (options.force) {
-      this.ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true);
+      disposers.push(this.ioHost.respondOnce(IO.CDK_TOOLKIT_I7010, true));
     }
 
     try {
@@ -1073,26 +1075,28 @@ export class CdkToolkit {
         express: options.express,
       });
     } finally {
-      this.ioHost.removeAllListeners();
+      disposers.forEach((dispose) => dispose());
     }
   }
 
+  // cdk ls stdout is the stack listing only. Suppress the info status lines synthesis emits next
+  // to it: the synth-time line (I1000) and the dependency-expansion note (I1002).
+  @suppressMessages(IO.CDK_TOOLKIT_I1000, IO.CDK_TOOLKIT_I1002)
   public async list(
     selectors: string[],
     options: { long?: boolean; json?: boolean; showDeps?: boolean } = {},
   ): Promise<number> {
-    this.ioHost.rewriteOnce(IO.CDK_TOOLKIT_I2901, (msg) => formatStackList(msg.data.stacks, options));
+    const dispose = this.ioHost.rewriteOnce(IO.CDK_TOOLKIT_I2901, (msg) => formatStackList(msg.data.stacks, options));
 
-    // cdk ls stdout is the stack listing only. Suppress the info status lines synthesis emits next
-    // to it: the synth-time line (I1000) and the dependency-expansion note (I1002).
-    this.ioHost.once(IO.CDK_TOOLKIT_I1000, () => ({ preventDefault: true }));
-    this.ioHost.once(IO.CDK_TOOLKIT_I1002, () => ({ preventDefault: true }));
-
-    await this.toolkit.list(this.props.cloudExecutable, {
-      stacks: selectors.length > 0
-        ? { patterns: selectors, strategy: StackSelectionStrategy.PATTERN_MATCH, expand: ExpandStackSelection.UPSTREAM }
-        : undefined,
-    });
+    try {
+      await this.toolkit.list(this.props.cloudExecutable, {
+        stacks: selectors.length > 0
+          ? { patterns: selectors, strategy: StackSelectionStrategy.PATTERN_MATCH, expand: ExpandStackSelection.UPSTREAM }
+          : undefined,
+      });
+    } finally {
+      dispose();
+    }
 
     return 0; // exit-code
   }

--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -1095,6 +1095,49 @@ export function matchAny(...selectors: MessageSelector<any>[]): (msg: IoMessage<
 }
 
 /**
+ * Method decorator that suppresses the given IoHost messages for the duration
+ * of the decorated method.
+ *
+ * Before the method runs, a single `preventDefault` listener covering all
+ * given selectors is registered on the instance's `ioHost`; when the method
+ * settles (returns or throws), exactly that listener is removed again. This
+ * replaces the manual pattern of registering drop-listeners at the top of a
+ * method and cleaning them up in a `finally`, and — unlike a blanket
+ * `removeAllListeners()` — it does not disturb listeners registered elsewhere.
+ *
+ * The decorated method must be async and live on a class whose instances carry
+ * the `CliIoHost` on an `ioHost` property (like `CdkToolkit`).
+ *
+ * @example
+ * class CdkToolkit {
+ *   \@suppressMessages(IO.CDK_TOOLKIT_I1001, IO.CDK_TOOLKIT_I1000)
+ *   public async metadata(stackName: string, json: boolean) {
+ *     // I1001/I1000 are dropped while this runs
+ *   }
+ * }
+ */
+export function suppressMessages(...selectors: MessageSelector<any>[]) {
+  return function <A extends any[], R>(
+    _target: object,
+    _propertyKey: string | symbol,
+    descriptor: TypedPropertyDescriptor<(...args: A) => Promise<R>>,
+  ): void {
+    const original = descriptor.value;
+    if (!original) {
+      throw new ToolkitError('InvalidDecoratorTarget', 'suppressMessages can only decorate methods');
+    }
+    descriptor.value = async function (this: { readonly ioHost: CliIoHost }, ...args: A): Promise<R> {
+      const dispose = this.ioHost.on(matchAny(...selectors), () => ({ preventDefault: true }));
+      try {
+        return await original.apply(this, args);
+      } finally {
+        dispose();
+      }
+    };
+  };
+}
+
+/**
  * This IoHost implementation considers a request promptable, if:
  * - it's a yes/no confirmation
  * - asking for a string or number value

--- a/packages/aws-cdk/test/_helpers/io-recorder.ts
+++ b/packages/aws-cdk/test/_helpers/io-recorder.ts
@@ -272,14 +272,20 @@ export class IoHostRecorder {
    * Build the ordered list of recorded entries from the observed message
    * stream. Observations are already in the order the host handled them, so no
    * separate ordering is needed.
+   *
+   * @param options - `includeDropped: true` includes suppressed messages
+   *   (tagged `dropped: true`) regardless of the recorder's `excludeDropped`
+   *   setting, so a test can assert on listener-based suppression directly
+   *   without the dropped entries ending up in the snapshot.
    */
-  public entries(): RecordedIoEntry[] {
+  public entries(options: { includeDropped?: boolean } = {}): RecordedIoEntry[] {
+    const includeDropped = options.includeDropped ?? !this.excludeDropped;
     const entries: RecordedIoEntry[] = [];
     let seq = 0;
     for (const { type, emitted, effective, dropped } of this.observations) {
       // Optionally omit suppressed messages so the snapshot reflects only what
       // the user sees.
-      if (dropped && this.excludeDropped) {
+      if (dropped && !includeDropped) {
         continue;
       }
       // The single decision point for which levels are included; uses the

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -272,25 +272,6 @@ describe('list', () => {
       'Test-Stack-B',
     ]);
   });
-
-  test('suppresses the synth-time (I1000) and dependency-expansion (I1002) lines on the list path', async () => {
-    // Both are info-level lines emitted next to the listing; in CI they would land on stdout and
-    // pollute the parseable output. The list path registers a one-shot suppressor for each so they
-    // are dropped before being written. (End-to-end stdout behavior is covered by the integ test.)
-    const toolkit = defaultToolkitSetup();
-    const onceSpy = jest.spyOn(ioHost, 'once');
-
-    // WHEN
-    await toolkit.list([]);
-
-    // THEN
-    for (const code of ['CDK_TOOLKIT_I1000', 'CDK_TOOLKIT_I1002']) {
-      const call = onceSpy.mock.calls.find(([sel]) => (sel as any)?.code === code);
-      expect(call).toBeDefined();
-      const listener = call![1] as (msg: any) => any;
-      expect(listener({ code })).toEqual({ preventDefault: true });
-    }
-  });
 });
 
 describe('deploy', () => {

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -7,7 +7,7 @@ import * as fs from 'fs-extra';
 import { Context } from '../../../lib/api/context';
 import { IO } from '../../../lib/api-private';
 import type { IoMessage, IoMessageLevel, IoRequest } from '../../../lib/cli/io-host';
-import { CliIoHost, matchAny } from '../../../lib/cli/io-host';
+import { CliIoHost, matchAny, suppressMessages } from '../../../lib/cli/io-host';
 import { CLI_PRIVATE_IO } from '../../../lib/cli/telemetry/messages';
 import { StackActivityProgress } from '../../../lib/commands/deploy';
 
@@ -366,6 +366,46 @@ describe('CliIoHost', () => {
       }));
 
       expect(observed).toEqual(['CDK_TOOLKIT_I2901:a', 'CDK_TOOLKIT_I1000:b']);
+    });
+
+    test('suppressMessages() decorator drops the given codes only while the method runs', async () => {
+      class Fixture {
+        public readonly ioHost = ioHost;
+
+        @suppressMessages(IO.CDK_TOOLKIT_I2901)
+        public async run(body: () => Promise<void>): Promise<number> {
+          await body();
+          return 42;
+        }
+      }
+
+      const result = await new Fixture().run(async () => {
+        await ioHost.notify(listMessage('while-suppressed'));
+      });
+
+      // suppressed inside the method, return value passed through
+      expect(result).toBe(42);
+      expect(mockStdout).not.toHaveBeenCalledWith('while-suppressed\n');
+
+      // listener is gone again after the method returned
+      await ioHost.notify(listMessage('after'));
+      expect(mockStdout).toHaveBeenCalledWith('after\n');
+    });
+
+    test('suppressMessages() decorator removes its listener when the method throws', async () => {
+      class Fixture {
+        public readonly ioHost = ioHost;
+
+        @suppressMessages(IO.CDK_TOOLKIT_I2901)
+        public async boom(): Promise<void> {
+          throw new Error('nope');
+        }
+      }
+
+      await expect(new Fixture().boom()).rejects.toThrow('nope');
+
+      await ioHost.notify(listMessage('after-throw'));
+      expect(mockStdout).toHaveBeenCalledWith('after-throw\n');
     });
 
     test('rewrite() replaces the printed text for every matching message', async () => {

--- a/packages/aws-cdk/test/commands/__io_snapshots__/list/cdk_list_suppresses_the_synth-time_and_dependency-expansion_lines.ndjson
+++ b/packages/aws-cdk/test/commands/__io_snapshots__/list/cdk_list_suppresses_the_synth-time_and_dependency-expansion_lines.ndjson
@@ -1,0 +1,4 @@
+{"seq":0,"type":"notify","action":"list","level":"trace","code":"CDK_TOOLKIT_I1001","message":"Starting Synthesis ..."}
+{"seq":1,"type":"notify","action":"list","level":"trace","code":"CDK_CLI_I1000","message":"Starting Synthesis ..."}
+{"seq":2,"type":"notify","action":"list","level":"trace","code":"CDK_CLI_I1001","message":"\n✨  Synthesis time: <DURATION>\n"}
+{"seq":3,"type":"notify","action":"list","level":"result","code":"CDK_TOOLKIT_I2901","message":"Test-Stack-A\nTest-Stack-B"}

--- a/packages/aws-cdk/test/commands/list.test.ts
+++ b/packages/aws-cdk/test/commands/list.test.ts
@@ -65,6 +65,19 @@ describe('cdk list', () => {
     await list([MockStack.MOCK_STACK_A, stackB()], ['Test-Stack-A', 'Test-Stack-B']);
   });
 
+  test('suppresses the synth-time and dependency-expansion lines', async () => {
+    // Selecting only the downstream stack expands the selection upstream, which
+    // emits the dependency-expansion note (I1002); synthesis emits the
+    // synth-time line (I1000). Both are dropped by @suppressMessages on the
+    // list path so the listing stays parseable: they must show up as emitted
+    // but dropped, and never in the visible stream (the snapshot).
+    await list([MockStack.MOCK_STACK_A, stackB({ depends: ['Test-Stack-A'] })], ['Test-Stack-B']);
+
+    const dropped = recorder.entries({ includeDropped: true }).filter((e) => e.dropped);
+    expect(dropped).toContainEqual(expect.objectContaining({ code: 'CDK_TOOLKIT_I1000' }));
+    expect(dropped).toContainEqual(expect.objectContaining({ code: 'CDK_TOOLKIT_I1002' }));
+  });
+
   test('shows the dependencies between stacks', async () => {
     await list(
       [MockStack.MOCK_STACK_A, stackB({ depends: ['Test-Stack-A'] })],


### PR DESCRIPTION
Several `CdkToolkit` methods drop specific toolkit-lib messages by registering `preventDefault` listeners on the `CliIoHost` and then restoring behavior with a blanket `removeAllListeners()` in a `finally` block. That pattern is repetitive, and the blanket removal is a blunt instrument: it tears down every user listener on the shared host, not just the ones the method registered.

This change introduces a `@suppressMessages(...codes)` method decorator that registers a single method-scoped drop-listener (via `matchAny`) before the decorated method runs and disposes exactly that listener when the method settles, whether it returns or throws. It is applied to `metadata`, `destroy`, and `list`, and every remaining `removeAllListeners()` call is replaced with disposal of exactly the listeners the method itself registered.

Scoping the disposal also fixes two latent bugs. When `destroy` ran as part of a `deploy` (a stack with no resources triggers a delete mid-deployment), its `removeAllListeners()` wiped deploy's `I5060` approval-rewrite listener for the rest of the deployment. And `list`'s one-shot `I2901` formatter leaked with stale options whenever synthesis failed before the listing was emitted.

Tested with new unit tests for the decorator (suppression is active only for the duration of the call, including the throwing path) and a behavioral test on the `cdk list` path that asserts the synth-time (`I1000`) and dependency-expansion (`I1002`) lines are emitted but dropped, using a new `IoHostRecorder.entries({ includeDropped: true })` override so dropped messages stay out of the committed NDJSON snapshots. The `destroy.test.ts` failures visible in this area reproduce identically on a clean `main` checkout and are unrelated.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
