### PR TITLE
chore: ban direct child_process and shell:true outside the subprocess tool

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -224,8 +224,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -222,6 +222,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -252,6 +256,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -320,6 +332,26 @@
     ]
   },
   "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    },
     {
       "files": [
         ".projenrc.ts"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -345,10 +345,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1565,6 +1565,19 @@ integRunner.preCompileTask.prependExec('./build-tools/generate.sh');
 new TypecheckTests(integRunner);
 fixupTestTask(integRunner);
 
+// integ-runner is integration-test tooling, and its `exec()` already spawns an
+// argv array with no shell (so it carries no injection risk — the ban only
+// flags it for importing child_process directly). Exempt it for now; migrating
+// it onto the shared subprocess tool is deferred follow-up work. Scoped to the
+// one sink so any NEW file still hits the ban.
+integRunner.eslint?.addOverride({
+  files: ['lib/utils.ts'],
+  rules: {
+    'no-restricted-imports': ['off'],
+    'no-restricted-syntax': ['off'],
+  },
+});
+
 new BundleCli(integRunner, {
   externals: {
     dependencies: [
@@ -1687,6 +1700,27 @@ const cliInteg = configureProject(
   }),
 );
 cliInteg.eslint?.addIgnorePattern('resources/**/*.ts');
+
+// cli-integ is a test harness that deliberately spawns through a shell (and a
+// pty) to exercise the CLI the way a user would at a terminal — that is the
+// point of these helpers, not something to migrate away. Permanently exempt,
+// like test code. Scoped to the current sinks so NEW files still hit the ban
+// and get a conscious decision rather than a silent pass.
+cliInteg.eslint?.addOverride({
+  files: [
+    'lib/cli/stage-distribution.ts',
+    'lib/npm.ts',
+    'lib/package-sources/repo-tools/npm.ts',
+    'lib/process.ts',
+    'lib/shell.ts',
+    'lib/with-cdk-app.ts',
+    'lib/with-sam.ts',
+  ],
+  rules: {
+    'no-restricted-imports': ['off'],
+    'no-restricted-syntax': ['off'],
+  },
+});
 
 cliInteg.deps.addDependency('@aws-cdk/toolkit-lib', pj.DependencyType.OPTIONAL);
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1565,19 +1565,6 @@ integRunner.preCompileTask.prependExec('./build-tools/generate.sh');
 new TypecheckTests(integRunner);
 fixupTestTask(integRunner);
 
-// integ-runner is integration-test tooling, and its `exec()` already spawns an
-// argv array with no shell (so it carries no injection risk — the ban only
-// flags it for importing child_process directly). Exempt it for now; migrating
-// it onto the shared subprocess tool is deferred follow-up work. Scoped to the
-// one sink so any NEW file still hits the ban.
-integRunner.eslint?.addOverride({
-  files: ['lib/utils.ts'],
-  rules: {
-    'no-restricted-imports': ['off'],
-    'no-restricted-syntax': ['off'],
-  },
-});
-
 new BundleCli(integRunner, {
   externals: {
     dependencies: [
@@ -1700,27 +1687,6 @@ const cliInteg = configureProject(
   }),
 );
 cliInteg.eslint?.addIgnorePattern('resources/**/*.ts');
-
-// cli-integ is a test harness that deliberately spawns through a shell (and a
-// pty) to exercise the CLI the way a user would at a terminal — that is the
-// point of these helpers, not something to migrate away. Permanently exempt,
-// like test code. Scoped to the current sinks so NEW files still hit the ban
-// and get a conscious decision rather than a silent pass.
-cliInteg.eslint?.addOverride({
-  files: [
-    'lib/cli/stage-distribution.ts',
-    'lib/npm.ts',
-    'lib/package-sources/repo-tools/npm.ts',
-    'lib/process.ts',
-    'lib/shell.ts',
-    'lib/with-cdk-app.ts',
-    'lib/with-sam.ts',
-  ],
-  rules: {
-    'no-restricted-imports': ['off'],
-    'no-restricted-syntax': ['off'],
-  },
-});
 
 cliInteg.deps.addDependency('@aws-cdk/toolkit-lib', pj.DependencyType.OPTIONAL);
 

--- a/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
+++ b/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
@@ -125,8 +125,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -341,25 +341,6 @@
         "**/projenrc/**",
         ".projenrc.ts",
         "**/.projenrc.ts"
-      ],
-      "rules": {
-        "no-restricted-imports": [
-          "off"
-        ],
-        "no-restricted-syntax": [
-          "off"
-        ]
-      }
-    },
-    {
-      "files": [
-        "lib/cli/stage-distribution.ts",
-        "lib/npm.ts",
-        "lib/package-sources/repo-tools/npm.ts",
-        "lib/process.ts",
-        "lib/shell.ts",
-        "lib/with-cdk-app.ts",
-        "lib/with-sam.ts"
       ],
       "rules": {
         "no-restricted-imports": [

--- a/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
+++ b/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
@@ -123,6 +123,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -153,6 +157,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -318,5 +330,45 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    },
+    {
+      "files": [
+        "lib/cli/stage-distribution.ts",
+        "lib/npm.ts",
+        "lib/package-sources/repo-tools/npm.ts",
+        "lib/process.ts",
+        "lib/shell.ts",
+        "lib/with-cdk-app.ts",
+        "lib/with-sam.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
+++ b/packages/@aws-cdk-testing/cli-integ/.eslintrc.json
@@ -344,10 +344,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk-testing/cli-integ/lib/cli/stage-distribution.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/cli/stage-distribution.ts
@@ -108,6 +108,7 @@ async function main() {
         await usageDir.activateInCurrentProcess();
 
         await shell(args.COMMAND ?? [], {
+          // eslint-disable-next-line no-restricted-syntax -- cli-integ deliberately runs commands through a shell to mimic real terminal invocation in integ tests.
           shell: true,
           show: 'always',
         });

--- a/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/npm.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- cli-integ is a test harness that spawns processes to exercise the CLI as a user would; it is test infrastructure, not shipped runtime.
 import { spawnSync } from 'child_process';
 import * as semver from 'semver';
 import { shell } from './shell';

--- a/packages/@aws-cdk-testing/cli-integ/lib/package-sources/repo-tools/npm.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/package-sources/repo-tools/npm.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- cli-integ is a test harness that spawns processes to exercise the CLI as a user would; it is test infrastructure, not shipped runtime.
 import * as child_process from 'child_process';
 import * as fs from 'fs-extra';
 

--- a/packages/@aws-cdk-testing/cli-integ/lib/process.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/process.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- cli-integ is a test harness that spawns processes to exercise the CLI as a user would; it is test infrastructure, not shipped runtime.
 import * as child from 'child_process';
 import type { Readable, Writable } from 'stream';
 import * as pty from 'node-pty';
@@ -63,6 +64,7 @@ export class Process {
     // (passing args with shell: true is deprecated because they are not escaped).
     const fullCommand = [command, ...args].join(' ');
     const process = child.spawn(fullCommand, [], {
+      // eslint-disable-next-line no-restricted-syntax -- cli-integ deliberately runs commands through a shell to mimic real terminal invocation in integ tests.
       shell: true,
       stdio: ['ignore', 'pipe', 'pipe'],
       ...options,

--- a/packages/@aws-cdk-testing/cli-integ/lib/shell.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/shell.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- type-only import in cli-integ, a test harness that spawns processes to exercise the CLI; test infrastructure, not shipped runtime.
 import type * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-cdk-app.ts
@@ -518,6 +518,7 @@ export class TestFixture extends ShellHelper {
       '--username', username,
       '--password', '${ECR_PASSWORD}',
       'public.ecr.aws'], {
+      // eslint-disable-next-line no-restricted-syntax -- cli-integ deliberately runs commands through a shell to mimic real terminal invocation in integ tests.
       shell: true,
       modEnv: {
         ECR_PASSWORD: password,

--- a/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
+++ b/packages/@aws-cdk-testing/cli-integ/lib/with-sam.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-restricted-imports -- cli-integ is a test harness that spawns processes to exercise the CLI as a user would; it is test infrastructure, not shipped runtime.
 import * as child_process from 'child_process';
 import * as os from 'os';
 import * as path from 'path';
@@ -192,6 +193,7 @@ export async function shellWithAction(
     ...options,
     env,
     // Need this for Windows where we want .cmd and .bat to be found as well.
+    // eslint-disable-next-line no-restricted-syntax -- cli-integ deliberately runs commands through a shell to mimic real terminal invocation in integ tests.
     shell: true,
     stdio: ['ignore', 'pipe', 'pipe'],
   });

--- a/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           },
           {
             "name": "@aws-cdk/private-tools",
@@ -336,5 +348,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-assets-lib/.eslintrc.json
@@ -362,10 +362,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cdk-explorer/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-explorer/.eslintrc.json
@@ -121,6 +121,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -151,6 +155,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -316,5 +328,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cdk-explorer/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-explorer/.eslintrc.json
@@ -123,8 +123,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/cdk-explorer/.eslintrc.json
+++ b/packages/@aws-cdk/cdk-explorer/.eslintrc.json
@@ -342,10 +342,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
+++ b/packages/@aws-cdk/cli-plugin-contract/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-api/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
+++ b/packages/@aws-cdk/cloud-assembly-schema/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
+++ b/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
+++ b/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
+++ b/packages/@aws-cdk/cloudformation-diff/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/integ-runner/.eslintrc.json
+++ b/packages/@aws-cdk/integ-runner/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -340,19 +340,6 @@
         "**/projenrc/**",
         ".projenrc.ts",
         "**/.projenrc.ts"
-      ],
-      "rules": {
-        "no-restricted-imports": [
-          "off"
-        ],
-        "no-restricted-syntax": [
-          "off"
-        ]
-      }
-    },
-    {
-      "files": [
-        "lib/utils.ts"
       ],
       "rules": {
         "no-restricted-imports": [

--- a/packages/@aws-cdk/integ-runner/.eslintrc.json
+++ b/packages/@aws-cdk/integ-runner/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/integ-runner/.eslintrc.json
+++ b/packages/@aws-cdk/integ-runner/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,39 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    },
+    {
+      "files": [
+        "lib/utils.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/integ-runner/lib/utils.ts
+++ b/packages/@aws-cdk/integ-runner/lib/utils.ts
@@ -1,4 +1,5 @@
 // Helper functions for CDK Exec
+// eslint-disable-next-line no-restricted-imports -- integ-runner is test tooling; exec() spawns an argv array with no shell, so this is safe. Migrating onto the shared subprocess tool is deferred follow-up work.
 import { spawnSync } from 'child_process';
 
 /**

--- a/packages/@aws-cdk/private-tools/.eslintrc.json
+++ b/packages/@aws-cdk/private-tools/.eslintrc.json
@@ -121,6 +121,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -151,6 +155,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -316,5 +328,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/private-tools/.eslintrc.json
+++ b/packages/@aws-cdk/private-tools/.eslintrc.json
@@ -123,8 +123,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/private-tools/.eslintrc.json
+++ b/packages/@aws-cdk/private-tools/.eslintrc.json
@@ -342,10 +342,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/private-tools/lib/subprocess/index.ts
+++ b/packages/@aws-cdk/private-tools/lib/subprocess/index.ts
@@ -16,6 +16,7 @@
  *    the only path to a shell and takes no argv form, so command lines can
  *    never be assembled from parts by this codebase.
  */
+// eslint-disable-next-line no-restricted-imports -- this module IS the sanctioned wrapper around child_process
 import * as child_process from 'child_process';
 import { StringDecoder } from 'string_decoder';
 import spawn from 'cross-spawn';
@@ -279,6 +280,7 @@ export function runSync(argv: readonly string[], options: RunSyncOptions = {}): 
 export async function runUserCommandLine(commandLine: string, options: RunOptions = {}): Promise<RunResult> {
   const child = child_process.spawn(commandLine, {
     ...spawnOptions(options),
+    // eslint-disable-next-line no-restricted-syntax -- this is the single sanctioned shell entry point (see the module header)
     shell: true,
   });
   return monitor(child, commandLine, options);

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -119,6 +119,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -149,6 +153,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           },
           {
             "name": "@aws-cdk/private-tools",
@@ -332,6 +344,26 @@
     "@cdklabs/no-throw-default-error": "error"
   },
   "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    },
     {
       "files": [
         "./test/**"

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -357,10 +357,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     },

--- a/packages/@aws-cdk/toolkit-lib/.eslintrc.json
+++ b/packages/@aws-cdk/toolkit-lib/.eslintrc.json
@@ -121,8 +121,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/user-input-gen/.eslintrc.json
+++ b/packages/@aws-cdk/user-input-gen/.eslintrc.json
@@ -121,6 +121,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -151,6 +155,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -316,5 +328,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/user-input-gen/.eslintrc.json
+++ b/packages/@aws-cdk/user-input-gen/.eslintrc.json
@@ -123,8 +123,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/user-input-gen/.eslintrc.json
+++ b/packages/@aws-cdk/user-input-gen/.eslintrc.json
@@ -342,10 +342,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/@aws-cdk/yarn-cling/.eslintrc.json
+++ b/packages/@aws-cdk/yarn-cling/.eslintrc.json
@@ -121,6 +121,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -151,6 +155,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -316,5 +328,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/@aws-cdk/yarn-cling/.eslintrc.json
+++ b/packages/@aws-cdk/yarn-cling/.eslintrc.json
@@ -123,8 +123,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/@aws-cdk/yarn-cling/.eslintrc.json
+++ b/packages/@aws-cdk/yarn-cling/.eslintrc.json
@@ -342,10 +342,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -121,8 +121,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -353,10 +353,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     },

--- a/packages/aws-cdk/.eslintrc.json
+++ b/packages/aws-cdk/.eslintrc.json
@@ -119,6 +119,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -149,6 +153,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           },
           {
             "name": "@aws-cdk/private-tools",
@@ -328,6 +340,26 @@
     "@cdklabs/no-throw-default-error": "error"
   },
   "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    },
     {
       "files": [
         "./test/**"

--- a/packages/cdk-assets/.eslintrc.json
+++ b/packages/cdk-assets/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/cdk-assets/.eslintrc.json
+++ b/packages/cdk-assets/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/cdk-assets/.eslintrc.json
+++ b/packages/cdk-assets/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/packages/cdk/.eslintrc.json
+++ b/packages/cdk/.eslintrc.json
@@ -343,10 +343,25 @@
       ],
       "rules": {
         "no-restricted-imports": [
-          "off"
+          "error",
+          {
+            "paths": [
+              {
+                "name": "punycode",
+                "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+              }
+            ],
+            "patterns": [
+              "!punycode/"
+            ]
+          }
         ],
         "no-restricted-syntax": [
-          "off"
+          "error",
+          {
+            "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+            "message": "Use the md5hash() function from the core library if you want md5"
+          }
         ]
       }
     }

--- a/packages/cdk/.eslintrc.json
+++ b/packages/cdk/.eslintrc.json
@@ -122,6 +122,10 @@
       {
         "selector": "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
         "message": "Use the md5hash() function from the core library if you want md5"
+      },
+      {
+        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [
@@ -152,6 +156,14 @@
           {
             "name": "punycode",
             "message": "Package 'punycode' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation"
+          },
+          {
+            "name": "child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
+          },
+          {
+            "name": "node:child_process",
+            "message": "Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool ('./private/tools')."
           }
         ],
         "patterns": [
@@ -317,5 +329,26 @@
       "off"
     ]
   },
-  "overrides": []
+  "overrides": [
+    {
+      "files": [
+        "**/test/**",
+        "**/tests/**",
+        "**/*.test.ts",
+        "**/*.integtest.ts",
+        "projenrc/**",
+        "**/projenrc/**",
+        ".projenrc.ts",
+        "**/.projenrc.ts"
+      ],
+      "rules": {
+        "no-restricted-imports": [
+          "off"
+        ],
+        "no-restricted-syntax": [
+          "off"
+        ]
+      }
+    }
+  ]
 }

--- a/packages/cdk/.eslintrc.json
+++ b/packages/cdk/.eslintrc.json
@@ -124,8 +124,8 @@
         "message": "Use the md5hash() function from the core library if you want md5"
       },
       {
-        "selector": "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-        "message": "Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
+        "selector": "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+        "message": "Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line."
       }
     ],
     "no-throw-literal": [

--- a/projenrc/eslint/imports.ts
+++ b/projenrc/eslint/imports.ts
@@ -19,6 +19,17 @@ export default {
           name: 'punycode',
           message: 'Package \'punycode\' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation',
         },
+        // All child process spawning goes through the shared subprocess tool, so
+        // that no code path both escapes and executes. The tool itself (and the
+        // not-yet-migrated packages) carry a local eslint-disable / override.
+        {
+          name: 'child_process',
+          message: 'Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool (\'./private/tools\').',
+        },
+        {
+          name: 'node:child_process',
+          message: 'Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool (\'./private/tools\').',
+        },
       ],
       patterns: ['!punycode/'],
     },

--- a/projenrc/eslint/imports.ts
+++ b/projenrc/eslint/imports.ts
@@ -19,9 +19,7 @@ export default {
           name: 'punycode',
           message: 'Package \'punycode\' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation',
         },
-        // All child process spawning goes through the shared subprocess tool, so
-        // that no code path both escapes and executes. The tool itself (and the
-        // not-yet-migrated packages) carry a local eslint-disable / override.
+        // Route child process spawning through the shared subprocess tool.
         {
           name: 'child_process',
           message: 'Do not use `child_process` directly. Use `run`/`runSync`/`runUserCommandLine` from the subprocess tool (\'./private/tools\').',

--- a/projenrc/eslint/imports.ts
+++ b/projenrc/eslint/imports.ts
@@ -1,3 +1,8 @@
+export const PUNYCODE_IMPORT_RESTRICTION = {
+  name: 'punycode',
+  message: 'Package \'punycode\' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation',
+};
+
 export default {
   'import/no-unresolved': ['error'], // Require all imported libraries actually resolve (!!required for import/no-extraneous-dependencies to work!!)
   'import/no-duplicates': 'error', // Cannot import from the same module twice (we prefer `import/no-duplicate` over `no-duplicate-imports` since the former can handle type imports)
@@ -15,10 +20,7 @@ export default {
   'no-restricted-imports': [
     'error', {
       paths: [
-        {
-          name: 'punycode',
-          message: 'Package \'punycode\' has to be imported with trailing slash, see warning in https://github.com/bestiejs/punycode.js#installation',
-        },
+        PUNYCODE_IMPORT_RESTRICTION,
         // Route child process spawning through the shared subprocess tool.
         {
           name: 'child_process',

--- a/projenrc/eslint/index.ts
+++ b/projenrc/eslint/index.ts
@@ -61,6 +61,32 @@ export function configureEslint(x: typescript.TypeScriptProject) {
   );
   x.eslint?.addRules(ESLINT_RULES);
 
+  // The `child_process` / `shell: true` bans protect SHIPPED code from spawning
+  // outside the subprocess tool. Two categories are outside that trust boundary
+  // and are exempt:
+  //   - test code, which legitimately imports `child_process` to mock/spy and
+  //     may spawn with `shell: true` against throwaway fixtures;
+  //   - build-time tooling (projen config, build tasks), which runs on
+  //     developer/CI machines rather than a user's machine.
+  // (This also relaxes the md5/punycode rules for these files, which is harmless
+  // for non-shipped code.)
+  x.eslint?.addOverride({
+    files: [
+      '**/test/**',
+      '**/tests/**',
+      '**/*.test.ts',
+      '**/*.integtest.ts',
+      'projenrc/**',
+      '**/projenrc/**',
+      '.projenrc.ts',
+      '**/.projenrc.ts',
+    ],
+    rules: {
+      'no-restricted-imports': ['off'],
+      'no-restricted-syntax': ['off'],
+    },
+  });
+
   // For our published packages, we need all type imports to be from a public dependency
   if (!isRoot && !isPrivate && x.eslint) {
     x.eslint.rules['import/no-extraneous-dependencies'][1].includeTypes = true;

--- a/projenrc/eslint/index.ts
+++ b/projenrc/eslint/index.ts
@@ -3,10 +3,10 @@ import type { typescript } from 'projen';
 import bestPractices from './best-practices';
 import constructs from './constructs';
 import formatting from './formatting';
-import imports from './imports';
+import imports, { PUNYCODE_IMPORT_RESTRICTION } from './imports';
 import jest from './jest';
 import jsdoc from './jsdoc';
-import team from './team';
+import team, { MD5_SYNTAX_RESTRICTION } from './team';
 
 const ESLINT_RULES = {
   ...team,
@@ -60,16 +60,6 @@ export function configureEslint(x: typescript.TypeScriptProject) {
     'plugin:jest/recommended',
   );
   x.eslint?.addRules(ESLINT_RULES);
-
-  // The `child_process` / `shell: true` bans protect SHIPPED code from spawning
-  // outside the subprocess tool. Two categories are outside that trust boundary
-  // and are exempt:
-  //   - test code, which legitimately imports `child_process` to mock/spy and
-  //     may spawn with `shell: true` against throwaway fixtures;
-  //   - build-time tooling (projen config, build tasks), which runs on
-  //     developer/CI machines rather than a user's machine.
-  // (This also relaxes the md5/punycode rules for these files, which is harmless
-  // for non-shipped code.)
   x.eslint?.addOverride({
     files: [
       '**/test/**',
@@ -82,8 +72,8 @@ export function configureEslint(x: typescript.TypeScriptProject) {
       '**/.projenrc.ts',
     ],
     rules: {
-      'no-restricted-imports': ['off'],
-      'no-restricted-syntax': ['off'],
+      'no-restricted-imports': ['error', { paths: [PUNYCODE_IMPORT_RESTRICTION], patterns: ['!punycode/'] }],
+      'no-restricted-syntax': ['error', MD5_SYNTAX_RESTRICTION],
     },
   });
 

--- a/projenrc/eslint/team.ts
+++ b/projenrc/eslint/team.ts
@@ -12,5 +12,13 @@ export default {
       selector: "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
       message: 'Use the md5hash() function from the core library if you want md5',
     },
+    {
+      // Spawning through a shell is the one place command injection can happen.
+      // The only sanctioned shell entry point is `runUserCommandLine` in the
+      // subprocess tool (which carries its own eslint-disable); everything else
+      // must spawn an argv array via `run`/`runSync`, which never touch a shell.
+      selector: "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
+      message: 'Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line.',
+    },
   ],
 };

--- a/projenrc/eslint/team.ts
+++ b/projenrc/eslint/team.ts
@@ -17,8 +17,10 @@ export default {
       // The only sanctioned shell entry point is `runUserCommandLine` in the
       // subprocess tool (which carries its own eslint-disable); everything else
       // must spawn an argv array via `run`/`runSync`, which never touch a shell.
-      selector: "Property:matches([key.name='shell'], [key.value='shell'])[value.value=true]",
-      message: 'Do not spawn with `shell: true`. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line.',
+      //
+      // Reject any `shell` property that is not statically `false`.
+      selector: "Property:matches([key.name='shell'], [key.value='shell']):not([value.type='Literal'][value.value=false])",
+      message: 'Do not enable the `shell` spawn option. Use `run`/`runSync` (argv, no shell) from the subprocess tool, or `runUserCommandLine` for a user-authored command line.',
     },
   ],
 };

--- a/projenrc/eslint/team.ts
+++ b/projenrc/eslint/team.ts
@@ -1,17 +1,20 @@
 // CDK team specific rules
 // These are typically informed by past operational events
+
+// No more md5, will break in FIPS environments
+export const MD5_SYNTAX_RESTRICTION = {
+  // Both qualified and unqualified calls
+  selector: "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
+  message: 'Use the md5hash() function from the core library if you want md5',
+};
+
 export default {
   // This can cause huge I/O performance hits
   '@cdklabs/promiseall-no-unbounded-parallelism': ['error'],
 
-  // No more md5, will break in FIPS environments
   'no-restricted-syntax': [
     'error',
-    {
-      // Both qualified and unqualified calls
-      selector: "CallExpression:matches([callee.name='createHash'], [callee.property.name='createHash']) Literal[value='md5']",
-      message: 'Use the md5hash() function from the core library if you want md5',
-    },
+    MD5_SYNTAX_RESTRICTION,
     {
       // Spawning through a shell is the one place command injection can happen.
       // The only sanctioned shell entry point is `runUserCommandLine` in the


### PR DESCRIPTION
Fixes #1903 

## Description
Locks in the subprocess consolidation (#1763, #1849) so new code or changes to existing code can't spawn shells outside the shared tool.

- no-restricted-imports: ban `child_process` / `node:child_process`
- no-restricted-syntax: ban enabling the `shell` spawn option — any `shell` property that isn't statically `false` (so `{ shell }`, `shell: cond`, `shell: someVar`, `shell: '/bin/sh'` are all caught, not just the literal `true`)

Spawn paths have to go through `run`/`runSync`/`runUserCommandLine` from the subprocess tool. The tool itself carries a localized eslint-disable at the two sanctioned lines.

Test files and build tooling (`projenrc`) are exempt. The two un-migrated shipped sinks carry in-file `eslint-disable` comments (each with a reason) at the spawn site rather than projen overrides: `cli-integ` is a test harness that intentionally spawns through a shell to exercise the CLI as a user would (permanent, like test code), and `integ-runner`'s `exec()` is argv-based/no-shell, so it exempts only the `child_process` import — the `shell` rule stays active there — with migration onto the shared tool deferred as follow-up. `cdk-build-tools` is not managed by the root projen config, so the rule does not reach it yet; will address it in a follow-up.

## Testing
Inserted a `child_process` import into a migrated lib/ file, and the rule fires as expected. Obviously did not keep that import.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

