### PR TITLE
chore(cli): publish toolkit versions to docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1899,14 +1899,14 @@ jobs:
         run: |-
           echo "Uploading aws-cdk-cli to S3"
           echo "::add-mask::$BUCKET_NAME"
-          S3_PATH="$DOCS_STREAM/aws-cdk-v$(cat dist/version.txt).zip"
+          S3_PATH="$DOCS_STREAM/toolkit-versions-v$(cat dist/version.txt).zip"
           LATEST="latest-CLI"
 
           # Capture both stdout and stderr
           if OUTPUT=$(aws s3api put-object \
             --bucket "$BUCKET_NAME" \
             --key "$S3_PATH" \
-            --body dist/api-extractor-docs.zip \
+            --body dist/toolkit-versions.zip \
             --if-none-match "*" 2>&1); then
             
             # File was uploaded successfully, update the latest pointer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1746,7 +1746,7 @@ jobs:
           path: dist/standalone
       - name: Authenticate Via OIDC Role
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
@@ -1782,7 +1782,7 @@ jobs:
         run: echo "version=$(cat dist/version.txt)" >> $GITHUB_OUTPUT
       - name: Authenticate Via OIDC Role
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
@@ -1793,8 +1793,8 @@ jobs:
         run: |-
           aws ssm put-parameter --name "/published/cdk/cli-npm/version" --type "String" --value "${{ steps.aws-cdk-version.outputs.version }}" --overwrite
           aws ssm put-parameter --name "/published/cdk/cli-npm/timestamp" --type "String" --value "$(date +%s)" --overwrite
-  aws-cdk-toolkit-lib_release_api_extractor:
-    name: "@aws-cdk/toolkit-lib: Publish api-extractor to S3"
+  aws-cdk-toolkit-lib_release_docs_toolkit-lib-api-model:
+    name: "@aws-cdk/toolkit-lib: Publish docs @aws-cdk/toolkit-lib toolkit-lib-api-model to S3"
     needs: aws-cdk-toolkit-lib_release_npm
     runs-on: ubuntu-latest
     permissions:
@@ -1811,28 +1811,28 @@ jobs:
           path: dist
       - name: Authenticate Via OIDC Role
         id: creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
-          role-session-name: s3-api-model-docs-publishing@aws-cdk-cli
+          role-session-name: s3-aws-cdk-toolkit-lib-toolkit-lib-api-model-docs-publishing@aws-cdk-cli
           mask-aws-account-id: true
       - name: Assume the publishing role
         id: publishing-creds
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           aws-region: us-east-1
           role-to-assume: ${{ vars.PUBLISH_TOOLKIT_LIB_DOCS_ROLE_ARN }}
-          role-session-name: s3-api-model-docs-publishing@aws-cdk-cli
+          role-session-name: s3-aws-cdk-toolkit-lib-toolkit-lib-api-model-docs-publishing@aws-cdk-cli
           mask-aws-account-id: true
           role-chaining: true
-      - name: Publish api-extractor
-        id: publish_api-extractor
+      - name: Publish docs @aws-cdk/toolkit-lib toolkit-lib-api-model
+        id: publish_docs_aws-cdk_toolkit-lib_toolkit-lib-api-model
         env:
           BUCKET_NAME: ${{ vars.DOCS_BUCKET_NAME }}
           DOCS_STREAM: toolkit-lib-api-model
         run: |-
-          echo "Uploading api-extractor to S3"
+          echo "Uploading aws-cdk-toolkit-lib-toolkit-lib-api-model to S3"
           echo "::add-mask::$BUCKET_NAME"
           S3_PATH="$DOCS_STREAM/aws-cdk-toolkit-lib-api-model-v$(cat dist/version.txt).zip"
           LATEST="latest-toolkit-lib-api-model"
@@ -1845,7 +1845,7 @@ jobs:
             --if-none-match "*" 2>&1); then
             
             # File was uploaded successfully, update the latest pointer
-            echo "New api-extractor artifact uploaded successfully, updating latest pointer"
+            echo "New aws-cdk-toolkit-lib-toolkit-lib-api-model artifact uploaded successfully, updating latest pointer"
             echo "$S3_PATH" | aws s3 cp - "s3://$BUCKET_NAME/$LATEST"
 
           elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
@@ -1855,6 +1855,71 @@ jobs:
 
           else
             # Any other error (permissions, etc)
