### PR TITLE
fix(toolkit-lib): throttled final event poll fails a successful deploy

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
+++ b/packages/@aws-cdk/toolkit-lib/docs/message-registry.md
@@ -120,6 +120,7 @@ Please let us know by [opening an issue](https://github.com/aws/aws-cdk-cli/issu
 | `CDK_TOOLKIT_W5400` | Hotswap disclosure message | `warn` | n/a |
 | `CDK_TOOLKIT_E5001` | No stacks found | `error` | n/a |
 | `CDK_TOOLKIT_E5500` | Stack Monitoring error | `error` | {@link ErrorPayload} |
+| `CDK_TOOLKIT_W5500` | Stack events could not be read; the reported event log may be incomplete | `warn` | {@link ErrorPayload} |
 | `CDK_TOOLKIT_I6000` | Provides rollback times | `info` | {@link Duration} |
 | `CDK_TOOLKIT_I6100` | Stack rollback progress | `info` | {@link StackRollbackProgress} |
 | `CDK_TOOLKIT_E6001` | No stacks found | `error` | n/a |

--- a/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/io/private/messages.ts
@@ -348,6 +348,11 @@ export const IO = {
     description: 'Stack Monitoring error',
     interface: 'ErrorPayload',
   }),
+  CDK_TOOLKIT_W5500: make.warn<ErrorPayload>({
+    code: 'CDK_TOOLKIT_W5500',
+    description: 'Stack events could not be read; the reported event log may be incomplete',
+    interface: 'ErrorPayload',
+  }),
 
   // 6: Rollback (6xxx)
   CDK_TOOLKIT_I6000: make.info<Duration>({

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -296,11 +296,13 @@ export class StackActivityMonitor {
     // of letting the failure propagate out of stop().
     try {
       await this.readNewEvents(monitorId);
-    } catch (e) {
+    } catch (e: any) {
+      const errorName = e instanceof Error ? e.name : String(e);
       await this.ioHelper.notify(IO.CDK_TOOLKIT_W5500.msg(
-        util.format('Error occurred during final stack event poll, event log may be incomplete: %s', e),
-        { error: e as any },
+        util.format('Could not read the final stack events, the event log may be incomplete (%s). Run again with -v to see the full error.', errorName),
+        { error: e },
       ));
+      await this.ioHelper.defaults.debug(util.format('Error occurred during final stack event poll: %s', e));
     }
   }
 

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -217,7 +217,6 @@ export class StackActivityMonitor {
     try {
       this.readPromise = this.readNewEvents(this.monitorId);
       await this.readPromise;
-      this.readPromise = undefined;
 
       // We might have been stop()ped while the network call was in progress.
       if (!this.monitorId) {
@@ -228,6 +227,9 @@ export class StackActivityMonitor {
         util.format('Error occurred while monitoring stack: %s', e),
         { error: e as any },
       ));
+    } finally {
+      // Clear on both paths, so `readPromise` only ever holds a read that is still in flight.
+      this.readPromise = undefined;
     }
     this.scheduleNextTick();
   }
@@ -283,11 +285,23 @@ export class StackActivityMonitor {
     // the moment we were sure we weren't going to get any new events anymore
     // so we need to do a new one anyway. Need to wait for this one though
     // because our state is single-threaded.
-    if (this.readPromise) {
+    try {
       await this.readPromise;
+    } catch {
+      // A failure of the in-flight poll has already been reported by tick().
     }
 
-    await this.readNewEvents(monitorId);
+    // Reading events only completes the event log shown to the user; it cannot change
+    // whether the monitored operation succeeded. Warn that the log may be short instead
+    // of letting the failure propagate out of stop().
+    try {
+      await this.readNewEvents(monitorId);
+    } catch (e) {
+      await this.ioHelper.notify(IO.CDK_TOOLKIT_W5500.msg(
+        util.format('Error occurred during final stack event poll, event log may be incomplete: %s', e),
+        { error: e as any },
+      ));
+    }
   }
 
   /**

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -1102,6 +1102,26 @@ test('rollback stack allows rolling back from UPDATE_FAILED', async () => {
   expect(mockCloudFormationClient).toHaveReceivedCommand(RollbackStackCommand);
 });
 
+test('rollback stack is not failed by a throttled stack event poll', async () => {
+  // GIVEN - reading stack events fails throughout, including the final poll in monitor.stop()
+  givenStacks({
+    '*': { template: {}, stackStatus: 'UPDATE_FAILED' },
+  });
+  mockCloudFormationClient.on(DescribeStackEventsCommand).rejects(
+    Object.assign(new Error('Rate exceeded'), { name: 'Throttling' }),
+  );
+
+  // WHEN
+  const response = await deployments.rollbackStack({
+    stack: testStack({ stackName: 'boop' }),
+    validateBootstrapStackVersion: false,
+  });
+
+  // THEN - the rollback succeeded, and the final poll failure was only reported
+  expect(response).toMatchObject({ success: true });
+  ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+});
+
 test('rollback stack allows continue rollback from UPDATE_ROLLBACK_FAILED', async () => {
   // GIVEN
   givenStacks({

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/cloudformation-deployments.test.ts
@@ -1119,7 +1119,7 @@ test('rollback stack is not failed by a throttled stack event poll', async () =>
 
   // THEN - the rollback succeeded, and the final poll failure was only reported
   expect(response).toMatchObject({ success: true });
-  ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+  ioHost.expectMessage({ level: 'warn', containing: 'the event log may be incomplete' });
 });
 
 test('rollback stack allows continue rollback from UPDATE_ROLLBACK_FAILED', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-event-poll-failures.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-event-poll-failures.test.ts
@@ -1,0 +1,117 @@
+import type { CloudFormationStackArtifact } from '@aws-cdk/cloud-assembly-api';
+import { deployStack, destroyStack } from '../../../lib/api/deployments/deploy-stack';
+import type { DeployStackOptions as DeployStackApiOptions } from '../../../lib/api/deployments/deploy-stack';
+import { CloudFormationStackDiagnoser } from '../../../lib/api/diagnosing/stack-diagnoser';
+import { NoBootstrapStackEnvironmentResources } from '../../../lib/api/environment';
+import { StackArtifactSourceTracer } from '../../../lib/api/source-tracing/private/stack-source-tracing';
+import { testStack } from '../../_helpers/assembly';
+import { FakeCloudFormation } from '../../_helpers/fake-aws/fake-cloudformation';
+import { advanceTime } from '../../_helpers/fake-time';
+import {
+  mockCloudFormationClient,
+  mockResolvedEnvironment,
+  MockSdk,
+  MockSdkProvider,
+  restoreSdkMocksToDefault,
+} from '../../_helpers/mock-sdk';
+import { TestIoHost } from '../../_helpers/test-io-host';
+
+const ioHost = new TestIoHost();
+const ioHelper = ioHost.asHelper('deploy');
+
+const FAKE_STACK = testStack({
+  stackName: 'withouterrors',
+  template: {
+    Resources: {
+      MyResource: {
+        Type: 'Test::Resource::Type',
+        Properties: {
+          Bar: 'Bar',
+        },
+      },
+    },
+  },
+});
+
+let sdk: MockSdk;
+let sdkProvider: MockSdkProvider;
+const fakeCfn = new FakeCloudFormation();
+
+beforeEach(() => {
+  fakeCfn.reset();
+  ioHost.clear();
+
+  sdkProvider = new MockSdkProvider();
+  sdk = new MockSdk();
+
+  restoreSdkMocksToDefault();
+  fakeCfn.installUsingAwsMock(mockCloudFormationClient);
+
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+function standardDeployStackArguments(stack: CloudFormationStackArtifact = FAKE_STACK): DeployStackApiOptions {
+  const resolvedEnvironment = mockResolvedEnvironment();
+  return {
+    stack,
+    sdk,
+    sdkProvider,
+    resolvedEnvironment,
+    envResources: new NoBootstrapStackEnvironmentResources(resolvedEnvironment, sdk, ioHelper),
+    diagnoser: new CloudFormationStackDiagnoser({
+      sdk,
+      sourceTracer: new StackArtifactSourceTracer(stack),
+      ioHelper,
+      topLevelStackHierarchicalId: stack.hierarchicalId,
+    }),
+  };
+}
+
+/**
+ * Throttle every stack event read, leaving the rest of the CloudFormation API working
+ */
+function throttleStackEventReads() {
+  const realClient = sdk.cloudFormation();
+  jest.spyOn(sdk, 'cloudFormation').mockReturnValue({
+    ...realClient,
+    describeStackEvents: () => Promise.reject(Object.assign(new Error('Rate exceeded'), { name: 'Throttling' })),
+  });
+}
+
+describe.each(['change-set', 'direct'] as const)('a successful %s deployment', (method) => {
+  test('is not failed by a throttled stack event poll', async () => {
+    // GIVEN - reading stack events fails throughout, including the final poll in monitor.stop()
+    throttleStackEventReads();
+
+    // WHEN
+    const result = await advanceTime(deployStack({
+      ...standardDeployStackArguments(),
+      deploymentMethod: { method },
+    }, ioHelper));
+
+    // THEN - the deployment succeeded, and the final poll failure was only reported
+    expect(result).toMatchObject({ type: 'did-deploy-stack' });
+    ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+  });
+});
+
+test('a successful destroy is not failed by a throttled stack event poll', async () => {
+  // GIVEN
+  fakeCfn.createStackSync({ StackName: 'withouterrors' });
+  throttleStackEventReads();
+
+  // WHEN
+  const result = await advanceTime(destroyStack({
+    stack: FAKE_STACK,
+    sdk,
+  }, ioHelper));
+
+  // THEN
+  expect(result.stackArn).toBeDefined();
+  ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+});

--- a/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-event-poll-failures.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/deployments/deploy-stack-event-poll-failures.test.ts
@@ -96,7 +96,7 @@ describe.each(['change-set', 'direct'] as const)('a successful %s deployment', (
 
     // THEN - the deployment succeeded, and the final poll failure was only reported
     expect(result).toMatchObject({ type: 'did-deploy-stack' });
-    ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+    ioHost.expectMessage({ level: 'warn', containing: 'the event log may be incomplete' });
   });
 });
 
@@ -113,5 +113,5 @@ test('a successful destroy is not failed by a throttled stack event poll', async
 
   // THEN
   expect(result.stackArn).toBeDefined();
-  ioHost.expectMessage({ level: 'warn', containing: 'Error occurred during final stack event poll' });
+  ioHost.expectMessage({ level: 'warn', containing: 'the event log may be incomplete' });
 });

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
@@ -112,6 +112,48 @@ describe('stack monitor event ordering and pagination', () => {
   });
 });
 
