### PR TITLE
fix(toolkit-lib): strip aws:-prefixed tags from Cloud Control hotswap patch

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/cloud-control-resource.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/hotswap/cloud-control-resource.ts
@@ -77,7 +77,7 @@ export async function isHotswappableCloudControlChange(
       const patchOps: Array<{ op: string; path: string; value?: any }> = [];
       for (const propName of classifiedChanges.namesOfHotswappableProps) {
         const diff = change.propertyUpdates[propName];
-        const newValue = evaluatedProps[propName];
+        const newValue = propName === 'Tags' ? withoutAwsPrefixedTags(evaluatedProps[propName]) : evaluatedProps[propName];
         if (diff.isRemoval) {
           patchOps.push({ op: 'remove', path: `/${propName}` });
         } else if (diff.isAddition) {
@@ -101,6 +101,36 @@ export async function isHotswappableCloudControlChange(
   });
 
   return ret;
+}
+
+/**
+ * Remove `aws:`-prefixed tag keys from an evaluated `Tags` property value before
+ * it is sent to Cloud Control API.
+ *
+ * Tags whose key begins with `aws:` are reserved for AWS system tags (e.g.
+ * `aws:cloudformation:stack-name`, `aws:cdk:*`). They are applied by the service
+ * and are read-only: Cloud Control's `UpdateResource` rejects any request that
+ * carries one with `ValidationException: aws: prefixed tag key names are not
+ * allowed for external use`. When such a tag ends up in the synthesized template
+ * (and therefore in the hotswap patch), a `replace /Tags` would send it verbatim
+ * and fail the whole hotswap. Dropping these keys keeps the customer-authored
+ * tags — the only ones we can legally set — and leaves the system tags to AWS.
+ *
+ * `Tags` appears in two shapes across CloudFormation resource types: a list of
+ * `{ Key, Value }` objects (most resources, including `AWS::SQS::Queue`) and a
+ * plain `{ key: value }` map (a few resources). Both are handled; any other shape
+ * is returned unchanged.
+ */
+function withoutAwsPrefixedTags(tags: any): any {
+  const isAwsKey = (key: unknown): boolean => typeof key === 'string' && key.toLowerCase().startsWith('aws:');
+
+  if (Array.isArray(tags)) {
+    return tags.filter((tag) => !(tag && typeof tag === 'object' && isAwsKey(tag.Key)));
+  }
+  if (tags && typeof tags === 'object') {
+    return Object.fromEntries(Object.entries(tags).filter(([key]) => !isAwsKey(key)));
+  }
+  return tags;
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/hotswap/cloud-control-hotswap-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/hotswap/cloud-control-hotswap-deployments.test.ts
@@ -740,3 +740,111 @@ describe.each([HotswapMode.FALL_BACK, HotswapMode.HOTSWAP_ONLY])('Property remov
     });
   });
 });
