### PR TITLE
docs(cli): document stack selection pattern semantics

### DIFF
--- a/packages/aws-cdk/README.md
+++ b/packages/aws-cdk/README.md
@@ -293,6 +293,8 @@ In order to deploy them, you can list the stacks you want to deploy. If your app
 
 If you want to deploy all of them, you can use the flag `--all` or the wildcard `*` to deploy all stacks in an app. Please note that, if you have a hierarchy of stacks as described above, `--all` and `*` will only match the stacks on the top level. If you want to match all the stacks in the hierarchy, use `**`. You can also combine these patterns. For example, if you want to deploy all stacks in the `Prod` stage, you can use `cdk deploy PipelineStack/Prod/**`.
 
+Stack arguments are glob patterns matched against the hierarchical stack ID. Multiple patterns are combined with OR: `cdk deploy StackA StackB` deploys both. A pattern starting with `!` matches every stack that does not match it: `cdk deploy '!Prod/Canary'` deploys everything except `Prod/Canary`. Since patterns combine with OR, to exclude multiple stacks use a single pattern: `cdk deploy '!(StackA|StackB)'`.
+
 `--concurrency N` allows deploying multiple stacks in parallel while respecting inter-stack dependencies to speed up deployments. It does not protect against CloudFormation and other AWS account rate limiting.
 
 #### Parameters


### PR DESCRIPTION
Follow-up to #1909.

Adds a short paragraph to the README explaining that stack patterns are globs matched with OR semantics, so `!A !B` selects everything — use `!(A|B)` to exclude multiple stacks.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license