### PR TITLE
fix(toolkit-lib): guard against a stack with no metadata in countAssemblyResults

### DIFF
--- a/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.ts
+++ b/packages/@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.ts
@@ -10,7 +10,7 @@ export function countAssemblyResults(span: IMessageSpan<any>, assembly: cxapi.Cl
   span.incCounter('warnings', sum(stacksRecursively.map(s => s.messages.filter(m => m.level === SynthesisMessageLevel.WARNING).length)));
 
   const annotationErrorCodes = stacksRecursively
-    .flatMap(s => Object.values(s.metadata)
+    .flatMap(s => Object.values(s.metadata ?? {})
       .flatMap(ms => ms.filter(m => m.type === ANNOTATION_ERROR_CODE_TYPE)));
   for (const annotationErrorCode of annotationErrorCodes) {
     span.incCounter(`errorAnn:${annotationErrorCode.data}`);

--- a/packages/@aws-cdk/toolkit-lib/test/toolkit/count-assembly-results.test.ts
+++ b/packages/@aws-cdk/toolkit-lib/test/toolkit/count-assembly-results.test.ts
@@ -1,0 +1,51 @@
+import { countAssemblyResults } from '../../lib/toolkit/private/count-assembly-results';
+
+// Minimal span that records incCounter calls; only the surface
+// countAssemblyResults touches is implemented.
+function fakeSpan() {
+  const counters: Array<{ name: string; delta?: number }> = [];
+  return {
+    counters,
+    span: {
+      incCounter: (name: string, delta?: number) => {
+        counters.push({ name, delta });
+      },
+    } as any,
+  };
+}
+
+// Minimal CloudAssembly stand-in. `metadata` is deliberately undefined on the
+// stack to reproduce the crash: countAssemblyResults used to call
+// Object.values(stack.metadata) with no null guard.
+function assemblyWithStack(stack: any): any {
+  return {
+    stacksRecursively: [stack],
+    nestedAssemblies: [],
+  };
+}
+
+describe('countAssemblyResults', () => {
+  test('does not throw when a stack has no metadata', () => {
+    const { span } = fakeSpan();
+    const stack = {
+      messages: [],
+      metadata: undefined, // the crashing input
+    };
+
+    expect(() => countAssemblyResults(span, assemblyWithStack(stack))).not.toThrow();
+  });
+
+  test('still counts annotation error codes when metadata is present', () => {
+    const { span, counters } = fakeSpan();
+    const stack = {
+      messages: [],
+      metadata: {
+        '/some/path': [{ type: 'aws:cdk:error-code', data: 'MY_ERROR' }],
+      },
+    };
+
+    countAssemblyResults(span, assemblyWithStack(stack));
+
+    expect(counters).toContainEqual({ name: 'errorAnn:MY_ERROR', delta: undefined });
+  });
+});


### PR DESCRIPTION
`countAssemblyResults` counts annotation error codes after synth by calling `Object.values(stack.metadata)` for every stack in `assembly.stacksRecursively`, with no null guard. When a synthesized stack has no metadata (`stack.metadata` is `undefined`), `Object.values(undefined)` throws:

```
TypeError: Cannot convert undefined or null to object
    at Object.values (<anonymous>)
    at countAssemblyResults (packages/@aws-cdk/toolkit-lib/lib/toolkit/private/count-assembly-results.ts:11)
    at synthAndMeasure (.../toolkit.ts)
    at Toolkit.synth (.../toolkit.ts)
```

This crashes `Toolkit.synth()` for otherwise-valid apps. It was reported downstream in AWS Amplify Gen 2, where a backend defining auth + a multi-model data schema + storage produces at least one nested stack whose `metadata` is undefined: aws-amplify/amplify-backend#3316.

This change guards the access with `stack.metadata ?? {}` (one line) and adds a regression test covering both the undefined-metadata case and the normal annotation-counting path.

Fixes #

<!--
No upstream issue is filed yet; the downstream report is aws-amplify/amplify-backend#3316.
-->

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed
  - Release notes for the new version:

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license
