### PR TITLE
fix(toolkit-lib): cdk validate drops the plugin's customSeverity label

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/validate/validate-formatting.ts
@@ -40,7 +40,7 @@ function flattenViolations(reports: PluginReportJson[]): FlattenedViolation[] {
     const pluginName = report.pluginName;
     return report.violations.flatMap((violation) => {
       return violation.violatingConstructs.map((construct) => ({
-        severity: normalizeSeverity(violation.severity),
+        severity: normalizeSeverity(violation.severity, violation.customSeverity),
         description: violation.description,
         ruleName: violation.ruleName,
         pluginName,

--- a/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/validate/validate-formatting.test.ts
@@ -36,6 +36,24 @@ describe('formatValidateResult', () => {
     ]);
   });
 
+  test('uses the plugin-supplied customSeverity label for a "custom" severity violation', () => {
+    const result = makeResult([{
+      pluginName: 'TestPlugin',
+      conclusion: 'failure',
+      violations: [{
+        ruleName: 'r1',
+        description: 'blocker issue',
+        severity: 'custom',
+        customSeverity: 'BLOCKER',
+        violatingConstructs: [{ constructPath: 'Stack/A' }],
+      }],
+    }]);
+
+    const output = formatValidateResult(result);
+    expect(output).toContain('BLOCKER');
+    expect(output).not.toContain('INFO');
+  });
+
   test('formats construct path with logical id', () => {
     const result = makeResult([{
       pluginName: 'TestPlugin',


### PR DESCRIPTION
### Reason for this change

`flattenViolations()` in `validate-formatting.ts` calls `normalizeSeverity(violation.severity)` without forwarding `violation.customSeverity`. `normalizeSeverity` already accepts a `customSeverity` parameter and uses it specifically for the `'custom'` severity case (`return customSeverity ?? 'INFO'`), but since the call site never passes it, that argument is always `undefined` — so every `severity: 'custom'` violation is mislabeled `INFO` in `cdk validate` output, silently discarding whatever severity the validation plugin actually intended (e.g. `BLOCKER`).

### Description of changes

Pass `violation.customSeverity` through at the one call site: `normalizeSeverity(violation.severity, violation.customSeverity)`.

### Description of how you validated changes

Added a regression test asserting that a violation with `severity: 'custom', customSeverity: 'BLOCKER'` renders `BLOCKER` (not `INFO`) in the formatted output. Verified the test fails against the unmodified code and passes with the fix. Ran the full `validate-formatting` test suite (13 tests) — all pass.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests added/updated — not applicable, pure formatting logic
- [x] No manual edits to generated files

---

Fixes #1893

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license