+
+describe.each([HotswapMode.FALL_BACK, HotswapMode.HOTSWAP_ONLY])('aws:-prefixed tag stripping in %p mode', (hotswapMode) => {
+  beforeEach(() => {
+    hotswapMockSdkProvider = setup.setupHotswapTests();
+
+    mockCloudFormationClient.on(DescribeTypeCommand).resolves({
+      Schema: JSON.stringify({ primaryIdentifier: ['/properties/QueueUrl'] }),
+    });
+    mockCloudControlClient.on(UpdateResourceCommand).resolves({});
+  });
+
+  test('strips aws:-prefixed keys from a list-shaped Tags patch (only user tags are sent)', async () => {
+    // GIVEN a Tags list carrying both a user tag and a reserved aws: system tag.
+    // Cloud Control rejects any request that carries an aws:-prefixed tag key
+    // ("aws: prefixed tag key names are not allowed for external use"), so it
+    // must be dropped from the patch before UpdateResource is called.
+    setup.setCurrentCfnStackTemplate({
+      Resources: {
+        Queue: {
+          Type: 'AWS::SQS::Queue',
+          Properties: {
+            QueueUrl: 'https://sqs/queue',
+            Tags: [
+              { Key: 'DynamicTag', Value: 'original' },
+              { Key: 'aws:cloudformation:stack-name', Value: 'my-stack' },
+            ],
+          },
+        },
+      },
+    });
+    setup.pushStackResourceSummaries(
+      setup.stackSummaryOf('Queue', 'AWS::SQS::Queue', 'https://sqs/queue'),
+    );
+    const cdkStackArtifact = setup.cdkStackArtifactOf({
+      template: {
+        Resources: {
+          Queue: {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+              QueueUrl: 'https://sqs/queue',
+              Tags: [
+                { Key: 'DynamicTag', Value: 'new' },
+                { Key: 'aws:cloudformation:stack-name', Value: 'my-stack' },
+              ],
+            },
+          },
+        },
+      },
+    });
+
+    // WHEN
+    const deployStackResult = await hotswapMockSdkProvider.tryHotswapDeployment(hotswapMode, cdkStackArtifact);
+
+    // THEN
+    expect(deployStackResult).not.toBeUndefined();
+    expect(mockCloudControlClient).toHaveReceivedCommandWith(UpdateResourceCommand, {
+      TypeName: 'AWS::SQS::Queue',
+      Identifier: 'https://sqs/queue',
+      PatchDocument: JSON.stringify([
+        { op: 'replace', path: '/Tags', value: [{ Key: 'DynamicTag', Value: 'new' }] },
+      ]),
+    });
+  });
+
+  test('strips aws:-prefixed keys from a map-shaped Tags patch', async () => {
+    // GIVEN a map-shaped Tags value (some resource types model Tags this way).
+    setup.setCurrentCfnStackTemplate({
+      Resources: {
+        Queue: {
+          Type: 'AWS::SQS::Queue',
+          Properties: {
+            QueueUrl: 'https://sqs/queue',
+            Tags: { DynamicTag: 'original', 'aws:cdk:owner': 'cdk' },
+          },
+        },
+      },
+    });
+    setup.pushStackResourceSummaries(
+      setup.stackSummaryOf('Queue', 'AWS::SQS::Queue', 'https://sqs/queue'),
+    );
+    const cdkStackArtifact = setup.cdkStackArtifactOf({
+      template: {
+        Resources: {
+          Queue: {
+            Type: 'AWS::SQS::Queue',
+            Properties: {
+              QueueUrl: 'https://sqs/queue',
+              Tags: { DynamicTag: 'new', 'aws:cdk:owner': 'cdk' },
+            },
+          },
+        },
+      },
+    });
+
+    // WHEN
+    const deployStackResult = await hotswapMockSdkProvider.tryHotswapDeployment(hotswapMode, cdkStackArtifact);
+
+    // THEN
+    expect(deployStackResult).not.toBeUndefined();
+    expect(mockCloudControlClient).toHaveReceivedCommandWith(UpdateResourceCommand, {
+      TypeName: 'AWS::SQS::Queue',
+      Identifier: 'https://sqs/queue',
+      PatchDocument: JSON.stringify([
+        { op: 'replace', path: '/Tags', value: { DynamicTag: 'new' } },
+      ]),
+    });
+  });
+});


### PR DESCRIPTION
## Problem

The `cc-hotswap` CLI integ test (and the CCAPI hotswap path generally) fails on the SQS Queue with:

```
❌ ...-cc-hotswap failed: ValidationException: aws: prefixed tag key names are not allowed for external use.
```

The Events Rule and CloudWatch Dashboard in the same stack hotswap fine; only the **Queue** fails, because its `DynamicTag` value changes between deploys, which makes `Tags` a hotswappable property.

## Root cause

`isHotswappableCloudControlChange` (in `cloud-control-resource.ts`) builds a JSON-patch from every changed property and sends it via Cloud Control `UpdateResource`. For a changed `Tags` property it produces `{ op: 'replace', path: '/Tags', value: <evaluated tags> }` **verbatim**. When the synthesized `Tags` include a reserved AWS system tag (keys prefixed `aws:`, e.g. `aws:cloudformation:*` / `aws:cdk:*`), CCAPI rejects the whole request: those keys are read-only and "not allowed for external use." The result is that the entire hotswap of that resource fails.

## Fix

Strip `aws:`-prefixed tag keys from the evaluated `Tags` value before constructing the patch. Customer-authored tags (the only ones we can legally set) are still applied; the reserved system tags are left for AWS to manage. The helper handles both tag shapes CloudFormation uses — a list of `{ Key, Value }` (most resources, including `AWS::SQS::Queue`) and a plain `{ key: value }` map — and is a no-op for any other shape. Matching is case-insensitive.

This is the correct defensive behavior regardless of *why* an `aws:` tag ended up in the template (a framework/lib change emitting one, or a resource inheriting stack-level system tags): the CLI must never forward reserved tag keys to CCAPI.

## Testing

- Added unit tests in `cloud-control-hotswap-deployments.test.ts` asserting that a Queue whose `Tags` carry both a user tag and an `aws:`-prefixed tag produces a patch containing **only** the user tag — for both the list and map tag shapes, in both `FALL_BACK` and `HOTSWAP_ONLY` modes.
- Existing CCAPI hotswap tests are unchanged and continue to assert non-Tags patches are built as before.

> [!NOTE]
> The exact upstream source of the `aws:` tag key was not pinned from the CI artifacts — the CLI does not log the outgoing `PatchDocument` at `-v`, and the failing environments are ephemeral Atmosphere accounts. The fix is deliberately defensive at the CCAPI boundary so it is correct independent of that origin. If reviewers can confirm the offending key from a CloudTrail `UpdateResource` event, it's worth noting in the changelog.

### Checklist
- [x] Unit tests added/updated
- [ ] Integration tests (covered by the existing `cc-hotswap` integ test once this ships)
- [x] No manual edits to generated files

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
