### PR TITLE
fix(cloudformation-diff): changeset-based diff hides static changes CloudFormation fails to detect

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,8 @@ Integration tests require AWS credentials and run against real accounts. During 
 
 **MUST: one `integTest` per file.** Each integration test lives in its own `*.integtest.ts` file containing exactly one `integTest(...)` call. Do not group multiple `integTest` calls in a single file. The file name should describe the scenario (e.g. `cdk-cdk-diff---method-change-set-detects-ssm-parameter-driven-changes.integtest.ts`). The runner discovers and parallelizes tests by file, so combining tests in one file serializes them and breaks isolation.
 
+**SHOULD: prefer a new fixture app over extending the default app.** When a test needs new stacks or resources, create a dedicated app under `packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/<name>/` (an `app.js` plus `cdk.json`, see `simple-app` for a minimal example) and use it via `withSpecificFixture('<name>', ...)`. Only add to the shared default app (`resources/cdk-apps/app/app.js`, used by `withDefaultFixture`) when the test genuinely needs to interact with its existing stacks — every stack added there is synthesized by every default-fixture test.
+
 ### Redacting Secrets from Integration Test Output
 
 Integration test output is captured and written to logs, and on PR runs it can end up in a public GitHub Actions job log. Secrets must never appear there. [`lib/corking.ts`](./packages/@aws-cdk-testing/cli-integ/lib/corking.ts) provides the two halves of the mechanism: `registerSecrets()` records the values, and `redactSecrets()` scrubs them out of text.

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/waf-app/app.js
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/waf-app/app.js
@@ -1,0 +1,33 @@
+const cdk = require('aws-cdk-lib/core');
+
+const stackPrefix = process.env.STACK_NAME_PREFIX;
+if (!stackPrefix) {
+  throw new Error(`the STACK_NAME_PREFIX environment variable is required`);
+}
+
+// WAFv2 WebACL whose action flips between Allow and Block via WAF_ACTION. CloudFormation
+// changesets do not detect exchanging one empty-object action for another, so this exercises
+// the diff keeping the template-detected change. See aws/aws-cdk-cli#1922.
+class WafWebAclStack extends cdk.Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+    const action = process.env.WAF_ACTION || 'Allow';
+    new cdk.CfnResource(this, 'WebAcl', {
+      type: 'AWS::WAFv2::WebACL',
+      properties: {
+        Scope: 'REGIONAL',
+        DefaultAction: { [action]: {} },
+        VisibilityConfig: {
+          MetricName: 'waf-diff-test',
+          CloudWatchMetricsEnabled: false,
+          SampledRequestsEnabled: false,
+        },
+      },
+    });
+  }
+}
+
+const app = new cdk.App();
+new WafWebAclStack(app, `${stackPrefix}-waf-web-acl`);
+
+app.synth();

--- a/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/waf-app/cdk.json
+++ b/packages/@aws-cdk-testing/cli-integ/resources/cdk-apps/waf-app/cdk.json
@@ -1,0 +1,4 @@
+{
+  "app": "node app.js",
+  "versionReporting": false
+}

--- a/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-diff---method-change-set-shows-static-changes-the-changeset-fails-to-detect.integtest.ts
+++ b/packages/@aws-cdk-testing/cli-integ/tests/cli-integ-tests/diff/cdk-diff---method-change-set-shows-static-changes-the-changeset-fails-to-detect.integtest.ts
@@ -1,0 +1,30 @@
+import { integTest, withSpecificFixture } from '../../../lib';
+
+/**
+ * Regression test for https://github.com/aws/aws-cdk-cli/issues/1922
+ *
+ * CloudFormation changesets do not detect exchanging one empty-object union member for
+ * another (e.g. a WAFv2 action `{"Allow":{}}` -> `{"Block":{}}`) and report no changes.
+ * The changeset-based diff must not let that hide the template-detected change.
+ */
+integTest(
+  'cdk diff --method=change-set shows static changes the changeset fails to detect',
+  withSpecificFixture('waf-app', async (fixture) => {
+    const stackName = fixture.fullStackName('waf-web-acl');
+
+    // GIVEN - a deployed WebACL with an Allow default action
+    await fixture.cdkDeploy('waf-web-acl', {
+      modEnv: { WAF_ACTION: 'Allow' },
+    });
+
+    // WHEN - the action changes to Block, a change CloudFormation's changeset does not report
+    const diff = await fixture.cdk(['diff', '--method=change-set', stackName], {
+      modEnv: { WAF_ACTION: 'Block' },
+    });
+
+    // THEN - the template-detected change is surfaced anyway
+    expect(diff).not.toContain('There were no differences');
+    expect(diff).toContain('AWS::WAFv2::WebACL');
+    expect(diff).toContain('DefaultAction');
+  }),
+);

