### PR TITLE
fix(cloud-assembly-schema): validation crashes with Invalid URL on Node >= 24.20.0

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -392,6 +392,11 @@ repoProject.tasks.tryFind('build')!.spawn(gitSecretsScan);
 
 const repo = configureProject(repoProject);
 
+// Exclude dist from the NX cache to avoid restoring stale release artifacts
+repoProject.tryFindObjectFile('nx.json')!.patch(
+  pj.JsonPatch.remove('/targetDefaults/build/outputs/4'), // {projectRoot}/dist
+);
+
 interface GenericProps {
   private?: boolean;
 }

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -476,6 +476,12 @@ const cloudAssemblySchema = configureProject(
 );
 fixupTestTask(cloudAssemblySchema);
 
+// Patch jsonschema: local $ref resolution crashes with "Invalid URL" on Node >= 24.20.0
+// Fix from https://github.com/tdegrunt/jsonschema/pull/424
+repoProject.package.addField('resolutions', {
+  [`${cloudAssemblySchema.name}/jsonschema`]: 'patch:jsonschema@npm%3A1.5.0#~/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch',
+});
+
 cloudAssemblySchema.with(new yarn.WorkspaceJsiiBuild({
   docgen: false,
   jsiiVersion: TYPESCRIPT_VERSION,

--- a/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch
+++ b/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch
@@ -1,0 +1,20 @@
+diff --git a/lib/validator.js b/lib/validator.js
+index cca5e9c2216fd72d5da7eb63a38cebdf025e366e..c79bf06040d0752d6ba18d831256f648cffe799b 100644
+--- a/lib/validator.js
++++ b/lib/validator.js
+@@ -259,9 +259,12 @@ Validator.prototype.resolve = function resolve (schema, switchSchema, ctx) {
+   if (ctx.schemas[switchSchema]) {
+     return {subschema: ctx.schemas[switchSchema], switchSchema: switchSchema};
+   }
+-  // Else try walking the property pointer
+-  let parsed = new URL(switchSchema,'thismessage::/');
+-  let fragment = parsed.hash;
++  // Else try walking the property pointer. Split the fragment off by hand:
++  // `switchSchema` may be a bare path such as "/undefined#/$defs/x", which is
++  // not a valid relative reference against an opaque-path base and is rejected
++  // by spec-conformant WHATWG URL parsers (ada >= 4.0.0: Node.js >= 26, and 24.20+).
++  let hashIndex = switchSchema.indexOf('#');
++  let fragment = (hashIndex === -1 || hashIndex === switchSchema.length - 1) ? '' : switchSchema.substr(hashIndex);
+   var document = fragment && fragment.length && switchSchema.substr(0, switchSchema.length - fragment.length);
+   if (!document || !ctx.schemas[document]) {
+     throw new SchemaError("no such schema <" + switchSchema + ">", schema);

--- a/nx.json
+++ b/nx.json
@@ -15,8 +15,7 @@
         "{projectRoot}/lib",
         "{projectRoot}/tsconfig.tsbuildinfo",
         "{projectRoot}/coverage",
-        "{projectRoot}/test-reports",
-        "{projectRoot}/dist"
+        "{projectRoot}/test-reports"
       ],
       "inputs": [
         "!{projectRoot}/test-reports/**"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "tsx": "^4.23.12",
     "typescript": "5.9"
   },
+  "resolutions": {
+    "@aws-cdk/cloud-assembly-schema/jsonschema": "patch:jsonschema@npm%3A1.5.0#~/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch"
+  },
   "engines": {
     "node": ">= 18.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -10994,10 +10994,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsonschema@npm:^1.5.0":
+"jsonschema@npm:1.5.0, jsonschema@npm:^1.5.0":
   version: 1.5.0
   resolution: "jsonschema@npm:1.5.0"
   checksum: 10c0/c24ddb8d741f02efc0da3ad9b597a275f6b595062903d3edbfaa535c3f9c4c98613df68da5cb6635ed9aeab30d658986fea61d7662fc5b2b92840d5a1e21235e
+  languageName: node
+  linkType: hard
+
+"jsonschema@patch:jsonschema@npm%3A1.5.0#~/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch":
+  version: 1.5.0
+  resolution: "jsonschema@patch:jsonschema@npm%3A1.5.0#~/.yarn/patches/jsonschema-npm-1.5.0-a1e4a2d9f7.patch::version=1.5.0&hash=07d501"
+  checksum: 10c0/6ddaa50071e800b800914d138c7f9d6df5f873b1acb79756fa6018e30b80ab1c25a0eb0a674624054d0a82abcf223b2d5c8866f581ac96a9e12b2f4d631d15b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Since GitHub runners started rolling out Node.js 24.20.0 (via `node-version: lts/*`), builds have been failing intermittently in `@aws-cdk/cloud-assembly-schema` with `TypeError: Invalid URL` during schema validation. The failure appears intermittent because it depends on which Node version the runner has cached; it will become permanent as the rollout completes.

The root cause is a latent bug in jsonschema@1.5.0 (the latest release). When no `base` option is passed to `validate()`, it stringifies `undefined` into its internal base URI, producing ref URIs like `/undefined#/definitions/X`. It then re-parses these against the opaque base `thismessage::/`, which is invalid per the WHATWG URL spec. Older URL parsers tolerated this; the Ada 4.0.0 parser shipped in Node.js 24.20.0 correctly rejects it, so every manifest validation throws. Our schemas and refs are standard and not at fault.

Since no fixed jsonschema release exists, this applies the upstream fix from tdegrunt/jsonschema#424 via `yarn patch`: it splits the `#` fragment manually instead of round-tripping through `new URL()`. The resolution is scoped to the jsonschema dependency of `@aws-cdk/cloud-assembly-schema` and declared in `.projenrc.ts`, because yarn only reads resolutions from the monorepo root. Note that jsonschema is a bundled dependency, so the patched code ships in the published package. The patch should be removed once upstream releases a fix.

Verified by running the full `@aws-cdk/cloud-assembly-schema` test suite (38 passed) and by exercising manifest loading with a simulated strict URL parser that throws like Node 24.20.0 does.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