-            echo "::error::Failed to upload api-extractor artifact"
+            echo "::error::Failed to upload aws-cdk-toolkit-lib-toolkit-lib-api-model artifact"
+            exit 1
+          fi
+  aws-cdk_release_docs_CLI:
+    name: "aws-cdk: Publish docs aws-cdk CLI to S3"
+    needs: aws-cdk_release_npm
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: releasing
+    if: ${{ !cancelled() && needs.aws-cdk_release_npm.result == 'success' && !inputs.dry_run }}
+    steps:
+      - name: Download artifact
+        id: download_artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: aws-cdk_build-artifact
+          path: dist
+      - name: Authenticate Via OIDC Role
+        id: creds
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}
+          role-session-name: s3-aws-cdk-cli-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
+      - name: Assume the publishing role
+        id: publishing-creds
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ vars.PUBLISH_CLI_VERSION_ROLE_ARN }}
+          role-session-name: s3-aws-cdk-cli-docs-publishing@aws-cdk-cli
+          mask-aws-account-id: true
+          role-chaining: true
+      - name: Publish docs aws-cdk CLI
+        id: publish_docs_aws-cdk_cli
+        env:
+          BUCKET_NAME: ${{ vars.DOCS_BUCKET_NAME }}
+          DOCS_STREAM: CLI
+        run: |-
+          echo "Uploading aws-cdk-cli to S3"
+          echo "::add-mask::$BUCKET_NAME"
+          S3_PATH="$DOCS_STREAM/aws-cdk-v$(cat dist/version.txt).zip"
+          LATEST="latest-CLI"
+
+          # Capture both stdout and stderr
+          if OUTPUT=$(aws s3api put-object \
+            --bucket "$BUCKET_NAME" \
+            --key "$S3_PATH" \
+            --body dist/api-extractor-docs.zip \
+            --if-none-match "*" 2>&1); then
+            
+            # File was uploaded successfully, update the latest pointer
+            echo "New aws-cdk-cli artifact uploaded successfully, updating latest pointer"
+            echo "$S3_PATH" | aws s3 cp - "s3://$BUCKET_NAME/$LATEST"
+
+          elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
+            # Check specifically for PreconditionFailed in the error output
+            echo "::warning::File already exists in S3. Skipping upload."
+            exit 0
+
+          else
+            # Any other error (permissions, etc)
+            echo "::error::Failed to upload aws-cdk-cli artifact"
             exit 1
           fi

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1467,11 +1467,22 @@ for (const tsconfig of [cli.tsconfig, cli.tsconfigDev]) {
 }
 
 // Publishing Toolkit CLI version
+// We don't actually publish CLI docs here, but we can collect some interesting version information
+const cliVersionsTask = cli.addTask('versions', {
+  exec: [
+    'tsx --tsconfig test/tsconfig.json scripts/gen-versions-json.ts',
+    'rm -f dist/toolkit-versions.zip',
+    'zip -j -q dist/toolkit-versions.zip dist/versions.json',
+  ].join(' && '),
+});
+cli.packageTask.spawn(cliVersionsTask);
+
 new S3DocsPublishing(cli, {
   docsStream: 'CLI',
-  artifactPath: 'api-extractor-docs.zip',
+  artifactPath: 'toolkit-versions.zip',
   bucketName: '${{ vars.DOCS_BUCKET_NAME }}',
   roleToAssume: '${{ vars.PUBLISH_CLI_VERSION_ROLE_ARN }}',
+  s3PathPrefix: 'toolkit-versions',
 });
 
 // #endregion

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -14,7 +14,7 @@ import { IssueRegressionLabeler } from './projenrc/issue-regression-labeler';
 import { LargePrChecker } from './projenrc/large-pr-checker';
 import { PrLabeler } from './projenrc/pr-labeler';
 import { RecordPublishingTimestamp } from './projenrc/record-publishing-timestamp';
-import { DocType, S3DocsPublishing } from './projenrc/s3-docs-publishing';
+import { S3DocsPublishing } from './projenrc/s3-docs-publishing';
 import { SelfMutationOnForks } from './projenrc/SelfMutationOnForks';
 import { defineTools } from './projenrc/tools';
 import { TypecheckTests } from './projenrc/TypecheckTests';