--- a/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
+++ b/packages/@aws-cdk/cloudformation-diff/lib/diff/template-and-changeset-diff-merger.ts
@@ -103,6 +103,11 @@ export class TemplateAndChangeSetDiffMerger {
     change.forEachDifference((type: 'Property' | 'Other', name: string, value: types.Difference<any> | types.PropertyDifference<any>) => {
       if (type === 'Property') {
         if (!this.changeSetResources[logicalId]) {
+          if (!propertyIsResolvedAtDeployTime(value)) {
+            // A static difference is a real change even if the changeset failed to detect it
+            // (e.g. WAFv2 empty-object actions, https://github.com/aws/aws-cdk-cli/issues/1922).
+            return;
+          }
           (value as types.PropertyDifference<any>).changeImpact = types.ResourceImpact.NO_CHANGE;
           (value as types.PropertyDifference<any>).isDifferent = false;
           return;
@@ -120,6 +125,10 @@ export class TemplateAndChangeSetDiffMerger {
             (value as types.PropertyDifference<any>).changeImpact = types.ResourceImpact.MAY_REPLACE;
             break;
           case undefined:
+            if (!propertyIsResolvedAtDeployTime(value)) {
+              // Same as above: keep static differences the changeset failed to detect.
+              break;
+            }
             (value as types.PropertyDifference<any>).changeImpact = types.ResourceImpact.NO_CHANGE;
             (value as types.PropertyDifference<any>).isDifferent = false;
             break;
@@ -482,4 +491,35 @@ function contextProperties(context: string | object | undefined): { [name: strin
     parsed = context;
   }
   return parsed && typeof parsed === 'object' ? parsed.Properties : undefined;
+}
+
+/**
+ * Whether either side of a property difference contains a value only resolved at deploy time:
+ * a `Ref`, an `Fn::*` intrinsic, or a dynamic reference (`{{resolve:...}}`).
+ *
+ * Only for such properties may the changeset legitimately report "no change" despite a
+ * textual difference in the template.
+ */
+function propertyIsResolvedAtDeployTime(difference: types.Difference<any>): boolean {
+  return containsDeployTimeValue(difference.oldValue) || containsDeployTimeValue(difference.newValue);
+}
+
+function containsDeployTimeValue(value: any): boolean {
+  if (typeof value === 'string') {
+    return value.includes('{{resolve:');
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsDeployTimeValue);
+  }
+  if (typeof value === 'object' && value !== null) {
+    for (const [key, nested] of Object.entries(value)) {
+      if (key === 'Ref' || key.startsWith('Fn::')) {
+        return true;
+      }
+      if (containsDeployTimeValue(nested)) {
+        return true;
+      }
+    }
+  }
+  return false;
 }

--- a/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
+++ b/packages/@aws-cdk/cloudformation-diff/test/template-and-changeset-diff-merger.test.ts
@@ -48,6 +48,55 @@ describe('fullDiff tests that include changeset', () => {
     expect(differences.differenceCount).toBe(0);
   });
 
+  test('static changes are not hidden by a changeset that fails to detect them', () => {
+    // GIVEN - CFN does not detect exchanging one empty-object union member for another
+    // (e.g. WAFv2 actions) and returns an empty changeset.
+    // https://github.com/aws/aws-cdk-cli/issues/1922
+    const currentTemplate = {
+      Resources: {
+        WebAcl: {
+          Type: 'AWS::WAFv2::WebACL',
+          Properties: {
+            Scope: 'CLOUDFRONT',
+            DefaultAction: { Allow: {} },
+            VisibilityConfig: {
+              MetricName: 'cf',
+              CloudWatchMetricsEnabled: true,
+              SampledRequestsEnabled: true,
+            },
+          },
+        },
+      },
+    };
+    const newTemplate = {
+      Resources: {
+        WebAcl: {
+          Type: 'AWS::WAFv2::WebACL',
+          Properties: {
+            Scope: 'CLOUDFRONT',
+            DefaultAction: { Block: {} },
+            VisibilityConfig: {
+              MetricName: 'cf',
+              CloudWatchMetricsEnabled: true,
+              SampledRequestsEnabled: true,
+            },
+          },
+        },
+      },
+    };
+
+    // WHEN - the changeset reports no changes at all (as observed from real CloudFormation)
+    const differences = fullDiff(currentTemplate, newTemplate, {
+      Changes: [],
+    });
+
+    // THEN - the purely static DefaultAction change is still surfaced
+    expect(differences.differenceCount).toBe(1);
+    const webAcl = differences.resources.get('WebAcl');
+    expect(webAcl.isDifferent).toBe(true);
+    expect(webAcl.propertyUpdates.DefaultAction.isDifferent).toBe(true);
+  });
+
   test('changeset replacements are respected', () => {
     // GIVEN
     const currentTemplate = {
@@ -1263,7 +1312,7 @@ describe('method tests', () => {
       expect(queue.changeImpact).toBe('NO_CHANGE');
     });
 
-    test('ignores changes that are not in changeset', async () => {
+    test('keeps static changes that are not in changeset', async () => {
       const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
         changeSet: {},
         changeSetResources: {},
@@ -1282,7 +1331,31 @@ describe('method tests', () => {
       // WHEN
       templateAndChangeSetDiffMerger.overrideDiffResourceChangeImpactWithChangeSetChangeImpact(logicalId, queue);
 
-      // THEN
+      // THEN - a static difference is a real change even if the changeset failed to report it
+      expect(queue.isDifferent).toBe(true);
+      expect(queue.changeImpact).toBe('WILL_UPDATE');
+    });
+
+    test('ignores deploy-time-resolved changes that are not in changeset', async () => {
+      const templateAndChangeSetDiffMerger = new TemplateAndChangeSetDiffMerger({
+        changeSet: {},
+        changeSetResources: {},
+      });
+      const queue = new ResourceDifference(
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param1' } } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param2' } } },
+        {
+          resourceType: { oldType: 'AWS::CDK::GREAT', newType: 'AWS::CDK::GREAT' },
+          propertyDiffs: { QueueName: new PropertyDifference<any>( { Ref: 'Param1' }, { Ref: 'Param2' }, { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          otherDiffs: {},
+        },
+      );
+      const logicalId = 'Queue';
+
+      // WHEN
+      templateAndChangeSetDiffMerger.overrideDiffResourceChangeImpactWithChangeSetChangeImpact(logicalId, queue);
+
+      // THEN - the changeset knows how deploy-time values resolve; trust its "no change" verdict
       expect(queue.isDifferent).toBe(false);
       expect(queue.changeImpact).toBe('NO_CHANGE');
     });
@@ -1298,11 +1371,11 @@ describe('method tests', () => {
         },
       });
       const queue = new ResourceDifference(
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'first' } },
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'second' } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param1' } } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param2' } } },
         {
           resourceType: { oldType: 'AWS::CDK::GREAT', newType: 'AWS::CDK::GREAT' },
-          propertyDiffs: { QueueName: new PropertyDifference<string>( 'first', 'second', { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          propertyDiffs: { QueueName: new PropertyDifference<any>( { Ref: 'Param1' }, { Ref: 'Param2' }, { changeImpact: ResourceImpact.WILL_UPDATE }) },
           otherDiffs: {},
         },
       );
@@ -1328,11 +1401,11 @@ describe('method tests', () => {
         },
       });
       const queue = new ResourceDifference(
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'first' } },
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'second' } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param1' } } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param2' } } },
         {
           resourceType: { oldType: 'AWS::CDK::GREAT', newType: 'AWS::CDK::GREAT' },
-          propertyDiffs: { QueueName: new PropertyDifference<string>( 'first', 'second', { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          propertyDiffs: { QueueName: new PropertyDifference<any>( { Ref: 'Param1' }, { Ref: 'Param2' }, { changeImpact: ResourceImpact.WILL_UPDATE }) },
           otherDiffs: {},
         },
       );
@@ -1360,11 +1433,11 @@ describe('method tests', () => {
         },
       });
       const queue = new ResourceDifference(
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'first' } },
-        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: 'second' } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param1' } } },
+        { Type: 'AWS::CDK::GREAT', Properties: { QueueName: { Ref: 'Param2' } } },
         {
           resourceType: { oldType: 'AWS::CDK::GREAT', newType: 'AWS::CDK::GREAT' },
-          propertyDiffs: { QueueName: new PropertyDifference<string>( 'first', 'second', { changeImpact: ResourceImpact.WILL_UPDATE }) },
+          propertyDiffs: { QueueName: new PropertyDifference<any>( { Ref: 'Param1' }, { Ref: 'Param2' }, { changeImpact: ResourceImpact.WILL_UPDATE }) },
           otherDiffs: {},
         },
       );


