### PR TITLE
fix(toolkit-lib): warn when hook failure detail can't be fetched

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
@@ -388,7 +388,9 @@ export class CloudFormationStackDiagnoser {
    * Find the hooks that failed this change set, and return their failure details as resource errors.
    *
    * Failures of hooks with failure mode WARN don't fail a change set, so those are excluded.
-   * Returns an empty array if hook results can't be listed (e.g. for lack of permissions).
+   * Returns an empty array if hook results can't be listed (e.g. lack of permissions, or the
+   * API being unavailable). We always tell the user that extra detail may be missing, at normal
+   * verbosity, so they aren't left thinking there simply is no more detail to find.
    */
   private async _changeSetHookErrors(changeSet: ChangeSetSummary): Promise<ResourceError[]> {
     let hookResults: HookResultSummary[];
@@ -398,7 +400,10 @@ export class CloudFormationStackDiagnoser {
         TargetId: changeSet.ChangeSetId,
       })).HookResults ?? [];
     } catch (e: any) {
-      await this.props.ioHelper.defaults.debug(`Could not list hook results for change set ${changeSet.ChangeSetName}: ${e.message}`);
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      await this.props.ioHelper.defaults.warn(
+        `Could not fetch extra hook failure detail for change set ${changeSet.ChangeSetName} (${errorMessage}). Run again with -v to see the full error.`,
+      );
       return [];
     }
 