@@ -1016,7 +1016,7 @@ new S3DocsPublishing(toolkitLib, {
   artifactPath: 'api-extractor-docs.zip',
   bucketName: '${{ vars.DOCS_BUCKET_NAME }}',
   roleToAssume: '${{ vars.PUBLISH_TOOLKIT_LIB_DOCS_ROLE_ARN }}',
-  docType: DocType.API_EXTRACTOR,
+  s3PathPrefix: 'aws-cdk-toolkit-lib-api-model',
 });
 
 // Add API Extractor configuration
@@ -1465,6 +1465,14 @@ for (const tsconfig of [cli.tsconfig, cli.tsconfigDev]) {
   tsconfig?.addExclude('test/integ/cli/sam_cdk_integ_app/**/*');
   tsconfig?.addExclude('vendor/**/*');
 }
+
+// Publishing Toolkit CLI version
+new S3DocsPublishing(cli, {
+  docsStream: 'CLI',
+  artifactPath: 'api-extractor-docs.zip',
+  bucketName: '${{ vars.DOCS_BUCKET_NAME }}',
+  roleToAssume: '${{ vars.PUBLISH_CLI_VERSION_ROLE_ARN }}',
+});
 
 // #endregion
 //////////////////////////////////////////////////////////////////////

--- a/packages/aws-cdk/.projen/tasks.json
+++ b/packages/aws-cdk/.projen/tasks.json
@@ -218,6 +218,9 @@
         },
         {
           "exec": "node-backpack pack --destination dist/js --allowed-license \"Apache-2.0\" --allowed-license \"MIT\" --allowed-license \"BSD-3-Clause\" --allowed-license \"ISC\" --allowed-license \"BSD-2-Clause\" --allowed-license \"0BSD\" --allowed-license \"MIT OR Apache-2.0\" --dont-attribute '^@aws-cdk/|^@cdklabs/|^cdk-assets$' --test 'bin/cdk --version' --entrypoint 'lib/index.js' --metafile dist/metafile.json"
+        },
+        {
+          "spawn": "versions"
         }
       ]
     },
@@ -351,6 +354,14 @@
         },
         {
           "spawn": "post-upgrade"
+        }
+      ]
+    },
+    "versions": {
+      "name": "versions",
+      "steps": [
+        {
+          "exec": "tsx --tsconfig test/tsconfig.json scripts/gen-versions-json.ts && rm -f dist/toolkit-versions.zip && zip -j -q dist/toolkit-versions.zip dist/versions.json"
         }
       ]
     },

--- a/packages/aws-cdk/package.json
+++ b/packages/aws-cdk/package.json
@@ -29,6 +29,7 @@
     "test:watch": "projen test:watch",
     "unbump": "projen unbump",
     "upgrade-aws-cdk-lib": "projen upgrade-aws-cdk-lib",
+    "versions": "projen versions",
     "watch": "projen watch",
     "projen": "projen"
   },

--- a/packages/aws-cdk/scripts/gen-versions-json.ts
+++ b/packages/aws-cdk/scripts/gen-versions-json.ts
@@ -1,0 +1,59 @@
+/**
+ * Generates `dist/versions.json`, describing the versions of the toolkit
+ * packages that are part of the current build.
+ *
+ * The release workflow zips this file into `dist/toolkit-versions.zip` and publishes
+ * it to the docs bucket (see `S3DocsPublishing` in `.projenrc.ts`).
+ *
+ * Package versions are read from the respective `package.json` files. During
+ * a release build these have been bumped to the versions being published;
+ * in a regular dev build they are `0.0.0`.
+ */
+import * as path from 'path';
+import * as fs from 'fs-extra';
+
+interface TrackedPackage {
+  readonly name: string;
+  readonly docsUrl: string;
+  readonly packageJsonPath: string;
+}
+
+const TRACKED_PACKAGES: TrackedPackage[] = [
+  {
+    name: 'aws-cdk',
+    docsUrl: 'https://docs.aws.amazon.com/cdk/v2/guide/ref-cli-cmd.html',
+    packageJsonPath: path.join(__dirname, '..', 'package.json'),
+  },
+  {
+    name: '@aws-cdk/toolkit-lib',
+    docsUrl: 'https://docs.aws.amazon.com/cdk/api/toolkit-lib/',
+    packageJsonPath: require.resolve('@aws-cdk/toolkit-lib/package.json'),
+  },
+  {
+    name: '@aws-cdk/cloud-assembly-schema',
+    docsUrl: 'https://docs.aws.amazon.com/cdk/api/v2/docs/cloud-assembly-schema-readme.html',
+    packageJsonPath: require.resolve('@aws-cdk/cloud-assembly-schema/package.json'),
+  },
+];
+
+async function main() {
+  const now = new Date().toISOString();
+
+  const versions = {
+    generatedAt: now,
+    packages: TRACKED_PACKAGES.map((pkg) => ({
+      package: pkg.name,
+      version: (fs.readJSONSync(pkg.packageJsonPath) as { version: string }).version,
+      date: now,
+      docsUrl: pkg.docsUrl,
+    })),
+  };
+
+  const outFile = path.join(__dirname, '..', 'dist', 'versions.json');
+  fs.mkdirpSync(path.dirname(outFile));
+  fs.writeJSONSync(outFile, versions, { spaces: 2 });
+}
+
+main().catch((e) => {
+  throw e;
+});

