### PR TITLE
fix(cli): --yes mode requires a TTY when a request's default is falsy

### DIFF
--- a/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
+++ b/packages/aws-cdk/lib/cli/io-host/cli-io-host.ts
@@ -1003,7 +1003,7 @@ export class CliIoHost implements IIoHost, ObservableIoHost {
         }
 
         // respond with the default for all other messages
-        if (msg.defaultResponse) {
+        if (msg.defaultResponse !== undefined) {
           await this.writeMessage({
             ...msg,
             message: `${chalk.cyan(msg.message)} (auto-responded with default: ${util.format(msg.defaultResponse)})`,

--- a/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
+++ b/packages/aws-cdk/test/cli/io-host/cli-io-host.test.ts
@@ -1336,6 +1336,37 @@ describe('CliIoHost', () => {
         }));
         expect(response).toBe('foobar');
       });
+
+      test('falsy defaults (empty string, zero) are auto-responded instead of requiring a TTY', async () => {
+        const nonTtyAutoRespondingIoHost = CliIoHost.instance({
+          logLevel: 'trace',
+          autoRespond: true,
+          isCI: false,
+          isTTY: false,
+        }, true);
+
+        // empty string default
+        const stringResponse = await nonTtyAutoRespondingIoHost.requestResponse(plainMessage({
+          time: new Date(),
+          level: 'info',
+          action: 'synth',
+          code: 'CDK_TOOLKIT_I5060',
+          message: 'test message',
+          defaultResponse: '',
+        }));
+        expect(stringResponse).toBe('');
+
+        // zero default
+        const numberResponse = await nonTtyAutoRespondingIoHost.requestResponse(plainMessage({
+          time: new Date(),
+          level: 'info',
+          action: 'synth',
+          code: 'CDK_TOOLKIT_I0001',
+          message: 'test message',
+          defaultResponse: 0,
+        }));
+        expect(numberResponse).toBe(0);
+      });
     });
 
     describe('non-promptable data', () => {


### PR DESCRIPTION
### Reason for this change

`CliIoHost.resolveRequest`'s `--yes` auto-respond path used a truthy check (`if (msg.defaultResponse)`) before returning the request's default response. Non-boolean prompts (booleans are handled separately via `isConfirmationPrompt`) whose default is falsy-but-valid — an empty string `''` or the number `0` — fail this check and fall through to the `isTTY` gate, throwing `TtyNotAttached` instead of using the default, even though `--yes` was passed specifically so the CLI wouldn't need a TTY.

This is inconsistent with the sibling `NonInteractiveIoHost` implementation, which handles the boolean case separately and then unconditionally returns `msg.defaultResponse` — the intended semantics `CliIoHost`'s `--yes` mode is supposed to mirror.

Two real call sites already pass an empty-string default and are affected today:
- `cdk import`'s per-property resource-identifier prompt (`importer.ts`) — empty default means "skip this identifier"
- The SDK's MFA-token prompt (`awscli-compatible.ts`, `CDK_SDK_I1100`)

So `cdk import --yes` (or any non-interactive/CI run hitting one of these prompts) currently aborts with `TtyNotAttached` instead of silently taking the default.

### Description of changes

Changed the truthy check to a definedness check: `if (msg.defaultResponse !== undefined)`, mirroring the `typeof ... === 'string' || 'number'` checks already used a few lines below in `isPromptableRequest`.

### Description of how you validated changes

Added a regression test in `cli-io-host.test.ts` that constructs a `CliIoHost` with `autoRespond: true, isTTY: false` and asserts that requests with `defaultResponse: ''` and `defaultResponse: 0` resolve to those values instead of throwing. Verified the test fails with `TtyNotAttached` against the old code and passes with the fix. Ran the full `cli-io-host` test suite (91 tests) — all pass.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated (if deploying new resource types or cross-service interactions) — not applicable, no AWS resource interaction
- [x] No manual edits to generated files

---

Fixes #1891

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license