+describe('stack monitor, failures while reading events', () => {
+  test('a failing final poll is reported but does not fail stop()', async () => {
+    mockCloudFormationClient.on(DescribeStackEventsCommand).rejects(throttlingError());
+
+    await eventually(() => expect(mockCloudFormationClient).toHaveReceivedCommand(DescribeStackEventsCommand), 2);
+
+    // The final poll only completes the event log, so its failure must not surface to the caller
+    await expect(monitor.stop()).resolves.toBeUndefined();
+    expect(ioHost.notify).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_W5500',
+      message: expect.stringContaining('event log may be incomplete: Throttling: Rate exceeded'),
+    }));
+    expect(ioHost.notify).toHaveBeenCalledWith(expectStop());
+  });
+
+  test('a poll that fails while stop() waits for it does not fail stop() either', async () => {
+    // GIVEN - a poll that is still in flight when the monitor is stopped
+    let failFirstPoll: (error: Error) => void;
+    const firstPoll = new Promise((_, reject) => {
+      failFirstPoll = reject;
+    });
+    let polls = 0;
+    mockCloudFormationClient.on(DescribeStackEventsCommand).callsFake(() => {
+      polls += 1;
+      return polls === 1 ? firstPoll : { StackEvents: [event(101)] };
+    });
+    await eventually(() => expect(mockCloudFormationClient).toHaveReceivedCommandTimes(DescribeStackEventsCommand, 1), 2);
+
+    // WHEN
+    const stopped = monitor.stop();
+    failFirstPoll!(throttlingError());
+
+    // THEN - the failure is reported by the tick that started the poll, and the final poll still runs
+    await expect(stopped).resolves.toBeUndefined();
+    expect(ioHost.notify).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'CDK_TOOLKIT_E5500',
+      message: expect.stringContaining('Error occurred while monitoring stack: Throttling: Rate exceeded'),
+    }));
+    expect(ioHost.notify).toHaveBeenCalledWith(expectEvent(101));
+  });
+});
+
 describe('stack monitor, collecting errors from events', () => {
   test('return errors from the root stack', async () => {
     mockCloudFormationClient.on(DescribeStackEventsCommand).resolvesOnce({
@@ -292,6 +334,10 @@ function event(nr: number): StackEvent {
 
 function errorEvent(nr: number, props?: Parameters<typeof addErrorToStackEvent>[1]) {
   return addErrorToStackEvent(event(nr), props);
+}
+
+function throttlingError(): Error {
+  return Object.assign(new Error('Rate exceeded'), { name: 'Throttling' });
 }
 
 function addErrorToStackEvent(

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
@@ -122,7 +122,13 @@ describe('stack monitor, failures while reading events', () => {
     await expect(monitor.stop()).resolves.toBeUndefined();
     expect(ioHost.notify).toHaveBeenCalledWith(expect.objectContaining({
       code: 'CDK_TOOLKIT_W5500',
-      message: expect.stringContaining('event log may be incomplete: Throttling: Rate exceeded'),
+      message: expect.stringContaining('the event log may be incomplete (Throttling). Run again with -v'),
+    }));
+
+    // The full error, stack trace and all, is only for `-v`
+    expect(ioHost.notify).toHaveBeenCalledWith(expect.objectContaining({
+      level: 'debug',
+      message: expect.stringContaining('Error occurred during final stack event poll: Throttling: Rate exceeded'),
     }));
     expect(ioHost.notify).toHaveBeenCalledWith(expectStop());
   });


### PR DESCRIPTION
> [!NOTE]
> **This PR was created by AI** (Claude Code, Anthropic's agentic CLI), including the code, tests and this description, working from the analysis in #1777. A human directed the work and reviewed the result, but the reasoning and wording below are the model's. Please review it on its merits rather than assuming human verification of every claim.

fixes #1777

That issue has the full diagnosis, the throttling arithmetic and the reproduction; this description covers only what was implemented.

## The fix

`StackActivityMonitor.finalPollToEnd()` is now guarded, which is the one place all three `monitor.stop()` call sites go through — `FullCloudFormationDeployment.monitorDeployment`, `destroyStack` (both in `deploy-stack.ts`) and `Deployments.rollbackStack`. Guarding at the call sites instead would have missed rollback.

Three changes in `packages/@aws-cdk/toolkit-lib`:

1. **`finalPollToEnd()` — the final read no longer propagates.** A failed `readNewEvents()` is reported as `CDK_TOOLKIT_W5500` and `stop()` returns normally. This read only completes the event log; the operation's outcome came from `DescribeStacks` via `waitForStackDeploy` long before.

2. **`finalPollToEnd()` — the awaited in-flight `readPromise` is caught.** This path was equally unguarded and is a separate failure mode: a poll that is still in flight when `stop()` is called, and rejects. It is swallowed rather than reported, because `tick()` awaits that same promise inside its own `try`/`catch` and has already emitted `CDK_TOOLKIT_E5500` for it. Without this catch, the rejection skips the final read entirely — the very flush `stop()` exists to perform.

3. **`tick()` — `readPromise` is cleared in a `finally`.** It was cleared only on the success path, so after any failed poll the field kept an already-rejected promise, and the next `stop()` re-raised it before doing anything. Now the field only ever holds a read that is genuinely in flight, which makes (2)'s "already reported by `tick()`" an invariant rather than an assumption.

Both (1) and (2) are load-bearing; see the mutation testing below.

## Error path

```
                     doPoll() ── DescribeStackEvents ── SDK retries exhausted (Throttling)
                        │
                        ▼
                    poll() → readNewEvents()
                        │
        ┌───────────────┴────────────────┐
        │                                │
   from tick()                    from stop() → finalPollToEnd()
        │                                │
        │                    ┌───────────┴────────────┐
        │                    │                        │
        │            await readPromise         await readNewEvents()
        │            (in-flight poll)             (the final read)
        │                    │                        │
   ┌────▼─────┐         ┌────▼─────┐            ┌─────▼──────┐
   │ caught   │         │ caught   │            │  caught    │
   │ E5500    │         │ ignored  │            │  W5500     │
   │ (before  │         │ (tick    │            │  (new)     │
   │  & after)│         │  reports)│            │            │
   └──────────┘         └──────────┘            └────────────┘
```

Before this PR, only the left branch was caught. Either branch under `stop()` threw, and because both call sites invoke `stop()` from a `finally`, the throw replaced the value the `try` was about to return:

```
finalPollToEnd() throws
  → monitor.stop() throws
  → finally { await monitor.stop() }      ← discards the successful return value
  → monitorDeployment() rejects
  → deployStack() rejects  →  Deploy action rejects  →  exec() rejects
  → cli() .catch()  →  process.exitCode = 1
```

## Before / after for `cdk` users

Scenario: a stack reaches `UPDATE_COMPLETE`, and the account is throttling `DescribeStackEvents` (10 req/s, non-adjustable) hard enough that a call exhausts its retries.

**Before**

```
 ✅  my-stack-a
 ❌  my-stack-b failed: Throttling: Rate exceeded
```

- The stack is `UPDATE_COMPLETE` in CloudFormation but reported as failed.
- `cdk deploy` exits `1`.
- Remaining stacks in a `--all` run are abandoned.
- `toolkit-lib` callers get a rejected `deployStack()` for a deployment that succeeded.

**After**

```
 ✅  my-stack-a
 ✅  my-stack-b
```

plus one warning on the affected stack:

```
[Warning at my-stack-b] Could not read the final stack events, the event log may be incomplete (Throttling). Run again with -v to see the full error.
```

- Exit code `0`; the rest of the `--all` run continues.
- Programmatic callers get `{ type: 'did-deploy-stack', ... }`.
- The only loss is presentational: trailing stack events for that stack may be missing from the printed log, which is what the warning says.

The full error, stack trace and all, is emitted as a `debug` message rather than printed by default, so `-v` shows:

```
Error occurred during final stack event poll: Throttling: Rate exceeded
    at ProtocolLib.getErrorSchemaOrThrowBaseException (...)
    at ... (11 more frames)
```

`CDK_TOOLKIT_W5500` still carries the untouched error object as its `ErrorPayload`, so programmatic consumers get the whole thing regardless of verbosity.

Unchanged: the periodic polls. `tick()` already swallowed throttles and re-polls 2s later, so missed events catch up there. Also unchanged: any failure from `DescribeStacks`/`waitForStackDeploy`, which is how the outcome is actually determined, still fails the deployment.

## Why `warn` and a new message code

The first draft reused `CDK_TOOLKIT_E5500`, matching what `tick()` emits for the identical failure on the identical API call. Changed to a new `CDK_TOOLKIT_W5500` (warn, `ErrorPayload`) because:

- `error` is the one level `CliIoHost.selectStreamFromLevel` does not redirect to stdout under `--ci`, so a green deploy wrote to stderr — noise for exactly the CI pipelines reporting this issue.
- Reporting `error` on an operation that succeeded misstates the outcome. #1777 asked for "at most warns".
- Sibling best-effort failures in the same directory already warn — `hook-result-details.ts` does so twice for the same "optional detail fetch failed, carry on" shape.

`tick()`'s existing `E5500` is deliberately left alone: it fires while the outcome is still unknown, so `error` remains defensible there. `docs/message-registry.md` was regenerated with `npx projen registry`. No API report change — `IO` lives under `lib/api/io/private`.

The warning names the error and points at `-v` rather than inlining it, following the shape #1950 established for `hook-result-details.ts` in this same directory. A throttle here would otherwise put 14 lines of minified SDK stack trace into a log for a deployment that succeeded.

## Trade-off worth reviewing

When the in-flight read fails, the final read now still runs, where previously the throw short-circuited it. Under sustained throttling that is one additional fully-retried `DescribeStackEvents` per stack — `ConfiguredRetryStrategy(7, cappedExponentialBackoff(1000, 15_000))`, so up to roughly a minute — inside a `finally`.

Kept deliberately: that read is the last chance to print the resource-level failure reasons for a stack that genuinely failed, so skipping it would lose diagnostics exactly when they matter. Cost is bounded per stack and concurrent across stacks, so it is tail latency rather than an additive delay, and the alternative it replaces is a wrongly failed deployment.

## Tests

- `test/api/stack-events/stack-activity-monitor.test.ts` — new `stack monitor, failures while reading events` block: a throttled final poll is reported as `W5500` and the full error as `debug` while `stop()` resolves and still emits `I5503`; a poll that fails while `stop()` is waiting on it does not fail `stop()` and does not skip the final read.
- `test/api/deployments/deploy-stack-event-poll-failures.test.ts` (new) — end-to-end: `describeStackEvents` throttling throughout, `deployStack` still returns `did-deploy-stack` for both `change-set` and `direct`, and `destroyStack` still returns its stack ARN.
- `test/api/deployments/cloudformation-deployments.test.ts` — `rollbackStack` under the same throttling still returns `{ success: true }`, pinning the third call site.

Verified by mutation, since these tests must fail for the right reason:

| Mutation | Result |
|---|---|
| Revert the guard entirely | 5 tests fail |
| Keep the swallow, drop the `W5500` notify | 5 tests fail |
| Keep the warning, drop the `debug` message | 1 test fails |
| Remove only the `readPromise` catch | 1 test fails (the in-flight case) |

`test/api/deployments` + `test/api/stack-events` pass (265 tests). Full `toolkit-lib` suite: 1989 pass, with 3 `bootstrap*` suites failing for a pre-existing local reason unrelated to this change (they need `post-compile` to copy `bootstrap-template.yaml`). `eslint` clean.

## Follow-ups, not in this PR

Both come from #1777 and are separate concerns:

- `cappedExponentialBackoff` is deterministic, so `ConfiguredRetryStrategy` replaces smithy's jittered default and throttled pollers re-collide at the same instants. Adding jitter would reduce how often the retry budget is exhausted in the first place.
- `stackEventPollingInterval` exists only in `toolkit-lib`; there is no `cdk deploy` flag for it, so CLI users cannot lower their request rate.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license

