### PR TITLE
fix(cloudformation-diff): classify retained removals as orphaned

### DIFF
--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/types.ts
@@ -722,7 +722,7 @@ export class ResourceDifference implements IDifference<Resource> {
         return ResourceImpact.WILL_CREATE;
       }
       if (this.resourceTypes.newType === undefined) {
-        return this.oldValue!.DeletionPolicy === 'Retain'
+        return this.oldValue!.DeletionPolicy === 'Retain' || this.oldValue!.DeletionPolicy === 'RetainExceptOnCreate'
           ? ResourceImpact.WILL_ORPHAN
           : ResourceImpact.WILL_DESTROY;
       }

--- a/packages/@aws-cdk/cloudformation-diff/test/diff-template.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/diff-template.test.ts
@@ -70,13 +70,13 @@ test('when a resource is deleted (no DeletionPolicy)', () => {
   expect(difference?.changeImpact).toBe(ResourceImpact.WILL_DESTROY);
 });
 
-test('when a resource is deleted (DeletionPolicy=Retain)', () => {
+test.each(['Retain', 'RetainExceptOnCreate'])('when a resource is deleted (DeletionPolicy=%s)', (deletionPolicy) => {
   const currentTemplate = {
     Resources: {
       BucketResource: { Type: 'AWS::S3::Bucket' },
       BucketPolicyResource: {
         Type: 'AWS::S3::BucketPolicy',
-        DeletionPolicy: 'Retain',
+        DeletionPolicy: deletionPolicy,
         Properties: {
           PolicyDocument: POLICY_DOCUMENT,
           Bucket: { Ref: 'BucketResource' },


### PR DESCRIPTION
Fixes #1882

`ResourceDifference.changeImpact` currently treats removed resources with `DeletionPolicy: RetainExceptOnCreate` as `WILL_DESTROY`. For a resource that already exists and is removed from a template, CloudFormation retains it under this policy, just as it does with `Retain`.

This changes removal classification to return `WILL_ORPHAN` for both `Retain` and `RetainExceptOnCreate`. Existing no-policy/`Delete` behavior remains `WILL_DESTROY`; `Snapshot` behavior is unchanged, leaving that separate API decision to maintainers.

The existing deletion-impact test is parameterized to cover both retention policies while retaining no-policy coverage.

Validation:
- `git diff --check`
- Focused Jest test could not run locally: Yarn is not installed, and Corepack could not download the repository's pinned Yarn version because `repo.yarnpkg.com` was unavailable (`EAI_AGAIN`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
