### PR TITLE
fix(toolkit-lib): stack selection ignores all but one exclusion pattern

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
@@ -205,11 +205,16 @@ export class StackAssembly implements IReadableCloudAssembly {
   private suggestionsForPatterns(patterns: string[], matched: StackCollection): Record<string, string[]> {
     const suggestions: Record<string, string[]> = {};
     for (const pattern of patterns) {
-      if (matched.stackArtifacts.some((stack) => picomatch(stack.hierarchicalId, pattern))) {
+      // An exclusion never matches the selection it produced, so judge it by what it removes.
+      const exclusion = isExclusionPattern(pattern);
+      const effective = exclusion ? pattern.slice(1) : pattern;
+      const haystack = exclusion ? this.allStacks : matched.stackArtifacts;
+
+      if (haystack.some((stack) => picomatch(stack.hierarchicalId, effective))) {
         continue;
       }
       suggestions[pattern] = this.allStacks
-        .filter((stack) => picomatch(stack.hierarchicalId.toLowerCase(), pattern.toLowerCase()))
+        .filter((stack) => picomatch(stack.hierarchicalId.toLowerCase(), effective.toLowerCase()))
         .map((stack) => stack.hierarchicalId);
     }
     return suggestions;
@@ -231,7 +236,17 @@ export class StackAssembly implements IReadableCloudAssembly {
     extend: ExpandStackSelection = ExpandStackSelection.NONE,
   ): Promise<StackCollection> {
     const matchingPattern = (pattern: string) => (stack: cxapi.CloudFormationStackArtifact) => picomatch(stack.hierarchicalId, pattern);
-    const matchedStacks = flatten(patterns.map(pattern => stacks.filter(matchingPattern(pattern))));
+
+    const includePatterns = patterns.filter(pattern => !isExclusionPattern(pattern));
+    const excludePatterns = patterns.filter(isExclusionPattern).map(pattern => pattern.slice(1));
+
+    // Exclusions on their own start from every stack, so `!Stack` means "every
+    // stack but Stack". No patterns at all still selects nothing.
+    const included = includePatterns.length === 0 && excludePatterns.length > 0
+      ? stacks
+      : flatten(includePatterns.map(pattern => stacks.filter(matchingPattern(pattern))));
+
+    const matchedStacks = included.filter(stack => !excludePatterns.some(pattern => matchingPattern(pattern)(stack)));
 
     return this.extendStacks(matchedStacks, stacks, extend);
   }
@@ -262,6 +277,15 @@ export class StackAssembly implements IReadableCloudAssembly {
 
     return new StackCollection(this, selectedList);
   }
+}
+
+/**
+ * Whether a pattern removes the stacks it matches, instead of selecting them.
+ *
+ * `!(...)` is extglob syntax that already means "anything but", not an exclusion.
+ */
+function isExclusionPattern(pattern: string): boolean {
+  return pattern.startsWith('!') && !pattern.startsWith('!(');
 }
 
 function indexByHierarchicalId(stacks: cxapi.CloudFormationStackArtifact[]): Map<string, cxapi.CloudFormationStackArtifact> {

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-selector.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/stack-selector.ts
@@ -78,6 +78,14 @@ export interface StackSelector {
   /**
    * A list of patterns to match the stack hierarchical ids
    * Only used with `PATTERN_*` selection strategies.
+   *
+   * A pattern starting with `!` excludes the stacks it matches. The selection is
+   * the union of the other patterns, minus everything the excluding ones match;
+   * exclusions on their own start from every stack. `!(...)` is extglob syntax
+   * and is matched as a regular pattern.
+   *
+   * - `['!Prod/Canary']` selects every stack except `Prod/Canary`
+   * - `['Prod/**', '!Prod/Canary']` selects every stack under `Prod` but that one
    */
   patterns?: string[];
 

--- a/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/stack-selection-exclusion.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/cloud-assembly/stack-selection-exclusion.test.ts
@@ -1,0 +1,102 @@
+import { ExpandStackSelection, StackSelectionStrategy } from '../../../lib/api/cloud-assembly';
+import { Toolkit } from '../../../lib/toolkit';
+import { TestIoHost } from '../../_helpers';
+import type { TestStackArtifact } from '../../_helpers/test-cloud-assembly-source';
+import { TestCloudAssemblySource } from '../../_helpers/test-cloud-assembly-source';
+
+const ioHost = new TestIoHost();
+const toolkit = new Toolkit({ ioHost });
+
+beforeEach(() => {
+  ioHost.notifySpy.mockClear();
+});
+
+// Patterns used to be matched independently and unioned, so `['!A', '!B']`
+// contributed "not A" and "not B" and returned every stack there is.
+
+const STACKS: TestStackArtifact[] = [
+  { stackName: 'StackA', displayName: 'Prod/StackA' },
+  { stackName: 'StackB', displayName: 'Prod/StackB' },
+  { stackName: 'Canary', displayName: 'Prod/Canary' },
+  { stackName: 'DevStack', displayName: 'Dev/DevStack' },
+];
+
+async function select(patterns: string[], expand = ExpandStackSelection.NONE) {
+  const cx = new TestCloudAssemblySource({ stacks: STACKS });
+  const stacks = await toolkit.list(cx, {
+    stacks: { patterns, strategy: StackSelectionStrategy.PATTERN_MATCH, expand },
+  });
+  return stacks.map(s => s.id).sort();
+}
+
+describe('exclusion patterns', () => {
+  test('a single exclusion selects everything else', async () => {
+    expect(await select(['!Prod/StackB'])).toEqual(['Dev/DevStack', 'Prod/Canary', 'Prod/StackA']);
+  });
+
+  test('multiple exclusions remove all of the stacks they match', async () => {
+    // Used to return every stack, including the two that were excluded
+    expect(await select(['!Prod/StackB', '!Prod/Canary'])).toEqual(['Dev/DevStack', 'Prod/StackA']);
+  });
+
+  test('an exclusion narrows down the stacks matched by the other patterns', async () => {
+    // Used to return every stack but Canary, because 'Prod/StackA' and
+    // '!Prod/Canary' were unioned instead of subtracted
+    expect(await select(['Prod/StackA', '!Prod/Canary'])).toEqual(['Prod/StackA']);
+  });
+
+  test('`!(...)` is extglob syntax, not an exclusion', async () => {
+    // Taken as an exclusion, `!(StackA)` would leave `(StackA)` to exclude and
+    // select `Prod/StackA` too. As an extglob it does not cross a `/`.
+    const cx = new TestCloudAssemblySource({
+      stacks: [{ stackName: 'StackA' }, { stackName: 'StackB' }, { stackName: 'Nested', displayName: 'Prod/StackA' }],
+    });
+    const stacks = await toolkit.list(cx, {
+      stacks: { patterns: ['!(StackA)'], strategy: StackSelectionStrategy.PATTERN_MATCH, expand: ExpandStackSelection.NONE },
+    });
+
+    expect(stacks.map(s => s.id).sort()).toEqual(['StackB']);
+  });
+
+  test('patterns without an exclusion are unaffected', async () => {
+    expect(await select(['Prod/StackA', 'Dev/*'])).toEqual(['Dev/DevStack', 'Prod/StackA']);
+  });
+
+  test('an empty pattern list still selects nothing', async () => {
+    expect(await select([])).toEqual([]);
+  });
+});
+
+describe('exclusion patterns and dependency expansion', () => {
+  const DEPENDENCY: TestStackArtifact = { stackName: 'DependencyStack' };
+  const DEPENDENT: TestStackArtifact = { stackName: 'DependentStack', depends: ['DependencyStack'] };
+
+  test('an excluded stack is still pulled back in as a dependency', async () => {
+    // Deploying the dependent stack without its dependency is not something the
+    // toolkit can do, so expansion wins over the exclusion. `--exclusively`
+    // (ExpandStackSelection.NONE) is how you keep the dependency out.
+    const cx = new TestCloudAssemblySource({ stacks: [DEPENDENCY, DEPENDENT] });
+    const stacks = await toolkit.list(cx, {
+      stacks: {
+        patterns: ['DependentStack', '!DependencyStack'],
+        strategy: StackSelectionStrategy.PATTERN_MATCH,
+        expand: ExpandStackSelection.UPSTREAM,
+      },
+    });
+
+    expect(stacks.map(s => s.id).sort()).toEqual(['DependencyStack', 'DependentStack']);
+  });
+
+  test('without expansion the exclusion holds', async () => {
+    const cx = new TestCloudAssemblySource({ stacks: [DEPENDENCY, DEPENDENT] });
+    const stacks = await toolkit.list(cx, {
+      stacks: {
+        patterns: ['DependentStack', '!DependencyStack'],
+        strategy: StackSelectionStrategy.PATTERN_MATCH,
+        expand: ExpandStackSelection.NONE,
+      },
+    });
+
+    expect(stacks.map(s => s.id).sort()).toEqual(['DependentStack']);
+  });
+});

--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -293,6 +293,18 @@ In order to deploy them, you can list the stacks you want to deploy. If your app
 
 If you want to deploy all of them, you can use the flag `--all` or the wildcard `*` to deploy all stacks in an app. Please note that, if you have a hierarchy of stacks as described above, `--all` and `*` will only match the stacks on the top level. If you want to match all the stacks in the hierarchy, use `**`. You can also combine these patterns. For example, if you want to deploy all stacks in the `Prod` stage, you can use `cdk deploy PipelineStack/Prod/**`.
 
+A pattern starting with `!` excludes the stacks it matches instead of selecting them, which is useful when you want everything but a handful of stacks. Quote the pattern so your shell does not try to expand the `!` itself:
+
+```console
+$ # every stack except NlbStack
+$ cdk deploy '!NlbStack'
+
+$ # every stack under Prod, except the canary
+$ cdk deploy 'PipelineStack/Prod/**' '!PipelineStack/Prod/Canary'
+```
+
+The selection is the union of all the patterns that do not start with `!`, minus everything matched by a pattern that does. When you only pass exclusions, they apply to every stack in the app. Note that `--all` cannot be combined with patterns, so use `**` when you want to spell out the starting point. Stacks that a selected stack depends on are still added to the deployment even if you excluded them; pass `--exclusively` (`-e`) to keep them out.
+
 `--concurrency N` allows deploying multiple stacks in parallel while respecting inter-stack dependencies to speed up deployments. It does not protect against CloudFormation and other AWS account rate limiting.
 
 #### Parameters


### PR DESCRIPTION
Fixes #1908
Relates to #758

Stack patterns are matched with picomatch, which reads a leading `!` as a negation, so `cdk deploy '!Stack'` already works today. Each pattern was matched on its own and the results unioned, so a second exclusion undid the first: `!A` contributes everything but A, `!B` contributes everything but B, and the union is every stack in the app. `StackA !Canary` went wrong the same way, returning everything except Canary instead of just StackA.

The non-excluding patterns are now matched first, and everything the excluding ones match is subtracted from that. Exclusions on their own start from the whole assembly, so `!Stack` keeps meaning "everything but Stack".

```console
$ cdk ls '!Prod/Canary' '!Prod/StackB'    # before: all four stacks
DevStack
Prod/StackA
```

- Patterns without a `!` take exactly the path they took before, and no existing test needed changing.
- The new selection is always a subset of the old one, so nothing gets deployed or destroyed that wasn't before. Checked over every combination of up to three patterns against a six-stack app: 1463 combinations, no case where a stack was added.
- The one behaviour people could be relying on is the union that made multiple exclusions a no-op. That reads as a bug rather than something to keep, but say the word if you'd rather it warn for a release first.
- `!(...)` is extglob syntax that already means "anything but", so it stays a regular pattern.
- An empty pattern list still selects nothing, leaving `PATTERN_MUST_MATCH` to reject it.
- `suggestionsForPatterns` asked whether a pattern matched the resulting selection, which is always true for an exclusion, so a typo like `!Cnary` was silently ignored. Exclusions are now checked against the assembly instead.
- Excluding a stack that a selected stack depends on does not drop it from the deployment; expansion still pulls it back in, as `--exclusively` exists for. Covered by a test and mentioned in the README.

Only `toolkit-lib` changes. The CLI passes its positional arguments straight through as `patterns`, so `deploy`, `diff`, `synth`, `destroy` and `ls` all pick this up.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
