### PR TITLE
fix(cli): shorten the agent detection notice

### DIFF
--- a/packages/aws-cdk/lib/cli/cli.ts
+++ b/packages/aws-cdk/lib/cli/cli.ts
@@ -119,7 +119,8 @@ export async function exec(args: string[], synthesizer?: Synthesizer): Promise<n
   // Progress updates are wasted tokens for AI agents
   if (guessAgent() && !argv.verbose && configuration.settings.get(['progress']) === undefined) {
     ioHost.stackProgress = StackActivityProgress.ERRORS_ONLY;
-    await ioHost.defaults.info('AI agent detected, using --progress "errors-only" (set --progress or the "progress" key in cdk.json to change)');
+    await ioHost.defaults.info('AI agent detected');
+    await ioHost.defaults.debug('Using --progress "errors-only" (set --progress or the "progress" key in cdk.json to change)');
   }
 
   // Always create and use ProxyAgent to support configuration via env vars

--- a/packages/aws-cdk/test/cli/cli.test.ts
+++ b/packages/aws-cdk/test/cli/cli.test.ts
@@ -627,7 +627,7 @@ describe('AI agent progress auto-default', () => {
     // Clear all env vars that guessAgent() detects, so the test environment doesn't interfere
     originalEnv = {};
     for (const key of Object.keys(process.env)) {
-      if (['CLAUDECODE', 'CURSOR_AGENT', 'VSCODE_AGENT', 'AWS_EXECUTION_ENV'].includes(key)
+      if (['AI_AGENT', 'AGENT', 'CLAUDECODE', 'CURSOR_AGENT', 'VSCODE_AGENT', 'AWS_EXECUTION_ENV'].includes(key)
         || key.startsWith('CODEX_') || key.startsWith('CLINE_')) {
         originalEnv[key] = process.env[key];
         delete process.env[key];


### PR DESCRIPTION
The auto-default notice from #1850 spent 30 tokens per invocation to agents that its meant to saves tokens for. The info-level message is now just `AI agent detected`

the progress mode and how to override it moved to debug.

### Checklist
- [ ] This change contains a major version upgrade for a dependency and I confirm all breaking changes are addressed

---
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license