@@ -431,7 +436,6 @@ export class CloudFormationStackDiagnoser {
     if (hook.HookResultId) {
       const details = await fetchHookResultDetails(this.cfn, hook.HookResultId, {
         ioHelper: this.props.ioHelper,
-        envResources: this.props.envResources,
       });
       if (details) {
         return details;
@@ -488,7 +492,6 @@ export class CloudFormationStackDiagnoser {
       let details = hook.hookInvocationId
         ? await fetchHookResultDetails(this.cfn, hook.hookInvocationId, {
           ioHelper: this.props.ioHelper,
-          envResources: this.props.envResources,
         })
         : undefined;
       details = details ?? (hook.hookStatusReason ? normalizeHookMessage(hook.hookStatusReason) : undefined);

--- a/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/diagnosing/stack-diagnoser.ts
@@ -375,37 +375,36 @@ export class CloudFormationStackDiagnoser {
 
     // The change set may have been failed by a CloudFormation Hook (e.g. a Lambda Hook
     // targeting change set operations). Those failures don't produce events; their
-    // details are only available through the hook results APIs.
-    const hookErrors = await this._changeSetHookErrors(changeSet);
+    // details are only available through the hook results APIs. If we can't fetch them
+    // (e.g. lack of permissions), report the generic error with a warning attached, so
+    // the user isn't left thinking there simply is no more detail to find.
+    let hookErrors: ResourceError[] = [];
+    let warnings: string[] = [];
+    try {
+      hookErrors = await this._changeSetHookErrors(changeSet);
+    } catch (e: any) {
+      const errorMessage = e instanceof Error ? e.message : String(e);
+      warnings = [`Could not fetch extra hook failure detail for change set ${changeSet.ChangeSetName} (${errorMessage}). Run again with -v to see the full error.`];
+    }
     if (hookErrors.length > 0) {
       return Diagnosis.problem(detectedBy, await this.enhanceErrors(hookErrors));
     }
 
-    return this._nonSpecificChangeSetError(changeSet, detectedBy);
+    return this._nonSpecificChangeSetError(changeSet, detectedBy, warnings);
   }
 
   /**
    * Find the hooks that failed this change set, and return their failure details as resource errors.
    *
    * Failures of hooks with failure mode WARN don't fail a change set, so those are excluded.
-   * Returns an empty array if hook results can't be listed (e.g. lack of permissions, or the
-   * API being unavailable). We always tell the user that extra detail may be missing, at normal
-   * verbosity, so they aren't left thinking there simply is no more detail to find.
+   * Throws if hook results can't be listed (e.g. lack of permissions, or the API being
+   * unavailable).
    */
   private async _changeSetHookErrors(changeSet: ChangeSetSummary): Promise<ResourceError[]> {
-    let hookResults: HookResultSummary[];
-    try {
-      hookResults = (await this.cfn.listHookResults({
-        TargetType: 'CHANGE_SET',
-        TargetId: changeSet.ChangeSetId,
-      })).HookResults ?? [];
-    } catch (e: any) {
-      const errorMessage = e instanceof Error ? e.message : String(e);
-      await this.props.ioHelper.defaults.warn(
-        `Could not fetch extra hook failure detail for change set ${changeSet.ChangeSetName} (${errorMessage}). Run again with -v to see the full error.`,
-      );
-      return [];
-    }
+    const hookResults: HookResultSummary[] = (await this.cfn.listHookResults({
+      TargetType: 'CHANGE_SET',
+      TargetId: changeSet.ChangeSetId,
+    })).HookResults ?? [];
 
     const failedHooks = hookResults.filter((r) => isFailedHookStatus(r.Status) && r.FailureMode === 'FAIL');
 
@@ -463,7 +462,11 @@ export class CloudFormationStackDiagnoser {
       this.hookFailureContext(err),
     ]);
 
-    const allContext = [...hookContext, ...additionalContext];
+    const allContext = [
+      ...hookContext,
+      ...additionalContext,
+      ...(err.warnings?.length ? [{ source: 'Warnings', messages: err.warnings }] : []),
+    ];
     return {
       ...err,
       sourceTrace,
@@ -524,8 +527,12 @@ export class CloudFormationStackDiagnoser {
    * Build a generic stack error from the given change set information
    *
    * We can't point to a specific resource.
+   *
+   * @param warnings - Warnings to attach to the error (e.g. a note that hook detail couldn't
+   * be fetched). Rendered after the main failure message, instead of appearing to precede or
+   * replace it.
    */
-  private async _nonSpecificChangeSetError(changeSet: ChangeSetSummary, detectedBy: StackProblemSource): Promise<Diagnosis> {
+  private async _nonSpecificChangeSetError(changeSet: ChangeSetSummary, detectedBy: StackProblemSource, warnings: string[] = []): Promise<Diagnosis> {
     return Diagnosis.problem(detectedBy, [
       await this.enhanceError({
         // It's about a stack
@@ -535,6 +542,7 @@ export class CloudFormationStackDiagnoser {
         stackArn: changeSet.StackId ?? '',
         physicalId: changeSet.StackId,
         resourceType: 'AWS::CloudFormation::Stack',
+        warnings,
       }),
     ]);
   }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/hook-result-details.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/hook-result-details.ts
@@ -1,8 +1,6 @@
 import * as util from 'node:util';
 import type { GetHookResultCommandOutput, HookResultSummary } from '@aws-sdk/client-cloudformation';
 import type { ICloudFormationClient } from '../aws-auth/private';
-import { isAccessDeniedError } from '../aws-auth/util';
-import type { EnvironmentResources } from '../environment';
 import type { IoHelper } from '../io/private';
 
 /**
@@ -63,14 +61,6 @@ export interface FetchHookResultDetailsOptions {
    * The IoHelper used to warn when the fetch fails.
    */
   readonly ioHelper: IoHelper;
-
-  /**
-   * Environment resources, used to look up the bootstrap toolkit version when
-   * diagnosing hook result fetch failures caused by missing permissions.
-   *
-   * @default - Bootstrap version is not reported in error messages
-   */
-  readonly envResources?: EnvironmentResources;
 }
 
 /**
@@ -79,9 +69,9 @@ export interface FetchHookResultDetailsOptions {
  *
  * For Guard Hooks the details come from the failed annotations; for other hooks
  * (e.g. Lambda Hooks) they come from the hook result's own status reason.
- * Returns undefined if the fetch fails (emitting a warning, with a bootstrap
- * upgrade hint if the failure looks permissions-related) or the result carries
- * no failure details.
+ * Returns undefined if the fetch fails (emitting a warning at normal verbosity, so the
+ * user knows extra detail may exist but couldn't be retrieved) or the result carries no
+ * failure details.
  */
 export async function fetchHookResultDetails(
   cfn: ICloudFormationClient,
@@ -93,31 +83,9 @@ export async function fetchHookResultDetails(
     return formatHookResultDetails(result);
   } catch (e: any) {
     const errorMessage = e instanceof Error ? e.message : String(e);
-
-    const isPermissionsError =
-      isAccessDeniedError(e) ||
-      (typeof errorMessage === 'string' && errorMessage.toLowerCase().includes('not authorized to perform: cloudformation:gethookresult'));
-
-    if (isPermissionsError && options.envResources) {
-      let currentVersion: number | undefined = undefined;
-      try {
-        currentVersion = (await options.envResources.lookupToolkit()).version;
-      } catch {
-        // ignore errors looking up the bootstrap version
-      }
-
-      await options.ioHelper.defaults.warn(
-        `Failed to fetch result details for Hook invocation ${hookInvocationId}: ${errorMessage}. ` +
-        'Make sure you have permissions to call the GetHookResult API, or re-bootstrap your environment ' +
-        "by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. " +
-        `Bootstrap toolkit stack version 31 or later is needed; current version: ${currentVersion ?? 'unknown'}.`,
-      );
-    } else {
-      await options.ioHelper.defaults.warn(
-        util.format('Failed to fetch Hook details for invocation %s: %s', hookInvocationId, errorMessage),
-      );
-    }
-
+    await options.ioHelper.defaults.warn(
+      util.format('Could not fetch extra detail for Hook invocation %s (%s). Run again with -v to see the full error.', hookInvocationId, errorMessage),
+    );
     return undefined;
   }
 }

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/resource-errors.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/resource-errors.ts
@@ -90,6 +90,15 @@ export interface ResourceError {
    * hook type appearing in the resource's status reason.
    */
   readonly hookFailures?: ResourceHookFailure[];
+
+  /**
+   * Warnings related to this error that should be surfaced alongside it, if any.
+   *
+   * For example, a note that CloudFormation Hook failure detail could not be fetched
+   * (e.g. `ListHookResults` failed due to missing permissions). Rendered as additional
+   * context after the main error message.
+   */
+  readonly warnings?: string[];
 }
 
 /**

--- a/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/api/stack-events/stack-activity-monitor.ts
@@ -64,10 +64,10 @@ export interface StackActivityMonitorProps {
   readonly pollingInterval?: number;
 
   /**
-   * Environment resources, used to look up the bootstrap toolkit version when
-   * diagnosing Guard Hook annotation fetch failures.
+   * Environment resources.
    *
-   * @default - Bootstrap version is not reported in error messages
+   * @deprecated no longer used by this class; kept for backwards compatibility of the constructor signature
+   * @default - not used
    */
   readonly envResources?: EnvironmentResources;
 
@@ -119,7 +119,6 @@ export class StackActivityMonitor {
   private readonly stackDisplayName: string;
   private readonly stack: CloudFormationStackArtifact;
   private readonly cfn: ICloudFormationClient;
-  private readonly envResources?: EnvironmentResources;
   private readonly isStackUpdate: boolean;
 
   constructor({
@@ -130,14 +129,12 @@ export class StackActivityMonitor {
     resourcesTotal,
     changeSetCreationTime,
     pollingInterval = 2_000,
-    envResources,
     isStackUpdate = false,
   }: StackActivityMonitorProps) {
     this.ioHelper = ioHelper;
     this.stack = stack;
     this.stackDisplayName = stackNameFromArn(stackArn);
     this.cfn = cfn;
-    this.envResources = envResources;
     this.isStackUpdate = isStackUpdate;
 
     this.progressMonitor = new StackProgressMonitor(resourcesTotal);
@@ -258,7 +255,6 @@ export class StackActivityMonitor {
       if (resourceEvent.event.HookInvocationId) {
         const details = await fetchHookResultDetails(this.cfn, resourceEvent.event.HookInvocationId, {
           ioHelper: this.ioHelper,
-          envResources: this.envResources,
         });
         if (details) {
           resourceEvent.event.HookStatusReason = details;

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
@@ -635,7 +635,7 @@ describe('CloudFormationStackDiagnoser', () => {
       expect(problem.problems[0].errorCode).not.toEqual('HookFailed');
     });
 
-    test('warns at normal verbosity when ListHookResults fails, without swallowing the error silently', async () => {
+    test('reports a note about missing hook detail after the main error, when ListHookResults fails', async () => {
       mockCloudFormationClient.on(ListHookResultsCommand).rejects(new Error(
         'User: arn:aws:sts::123456789012:assumed-role/cdk-pipeline-deploy-role/example-runner is not authorized ' +
         'to perform: cloudformation:ListHookResults on resource: ' + STACK_ARN,
@@ -646,9 +646,10 @@ describe('CloudFormationStackDiagnoser', () => {
       const problem = assertProblem(result);
       expect(problem.problems).toEqual([expect.objectContaining({
         message: expect.stringContaining('The following hook(s) failed'),
+        additionalContext: [expect.objectContaining({
+          messages: [expect.stringContaining('Could not fetch extra hook failure detail for change set my-cs')],
+        })],
       })]);
-      ioHost.expectMessage({ level: 'warn', containing: 'Could not fetch extra hook failure detail for change set my-cs' });
-      ioHost.expectMessage({ level: 'warn', containing: 'Run again with -v to see the full error' });
     });
 
     test('errors from DescribeEvents take precedence over hook results', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/diagnosing/stack-diagnoser.test.ts
@@ -635,8 +635,11 @@ describe('CloudFormationStackDiagnoser', () => {
       expect(problem.problems[0].errorCode).not.toEqual('HookFailed');
     });
 
-    test('reports the non-specific change set error when ListHookResults fails', async () => {
-      mockCloudFormationClient.on(ListHookResultsCommand).rejects(new Error('not authorized'));
+    test('warns at normal verbosity when ListHookResults fails, without swallowing the error silently', async () => {
+      mockCloudFormationClient.on(ListHookResultsCommand).rejects(new Error(
+        'User: arn:aws:sts::123456789012:assumed-role/cdk-pipeline-deploy-role/example-runner is not authorized ' +
+        'to perform: cloudformation:ListHookResults on resource: ' + STACK_ARN,
+      ));
 
       const result = await makeDiagnoser().diagnoseChangeSet(failedChangeSet());
 
@@ -644,6 +647,8 @@ describe('CloudFormationStackDiagnoser', () => {
       expect(problem.problems).toEqual([expect.objectContaining({
         message: expect.stringContaining('The following hook(s) failed'),
       })]);
+      ioHost.expectMessage({ level: 'warn', containing: 'Could not fetch extra hook failure detail for change set my-cs' });
+      ioHost.expectMessage({ level: 'warn', containing: 'Run again with -v to see the full error' });
     });
 
     test('errors from DescribeEvents take precedence over hook results', async () => {

--- a/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/api/stack-events/stack-activity-monitor.test.ts
@@ -444,7 +444,7 @@ describe('GuardHook GetHookResult fetching', () => {
     expect(ioHost.notify).toHaveBeenNthCalledWith(2,
       expect.objectContaining({
         level: 'warn',
-        message: `Failed to fetch Hook details for invocation ${hookInvocationId}: ${errorMessage}`,
+        message: `Could not fetch extra detail for Hook invocation ${hookInvocationId} (${errorMessage}). Run again with -v to see the full error.`,
       }),
     );
     expect(ioHost.notify).toHaveBeenNthCalledWith(3,
@@ -460,12 +460,11 @@ describe('GuardHook GetHookResult fetching', () => {
     expect(ioHost.notify).toHaveBeenNthCalledWith(4, expectStop());
   });
 
-  test('warns with bootstrap upgrade message when GetHookResult fails due to permissions', async () => {
+  test('warns with a generic message when GetHookResult fails due to permissions', async () => {
     const hookInvocationId = 'failing-invocation-id';
     const originalMessage = 'Template failed validation, the following rule(s) failed: AWS_S3_Bucket_AccessControl.';
 
     const errorMessage = 'User: arn:aws:iam::123456789012:role/test is not authorized to perform: cloudformation:GetHookResult';
-    const currentVersion = 30;
     mockCloudFormationClient.on(GetHookResultCommand).rejectsOnce(errorMessage);
 
     mockCloudFormationClient.on(DescribeStackEventsCommand).resolvesOnce({
@@ -494,10 +493,7 @@ describe('GuardHook GetHookResult fetching', () => {
     expect(ioHost.notify).toHaveBeenNthCalledWith(2,
       expect.objectContaining({
         level: 'warn',
-        message: `Failed to fetch result details for Hook invocation ${hookInvocationId}: ${errorMessage}. ` +
-          'Make sure you have permissions to call the GetHookResult API, or re-bootstrap your environment ' +
-          "by running 'cdk bootstrap' to update the Bootstrap CDK Toolkit stack. " +
-          `Bootstrap toolkit stack version 31 or later is needed; current version: ${currentVersion}.`,
+        message: `Could not fetch extra detail for Hook invocation ${hookInvocationId} (${errorMessage}). Run again with -v to see the full error.`,
       }),
     );
     expect(ioHost.notify).toHaveBeenNthCalledWith(3,


### PR DESCRIPTION
Fixes #1923

If your deploy role doesn't have `cloudformation:ListHookResults` / `cloudformation:GetHookResult` (common for custom CDK Pipelines deploy roles or hand-rolled least-privilege roles), a failed CloudFormation Hook used to give you no indication that more detail existed — the lookup failed silently and only showed up in `--debug` logs. You'd see the exact same generic message whether the hook truly had nothing more to say, or the CLI just couldn't ask.

**Before**

```
❌  Deployment failed: Error: The stack named MyStack failed creation, it may need to be manually deleted.

Change set creation failed. The following hook(s) failed: [Example::CFNHook::Full]
```

(No hint that more detail exists. The real reason is buried in `--debug` output.)

**After**

```
❌  Deployment failed: Error: The stack named MyStack failed creation, it may need to be manually deleted.

Change set creation failed. The following hook(s) failed: [Example::CFNHook::Full]

   Could not fetch extra hook failure detail for change set cdk-deploy-change-set (User: arn:aws:sts::123456789012:assumed-role/cdk-pipeline-deploy-role/example-runner is not authorized to perform: cloudformation:ListHookResults ...). Run again with -v to see the full error.
```

The warning is attached to the reported error itself and rendered right after the failure message, so you know it's worth investigating instead of assuming the hook had nothing more to say. The full underlying error is available with `-v`.

This applies both to `ListHookResults` (used by `cdk deploy` and `cdk diagnose` to find hooks that failed a change set) and `GetHookResult` (used to fetch a hook's detailed failure reason, e.g. Guard Hook annotations).

### What was tested

Updated and added unit tests in `stack-diagnoser.test.ts` and `stack-activity-monitor.test.ts` covering the warning being attached on fetch failure. Full `toolkit-lib` test suite (134 suites, 2031 tests) and lint pass.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