### PR DESCRIPTION
`cdk diff` reported "There were no differences" for changes CloudFormation changesets fail to detect, while `cdk deploy` still applied them. The reported case is a WAFv2 WebACL where an action switches from `{"Allow":{}}` to `{"Block":{}}`: exchanging one empty-object union member for another is invisible to CloudFormation's changeset engine. Verified against real CloudFormation — the changeset completes with an empty `Changes` list for exactly this update (reproduced with both CLOUDFRONT and REGIONAL scope, for `DefaultAction` and `Rules[].Action`). An internal ticket has been filed with the CloudFormation team for the underlying detection gap.

The template diff detects the change correctly, but the changeset merger then discards it: any template-detected property change that the changeset does not mention was overridden to "no change". That veto exists so the changeset can silence false positives on deploy-time values (e.g. an SSM-parameter-driven name that resolves to the same value, see #641) — but for a purely static difference the changeset has no better knowledge than the template, and its silence only means it failed to detect the change.

The merger now checks what kind of value changed before letting the changeset suppress it. If either side of the difference contains a deploy-time construct (`Ref`, an `Fn::*` intrinsic, or a `{{resolve:...}}` dynamic reference), the changeset verdict wins as before. A static difference is always kept. Unit tests that encoded the old blanket suppression were updated accordingly, and a regression test replays the WAF scenario against the empty changeset observed from the real service.

A new integration test deploys a WebACL from a dedicated `waf-app` fixture, flips the action, and asserts `cdk diff --method=change-set` surfaces the change (verified passing against a real account). Following recent guidance, the fixture is a standalone app rather than an addition to the shared default app; a note codifying that preference was added to AGENTS.md.

Fixes #1922

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
