### PR TITLE
refactor(toolkit-lib): rename versioned stack selection methods

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/actions/bootstrap/index.ts
@@ -28,7 +28,7 @@ export class BootstrapEnvironments {
     return new BootstrapEnvironments(async (ioHost: IIoHost) => {
       const ioHelper = asIoHelper(ioHost, 'bootstrap');
       await using assembly = await assemblyFromSource(ioHelper, cx);
-      const stackCollection = await assembly.selectStacksV2(ALL_STACKS);
+      const stackCollection = await assembly.selectStacks(ALL_STACKS);
       return stackCollection.stackArtifacts.map(stack => stack.environment);
     });
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/cloud-assembly/private/stack-assembly.ts
@@ -13,12 +13,12 @@ import { ExpandStackSelection, StackSelectionStrategy } from '../stack-selector'
 import type { IReadableCloudAssembly } from '../types';
 
 /**
- * Options for `StackAssembly.selectStacksV3`.
+ * Options for `StackAssembly.selectStacksWithSuggestions`.
  */
-export interface SelectStacksV3Options {
+export interface SelectStacksWithSuggestionsOptions {
   /**
    * For a pattern selector, also compute suggestions for every pattern that
-   * matched no stack (see `SelectStacksV3Result.suggestions`).
+   * matched no stack (see `StacksWithSuggestions.suggestions`).
    *
    * @default false
    */
@@ -26,9 +26,9 @@ export interface SelectStacksV3Options {
 }
 
 /**
- * Result of `StackAssembly.selectStacksV3`.
+ * Result of `StackAssembly.selectStacksWithSuggestions`.
  */
-export interface SelectStacksV3Result {
+export interface StacksWithSuggestions {
   /**
    * The selected stacks.
    */
@@ -122,10 +122,10 @@ export class StackAssembly implements IReadableCloudAssembly {
    * @throws when the assembly does not contain any stacks, unless `selector.failOnEmpty` is `false`
    * @throws when individual selection strategies are not satisfied
    *
-   * Thin wrapper around `selectStacksV3` that keeps the historic return shape.
+   * Thin wrapper around `selectStacksWithSuggestions` that keeps a simpler return shape.
    */
-  public async selectStacksV2(selector: StackSelector): Promise<StackCollection> {
-    return (await this.selectStacksV3(selector)).stacks;
+  public async selectStacks(selector: StackSelector): Promise<StackCollection> {
+    return (await this.selectStacksWithSuggestions(selector)).stacks;
   }
 
   /**
@@ -135,7 +135,10 @@ export class StackAssembly implements IReadableCloudAssembly {
    * @throws when the assembly does not contain any stacks, unless `selector.failOnEmpty` is `false`
    * @throws when individual selection strategies are not satisfied
    */
-  public async selectStacksV3(selector: StackSelector, options: SelectStacksV3Options = {}): Promise<SelectStacksV3Result> {
+  public async selectStacksWithSuggestions(
+    selector: StackSelector,
+    options: SelectStacksWithSuggestionsOptions = {},
+  ): Promise<StacksWithSuggestions> {
     const asm = this.assembly;
     const topLevelStacks = asm.stacks;
     const allStacks = this.allStacks;

--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/toolkit.ts
@@ -353,7 +353,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'synth');
 
     await using assembly = new AsyncDisposableBox(await synthAndMeasure(ioHelper, cx, stacksOpt(options)));
-    const stacks = await assembly.value.selectStacksV2(stacksOpt(options));
+    const stacks = await assembly.value.selectStacks(stacksOpt(options));
     const autoValidateStacks = options.validateStacks ? [assembly.value.selectStacksForValidation()] : [];
     await throwIfValidationFailures(assembly.value, stacks.concat(...autoValidateStacks), this.assemblyFailureAt, ioHelper);
 
@@ -396,7 +396,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const selectStacks = stacksOpt(options);
     await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
-    const stacks = await assembly.selectStacksV2(selectStacks);
+    const stacks = await assembly.selectStacks(selectStacks);
     const diffSpan = await ioHelper.span(SPAN.DIFF_STACK).begin({ stacks: selectStacks });
     const deployments = await this.deploymentsForAction('diff');
 
@@ -456,7 +456,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const selectStacks = stacksOpt(options);
     await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
-    const stacks = await assembly.selectStacksV2(selectStacks);
+    const stacks = await assembly.selectStacks(selectStacks);
 
     const driftSpan = await ioHelper.span(SPAN.DRIFT_APP).begin({ stacks: selectStacks });
     const allDriftResults: { [name: string]: DriftResult } = {};
@@ -535,7 +535,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const selectStacks = stacksOpt(options);
     await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
-    const stackCollection = await assembly.selectStacksV2(selectStacks);
+    const stackCollection = await assembly.selectStacks(selectStacks);
     await throwIfValidationFailures(assembly, stackCollection, this.assemblyFailureAt, ioHelper);
 
     if (stackCollection.stackCount === 0) {
@@ -608,7 +608,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const selectStacks = stacksOpt(options);
     await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
 
-    const stackCollection = await assembly.selectStacksV2(selectStacks);
+    const stackCollection = await assembly.selectStacks(selectStacks);
     const stacks = stackCollection.withDependencies();
     const message = stacks.map(s => s.id).join('\n');
 
@@ -631,7 +631,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'diagnose');
     const selectStacks = stacksOpt(options);
     await using assembly = await synthAndMeasure(ioHelper, cx, selectStacks);
-    const stackCollection = await assembly.selectStacksV2(selectStacks);
+    const stackCollection = await assembly.selectStacks(selectStacks);
     const envs = new EnvironmentAccess(await this.sdkProvider('diagnose'), options.toolkitStackName ?? DEFAULT_TOOLKIT_STACK_NAME, ioHelper);
 
     // Do stacks in parallel, for speed.
@@ -689,7 +689,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const ioHelper = asIoHelper(this.ioHost, 'validate');
     const selectStacks = stacksOpt(options);
 
-    const stacks = await assembly.selectStacksV2(selectStacks);
+    const stacks = await assembly.selectStacks(selectStacks);
 
     const reports = await obtainUnifiedValidationReport(assembly, stacks);
 
@@ -789,7 +789,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   private async _deploy(assembly: StackAssembly, action: 'deploy' | 'watch', synthDuration: ElapsedTime, options: PrivateDeployOptions = {}): Promise<DeployResult> {
     const ioHelper = asIoHelper(this.ioHost, action);
     const selectStacks = stacksOpt(options);
-    const stackCollection = await assembly.selectStacksV2(selectStacks);
+    const stackCollection = await assembly.selectStacks(selectStacks);
     await throwIfValidationFailures(assembly, stackCollection, this.assemblyFailureAt, ioHelper);
 
     const ret: DeployResult = {
@@ -1454,7 +1454,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
     const selectStacks = stacksOpt(options);
     const ioHelper = asIoHelper(this.ioHost, action);
 
-    const stacks = await assembly.selectStacksV2(selectStacks);
+    const stacks = await assembly.selectStacks(selectStacks);
     await throwIfValidationFailures(assembly, stacks, this.assemblyFailureAt, ioHelper);
 
     const ret: RollbackResult = {
@@ -1520,7 +1520,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
     // Synth all stacks, then resolve the construct paths against the real stack IDs.
     await using assembly = await synthAndMeasure(ioHelper, cx, ALL_STACKS);
-    const allStacks = await assembly.selectStacksV2(ALL_STACKS);
+    const allStacks = await assembly.selectStacks(ALL_STACKS);
 
     const parsed = resolveStackAndConstructPaths(
       options.constructPaths,
@@ -1585,7 +1585,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
 
   private async _refactor(assembly: StackAssembly, ioHelper: IoHelper, cx: ICloudAssemblySource, options: RefactorOptions = {}): Promise<void> {
     const sdkProvider = await this.sdkProvider('refactor');
-    const selectedStacks = await assembly.selectStacksV2(stacksOpt(options));
+    const selectedStacks = await assembly.selectStacks(stacksOpt(options));
     const groups = await groupStacks(sdkProvider, selectedStacks.stackArtifacts, options.additionalStackNames ?? []);
 
     for (let { environment, localStacks, deployedStacks } of groups) {
@@ -1773,7 +1773,7 @@ export class Toolkit extends CloudAssemblySourceBuilder {
   private async _destroy(assembly: StackAssembly, action: 'deploy' | 'destroy', options: DestroyOptions): Promise<DestroyResult> {
     const selectStacks = stacksOpt(options);
     const ioHelper = asIoHelper(this.ioHost, action);
-    const { stacks, suggestions } = await assembly.selectStacksV3(selectStacks, { suggestPatternMatches: true });
+    const { stacks, suggestions } = await assembly.selectStacksWithSuggestions(selectStacks, { suggestPatternMatches: true });
 
     // Warn about each provided pattern that matched no stack, suggesting a close
     // match when one exists (e.g. only the casing differs).

--- a/packages/aws-cdk/docs/deploy-architecture.md
+++ b/packages/aws-cdk/docs/deploy-architecture.md
@@ -31,7 +31,7 @@ graph TD
     n13["Return CloudAssembly object"]
     
     %% Stack Selection
-    n14["stack-assembly.ts (toolkit-lib):<br/>assembly.selectStacksV2()"]
+    n14["stack-assembly.ts (toolkit-lib):<br/>assembly.selectStacks()"]
     n15["cdk-toolkit.ts:<br/>validateStacks()"]
     n16["Return StackCollection"]
     

--- a/packages/aws-cdk/lib/cli/cdk-toolkit.ts
+++ b/packages/aws-cdk/lib/cli/cdk-toolkit.ts
@@ -506,7 +506,7 @@ export class CdkToolkit {
 
     const startSynthTime = new Date().getTime();
     const assembly = await this.assembly(options.cacheCloudAssembly);
-    const stackCollection = await assembly.selectStacksV2(options.selector);
+    const stackCollection = await assembly.selectStacks(options.selector);
     await this.validateStacks(assembly, stackCollection);
     const elapsedSynthTime = new Date().getTime() - startSynthTime;
     await this.ioHost.asIoHelper().defaults.info(`\n✨  Synthesis time: ${formatTime(elapsedSynthTime)}s\n`);
@@ -701,7 +701,7 @@ export class CdkToolkit {
   public async rollback(options: RollbackOptions) {
     const startSynthTime = new Date().getTime();
     const assembly = await this.assembly();
-    const stackCollection = await assembly.selectStacksV2(options.selector);
+    const stackCollection = await assembly.selectStacks(options.selector);
     await this.validateStacks(assembly, stackCollection);
     const elapsedSynthTime = new Date().getTime() - startSynthTime;
     await this.ioHost.asIoHelper().defaults.info(`\n✨  Synthesis time: ${formatTime(elapsedSynthTime)}s\n`);
@@ -873,7 +873,7 @@ export class CdkToolkit {
 
   public async import(options: ImportOptions) {
     const assembly = await this.assembly();
-    const stacks = await assembly.selectStacksV2(options.selector);
+    const stacks = await assembly.selectStacks(options.selector);
     await this.validateStacks(assembly, stacks);
 
     // set progress from options, this includes user and app config
@@ -1223,7 +1223,7 @@ export class CdkToolkit {
     // If there is an '--app' argument, select the environments from the app.
     if (this.props.cloudExecutable.hasApp) {
       const assembly = await this.assembly();
-      const allStacks = await assembly.selectStacksV2(ALL_STACKS);
+      const allStacks = await assembly.selectStacks(ALL_STACKS);
       environments.push(
         ...(await globEnvironmentsFromStacks(allStacks, globSpecs, this.props.sdkProvider)),
       );
@@ -1383,19 +1383,19 @@ export class CdkToolkit {
     exclusively?: boolean,
   ): Promise<StackCollection> {
     if (patterns.length > 0) {
-      return assembly.selectStacksV2(
+      return assembly.selectStacks(
         mustMatch(exclusively ? selectExact(...patterns) : selectWithUpstream(...patterns)),
       );
     }
 
     if (assembly.cloudAssembly.stacks.length > 0) {
-      return assembly.selectStacksV2(selectAllTopLevel(ExpandStackSelection.NONE));
+      return assembly.selectStacks(selectAllTopLevel(ExpandStackSelection.NONE));
     }
 
     // Stage-only app: nothing to select, which is not an error. An app
     // without any stacks at all still is: this selection throws
     // 'This app contains no stacks' in that case.
-    await assembly.selectStacksV2(ALL_STACKS);
+    await assembly.selectStacks(ALL_STACKS);
     return new StackCollection(assembly, []);
   }
 

--- a/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
+++ b/packages/aws-cdk/test/cli/cdk-toolkit.test.ts
@@ -2421,7 +2421,7 @@ describe('synth', () => {
     const toolkit = defaultToolkitSetup();
     // `jest.resetAllMocks()` in beforeEach would leave this prototype spy as
     // an undefined-returning mock for every later test, so restore it here.
-    const selectSpy = jest.spyOn(StackAssembly.prototype, 'selectStacksV2');
+    const selectSpy = jest.spyOn(StackAssembly.prototype, 'selectStacks');
     try {
       await toolkit.synth({ stackNames: [], quiet: true });
 

--- a/packages/aws-cdk/test/cxapp/cloud-assembly.test.ts
+++ b/packages/aws-cdk/test/cxapp/cloud-assembly.test.ts
@@ -9,7 +9,7 @@ test('select all top level stacks in the presence of nested assemblies', async (
   const cxasm = await testNestedCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ strategy: StackSelectionStrategy.MAIN_ASSEMBLY });
+  const x = await cxasm.selectStacks({ strategy: StackSelectionStrategy.MAIN_ASSEMBLY });
 
   // THEN
   expect(x.stackCount).toBe(2);
@@ -22,7 +22,7 @@ test('select stacks by glob pattern', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ patterns: ['with*'], strategy: StackSelectionStrategy.PATTERN_MATCH });
+  const x = await cxasm.selectStacks({ patterns: ['with*'], strategy: StackSelectionStrategy.PATTERN_MATCH });
 
   // THEN
   expect(x.stackCount).toBe(3);
@@ -35,7 +35,7 @@ test('select behavior: all', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ALL_STACKS });
+  const x = await cxasm.selectStacks({ strategy: StackSelectionStrategy.ALL_STACKS });
 
   // THEN
   expect(x.stackCount).toBe(3);
@@ -46,7 +46,7 @@ test('select behavior: none', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ patterns: [], strategy: StackSelectionStrategy.PATTERN_MATCH });
+  const x = await cxasm.selectStacks({ patterns: [], strategy: StackSelectionStrategy.PATTERN_MATCH });
 
   // THEN
   expect(x.stackCount).toBe(0);
@@ -57,7 +57,7 @@ test('select behavior: single', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow('Since this app includes more than a single stack, specify which stacks to use (wildcards are supported) or specify `--all`');
 });
 
@@ -66,7 +66,7 @@ test('stack list error contains node paths', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow('withouterrorsNODEPATH');
 });
 
@@ -75,7 +75,7 @@ test('select behavior: repeat', async () => {
   const cxasm = await testCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({
+  const x = await cxasm.selectStacks({
     patterns: ['withouterrorsNODEPATH', 'withouterrorsNODEPATH'],
     strategy: StackSelectionStrategy.PATTERN_MATCH,
   });
@@ -89,7 +89,7 @@ test('select behavior with nested assemblies: all', async () => {
   const cxasm = await testNestedCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ALL_STACKS });
+  const x = await cxasm.selectStacks({ strategy: StackSelectionStrategy.ALL_STACKS });
 
   // THEN
   expect(x.stackCount).toBe(3);
@@ -100,7 +100,7 @@ test('select behavior with nested assemblies: none', async () => {
   const cxasm = await testNestedCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ patterns: [], strategy: StackSelectionStrategy.PATTERN_MATCH });
+  const x = await cxasm.selectStacks({ patterns: [], strategy: StackSelectionStrategy.PATTERN_MATCH });
 
   // THEN
   expect(x.stackCount).toBe(0);
@@ -111,7 +111,7 @@ test('select behavior with nested assemblies: single', async () => {
   const cxasm = await testNestedCloudAssembly();
 
   // WHEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow('Since this app includes more than a single stack, specify which stacks to use (wildcards are supported) or specify `--all`');
 });
 
@@ -122,9 +122,9 @@ test('single-stack selection error guides Stage users towards the wildcard patte
 
   // WHEN / THEN - the error should point the user at the pattern that selects
   // the stacks in that Stage, e.g. `'MyStage/*'`, instead of only suggesting `--all`.
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow('Some of these stacks are nested inside a Stage');
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow(/'MyStage\/\*'/);
 });
 
@@ -133,9 +133,9 @@ test('single-stack selection error without Stages does not mention Stages', asyn
   const cxasm = await testCloudAssembly();
 
   // WHEN / THEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.toThrow('Since this app includes more than a single stack');
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ONLY_SINGLE }))
     .rejects.not.toThrow('Some of these stacks are nested inside a Stage');
 });
 
@@ -144,7 +144,7 @@ test('select behavior with nested assemblies: repeat', async() => {
   const cxasm = await testNestedCloudAssembly();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({
+  const x = await cxasm.selectStacks({
     patterns: ['deeply/hidden/withouterrors', 'nested'],
     strategy: StackSelectionStrategy.PATTERN_MATCH,
   });
@@ -158,7 +158,7 @@ test('select behavior with no stacks and ignore stacks option', async() => {
   const cxasm = await testCloudAssemblyNoStacks();
 
   // WHEN
-  const x = await cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ALL_STACKS, failOnEmpty: false });
+  const x = await cxasm.selectStacks({ strategy: StackSelectionStrategy.ALL_STACKS, failOnEmpty: false });
 
   // THEN
   expect(x.stackCount).toBe(0);
@@ -169,7 +169,7 @@ test('select behavior with no stacks and no ignore stacks option', async() => {
   const cxasm = await testCloudAssemblyNoStacks();
 
   // WHEN & THEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ALL_STACKS, failOnEmpty: true }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ALL_STACKS, failOnEmpty: true }))
     .rejects.toThrow('This app contains no stacks');
 });
 
@@ -178,7 +178,7 @@ test('select behavior with no stacks and default ignore stacks options (false)',
   const cxasm = await testCloudAssemblyNoStacks();
 
   // WHEN & THEN
-  await expect(cxasm.selectStacksV2({ strategy: StackSelectionStrategy.ALL_STACKS }))
+  await expect(cxasm.selectStacks({ strategy: StackSelectionStrategy.ALL_STACKS }))
     .rejects.toThrow('This app contains no stacks');
 });
 
@@ -188,7 +188,7 @@ describe('StackCollection', () => {
     const cxasm = await testNestedCloudAssembly();
 
     // WHEN
-    const x = await cxasm.selectStacksV2({ strategy: StackSelectionStrategy.MAIN_ASSEMBLY });
+    const x = await cxasm.selectStacks({ strategy: StackSelectionStrategy.MAIN_ASSEMBLY });
 
     // THEN
     expect(x.stackCount).toBe(2);
@@ -201,7 +201,7 @@ describe('StackCollection', () => {
       const cxasm = await testCloudAssembly();
 
       // WHEN
-      const selected = await cxasm.selectStacksV2({
+      const selected = await cxasm.selectStacks({
         patterns: ['withouterrorsNODEPATH'],
         strategy: StackSelectionStrategy.PATTERN_MATCH,
       });
@@ -217,7 +217,7 @@ describe('StackCollection', () => {
       const cxasm = await testCloudAssembly();
 
       // WHEN
-      const selected = await cxasm.selectStacksV2({
+      const selected = await cxasm.selectStacks({
         patterns: ['withwarns'],
         strategy: StackSelectionStrategy.PATTERN_MATCH,
       });
@@ -233,7 +233,7 @@ describe('StackCollection', () => {
       const cxasm = await testCloudAssembly();
 
       // WHEN
-      const selected = await cxasm.selectStacksV2({
+      const selected = await cxasm.selectStacks({
         patterns: ['witherrors'],
         strategy: StackSelectionStrategy.PATTERN_MATCH,
       });
@@ -249,7 +249,7 @@ describe('StackCollection', () => {
       const cxasm = await testCloudAssembly();
 
       // WHEN
-      const selected = await cxasm.selectStacksV2({
+      const selected = await cxasm.selectStacks({
         patterns: ['witherrors'],
         strategy: StackSelectionStrategy.PATTERN_MATCH,
       });
@@ -264,7 +264,7 @@ describe('StackCollection', () => {
       const cxasm = await testCloudAssembly();
 
       // WHEN
-      const selected = await cxasm.selectStacksV2({
+      const selected = await cxasm.selectStacks({
         patterns: ['withwarns'],
         strategy: StackSelectionStrategy.PATTERN_MATCH,
       });

--- a/packages/aws-cdk/test/cxapp/cloud-executable.test.ts
+++ b/packages/aws-cdk/test/cxapp/cloud-executable.test.ts
@@ -52,7 +52,7 @@ test('stop executing if context providers are not making progress', async () => 
   const cxasm = await cloudExecutable.synthesize();
 
   // WHEN
-  await cxasm.selectStacksV2({ patterns: ['thestack'], strategy: StackSelectionStrategy.PATTERN_MATCH });
+  await cxasm.selectStacks({ patterns: ['thestack'], strategy: StackSelectionStrategy.PATTERN_MATCH });
 
   // THEN: the test finishes normally});
 });


### PR DESCRIPTION
The internal stack selection methods on `StackAssembly` carried version suffixes that told callers nothing about what they do. `selectStacksV2` is now `selectStacks`, and `selectStacksV3` — which additionally returns suggestions for patterns that matched no stack — is now `selectStacksWithSuggestions`. Its option and result types follow: `SelectStacksV3Options` becomes `SelectStacksWithSuggestionsOptions`, and `SelectStacksV3Result` becomes `StacksWithSuggestions`.

The original naming came from the period of having toolkit-lib and the CLI with somewhat duplicated functionality. Naming the methods after what they return makes the two entry points self-explanatory and removes the implicit assumption that a higher number is the one to prefer. This is a pure rename with no behavioural change. `StackAssembly` lives under `lib/api/cloud-assembly/private/`, so none of these names are part of the `toolkit-lib` public API and no consumers are affected.

Fixes #

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
