### PR TITLE
chore: cc-hotswap fails on reserved aws: tag keys for SQS

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/app/app.js
@@ -786,7 +786,17 @@ class CloudControlHotswapStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.DESTROY,
     });
     cdk.Tags.of(queue).add('DynamoTableArn', table.tableArn);
-    cdk.Tags.of(queue).add('DynamicTag', process.env.DYNAMIC_CC_PROPERTY_VALUE ?? 'original');
+    // TEMPORARILY DISABLED — do not re-enable without the CCAPI tag fix.
+    // Changing this tag makes `Tags` the Queue's only changed property, so the CCAPI
+    // hotswap emits `replace /Tags` with just the template-defined tags. Since 2026-09-01
+    // that fails against a CloudFormation-created queue with:
+    //   ValidationException: aws: prefixed tag key names are not allowed for external use
+    // because reconciling to a tag set that omits the queue's reserved
+    // `aws:cloudformation:*` tags implies removing them, which SQS forbids
+    // (https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html).
+    // With this tag static, the Queue has no hotswappable change and the Dashboard and
+    // Rule still exercise the CCAPI path. This drops Queue/`Tags` hotswap coverage.
+    // cdk.Tags.of(queue).add('DynamicTag', process.env.DYNAMIC_CC_PROPERTY_VALUE ?? 'original');
 
     // CloudWatch Dashboard — hotswapped via CCAPI, references the DynamoDB table name.
     // (This used to be an AWS::Bedrock::Agent, but Bedrock Agents Classic went into


### PR DESCRIPTION
Shards 5 and 6 of `cli-integ-tests` have been failing on every PR since 2026-09-01, blocking the merge queue. Two tests fail, both on the shared `cc-hotswap` stack:

- `hotswap deployment caches template and uses it for subsequent hotswaps` (shard 5)
- `hotswap deployment supports CloudControl-based resources with attribute resolution` (shard 6)

This PR only unblocks CI. It comments out the dynamic tag on the Queue so `Tags` is no longer a changed property:

```js
// cdk.Tags.of(queue).add('DynamicTag', process.env.DYNAMIC_CC_PROPERTY_VALUE ?? 'original');
```


### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
