### PR TITLE
docs(cli): add Nub app runner recipe

### DIFF
--- a/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/init-typescript-app/init-typescript-app.integtest.ts
@@ -4,6 +4,8 @@ import type { TemporaryDirectoryContext } from '../../lib';
 import { integTest, withTemporaryDirectory, ShellHelper, withPackages } from '../../lib';
 import { typescriptVersionsSync, typescriptVersionsYoungerThanDaysSync } from '../../lib/npm';
 
+const NUB_VERSION = '0.8.3';
+
 ['app', 'sample-app'].forEach(template => {
   integTest(`typescript init ${template}`, withTemporaryDirectory(withPackages(async (context) => {
     const shell = ShellHelper.fromContext(context);
@@ -21,6 +23,26 @@ import { typescriptVersionsSync, typescriptVersionsYoungerThanDaysSync } from '.
     await shell.shell(['cdk', 'synth']);
   })), 600_000);
 });
+
+integTest('typescript init app can synthesize with Nub', withTemporaryDirectory(withPackages(async (context) => {
+  const shell = ShellHelper.fromContext(context);
+  await context.cli.makeCliAvailable();
+
+  await shell.shell(['cdk', 'init', '--lib-version', context.library.requestedVersion(), '-l', 'typescript', 'app', '--generate-only']);
+  await shell.shell(['npm', 'install']);
+
+  const defaultAssembly = path.join(context.integTestDir, 'cdk.out.default');
+  await shell.shell(['cdk', 'synth', '--output', defaultAssembly]);
+
+  await shell.shell(['npm', 'install', '--save-dev', '--save-exact', `@nubjs/nub@${NUB_VERSION}`]);
+  await replaceAppRunner(context.integTestDir);
+  await shell.shell(['npm', 'run', 'build']);
+
+  const nubAssembly = path.join(context.integTestDir, 'cdk.out.nub');
+  await shell.shell(['cdk', 'synth', '--output', nubAssembly]);
+
+  await assertAssemblyDirsEqual(defaultAssembly, nubAssembly);
+})), 600_000);
 
 // Same as https://github.com/DefinitelyTyped/DefinitelyTyped?tab=readme-ov-file#support-window
 const TYPESCRIPT_VERSION_AGE_DAYS = 2 * 365;
@@ -74,4 +96,65 @@ async function removeDevDependencies(context: TemporaryDirectoryContext) {
   const tsconfig = JSON.parse(await fs.readFile(tsconfigFilename, { encoding: 'utf-8' }));
   delete tsconfig.compilerOptions.types;
   await fs.writeFile(tsconfigFilename, JSON.stringify(tsconfig, undefined, 2), { encoding: 'utf-8' });
+}
+
+async function replaceAppRunner(directory: string) {
+  const filename = path.join(directory, 'cdk.json');
+  const config = JSON.parse(await fs.readFile(filename, { encoding: 'utf-8' }));
+  expect(config.app).toMatch(/^npx tsc && npx tsx bin\/.+\.ts$/);
+  config.app = config.app.replace('npx tsx', 'npx nub');
+  expect(config.app).toMatch(/^npx tsc && npx nub bin\/.+\.ts$/);
+  await fs.writeFile(filename, JSON.stringify(config, undefined, 2), { encoding: 'utf-8' });
+}
+
+async function assertAssemblyDirsEqual(dirA: string, dirB: string) {
+  const filesA = await relativeFiles(dirA);
+  const filesB = await relativeFiles(dirB);
+  expect(filesB).toEqual(filesA);
+
+  for (const file of filesA) {
+    const contentsA = await fs.readFile(path.join(dirA, file), 'utf-8');
+    const contentsB = await fs.readFile(path.join(dirB, file), 'utf-8');
+    if (normalizeAssemblyContents(file, contentsA) !== normalizeAssemblyContents(file, contentsB)) {
+      throw new Error(`File ${file} differs between ${dirA} and ${dirB}`);
+    }
+  }
+}
+
+function normalizeAssemblyContents(file: string, contents: string): string {
+  if (!file.endsWith('.metadata.json')) {
+    return contents;
+  }
+
+  const metadata = JSON.parse(contents);
+  for (const entries of Object.values(metadata)) {
+    if (Array.isArray(entries)) {
+      for (const entry of entries) {
+        if (entry.type === 'aws:cdk:creationStack' && Array.isArray(entry.data)) {
+          entry.data = removeRunnerFrames(entry.data);
+        }
+      }
+    }
+  }
+  return JSON.stringify(metadata);
+}
+
+function removeRunnerFrames(frames: unknown[]): unknown[] {
+  // CDK records the terminal runner frames in creation-stack metadata. `tsx`
+  // adds a duplicate source location with a different column number.
+  return frames
+    .filter(frame => typeof frame !== 'string' || !/^\.\.\.node internals(?:, tsx)?\.\.\.$/.test(frame))
+    .filter((frame, index, remaining) => index === 0 || normalizedFrame(frame) !== normalizedFrame(remaining[index - 1]));
+}
+
+function normalizedFrame(frame: unknown): unknown {
+  return typeof frame === 'string' ? frame.replace(/:\d+\)$/, ')') : frame;
+}
+
+async function relativeFiles(root: string): Promise<string[]> {
+  const entries = await fs.readdir(root, { recursive: true, withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile())
+    .map((entry) => path.join(path.relative(root, entry.parentPath), entry.name))
+    .sort();
 }

--- a/packages/aws-cdk/lib/init-templates/app/typescript/README.md
+++ b/packages/aws-cdk/lib/init-templates/app/typescript/README.md
@@ -4,6 +4,24 @@ This is a blank project for CDK development with TypeScript.
 
 The `cdk.json` file tells the CDK Toolkit how to execute your app.
 
+## Run the app with Nub
+
+Install the pinned Nub runner without changing the project's package manager:
+
+```console
+npm install --save-dev --save-exact @nubjs/nub@0.8.3
+```
+
+Then replace the `tsx` portion of the `app` command in `cdk.json`. Keep the type-check step:
+
+```json
+{
+  "app": "npx tsc && npx nub bin/my-project.ts"
+}
+```
+
+This changes only how the CDK app runs. Lambda bundling and dependency installation remain unchanged.
+
 ## Useful commands
 
 * `%pm-cmd% build`   type-check the project


### PR DESCRIPTION
Adds an opt-in TypeScript application-runner recipe for Nub.

- Pins `@nubjs/nub` to `0.8.3` and keeps the template type-check command.
- Adds the TypeScript init integration test. It synthesizes with the default runner and Nub, then compares the resulting assembly.

Validation: a clean Linux VM ran the published `@nubjs/nub@0.8.3` package through `npx`, type-checked both commands, synthesized with context, and compared all assembly files. Creation-stack metadata differs only in terminal runner frames; the test normalizes those frames and compares all remaining metadata.

The PR remains ready for review while the repository CI and init-template integration matrix run remotely.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
