### PR TITLE
chore(cli-integ): pin integ test Node version to 24.19

### DIFF
--- a/.github/workflows/integ.yml
+++ b/.github/workflows/integ.yml
@@ -207,7 +207,7 @@ jobs:
         suite:
           - cli-integ-tests
         node:
-          - lts/*
+          - "24.19"
         shard:
           - 1
           - 2
@@ -339,7 +339,7 @@ jobs:
         suite:
           - toolkit-lib-integ-tests
         node:
-          - lts/*
+          - "24.19"
           - "20"
           - "22"
           - "24"
@@ -461,7 +461,7 @@ jobs:
         suite:
           - telemetry-integ-tests
         node:
-          - lts/*
+          - "24.19"
   integ_init-templates:
     needs: prepare
     runs-on: aws-cdk_ubuntu-latest_16-core
@@ -594,7 +594,7 @@ jobs:
           - init-typescript-app
           - init-typescript-lib
         node:
-          - lts/*
+          - "24.19"
   integ_tool-integrations:
     needs: prepare
     runs-on: aws-cdk_ubuntu-latest_16-core

--- a/projenrc/cdk-cli-integ-tests.ts
+++ b/projenrc/cdk-cli-integ-tests.ts
@@ -12,6 +12,10 @@ export function fixupTestTask(project: Project, taskName = 'test'): void {
 
 const NOT_FLAGGED_EXPR = "!contains(github.event.pull_request.labels.*.name, 'pr/exempt-integ-test')";
 
+// Pinned instead of 'lts/*': Node >= 24.20.0 breaks CDK apps (jsonschema throws "Invalid URL").
+// Restore 'lts/*' once aws-cdk-lib bundles a fixed cloud-assembly-schema.
+const DEFAULT_TEST_NODE_VERSION = '24.19';
+
 function setupNodeStep(nodeVersion: string): github.workflows.JobStep {
   return {
     name: 'Setup Node.js',
@@ -464,7 +468,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
           suite: [
             'toolkit-lib-integ-tests',
           ],
-          node: ['lts/*', ...additionalNodeVersionsToTest],
+          node: [DEFAULT_TEST_NODE_VERSION, ...additionalNodeVersionsToTest],
         },
       }),
 
@@ -490,7 +494,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
             'init-typescript-app',
             'init-typescript-lib',
           ],
-          node: ['lts/*'],
+          node: [DEFAULT_TEST_NODE_VERSION],
         },
         // Run the the typescript-app test with multiple Node versions
         include: additionalNodeVersionsToTest.map(node => ({
@@ -573,7 +577,7 @@ export class CdkCliIntegTestsWorkflow extends Component {
         matrix: {
           domain: {
             suite: props.domain.suite,
-            node: props.domain.node ?? ['lts/*'],
+            node: props.domain.node ?? [DEFAULT_TEST_NODE_VERSION],
             shard,
           },
           include: props.include,


### PR DESCRIPTION
Integ tests are failing on every synth with `TypeError: Invalid URL` since GitHub runners started resolving `node-version: lts/*` to Node.js 24.20.0 (see the init-templates failures). Node 24.20.0 ships the ada 4.0.0 URL parser, which correctly rejects the invalid URLs jsonschema builds while resolving local $refs during manifest validation (enabled in integ tests via `TESTING_CDK=1`). The failing code lives in the published `aws-cdk-lib`, which bundles `@aws-cdk/cloud-assembly-schema` with the unfixed jsonschema — so the patch merged in #1945 cannot reach it.

This pins the integ test matrix Node version to 24.19 until a fixed `@aws-cdk/cloud-assembly-schema` is released and re-bundled by `aws-cdk-lib`, at which point the pin should be reverted to `lts/*`. The prepare/build job keeps `lts/*` since it builds this repo, which already carries the patch; the tool-integrations job keeps its existing Node 20 override.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