--- a/projenrc/adc-publishing.ts
+++ b/projenrc/adc-publishing.ts
@@ -56,7 +56,7 @@ export class AdcPublishing extends Component {
         {
           name: 'Authenticate Via OIDC Role',
           id: 'creds',
-          uses: 'aws-actions/configure-aws-credentials@v4',
+          uses: 'aws-actions/configure-aws-credentials@v6',
           with: {
             'aws-region': 'us-east-1',
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',

--- a/projenrc/record-publishing-timestamp.ts
+++ b/projenrc/record-publishing-timestamp.ts
@@ -44,7 +44,7 @@ export class RecordPublishingTimestamp extends Component {
         {
           name: 'Authenticate Via OIDC Role',
           id: 'creds',
-          uses: 'aws-actions/configure-aws-credentials@v4',
+          uses: 'aws-actions/configure-aws-credentials@v6',
           with: {
             'aws-region': 'us-east-1',
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',

--- a/projenrc/s3-docs-publishing.ts
+++ b/projenrc/s3-docs-publishing.ts
@@ -2,18 +2,6 @@ import type { Monorepo, TypeScriptWorkspace } from 'cdklabs-projen-project-types
 import { Component, github } from 'projen';
 import { runAfterPublish } from './util';
 
-export enum DocType {
-  /**
-   * TypeDoc documentation (HTML)
-   */
-  TYPEDOC = 'typedoc',
-
-  /**
-   * API Extractor documentation (JSON)
-   */
-  API_EXTRACTOR = 'api-extractor',
-}
-
 export interface S3DocsPublishingProps {
   /**
    * The docs stream to publish to.
@@ -36,10 +24,12 @@ export interface S3DocsPublishingProps {
   readonly bucketName: string;
 
   /**
-   * The type of documentation to publish.
+   * The path prefix for the versioned docs artifacts
    *
+   * @example "foobar" -> "foobar-v1.2.3.zip"
+   * @default - sanitized package name
    */
-  readonly docType: DocType;
+  readonly s3PathPrefix?: string;
 }
 
 export class S3DocsPublishing extends Component {
@@ -64,20 +54,18 @@ export class S3DocsPublishing extends Component {
       throw new Error('Could not find release workflow');
     }
 
-    const safeName = this.project.name.replace('@', '').replace('/', '-');
-    const isApiExtractor = this.props.docType === DocType.API_EXTRACTOR;
+    // Declare variables used for naming various things
+    const niceName = `${this.project.name} ${this.props.docsStream}`;
+    const safePackageName = this.project.name.replace('@', '').replace('/', '-');
+    const docsStreamId= `${safePackageName}-${this.props.docsStream.toLowerCase()}`;
+    const s3PathPrefix = this.props.s3PathPrefix ? `${this.props.s3PathPrefix}-v` : `${safePackageName}-v`;
 
-    // Determine job ID, name suffix, S3 path based on doc type
-    const jobIdSuffix = isApiExtractor ? '_api_extractor' : '_typedoc';
-    const nameSuffix = isApiExtractor ? 'api-extractor' : 'typedoc';
-    const s3PathPrefix = isApiExtractor ? `${safeName}-api-model-v` : `${safeName}-v`;
-
-    releaseWf.addJob(`${safeName}_release${jobIdSuffix}`, {
-      name: `${this.project.name}: Publish ${nameSuffix} to S3`,
+    releaseWf.addJob(`${safePackageName}_release_docs_${this.props.docsStream}`, {
+      name: `${this.project.name}: Publish docs ${niceName} to S3`,
       environment: 'releasing', // <-- this has the configuration
-      needs: [`${safeName}_release_npm`],
+      needs: [`${safePackageName}_release_npm`],
       runsOn: ['ubuntu-latest'],
-      if: runAfterPublish(`${safeName}_release_npm`),
+      if: runAfterPublish(`${safePackageName}_release_npm`),
       permissions: {
         idToken: github.workflows.JobPermission.WRITE,
         contents: github.workflows.JobPermission.READ,
@@ -85,40 +73,40 @@ export class S3DocsPublishing extends Component {
       steps: [
         github.WorkflowSteps.downloadArtifact({
           with: {
-            name: `${safeName}_build-artifact`,
+            name: `${safePackageName}_build-artifact`,
             path: 'dist',
           },
         }),
         {
           name: 'Authenticate Via OIDC Role',
           id: 'creds',
-          uses: 'aws-actions/configure-aws-credentials@v4',
+          uses: 'aws-actions/configure-aws-credentials@v6',
           with: {
             'aws-region': 'us-east-1',
             'role-to-assume': '${{ vars.AWS_ROLE_TO_ASSUME_FOR_ACCOUNT }}',
-            'role-session-name': `s3-${isApiExtractor ? 'api-model-' : ''}docs-publishing@aws-cdk-cli`,
+            'role-session-name': `s3-${docsStreamId}-docs-publishing@aws-cdk-cli`,
             'mask-aws-account-id': true,
           },
         },
         {
           name: 'Assume the publishing role',
           id: 'publishing-creds',
-          uses: 'aws-actions/configure-aws-credentials@v4',
+          uses: 'aws-actions/configure-aws-credentials@v6',
           with: {
             'aws-region': 'us-east-1',
             'role-to-assume': this.props.roleToAssume,
-            'role-session-name': `s3-${isApiExtractor ? 'api-model-' : ''}docs-publishing@aws-cdk-cli`,
+            'role-session-name': `s3-${docsStreamId}-docs-publishing@aws-cdk-cli`,
             'mask-aws-account-id': true,
             'role-chaining': true,
           },
         },
         {
-          name: `Publish ${nameSuffix}`,
+          name: `Publish docs ${this.project.name} ${this.props.docsStream}`,
           env: {
             BUCKET_NAME: this.props.bucketName,
             DOCS_STREAM: this.props.docsStream,
           },
-          run: `echo "Uploading ${nameSuffix} to S3"
+          run: `echo "Uploading ${docsStreamId} to S3"
 echo "::add-mask::$BUCKET_NAME"
 S3_PATH="$DOCS_STREAM/${s3PathPrefix}$(cat dist/version.txt).zip"
 LATEST="latest-${this.props.docsStream}"
@@ -131,7 +119,7 @@ if OUTPUT=$(aws s3api put-object \\
   --if-none-match "*" 2>&1); then
   
   # File was uploaded successfully, update the latest pointer
-  echo "New ${nameSuffix} artifact uploaded successfully, updating latest pointer"
+  echo "New ${docsStreamId} artifact uploaded successfully, updating latest pointer"
   echo "$S3_PATH" | aws s3 cp - "s3://$BUCKET_NAME/$LATEST"
 
 elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
@@ -141,7 +129,7 @@ elif echo "$OUTPUT" | grep -q "PreconditionFailed"; then
 
 else
   # Any other error (permissions, etc)
-  echo "::error::Failed to upload ${nameSuffix} artifact"
+  echo "::error::Failed to upload ${docsStreamId} artifact"
   exit 1
 fi`,
         },


### PR DESCRIPTION
This adds a new release artifact that publishes the CLI toolkit version information to the docs bucket, so that documentation tooling can discover which versions of the toolkit packages are currently published without querying npm.

During the `aws-cdk` package step, a new `versions` task generates a `versions.json` describing the versions of `aws-cdk`, `@aws-cdk/toolkit-lib`, and `@aws-cdk/cloud-assembly-schema` for the current build, together with a link to each package's documentation. Versions are read from the respective `package.json` files, which have been bumped to the released versions by the time the package step runs. The file is zipped into `dist/toolkit-versions.zip` and uploaded to the docs bucket by a new release job, reusing the existing `S3DocsPublishing` mechanism.

To support this, the `S3DocsPublishing` component was generalized: the previous `docType` enum only covered the two toolkit-lib documentation flavors, so it was replaced with an optional `s3PathPrefix`, which lets each stream choose its versioned artifact name. The credentials actions were also upgraded from v4 to v6 in passing.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
